### PR TITLE
Support media-upload option

### DIFF
--- a/vgen/src/main/java/io/gapi/vgen/ApiaryConfig.java
+++ b/vgen/src/main/java/io/gapi/vgen/ApiaryConfig.java
@@ -23,8 +23,10 @@ import com.google.protobuf.Field;
 import com.google.protobuf.Type;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.annotation.Nullable;
 
@@ -71,6 +73,11 @@ public class ApiaryConfig {
   private final Table<String, String, String> stringFormat =
       HashBasedTable.<String, String, String>create();
 
+  /**
+   * Records whether or not the method allows media upload.
+   */
+  private final Set<String> mediaUpload = new HashSet<>();
+
   /*
    * Maps type name to type (from {@link DiscoveryImporter}).
    */
@@ -111,6 +118,10 @@ public class ApiaryConfig {
 
   public Table<Type, String, Field> getFields() {
     return fields;
+  }
+
+  public Set<String> getMediaUpload() {
+    return mediaUpload;
   }
 
   /**

--- a/vgen/src/main/java/io/gapi/vgen/DiscoveryContext.java
+++ b/vgen/src/main/java/io/gapi/vgen/DiscoveryContext.java
@@ -126,6 +126,10 @@ public abstract class DiscoveryContext extends LanguageContext {
         apiaryConfig.getType(method.getRequestTypeUrl()), DiscoveryImporter.REQUEST_FIELD_NAME);
   }
 
+  public boolean hasMediaUpload(Method method) {
+    return apiaryConfig.getMediaUpload().contains(method.getName());
+  }
+
   public List<String> getMethodParams(Method method) {
     // used to handle inconsistency in list methods for Cloud Monitoring API
     // remove if inconsistency is resolved in discovery docs

--- a/vgen/src/main/java/io/gapi/vgen/DiscoveryImporter.java
+++ b/vgen/src/main/java/io/gapi/vgen/DiscoveryImporter.java
@@ -391,6 +391,10 @@ public class DiscoveryImporter {
     types.put(synthetic, type);
     builder.setRequestTypeUrl(synthetic);
 
+    if (root.get("supportsMediaUpload") != null && root.get("supportsMediaUpload").asBoolean()) {
+     config.getMediaUpload().add(methodName);
+   }
+
     // TODO: add google.api.http
     return builder.build();
   }


### PR DESCRIPTION
Previously we have missed media-upload when parsing Discovery Doc.
Since Java API Client Libraries provide overloads for methods with
media-upload, one with the media content as a parameter and one without,
compilecheck never complained.

This change detects media-upload option in Discovery Doc, but
leaves the code samples unchanged.