### PR TITLE
Add Media-Upload Sample to NodeJS

### DIFF
--- a/vgen/src/main/resources/io/gapi/vgen/nodejs/discovery_fragment.snip
+++ b/vgen/src/main/resources/io/gapi/vgen/nodejs/discovery_fragment.snip
@@ -55,6 +55,13 @@
     @if context.hasRequestField(method)
       resource: {},
     @end
+    @if context.hasMediaUpload(method)
+      media: {
+        // See https://github.com/google/google-api-nodejs-client#media-uploads
+        mimeType: 'text/plain',
+        body: 'Hello World!'
+      },
+    @end
   @end
 @end
 

--- a/vgen/src/test/java/io/gapi/vgen/testdata/discoveries/nodejs/nodejs_bigquery.v2.json.baseline
+++ b/vgen/src/test/java/io/gapi/vgen/testdata/discoveries/nodejs/nodejs_bigquery.v2.json.baseline
@@ -342,6 +342,11 @@ authFactory.getApplicationDefault(function(err, authClient) {
     // Project ID of the project that will be billed for the job
     projectId: "",
     resource: {},
+    media: {
+      // See https://github.com/google/google-api-nodejs-client#media-uploads
+      mimeType: 'text/plain',
+      body: 'Hello World!'
+    },
     // Auth client
     auth: authClient
   };

--- a/vgen/src/test/java/io/gapi/vgen/testdata/discoveries/nodejs/nodejs_dataproc.v1.json.baseline
+++ b/vgen/src/test/java/io/gapi/vgen/testdata/discoveries/nodejs/nodejs_dataproc.v1.json.baseline
@@ -54,6 +54,11 @@ authFactory.getApplicationDefault(function(err, authClient) {
     // Name of the media that is being downloaded. See ByteStream.ReadRequest.resource_name.
     resourceName: "",
     resource: {},
+    media: {
+      // See https://github.com/google/google-api-nodejs-client#media-uploads
+      mimeType: 'text/plain',
+      body: 'Hello World!'
+    },
     // Auth client
     auth: authClient
   };

--- a/vgen/src/test/java/io/gapi/vgen/testdata/discoveries/nodejs/nodejs_storage.v1.json.baseline
+++ b/vgen/src/test/java/io/gapi/vgen/testdata/discoveries/nodejs/nodejs_storage.v1.json.baseline
@@ -1046,6 +1046,11 @@ authFactory.getApplicationDefault(function(err, authClient) {
     // Name of the bucket in which to store the new object. Overrides the provided object metadata's bucket value, if any.
     bucket: "",
     resource: {},
+    media: {
+      // See https://github.com/google/google-api-nodejs-client#media-uploads
+      mimeType: 'text/plain',
+      body: 'Hello World!'
+    },
     // Auth client
     auth: authClient
   };


### PR DESCRIPTION
Fixes #10.

This commit adds 'media' object to requests that allows media upload.
This addresses some of compilecheck's warnings.