### PR TITLE
Rename Python path template render method

### DIFF
--- a/vgen/src/main/resources/io/gapi/vgen/py/main.snip
+++ b/vgen/src/main/resources/io/gapi/vgen/py/main.snip
@@ -301,8 +301,8 @@
     {@"@classmethod"}
     def {@collectionConfig.getMethodBaseName}_path(cls, {@createResourceFunctionParams(collectionConfig)}):
         """Returns a fully-qualified {@collectionConfig.getMethodBaseName} resource name string."""
-        return cls.{@pathTemplateName(collectionConfig)}.instantiate({
-            {@createInstantiateDictionary(collectionConfig)}
+        return cls.{@pathTemplateName(collectionConfig)}.render({
+            {@createRenderDictionary(collectionConfig)}
         })
 @end
 
@@ -312,7 +312,7 @@
     @end
 @end
 
-@private createInstantiateDictionary(collectionConfig)
+@private createRenderDictionary(collectionConfig)
     @join param: collectionConfig.getNameTemplate.vars() on BREAK
         '{@param}': {@param},
     @end

--- a/vgen/src/test/java/io/gapi/vgen/testdata/python_library.baseline
+++ b/vgen/src/test/java/io/gapi/vgen/testdata/python_library.baseline
@@ -111,14 +111,14 @@ class LibraryServiceApi(object):
     @classmethod
     def shelf_path(cls, shelf):
         """Returns a fully-qualified shelf resource name string."""
-        return cls._SHELF_PATH_TEMPLATE.instantiate({
+        return cls._SHELF_PATH_TEMPLATE.render({
             'shelf': shelf,
         })
 
     @classmethod
     def book_path(cls, shelf, book):
         """Returns a fully-qualified book resource name string."""
-        return cls._BOOK_PATH_TEMPLATE.instantiate({
+        return cls._BOOK_PATH_TEMPLATE.render({
             'shelf': shelf,
             'book': book,
         })


### PR DESCRIPTION
Was `instantiate`; now `render`.

Corresponding GAX change is googleapis/gax-python#93