### PR TITLE
Fix a few ruby generator bugs

### DIFF
--- a/vgen/src/main/resources/io/gapi/vgen/ruby/main.snip
+++ b/vgen/src/main/resources/io/gapi/vgen/ruby/main.snip
@@ -219,7 +219,7 @@
       {@constructDefaults(service)}
       google_api_client = "#{app_name}/#{app_version} " @\
         "#{CODE_GEN_NAME_VERSION} ruby/#{RUBY_VERSION}".freeze
-      @@headers = { 'x-goog-api-client' => google_api_client }
+      @@headers = { :'x-goog-api-client' => google_api_client }
       @@stub = Google::Gax::Grpc.create_stub(
         service_path,
         port,
@@ -278,8 +278,8 @@
 @private createResourceFunction(collectionConfig)
   @# Returns a fully-qualified {@collectionConfig.getMethodBaseName} resource name string.
   def self.{@collectionConfig.getMethodBaseName}_path({@createResourceFunctionParams(collectionConfig)})
-    {@pathTemplateName(collectionConfig)}.instantiate(
-      {@createInstantiateDictionary(collectionConfig)})
+    {@pathTemplateName(collectionConfig)}.render(
+      {@createRenderDictionary(collectionConfig)})
   end
 @end
 
@@ -289,9 +289,9 @@
   @end
 @end
 
-@private createInstantiateDictionary(collectionConfig)
+@private createRenderDictionary(collectionConfig)
   @join param: collectionConfig.getNameTemplate.vars() on {@","}.add(BREAK)
-    '{@param}' => {@param}
+    :'{@param}' => {@param}
   @end
 @end
 

--- a/vgen/src/test/java/io/gapi/vgen/testdata/ruby_library.baseline
+++ b/vgen/src/test/java/io/gapi/vgen/testdata/ruby_library.baseline
@@ -98,15 +98,15 @@ module Google
 
           # Returns a fully-qualified shelf resource name string.
           def self.shelf_path(shelf)
-            SHELF_PATH_TEMPLATE.instantiate(
-              'shelf' => shelf)
+            SHELF_PATH_TEMPLATE.render(
+              :'shelf' => shelf)
           end
 
           # Returns a fully-qualified book resource name string.
           def self.book_path(shelf, book)
-            BOOK_PATH_TEMPLATE.instantiate(
-              'shelf' => shelf,
-              'book' => book)
+            BOOK_PATH_TEMPLATE.render(
+              :'shelf' => shelf,
+              :'book' => book)
           end
 
           # @param service_path [String]
@@ -161,7 +161,7 @@ module Google
             end
             google_api_client = "#{app_name}/#{app_version} " \
               "#{CODE_GEN_NAME_VERSION} ruby/#{RUBY_VERSION}".freeze
-            @headers = { 'x-goog-api-client' => google_api_client }
+            @headers = { :'x-goog-api-client' => google_api_client }
             @stub = Google::Gax::Grpc.create_stub(
               service_path,
               port,


### PR DESCRIPTION
- PathTemplate now uses 'render' for the method name of creating
  the result. Generator should use it.
- render assumes keyword arguments, whose keys are symbols, not
  strings.
- similarly, headers keys should be symbol as well.
- fixes a bug of TYPE_ENUM in rubyType() method -- should invoke
  getEnumType() instead of getMessageType() for TYPE_ENUM.