### PR TITLE
Special-Case Inconsistencies in NodeJS Discovery

### DIFF
--- a/vgen/src/main/java/io/gapi/vgen/DiscoveryContext.java
+++ b/vgen/src/main/java/io/gapi/vgen/DiscoveryContext.java
@@ -105,12 +105,6 @@ public abstract class DiscoveryContext extends LanguageContext {
   }
 
   public boolean hasRequestField(Method method) {
-    // used to handle inconsistency in list methods for Cloud Monitoring API
-    // remove if inconsistency is resolved in discovery docs
-    if (isCloudMonitoringListMethod(method)) {
-      return false;
-    }
-
     List<String> params = apiaryConfig.getMethodParams(method.getName());
     return params.size() > 0 && isRequestField(getLast(params));
   }
@@ -126,12 +120,6 @@ public abstract class DiscoveryContext extends LanguageContext {
   }
 
   public List<String> getMethodParams(Method method) {
-    // used to handle inconsistency in list methods for Cloud Monitoring API
-    // remove if inconsistency is resolved in discovery docs
-    if (isCloudMonitoringListMethod(method)) {
-      return getMost(apiaryConfig.getMethodParams(method.getName()));
-    }
-
     return apiaryConfig.getMethodParams(method.getName());
   }
 
@@ -157,12 +145,6 @@ public abstract class DiscoveryContext extends LanguageContext {
   }
 
   public boolean isPageStreaming(Method method) {
-    // used to handle inconsistency in users list method for SQLAdmin API
-    // remove if inconsistency is resolved
-    if (isSQLAdminUsersListMethod(method)) {
-      return false;
-    }
-
     if (isResponseEmpty(method)) {
       return false;
     }
@@ -176,35 +158,5 @@ public abstract class DiscoveryContext extends LanguageContext {
 
   public boolean isPatch(Method method) {
     return apiaryConfig.getHttpMethod(method.getName()).equals("PATCH");
-  }
-
-  // Flaggers for Exceptional Inconsistencies
-  // ========================================
-
-  // used to handle inconsistency in list methods for Cloud Monitoring API
-  // remove if inconsistency is resolved in discovery docs
-  public boolean isCloudMonitoringListMethod(Method method) {
-    Api api = getApi();
-    return api.getName().equals("cloudmonitoring")
-        && api.getVersion().equals("v2beta2")
-        && isPageStreaming(method);
-  }
-
-  // used to handle inconsistency in log entries list method for Logging API
-  // remove if inconsistency is resolved
-  public boolean isLogEntriesListMethod(Method method) {
-    Api api = getApi();
-    return api.getName().equals("logging")
-        && api.getVersion().equals("v2beta1")
-        && method.getName().equals("logging.entries.list");
-  }
-
-  // used to handle inconsistency in users list method for SQLAdmin API
-  // remove if inconsistency is resolved
-  public boolean isSQLAdminUsersListMethod(Method method) {
-    Api api = getApi();
-    return api.getName().equals("sqladmin")
-        && api.getVersion().equals("v1beta4")
-        && method.getName().equals("sql.users.list");
   }
 }

--- a/vgen/src/main/java/io/gapi/vgen/java/JavaDiscoveryContext.java
+++ b/vgen/src/main/java/io/gapi/vgen/java/JavaDiscoveryContext.java
@@ -28,6 +28,8 @@ import io.gapi.vgen.ApiaryConfig;
 import io.gapi.vgen.DiscoveryContext;
 import io.gapi.vgen.DiscoveryImporter;
 
+import java.util.List;
+
 /**
  * A DiscoveryContext specialized for Java.
  */
@@ -364,5 +366,66 @@ public class JavaDiscoveryContext extends DiscoveryContext implements JavaContex
       }
       return "null;";
     }
+  }
+
+  // Flaggers for Exceptional Inconsistencies
+  // ========================================
+
+  // used to handle inconsistency in list methods for Cloud Monitoring API
+  // remove if inconsistency is resolved in discovery docs
+  private boolean isCloudMonitoringListMethod(Method method) {
+    Api api = getApi();
+    return api.getName().equals("cloudmonitoring")
+        && api.getVersion().equals("v2beta2")
+        && isPageStreaming(method);
+  }
+
+  // used to handle inconsistency in log entries list method for Logging API
+  // remove if inconsistency is resolved
+  public boolean isLogEntriesListMethod(Method method) {
+    Api api = getApi();
+    return api.getName().equals("logging")
+        && api.getVersion().equals("v2beta1")
+        && method.getName().equals("logging.entries.list");
+  }
+
+  // used to handle inconsistency in users list method for SQLAdmin API
+  // remove if inconsistency is resolved
+  private boolean isSQLAdminUsersListMethod(Method method) {
+    Api api = getApi();
+    return api.getName().equals("sqladmin")
+        && api.getVersion().equals("v1beta4")
+        && method.getName().equals("sql.users.list");
+  }
+
+  @Override
+  public boolean hasRequestField(Method method) {
+    // used to handle inconsistency in list methods for Cloud Monitoring API
+    // remove if inconsistency is resolved in discovery docs
+    if (isCloudMonitoringListMethod(method)) {
+      return false;
+    }
+    return super.hasRequestField(method);
+  }
+
+  @Override
+  public List<String> getMethodParams(Method method) {
+    // used to handle inconsistency in list methods for Cloud Monitoring API
+    // remove if inconsistency is resolved in discovery docs
+    if (isCloudMonitoringListMethod(method)) {
+      return getMost(getApiaryConfig().getMethodParams(method.getName()));
+    }
+
+    return super.getMethodParams(method);
+  }
+
+  @Override
+  public boolean isPageStreaming(Method method) {
+    // used to handle inconsistency in users list method for SQLAdmin API
+    // remove if inconsistency is resolved
+    if (isSQLAdminUsersListMethod(method)) {
+      return false;
+    }
+    return super.isPageStreaming(method);
   }
 }

--- a/vgen/src/main/resources/io/gapi/vgen/nodejs/discovery_fragment.snip
+++ b/vgen/src/main/resources/io/gapi/vgen/nodejs/discovery_fragment.snip
@@ -46,7 +46,7 @@
 
     @join param : params
       @let paramField = context.getField(signatureType, param), \
-           paramValue = context.typeDefaultValue(signatureType, paramField), \
+           paramValue = context.typeDefaultValue(signatureType, paramField, method), \
            paramDescription = apiaryConfig.getDescription(signatureType.getName, param)
         {@item(paramDescription)}
         {@context.mapParamName(param)}: {@paramValue}

--- a/vgen/src/test/java/io/gapi/vgen/testdata/discoveries/nodejs/nodejs_cloudmonitoring.v2beta2.json.baseline
+++ b/vgen/src/test/java/io/gapi/vgen/testdata/discoveries/nodejs/nodejs_cloudmonitoring.v2beta2.json.baseline
@@ -89,6 +89,7 @@ authFactory.getApplicationDefault(function(err, authClient) {
 
     // The project id. The value can be the numeric project ID or string-based project name.
     project: "",
+    resource: {},
     // Auth client
     auth: authClient
   };
@@ -133,6 +134,7 @@ authFactory.getApplicationDefault(function(err, authClient) {
     metric: "",
     // End of the time interval (inclusive), which is expressed as an RFC 3339 timestamp.
     youngest: "",
+    resource: {},
     // Auth client
     auth: authClient
   };
@@ -211,6 +213,7 @@ authFactory.getApplicationDefault(function(err, authClient) {
     metric: "",
     // End of the time interval (inclusive), which is expressed as an RFC 3339 timestamp.
     youngest: "",
+    resource: {},
     // Auth client
     auth: authClient
   };

--- a/vgen/src/test/java/io/gapi/vgen/testdata/discoveries/nodejs/nodejs_sqladmin.v1beta4.json.baseline
+++ b/vgen/src/test/java/io/gapi/vgen/testdata/discoveries/nodejs/nodejs_sqladmin.v1beta4.json.baseline
@@ -1331,13 +1331,20 @@ authFactory.getApplicationDefault(function(err, authClient) {
     auth: authClient
   };
 
-  sqladmin.users.list(request, function(err, result) {
+
+  var recur = function(err, result) {
     if (err) {
       console.log(err);
     } else {
       console.log(result);
+      if (result.nextPageToken) {
+        request.pageToken = result.nextPageToken;
+        sqladmin.users.list(request, recur);
+      }
     }
-  });
+  };
+
+  sqladmin.users.list(request, recur);
 });
 var google = require('googleapis');
 var GoogleAuth = require('google-auth-library');

--- a/vgen/src/test/java/io/gapi/vgen/testdata/discoveries/nodejs/nodejs_translate.v2.json.baseline
+++ b/vgen/src/test/java/io/gapi/vgen/testdata/discoveries/nodejs/nodejs_translate.v2.json.baseline
@@ -19,7 +19,7 @@ authFactory.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to values for parameters to the 'list' method:
 
     // The text to detect
-    q: [],
+    q: "",
     // Auth client
     auth: authClient
   };
@@ -83,7 +83,7 @@ authFactory.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to values for parameters to the 'list' method:
 
     // The text to translate
-    q: [],
+    q: "",
     // The target language into which the text should be translated
     target: "",
     // Auth client


### PR DESCRIPTION
In some cases, the generated API libraries do not completely agree with
Discovery docs.
Previously, we have special-cased inconsistencies when we implemented
Java Discovery code samples. However, we did this believing that other
languages will have similar inconsistencies.
However, they seem to have *different* inconsistencies.
Meaning each language's API library are inconsistent with not only
the Discovery doc but also each other.

This commit moves the special-cases implemented earlier so that they
become Java-specific and implements more special-cases as needed for
NodeJS. Together with #25, this solves all known compilecheck issues.