### PR TITLE
Setup to use gradle's protoc for generating protoc code.

### DIFF
--- a/vgen/build.gradle
+++ b/vgen/build.gradle
@@ -40,6 +40,12 @@ sourceSets {
   }
 }
 
+task setupProtocEnvironment << {
+  test.setEnvironment(PROTOC_COMPILER: project.protobuf.tools.protoc.path)
+}
+
+test.dependsOn setupProtocEnvironment
+
 task showRuntimeClassPath << {
   println sourceSets.main.runtimeClasspath.asPath
 }


### PR DESCRIPTION
Fixes issue #11 

Well, I'm actually not so familiar with gradle, but this passes java8 tests on travis (see https://travis-ci.org/jmuk/toolkit/jobs/125122347).
