### PR TITLE
Fix go codegen for primitive resource field types

### DIFF
--- a/vgen/src/main/resources/io/gapi/vgen/go/main.snip
+++ b/vgen/src/main/resources/io/gapi/vgen/go/main.snip
@@ -206,7 +206,6 @@
                      resourceFieldName = context.lowerUnderscoreToUpperCamel(pageStreaming.getResourcesField().getSimpleName), \
                      requestTokenFieldName = context.lowerUnderscoreToUpperCamel(pageStreaming.getRequestTokenField().getSimpleName), \
                      responseTokenFieldName = context.lowerUnderscoreToUpperCamel(pageStreaming.getResponseTokenField().getSimpleName), \
-                     tokenType = context.getNextPageTokenType(service, pageStreaming), \
                      tokenZeroValue = context.zeroValue(pageStreaming.getRequestTokenField().getType)
 
                     {@methodComment(method, methodName)}

--- a/vgen/src/test/java/io/gapi/vgen/testdata/csharp_wrapper_library.baseline
+++ b/vgen/src/test/java/io/gapi/vgen/testdata/csharp_wrapper_library.baseline
@@ -77,6 +77,7 @@ namespace Google.Example.Library.V1
             DeleteBookRetry = existing.DeleteBookRetry?.Clone();
             UpdateBookRetry = existing.UpdateBookRetry?.Clone();
             MoveBookRetry = existing.MoveBookRetry?.Clone();
+            ListStringsRetry = existing.ListStringsRetry?.Clone();
         }
 
         /// <summary>
@@ -470,6 +471,34 @@ namespace Google.Example.Library.V1
             RetryBackoff = GetDefaultRetryBackoff(),
             TimeoutBackoff = GetDefaultTimeoutBackoff(),
             RetryFilter = NonIdempotentRetryFilter,
+        };
+
+        /// <summary>
+        /// <see cref="RetrySettings"/> for asynchronous and synchronous calls to
+        /// <see cref="LibraryServiceClient.ListStrings"/> and <see cref="LibraryServiceClient.ListStringsAsync"/>.
+        /// </summary>
+        /// <remarks>
+        /// The default <see cref="LibraryServiceClient.ListStrings"/> and
+        /// <see cref="LibraryServiceClient.ListStringsAsync"/> <see cref="RetrySettings"/> are:
+        /// <list type="bullet">
+        /// <item><description>Initial retry delay: 100 milliseconds</description></item>
+        /// <item><description>Retry delay multiplier: 1.2</description></item>
+        /// <item><description>Retry maximum delay: 1000 milliseconds</description></item>
+        /// <item><description>Initial timeout: 300 milliseconds</description></item>
+        /// <item><description>Timeout multiplier: 1.3</description></item>
+        /// <item><description>Timeout maximum delay: 3000 milliseconds</description></item>
+        /// </list>
+        /// Retry will be attempted on the following response status codes:
+        /// <list>
+        /// <item><description><see cref="StatusCode.DeadlineExceeded"/></description></item>
+        /// <item><description><see cref="StatusCode.Unavailable"/></description></item>
+        /// </list>
+        /// </remarks>
+        public RetrySettings ListStringsRetry { get; set; } = new RetrySettings
+        {
+            RetryBackoff = GetDefaultRetryBackoff(),
+            TimeoutBackoff = GetDefaultTimeoutBackoff(),
+            RetryFilter = IdempotentRetryFilter,
         };
 
 
@@ -1222,6 +1251,28 @@ namespace Google.Example.Library.V1
             throw new NotImplementedException();
         }
 
+        /// <summary>
+        /// Lists a primitive resource. To test go page streaming.
+        /// </summary>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A Task containing the RPC response.</returns>
+        public virtual IAsyncEnumerable<string> ListStringsAsync(
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Lists a primitive resource. To test go page streaming.
+        /// </summary>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>The RPC response.</returns>
+        public virtual IEnumerable<string> ListStrings(
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
     }
 
     public sealed partial class LibraryServiceClientImpl : LibraryServiceClient
@@ -1248,6 +1299,17 @@ namespace Google.Example.Library.V1
                 "" // An empty page-token
             );
 
+        private static readonly PageStreamer<string, ListStringsRequest, ListStringsResponse, string> s_listStringsPageStreamer =
+            new PageStreamer<string, ListStringsRequest, ListStringsResponse, string>(
+                (request, token) => {
+                    request.PageToken = token;
+                    return request;
+                },
+                response => response.NextPageToken,
+                response => response.Strings,
+                "" // An empty page-token
+            );
+
         private readonly ClientHelper _clientHelper;
         private readonly ApiCall<CreateShelfRequest, Shelf> _callCreateShelf;
         private readonly ApiCall<GetShelfRequest, Shelf> _callGetShelf;
@@ -1261,6 +1323,7 @@ namespace Google.Example.Library.V1
         private readonly ApiCall<DeleteBookRequest, Empty> _callDeleteBook;
         private readonly ApiCall<UpdateBookRequest, Book> _callUpdateBook;
         private readonly ApiCall<MoveBookRequest, Book> _callMoveBook;
+        private readonly ApiCall<ListStringsRequest, ListStringsResponse> _callListStrings;
 
         public LibraryServiceClientImpl(LibraryService.ILibraryServiceClient grpcClient, LibraryServiceSettings settings)
         {
@@ -1292,6 +1355,8 @@ namespace Google.Example.Library.V1
                 .WithRetry(effectiveSettings.UpdateBookRetry, effectiveClock, null);
             _callMoveBook = _clientHelper.BuildApiCall<MoveBookRequest, Book>(GrpcClient.MoveBookAsync, GrpcClient.MoveBook)
                 .WithRetry(effectiveSettings.MoveBookRetry, effectiveClock, null);
+            _callListStrings = _clientHelper.BuildApiCall<ListStringsRequest, ListStringsResponse>(GrpcClient.ListStringsAsync, GrpcClient.ListStrings)
+                .WithRetry(effectiveSettings.ListStringsRetry, effectiveClock, null);
         }
 
         public override LibraryService.ILibraryServiceClient GrpcClient { get; }
@@ -1811,5 +1876,30 @@ namespace Google.Example.Library.V1
                     OtherShelfName = otherShelfName,
                 },
                 callSettings);
+        /// <summary>
+        /// Lists a primitive resource. To test go page streaming.
+        /// </summary>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A Task containing the RPC response.</returns>
+        public override IAsyncEnumerable<string> ListStringsAsync(
+            CallSettings callSettings = null) => s_listStringsPageStreamer.FetchAsync(
+                callSettings,
+                new ListStringsRequest
+                {
+                },
+                _callListStrings);
+
+        /// <summary>
+        /// Lists a primitive resource. To test go page streaming.
+        /// </summary>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>The RPC response.</returns>
+        public override IEnumerable<string> ListStrings(
+            CallSettings callSettings = null) => s_listStringsPageStreamer.Fetch(
+                callSettings,
+                new ListStringsRequest
+                {
+                },
+                _callListStrings);
     }
 }

--- a/vgen/src/test/java/io/gapi/vgen/testdata/go_library.baseline
+++ b/vgen/src/test/java/io/gapi/vgen/testdata/go_library.baseline
@@ -441,6 +441,41 @@ func (client *Client) MoveBook(ctx context.Context, req *google_example_library_
 }
 
 
+// AUTO-GENERATED DOCUMENTATION AND METHOD -- see instructions at the top of the file for editing.
+
+// ListStrings lists a primitive resource. To test go page streaming.
+func (client *Client) ListStrings(ctx context.Context, req *google_example_library_v1.ListStringsRequest, opts ...gax.CallOption) (*StringIterator, error) {
+	callOpts := append(idempotentRetryCodes(), defaultRetryParams(), client.CallOptions["ListStrings"]...)
+	callOpts = append(callOpts, opts...)
+	atLastPage := false
+	return &StringIterator{
+		apiCall: func() (StringPage, error) {
+			if atLastPage {
+				return StringPage{}, io.EOF
+			}
+			var resp *google_example_library_v1.ListStringsResponse
+			err := gax.Invoke(ctx, func (c context.Context) error {
+				var err error
+				resp, err = client.client.ListStrings(c, req)
+				return err
+			}, callOpts...)
+			if err != nil {
+				return StringPage{}, err
+			}
+			if resp.NextPageToken == "" {
+				atLastPage = true
+			} else {
+				req.PageToken = resp.NextPageToken
+			}
+			return StringPage{
+				Items: resp.Strings,
+				NextPageToken: resp.NextPageToken,
+			}, nil
+		},
+	}, nil
+}
+
+
 // Iterators.
 //
 
@@ -518,6 +553,49 @@ func (iterator *BookIterator) Advance() error {
 // Next returns the next element in the stream. This returns io.EOF at the end of
 // the stream.
 func (iterator *BookIterator) Next() (*google_example_library_v1.Book, error) {
+	for iterator.currentIndex >= len(iterator.Page.Items) {
+		err := iterator.Advance()
+		if err != nil {
+			return nil, err
+		}
+		iterator.currentIndex = 0
+	}
+	result := iterator.Page.Items[iterator.currentIndex]
+	iterator.currentIndex++
+	return result, nil
+}
+
+// StringPage represents a page in a stream of StringIterator.
+// This will be updated through StringIterator.Advance.
+type StringPage struct {
+	// The elements in the current page.
+	Items []string
+
+	// The token to get the next page response. This can be used to resume the iteration.
+	NextPageToken string
+}
+
+// StringIterator manages a stream of string.
+type StringIterator struct {
+	// The current page data.
+	Page         StringPage
+	currentIndex int
+	apiCall      func() (StringPage, error)
+}
+
+// Advance moves to the next page and updates its internal data.
+// This returns io.EOF if no more pages exist.
+func (iterator *StringIterator) Advance() error {
+	page, err := iterator.apiCall()
+	if err == nil {
+		iterator.Page = page
+	}
+	return err
+}
+
+// Next returns the next element in the stream. This returns io.EOF at the end of
+// the stream.
+func (iterator *StringIterator) Next() (string, error) {
 	for iterator.currentIndex >= len(iterator.Page.Items) {
 		err := iterator.Advance()
 		if err != nil {

--- a/vgen/src/test/java/io/gapi/vgen/testdata/java_main_library.baseline
+++ b/vgen/src/test/java/io/gapi/vgen/testdata/java_main_library.baseline
@@ -46,6 +46,8 @@ import com.google.example.library.v1.ListBooksRequest;
 import com.google.example.library.v1.ListBooksResponse;
 import com.google.example.library.v1.ListShelvesRequest;
 import com.google.example.library.v1.ListShelvesResponse;
+import com.google.example.library.v1.ListStringsRequest;
+import com.google.example.library.v1.ListStringsResponse;
 import com.google.example.library.v1.MergeShelvesRequest;
 import com.google.example.library.v1.MoveBookRequest;
 import com.google.example.library.v1.PublishSeriesRequest;
@@ -155,6 +157,9 @@ public class LibraryServiceApi implements AutoCloseable {
   private final ApiCallable<DeleteBookRequest, Empty> deleteBookCallable;
   private final ApiCallable<UpdateBookRequest, Book> updateBookCallable;
   private final ApiCallable<MoveBookRequest, Book> moveBookCallable;
+  private final ApiCallable<ListStringsRequest, ListStringsResponse> listStringsCallable;
+  private final ApiCallable<ListStringsRequest, Iterable<String>>
+      listStringsIterableCallable;
 
   public final LibraryServiceSettings getSettings() {
     return settings;
@@ -278,6 +283,9 @@ public class LibraryServiceApi implements AutoCloseable {
     this.deleteBookCallable = ApiCallable.create(settings.deleteBookSettings(), this.channel, this.executor);
     this.updateBookCallable = ApiCallable.create(settings.updateBookSettings(), this.channel, this.executor);
     this.moveBookCallable = ApiCallable.create(settings.moveBookSettings(), this.channel, this.executor);
+    this.listStringsCallable = ApiCallable.create(settings.listStringsSettings(), this.channel, this.executor);
+    this.listStringsIterableCallable =
+        ApiCallable.createIterable(settings.listStringsSettings(), this.channel, this.executor);
 
     if (settings.getChannelProvider().shouldAutoClose()) {
       closeables.add(
@@ -1311,6 +1319,99 @@ public class LibraryServiceApi implements AutoCloseable {
    */
   public final ApiCallable<MoveBookRequest, Book> moveBookCallable() {
     return moveBookCallable;
+  }
+
+  // ----- listStrings -----
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD - see instructions at the top of the file for editing.
+  /**
+   * Lists a primitive resource. To test go page streaming.
+   *
+   * <pre><code>
+   * try (LibraryServiceApi libraryServiceApi = LibraryServiceApi.createWithDefaults()) {
+   *
+   *   for (String elements : libraryServiceApi.listStrings()) {
+   *     // doThingsWith(elements);
+   *   }
+   * }
+   * </code></pre>
+   *
+   * <!-- manual edit -->
+   * <!-- end manual edit -->
+   *
+   * @throws com.google.api.gax.grpc.ApiException if the remote call fails
+   */
+  public final Iterable<String> listStrings() {
+    ListStringsRequest request =
+        ListStringsRequest.newBuilder()
+
+        .build();
+    return listStrings(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD - see instructions at the top of the file for editing.
+  /**
+   * Lists a primitive resource. To test go page streaming.
+   *
+   * <pre><code>
+   * try (LibraryServiceApi libraryServiceApi = LibraryServiceApi.createWithDefaults()) {
+   *   ListStringsRequest request = ListStringsRequest.newBuilder().build();
+   *
+   *   for (String elements : libraryServiceApi.listStrings(request)) {
+   *     // doThingsWith(elements);
+   *   }
+   * }
+   * </code></pre>
+   *
+   * <!-- manual edit -->
+   * <!-- end manual edit -->
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.grpc.ApiException if the remote call fails
+   */
+  private final Iterable<String> listStrings(ListStringsRequest request) {
+    return listStringsIterableCallable()
+        .call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD - see instructions at the top of the file for editing.
+  /**
+   * Lists a primitive resource. To test go page streaming.
+   *
+   * <pre><code>
+   * try (LibraryServiceApi libraryServiceApi = LibraryServiceApi.createWithDefaults()) {
+   *   ListStringsRequest request = ListStringsRequest.newBuilder().build();
+   *
+   *   for (String elements : libraryServiceApi.listStringsIterableCallable().call(request)) {
+   *     // doThingsWith(elements);
+   *   }
+   * }
+   * </code></pre>
+   *
+   * <!-- manual edit -->
+   * <!-- end manual edit -->
+   */
+  public final ApiCallable<ListStringsRequest, Iterable<String>> listStringsIterableCallable() {
+    return listStringsIterableCallable;
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD - see instructions at the top of the file for editing.
+  /**
+   * Lists a primitive resource. To test go page streaming.
+   *
+   * <pre><code>
+   * try (LibraryServiceApi libraryServiceApi = LibraryServiceApi.createWithDefaults()) {
+   *   ListStringsRequest request = ListStringsRequest.newBuilder().build();
+   *
+   *   ListStringsResponse callResult = libraryServiceApi.listStringsCallable().call(request);
+   * }
+   * </code></pre>
+   *
+   * <!-- manual edit -->
+   * <!-- end manual edit -->
+   */
+  public final ApiCallable<ListStringsRequest, ListStringsResponse> listStringsCallable() {
+    return listStringsCallable;
   }
 
 

--- a/vgen/src/test/java/io/gapi/vgen/testdata/java_settings_library.baseline
+++ b/vgen/src/test/java/io/gapi/vgen/testdata/java_settings_library.baseline
@@ -61,6 +61,8 @@ import com.google.example.library.v1.ListBooksRequest;
 import com.google.example.library.v1.ListBooksResponse;
 import com.google.example.library.v1.ListShelvesRequest;
 import com.google.example.library.v1.ListShelvesResponse;
+import com.google.example.library.v1.ListStringsRequest;
+import com.google.example.library.v1.ListStringsResponse;
 import com.google.example.library.v1.MergeShelvesRequest;
 import com.google.example.library.v1.MoveBookRequest;
 import com.google.example.library.v1.PublishSeriesRequest;
@@ -161,6 +163,9 @@ public class LibraryServiceSettings extends ServiceApiSettings {
   private final SimpleCallSettings<DeleteBookRequest, Empty> deleteBookSettings;
   private final SimpleCallSettings<UpdateBookRequest, Book> updateBookSettings;
   private final SimpleCallSettings<MoveBookRequest, Book> moveBookSettings;
+  private final PageStreamingCallSettings<ListStringsRequest, ListStringsResponse, String>
+      listStringsSettings;
+
 
   /**
    * Returns the object with the settings used for calls to createShelf.
@@ -248,6 +253,14 @@ public class LibraryServiceSettings extends ServiceApiSettings {
     return moveBookSettings;
   }
 
+  /**
+   * Returns the object with the settings used for calls to listStrings.
+   */
+  public PageStreamingCallSettings<ListStringsRequest, ListStringsResponse, String>
+      listStringsSettings() {
+    return listStringsSettings;
+  }
+
 
   /**
    * Returns a builder for this class with recommended defaults.
@@ -290,6 +303,7 @@ public class LibraryServiceSettings extends ServiceApiSettings {
     deleteBookSettings = settingsBuilder.deleteBookSettings().build();
     updateBookSettings = settingsBuilder.updateBookSettings().build();
     moveBookSettings = settingsBuilder.moveBookSettings().build();
+    listStringsSettings = settingsBuilder.listStringsSettings().build();
   }
 
   private static PageStreamingDescriptor<ListShelvesRequest, ListShelvesResponse, Shelf> LIST_SHELVES_PAGE_STR_DESC =
@@ -337,6 +351,30 @@ public class LibraryServiceSettings extends ServiceApiSettings {
         @Override
         public Iterable<Book> extractResources(ListBooksResponse payload) {
           return payload.getBooksList();
+        }
+      };
+
+  private static PageStreamingDescriptor<ListStringsRequest, ListStringsResponse, String> LIST_STRINGS_PAGE_STR_DESC =
+      new PageStreamingDescriptor<ListStringsRequest, ListStringsResponse, String>() {
+        @Override
+        public Object emptyToken() {
+          return "";
+        }
+        @Override
+        public ListStringsRequest injectToken(
+            ListStringsRequest payload, Object token) {
+          return ListStringsRequest
+            .newBuilder(payload)
+            .setPageToken((String) token)
+            .build();
+        }
+        @Override
+        public Object extractNextToken(ListStringsResponse payload) {
+          return payload.getNextPageToken();
+        }
+        @Override
+        public Iterable<String> extractResources(ListStringsResponse payload) {
+          return payload.getStringsList();
         }
       };
 
@@ -424,6 +462,8 @@ public class LibraryServiceSettings extends ServiceApiSettings {
     private SimpleCallSettings.Builder<DeleteBookRequest, Empty> deleteBookSettings;
     private SimpleCallSettings.Builder<UpdateBookRequest, Book> updateBookSettings;
     private SimpleCallSettings.Builder<MoveBookRequest, Book> moveBookSettings;
+    private PageStreamingCallSettings.Builder<ListStringsRequest, ListStringsResponse, String>
+        listStringsSettings;
 
     private static final ImmutableMap<String, ImmutableSet<Status.Code>> RETRYABLE_CODE_DEFINITIONS;
 
@@ -489,8 +529,12 @@ public class LibraryServiceSettings extends ServiceApiSettings {
 
       moveBookSettings = SimpleCallSettings.newBuilder(LibraryServiceGrpc.METHOD_MOVE_BOOK);
 
+      listStringsSettings = PageStreamingCallSettings.newBuilder(
+          LibraryServiceGrpc.METHOD_LIST_STRINGS,
+          LIST_STRINGS_PAGE_STR_DESC);
+
       methodSettingsBuilders = ImmutableList.<ApiCallSettings.Builder>of(
-          createShelfSettings,getShelfSettings,listShelvesSettings,deleteShelfSettings,mergeShelvesSettings,createBookSettings,publishSeriesSettings,getBookSettings,listBooksSettings,deleteBookSettings,updateBookSettings,moveBookSettings
+          createShelfSettings,getShelfSettings,listShelvesSettings,deleteShelfSettings,mergeShelvesSettings,createBookSettings,publishSeriesSettings,getBookSettings,listBooksSettings,deleteBookSettings,updateBookSettings,moveBookSettings,listStringsSettings
       );
     }
 
@@ -551,6 +595,10 @@ public class LibraryServiceSettings extends ServiceApiSettings {
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
           .setRetrySettingsBuilder(RETRY_PARAM_DEFINITIONS.get("default"));
 
+      builder.listStringsSettings()
+              .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
+              .setRetrySettingsBuilder(RETRY_PARAM_DEFINITIONS.get("default"));
+
       return builder;
     }
 
@@ -569,9 +617,10 @@ public class LibraryServiceSettings extends ServiceApiSettings {
       deleteBookSettings = settings.deleteBookSettings.toBuilder();
       updateBookSettings = settings.updateBookSettings.toBuilder();
       moveBookSettings = settings.moveBookSettings.toBuilder();
+      listStringsSettings = settings.listStringsSettings.toBuilder();
 
       methodSettingsBuilders = ImmutableList.<ApiCallSettings.Builder>of(
-          createShelfSettings,getShelfSettings,listShelvesSettings,deleteShelfSettings,mergeShelvesSettings,createBookSettings,publishSeriesSettings,getBookSettings,listBooksSettings,deleteBookSettings,updateBookSettings,moveBookSettings
+          createShelfSettings,getShelfSettings,listShelvesSettings,deleteShelfSettings,mergeShelvesSettings,createBookSettings,publishSeriesSettings,getBookSettings,listBooksSettings,deleteBookSettings,updateBookSettings,moveBookSettings,listStringsSettings
       );
     }
 
@@ -709,6 +758,14 @@ public class LibraryServiceSettings extends ServiceApiSettings {
      */
     public SimpleCallSettings.Builder<MoveBookRequest, Book> moveBookSettings() {
       return moveBookSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to listStrings.
+     */
+    public PageStreamingCallSettings.Builder<ListStringsRequest, ListStringsResponse, String>
+        listStringsSettings() {
+      return listStringsSettings;
     }
 
     @Override

--- a/vgen/src/test/java/io/gapi/vgen/testdata/library.proto
+++ b/vgen/src/test/java/io/gapi/vgen/testdata/library.proto
@@ -95,6 +95,11 @@ service LibraryService {
   rpc MoveBook(MoveBookRequest) returns (Book) {
     option (google.api.http) = { post: "/v1/{name=shelves/*/books/*}:move" body: "*" };
   }
+
+  // Lists a primitive resource. To test go page streaming.
+  rpc ListStrings(ListStringsRequest) returns (ListStringsResponse) {
+    option (google.api.http) = { get: "/v1/strings" };
+  }
 }
 
 // A single book in the library.
@@ -326,4 +331,15 @@ message MoveBookRequest {
 
   // The name of the destination shelf.
   string other_shelf_name = 2;
+}
+
+message ListStringsRequest {
+  string name = 1;
+  int32 page_size = 2;
+  string page_token = 3;
+}
+
+message ListStringsResponse {
+  repeated string strings = 1;
+  string next_page_token = 2;
 }

--- a/vgen/src/test/java/io/gapi/vgen/testdata/library_gapic.yaml
+++ b/vgen/src/test/java/io/gapi/vgen/testdata/library_gapic.yaml
@@ -198,3 +198,16 @@ interfaces:
     retry_codes_name: non_idempotent
     retry_params_name: default
     request_object_method: true
+  - name: ListStrings
+    flattening:
+      groups:
+      - parameters: []
+    page_streaming:
+      request:
+        token_field: page_token
+      response:
+        token_field: next_page_token
+        resources_field: strings
+    retry_codes_name: idempotent
+    retry_params_name: default
+    request_object_method: false

--- a/vgen/src/test/java/io/gapi/vgen/testdata/python_library.baseline
+++ b/vgen/src/test/java/io/gapi/vgen/testdata/python_library.baseline
@@ -82,6 +82,11 @@ class LibraryServiceApi(object):
             'page_token',
             'next_page_token',
             'books'
+        ),
+        'list_strings': _PageDesc(
+            'page_token',
+            'next_page_token',
+            'strings'
         )
     }
 
@@ -537,6 +542,35 @@ class LibraryServiceApi(object):
         settings = self._defaults['move_book'].merge(options)
         api_call = api_callable.create_api_call(
             self.stub.MoveBook, settings=settings)
+        return api_call(req, metadata=self._headers)
+
+    def list_strings(
+            self,
+            name='',
+            options=None):
+        """
+        Lists a primitive resource. To test go page streaming.
+
+        Args:
+          name (string)
+          options (:class:`google.gax.CallOptions`): Overrides the default
+            settings for this call, e.g, timeout, retries etc.
+
+        Yields:
+          Instances of string
+          unless page streaming is disabled through the call options. If
+          page streaming is disabled, a single
+          :class:`google.example.library.v1.library_pb2.ListStringsResponse` instance
+          is returned.
+
+        Raises:
+          :exc:`google.gax.errors.GaxError` if the RPC is aborted.
+        """
+        req = library_pb2.ListStringsRequest(
+            name=name)
+        settings = self._defaults['list_strings'].merge(options)
+        api_call = api_callable.create_api_call(
+            self.stub.ListStrings, settings=settings)
         return api_call(req, metadata=self._headers)
 
 ============== file: field_mask_pb2.py ==============
@@ -1370,6 +1404,27 @@ class MoveBookRequest(object):
     Attributes:
       name (string): The name of the book to move.
       other_shelf_name (string): The name of the destination shelf.
+
+    """
+    pass
+
+
+class ListStringsRequest(object):
+    """
+    Attributes:
+      name (string)
+      page_size (int32)
+      page_token (string)
+
+    """
+    pass
+
+
+class ListStringsResponse(object):
+    """
+    Attributes:
+      strings (list[string])
+      next_page_token (string)
 
     """
     pass

--- a/vgen/src/test/java/io/gapi/vgen/testdata/ruby_library.baseline
+++ b/vgen/src/test/java/io/gapi/vgen/testdata/ruby_library.baseline
@@ -63,7 +63,11 @@ module Google
             'list_books' => Google::Gax::PageDescriptor.new(
               'page_token',
               'next_page_token',
-              'books')
+              'books'),
+            'list_strings' => Google::Gax::PageDescriptor.new(
+              'page_token',
+              'next_page_token',
+              'strings')
           }.freeze
 
           private_constant :PAGE_DESCRIPTORS
@@ -463,6 +467,31 @@ module Google
             settings = @defaults['move_book'].merge(options)
             api_call = Google::Gax.create_api_call(
               @stub.method(:move_book), settings)
+            api_call.call(req, **@headers)
+          end
+
+          # Lists a primitive resource. To test go page streaming.
+          #
+          # @param name [String]
+          # @param options [Google::Gax::CallOptions]
+          #   Overrides the default settings for this call, e.g, timeout,
+          #   retries, etc.
+          # @return [
+          #   Google::Gax::PagedEnumerable<String>,
+          #   Google::Example::Library::V1::ListStringsResponse]
+          #   An enumerable of String instances unless
+          #   page streaming is disabled through the call options. If page
+          #   streaming is disabled, a single Google::Example::Library::V1::ListStringsResponse
+          #   instance is returned.
+          # @raise [Google::Gax::GaxError] if the RPC is aborted.
+          def list_strings(
+            name: '',
+            options: nil)
+            req = Google::Example::Library::V1::ListStringsRequest.new(
+              name: name)
+            settings = @defaults['list_strings'].merge(options)
+            api_call = Google::Gax.create_api_call(
+              @stub.method(:list_strings), settings)
             api_call.call(req, **@headers)
           end
         end
@@ -1240,6 +1269,20 @@ module Google
         #   @return [String]
         #     The name of the destination shelf.
         class MoveBookRequest; end
+
+        # @!attribute [rw] name
+        #   @return [String]
+        # @!attribute [rw] page_size
+        #   @return [Integer]
+        # @!attribute [rw] page_token
+        #   @return [String]
+        class ListStringsRequest; end
+
+        # @!attribute [rw] strings
+        #   @return [Array<String>]
+        # @!attribute [rw] next_page_token
+        #   @return [String]
+        class ListStringsResponse; end
       end
     end
   end


### PR DESCRIPTION
Also adds a page streaming method to `library.proto` that has a
primitive type resource field for test coverage.

Fixes #44 