### PR TITLE
Introduce 'call_settings' parameter

### DIFF
--- a/src/main/resources/com/google/api/codegen/py/main.snip
+++ b/src/main/resources/com/google/api/codegen/py/main.snip
@@ -154,46 +154,37 @@
     @end
 @end
 
-@private constructSettings(prefix, config, service, ifaceConfig)
-    @if or(context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods), \
-           context.messages.filterBundlingMethods(ifaceConfig, service.getMethods))
-        {@prefix}api_callable.construct_settings(
-            '{@service.getFullName}',
-            {@config},
-            {},
-            {},
-            config.STATUS_CODE_NAMES,
-            timeout,
-            @if context.messages.filterBundlingMethods(ifaceConfig, service.getMethods)
-                @if context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods)
-                    bundle_descriptors=self._BUNDLE_DESCRIPTORS,
-                @else
-                    bundle_descriptors=self._BUNDLE_DESCRIPTORS)
-                @end
-            @end
-            @if context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods)
-                page_descriptors=self._PAGE_DESCRIPTORS)
-            @end
-    @else
-        {@prefix}api_callable.construct_settings(
-            '{@service.getFullName}',
-            {@config},
-            {},
-            {},
-            config.STATUS_CODE_NAMES,
-            timeout)
-    @end
-@end
-
 @private constructDefaults(service)
     @let ifaceConfig = context.getApiConfig.getInterfaceConfig(service), \
          jsonBaseName = {@context.upperCamelToLowerUnderscore(service.getSimpleName)}
         default_client_config = json.loads(pkg_resources.resource_string(
             __name__, '{@jsonBaseName}_client_config.json'))
-        {@constructSettings("self._defaults = ", "default_client_config", service, ifaceConfig)}
-        if client_config:
-            {@constructSettings("self._defaults.update(", "client_config", service, ifaceConfig)}
-            )
+        @if or(context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods), \
+               context.messages.filterBundlingMethods(ifaceConfig, service.getMethods))
+            self._defaults = api_callable.construct_settings(
+                '{@service.getFullName}',
+                default_client_config,
+                client_config,
+                config.STATUS_CODE_NAMES,
+                timeout,
+                @if context.messages.filterBundlingMethods(ifaceConfig, service.getMethods)
+                    @if context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods)
+                        bundle_descriptors=self._BUNDLE_DESCRIPTORS,
+                    @else
+                        bundle_descriptors=self._BUNDLE_DESCRIPTORS)
+                    @end
+                @end
+                @if context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods)
+                    page_descriptors=self._PAGE_DESCRIPTORS)
+                @end
+        @else
+            self._defaults = api_callable.construct_settings(
+                '{@service.getFullName}',
+                default_client_config,
+                client_config,
+                config.STATUS_CODE_NAMES,
+                timeout)
+        @end
     @end
 @end
 
@@ -222,13 +213,10 @@
               ssl_creds (:class:`grpc.beta.implementations.ClientCredentials`):
                 A `ClientCredentials` for use with an SSL-enabled channel.
               client_config (dict):
-                The default client config for methods. When specified, the value is
-                passed to :method:`google.gax.construct_settings` to build the
-                actual call settings, so it has to have the same structure of
-                the data. See :method:`google.gax.construct_settings` for the
-                structure of the data.
-                client_config can specify a subset of the methods. If a method
-                config is not specified, it falls back to the default config.
+                A dictionary for call settings for each method. See
+                :method:`google.gax.construct_settings` for the structure of
+                this data. Falls back to the default config if not specified
+                or the specified config is missing data points.
               timeout (int): The default timeout, in seconds, for calls made
                 through this client
               app_name (string): The codename of the calling service.
@@ -239,6 +227,8 @@
             """
             if scopes is None:
                 scopes = self._ALL_SCOPES
+            if client_config is None:
+                client_config = {}
             {@constructDefaults(service)}
             goog_api_client = '{}/{} {} gax/{} python/{}'.format(
                 app_name,

--- a/src/main/resources/com/google/api/codegen/py/main.snip
+++ b/src/main/resources/com/google/api/codegen/py/main.snip
@@ -155,14 +155,18 @@
 @end
 
 @private constructDefaults(service)
-    @let ifaceConfig = context.getApiConfig.getInterfaceConfig(service)
+    @let ifaceConfig = context.getApiConfig.getInterfaceConfig(service), \
+         jsonBaseName = {@context.upperCamelToLowerUnderscore(service.getSimpleName)}
+        if not client_config:
+            client_config = json.loads(pkg_resources.resource_string(
+                __name__, '{@jsonBaseName}_client_config.json'))
         @if or(context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods), \
                context.messages.filterBundlingMethods(ifaceConfig, service.getMethods))
             self._defaults = api_callable.construct_settings(
                 '{@service.getFullName}',
-                json.loads(client_config),
-                bundling_override,
-                retrying_override,
+                client_config,
+                {},
+                {},
                 config.STATUS_CODE_NAMES,
                 timeout,
                 @if context.messages.filterBundlingMethods(ifaceConfig, service.getMethods)
@@ -179,9 +183,9 @@
         @else
             self._defaults = api_callable.construct_settings(
                 '{@service.getFullName}',
-                json.loads(client_config),
-                bundling_override,
-                retrying_override,
+                client_config,
+                {},
+                {},
                 config.STATUS_CODE_NAMES,
                 timeout
             )
@@ -192,7 +196,6 @@
 @private initMethodSection(service)
     @let stubModule = pyproto.getPbFileName(service), \
              stubService = service.getSimpleName(), \
-             jsonBaseName = {@context.upperCamelToLowerUnderscore(service.getSimpleName)}, \
              ifaceConfig = context.getApiConfig.getInterfaceConfig(service)
         def __init__(
                 self,
@@ -201,8 +204,7 @@
                 channel=None,
                 ssl_creds=None,
                 scopes=None,
-                retrying_override=None,
-                bundling_override=None,
+                client_config=None,
                 timeout=_DEFAULT_TIMEOUT,
                 app_name='gax',
                 app_version=_GAX_VERSION):
@@ -215,18 +217,13 @@
                 object through which to make calls.
               ssl_creds (:class:`grpc.beta.implementations.ClientCredentials`):
                 A `ClientCredentials` for use with an SSL-enabled channel.
-              retrying_override (dict[string, :class:`google.gax.RetryOptions`]): A
-                dictionary that overrides default retrying settings.
-                ``retrying_override`` maps method names (e.g., ``'list_foo'``) to
-                custom RetryOptions objects, or to None. A value of None indicates
-                that the method in question should not retry.
-              bundling_override (dict[string, :class:`google.gax.BundleOptions`]): A
-                dictionary that overrides default bundling settings.
-                ``bundling_override`` maps bundling method names (e.g.,
-                'publish_foo') to custom BundleOptions objects, or to None. It is
-                invalid to have a key for a method that is not bundling-enabled. A
-                value of None indicates that the method in question should not
-                bundle.
+              client_config (dict):
+                The default client config for methods. When specified, the value is
+                passed to :method:`google.gax.construct_settings` to build the
+                actual call settings, so it has to have the same structure of
+                the data. See :method:`google.gax.construct_settings` for the
+                structure of the data.
+                Use the default config if not specified.
               timeout (int): The default timeout, in seconds, for calls made
                 through this client
               app_name (string): The codename of the calling service.
@@ -237,10 +234,6 @@
             """
             if scopes is None:
                 scopes = self._ALL_SCOPES
-            bundling_override = bundling_override or {}
-            retrying_override = retrying_override or {}
-            client_config = pkg_resources.resource_string(
-                __name__, '{@jsonBaseName}_client_config.json')
             {@constructDefaults(service)}
             goog_api_client = '{}/{} {} gax/{} python/{}'.format(
                 app_name,

--- a/src/main/resources/com/google/api/codegen/py/main.snip
+++ b/src/main/resources/com/google/api/codegen/py/main.snip
@@ -154,42 +154,46 @@
     @end
 @end
 
+@private constructSettings(prefix, config, service, ifaceConfig)
+    @if or(context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods), \
+           context.messages.filterBundlingMethods(ifaceConfig, service.getMethods))
+        {@prefix}api_callable.construct_settings(
+            '{@service.getFullName}',
+            {@config},
+            {},
+            {},
+            config.STATUS_CODE_NAMES,
+            timeout,
+            @if context.messages.filterBundlingMethods(ifaceConfig, service.getMethods)
+                @if context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods)
+                    bundle_descriptors=self._BUNDLE_DESCRIPTORS,
+                @else
+                    bundle_descriptors=self._BUNDLE_DESCRIPTORS)
+                @end
+            @end
+            @if context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods)
+                page_descriptors=self._PAGE_DESCRIPTORS)
+            @end
+    @else
+        {@prefix}api_callable.construct_settings(
+            '{@service.getFullName}',
+            {@config},
+            {},
+            {},
+            config.STATUS_CODE_NAMES,
+            timeout)
+    @end
+@end
+
 @private constructDefaults(service)
     @let ifaceConfig = context.getApiConfig.getInterfaceConfig(service), \
          jsonBaseName = {@context.upperCamelToLowerUnderscore(service.getSimpleName)}
-        if not client_config:
-            client_config = json.loads(pkg_resources.resource_string(
-                __name__, '{@jsonBaseName}_client_config.json'))
-        @if or(context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods), \
-               context.messages.filterBundlingMethods(ifaceConfig, service.getMethods))
-            self._defaults = api_callable.construct_settings(
-                '{@service.getFullName}',
-                client_config,
-                {},
-                {},
-                config.STATUS_CODE_NAMES,
-                timeout,
-                @if context.messages.filterBundlingMethods(ifaceConfig, service.getMethods)
-                    @if context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods)
-                        bundle_descriptors=self._BUNDLE_DESCRIPTORS,
-                    @else
-                        bundle_descriptors=self._BUNDLE_DESCRIPTORS
-                    @end
-                @end
-                @if context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods)
-                    page_descriptors=self._PAGE_DESCRIPTORS
-                @end
+        default_client_config = json.loads(pkg_resources.resource_string(
+            __name__, '{@jsonBaseName}_client_config.json'))
+        {@constructSettings("self._defaults = ", "default_client_config", service, ifaceConfig)}
+        if client_config:
+            {@constructSettings("self._defaults.update(", "client_config", service, ifaceConfig)}
             )
-        @else
-            self._defaults = api_callable.construct_settings(
-                '{@service.getFullName}',
-                client_config,
-                {},
-                {},
-                config.STATUS_CODE_NAMES,
-                timeout
-            )
-        @end
     @end
 @end
 
@@ -223,7 +227,8 @@
                 actual call settings, so it has to have the same structure of
                 the data. See :method:`google.gax.construct_settings` for the
                 structure of the data.
-                Use the default config if not specified.
+                client_config can specify a subset of the methods. If a method
+                config is not specified, it falls back to the default config.
               timeout (int): The default timeout, in seconds, for calls made
                 through this client
               app_name (string): The codename of the calling service.

--- a/src/main/resources/com/google/api/codegen/py/main.snip
+++ b/src/main/resources/com/google/api/codegen/py/main.snip
@@ -213,7 +213,7 @@
               ssl_creds (:class:`grpc.beta.implementations.ClientCredentials`):
                 A `ClientCredentials` for use with an SSL-enabled channel.
               client_config (dict):
-                A dictionary for call settings for each method. See
+                A dictionary for call options for each method. See
                 :method:`google.gax.construct_settings` for the structure of
                 this data. Falls back to the default config if not specified
                 or the specified config is missing data points.

--- a/src/main/resources/com/google/api/codegen/ruby/main.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/main.snip
@@ -176,7 +176,7 @@
     @# @@param ssl_creds [Grpc::ClientCredentials]
     @#   A ClientCredentials for use with an SSL-enabled channel.
     @# @@param client_config[Hash]
-    @#   A Hash for call settings for each method. See
+    @#   A Hash for call options for each method. See
     @#   Google::Gax#construct_settings for the structure of
     @#   this data. Falls back to the default config if not specified
     @#   or the specified config is missing data points.

--- a/src/main/resources/com/google/api/codegen/ruby/main.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/main.snip
@@ -130,43 +130,48 @@
 @end
 
 @private constructDefaults(service)
-  @let ifaceConfig = context.getApiConfig.getInterfaceConfig(service)
-    @@defaults = client_config.open do |f|
-      @if or(context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods), \
-             context.messages.filterBundlingMethods(ifaceConfig, service.getMethods))
-        Google::Gax.construct_settings(
-          '{@service.getFullName}',
-          JSON.parse(f.read),
-          bundling_override,
-          retrying_override,
-          Google::Gax::Grpc::STATUS_CODE_NAMES,
-          timeout,
-          @if context.messages.filterBundlingMethods(ifaceConfig, service.getMethods)
-            @if context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods)
-              bundle_descriptors: BUNDLE_DESCRIPTORS,
-            @else
-              bundle_descriptors: BUNDLE_DESCRIPTORS)
-            @end
-          @end
-          @if context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods)
-            page_descriptors: PAGE_DESCRIPTORS)
-          @end
-      @else
-        Google::Gax.construct_settings(
-          '{@service.getFullName}',
-          json.loads(client_config),
-          bundling_override,
-          retrying_override,
-          config.STATUS_CODE_NAMES,
-          timeout)
-      @end
+  @let ifaceConfig = context.getApiConfig.getInterfaceConfig(service), \
+       jsonBaseName = {@context.upperCamelToLowerUnderscore(service.getSimpleName)}
+    unless client_config
+      client_config_file = Pathname.new(__dir__).join(
+        '{@jsonBaseName}_client_config.json')
+      client_config_file.open do |f|
+        client_config = JSON.parse(f.read)
+      end
     end
+    @if or(context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods), \
+           context.messages.filterBundlingMethods(ifaceConfig, service.getMethods))
+      @@defaults = Google::Gax.construct_settings(
+        '{@service.getFullName}',
+        client_config,
+        {},
+        {},
+        Google::Gax::Grpc::STATUS_CODE_NAMES,
+        timeout,
+        @if context.messages.filterBundlingMethods(ifaceConfig, service.getMethods)
+          @if context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods)
+            bundle_descriptors: BUNDLE_DESCRIPTORS,
+          @else
+            bundle_descriptors: BUNDLE_DESCRIPTORS)
+          @end
+        @end
+        @if context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods)
+          page_descriptors: PAGE_DESCRIPTORS)
+        @end
+    @else
+      @@defaults = Google::Gax.construct_settings(
+        '{@service.getFullName}',
+        client_config,
+        {},
+        {},
+        config.STATUS_CODE_NAMES,
+        timeout)
+    @end
   @end
 @end
 
 @private initMethodSection(service)
-  @let jsonBaseName = {@context.upperCamelToLowerUnderscore(service.getSimpleName)}, \
-       ifaceConfig = context.getApiConfig.getInterfaceConfig(service)
+  @let ifaceConfig = context.getApiConfig.getInterfaceConfig(service)
     @# @@param service_path [String]
     @#   The domain name of the API remote host.
     @# @@param port [Integer]
@@ -175,18 +180,12 @@
     @#   A Channel object through which to make calls.
     @# @@param ssl_creds [Grpc::ClientCredentials]
     @#   A ClientCredentials for use with an SSL-enabled channel.
-    @# @@param retrying_override [Hash{String => RetryOptions}]
-    @#   A Hash that overrides default retrying settings.
-    @#   +retrying_override+ maps method names (e.g., +'list_foo'+) to
-    @#   custom RetryOptions objects, or to nil. A value of nil indicates
-    @#   that the method in question should not retry.
-    @# @@param bundling_override [Hash{String => BundleOptions}]
-    @#   A Hash that overrides default bundling settings.
-    @#   +bundling_override+ maps bundling method names (e.g.,
-    @#   +'publish_foo'+) to custom BundleOptions objects, or to nil. It is
-    @#   invalid to have a key for a method that is not bundling-enabled. A
-    @#   value of nil indicates that the method in question should not
-    @#   bundle.
+    @# @@param client_config[Hash]
+    @#   The default client config for methods. When specified, the value is
+    @#   passed to Google::Gax#construct_settings to build the actual call
+    @#   settings, so it has to have the same structure of the data. See
+    @#   Google::Gax#construct_settings for the structure of the data.
+    @#   Use the default config if not specified.
     @# @@param timeout [Numeric]
     @#   The default timeout, in seconds, for calls made through this client.
     @# @@param app_name [String]
@@ -199,13 +198,10 @@
       channel: nil,
       ssl_creds: nil,
       scopes: ALL_SCOPES,
-      retrying_override: {},
-      bundling_override: {},
+      client_config: nil,
       timeout: DEFAULT_TIMEOUT,
       app_name: 'gax',
       app_version: Google::Gax::VERSION)
-      client_config = Pathname.new(__dir__).join(
-        '{@jsonBaseName}_client_config.json')
       {@constructDefaults(service)}
       google_api_client = "#{app_name}/#{app_version} " @\
         "#{CODE_GEN_NAME_VERSION} ruby/#{RUBY_VERSION}".freeze

--- a/src/main/resources/com/google/api/codegen/ruby/main.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/main.snip
@@ -129,48 +129,38 @@
   @end
 @end
 
-@private constructSettings(prefix, config, service, ifaceConfig)
-  @if or(context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods), \
-         context.messages.filterBundlingMethods(ifaceConfig, service.getMethods))
-    {@prefix}Google::Gax.construct_settings(
-      '{@service.getFullName}',
-      {@config},
-      {},
-      {},
-      Google::Gax::Grpc::STATUS_CODE_NAMES,
-      timeout,
-      @if context.messages.filterBundlingMethods(ifaceConfig, service.getMethods)
-        @if context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods)
-          bundle_descriptors: BUNDLE_DESCRIPTORS,
-        @else
-          bundle_descriptors: BUNDLE_DESCRIPTORS)
-        @end
-      @end
-      @if context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods)
-        page_descriptors: PAGE_DESCRIPTORS)
-      @end
-  @else
-    {@prefix}Google::Gax.construct_settings(
-      '{@service.getFullName}',
-      {@config},
-      {},
-      {},
-      Google::Gax::Grpc::STATUS_CODE_NAMES,
-      timeout)
-  @end
-@end
-
 @private constructDefaults(service)
   @let ifaceConfig = context.getApiConfig.getInterfaceConfig(service), \
        jsonBaseName = {@context.upperCamelToLowerUnderscore(service.getSimpleName)}
     client_config_file = Pathname.new(__dir__).join(
       '{@jsonBaseName}_client_config.json')
-    client_config_file.open do |f|
-      {@constructSettings("@defaults = ", "JSON.parse(f.read)", service, ifaceConfig)}
-    end
-    if client_config
-      {@constructSettings("@defaults.update(", "client_config", service, ifaceConfig)}
-      )
+    @@defaults = client_config_file.open do |f|
+      @if or(context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods), \
+             context.messages.filterBundlingMethods(ifaceConfig, service.getMethods))
+        Google::Gax.construct_settings(
+          '{@service.getFullName}',
+          JSON.parse(f.read),
+          client_config,
+          Google::Gax::Grpc::STATUS_CODE_NAMES,
+          timeout,
+          @if context.messages.filterBundlingMethods(ifaceConfig, service.getMethods)
+            @if context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods)
+              bundle_descriptors: BUNDLE_DESCRIPTORS,
+            @else
+              bundle_descriptors: BUNDLE_DESCRIPTORS)
+            @end
+          @end
+          @if context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods)
+            page_descriptors: PAGE_DESCRIPTORS)
+          @end
+      @else
+        Google::Gax.construct_settings(
+          '{@service.getFullName}',
+          JSON.parse(f.read),
+          client_config,
+          Google::Gax::Grpc::STATUS_CODE_NAMES,
+          timeout)
+      @end
     end
   @end
 @end
@@ -186,12 +176,10 @@
     @# @@param ssl_creds [Grpc::ClientCredentials]
     @#   A ClientCredentials for use with an SSL-enabled channel.
     @# @@param client_config[Hash]
-    @#   The default client config for methods. When specified, the value is
-    @#   passed to Google::Gax#construct_settings to build the actual call
-    @#   settings, so it has to have the same structure of the data. See
-    @#   Google::Gax#construct_settings for the structure of the data.
-    @#   client_config can specify a subset of the methods. If a method
-    @#   config is not specified, it falls back to the default config.
+    @#   A Hash for call settings for each method. See
+    @#   Google::Gax#construct_settings for the structure of
+    @#   this data. Falls back to the default config if not specified
+    @#   or the specified config is missing data points.
     @# @@param timeout [Numeric]
     @#   The default timeout, in seconds, for calls made through this client.
     @# @@param app_name [String]
@@ -204,7 +192,7 @@
       channel: nil,
       ssl_creds: nil,
       scopes: ALL_SCOPES,
-      client_config: nil,
+      client_config: {},
       timeout: DEFAULT_TIMEOUT,
       app_name: 'gax',
       app_version: Google::Gax::VERSION)

--- a/src/main/resources/com/google/api/codegen/ruby/main.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/main.snip
@@ -129,44 +129,49 @@
   @end
 @end
 
+@private constructSettings(prefix, config, service, ifaceConfig)
+  @if or(context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods), \
+         context.messages.filterBundlingMethods(ifaceConfig, service.getMethods))
+    {@prefix}Google::Gax.construct_settings(
+      '{@service.getFullName}',
+      {@config},
+      {},
+      {},
+      Google::Gax::Grpc::STATUS_CODE_NAMES,
+      timeout,
+      @if context.messages.filterBundlingMethods(ifaceConfig, service.getMethods)
+        @if context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods)
+          bundle_descriptors: BUNDLE_DESCRIPTORS,
+        @else
+          bundle_descriptors: BUNDLE_DESCRIPTORS)
+        @end
+      @end
+      @if context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods)
+        page_descriptors: PAGE_DESCRIPTORS)
+      @end
+  @else
+    {@prefix}Google::Gax.construct_settings(
+      '{@service.getFullName}',
+      {@config},
+      {},
+      {},
+      Google::Gax::Grpc::STATUS_CODE_NAMES,
+      timeout)
+  @end
+@end
+
 @private constructDefaults(service)
   @let ifaceConfig = context.getApiConfig.getInterfaceConfig(service), \
        jsonBaseName = {@context.upperCamelToLowerUnderscore(service.getSimpleName)}
-    unless client_config
-      client_config_file = Pathname.new(__dir__).join(
-        '{@jsonBaseName}_client_config.json')
-      client_config_file.open do |f|
-        client_config = JSON.parse(f.read)
-      end
+    client_config_file = Pathname.new(__dir__).join(
+      '{@jsonBaseName}_client_config.json')
+    client_config_file.open do |f|
+      {@constructSettings("@defaults = ", "JSON.parse(f.read)", service, ifaceConfig)}
     end
-    @if or(context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods), \
-           context.messages.filterBundlingMethods(ifaceConfig, service.getMethods))
-      @@defaults = Google::Gax.construct_settings(
-        '{@service.getFullName}',
-        client_config,
-        {},
-        {},
-        Google::Gax::Grpc::STATUS_CODE_NAMES,
-        timeout,
-        @if context.messages.filterBundlingMethods(ifaceConfig, service.getMethods)
-          @if context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods)
-            bundle_descriptors: BUNDLE_DESCRIPTORS,
-          @else
-            bundle_descriptors: BUNDLE_DESCRIPTORS)
-          @end
-        @end
-        @if context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods)
-          page_descriptors: PAGE_DESCRIPTORS)
-        @end
-    @else
-      @@defaults = Google::Gax.construct_settings(
-        '{@service.getFullName}',
-        client_config,
-        {},
-        {},
-        config.STATUS_CODE_NAMES,
-        timeout)
-    @end
+    if client_config
+      {@constructSettings("@defaults.update(", "client_config", service, ifaceConfig)}
+      )
+    end
   @end
 @end
 
@@ -185,7 +190,8 @@
     @#   passed to Google::Gax#construct_settings to build the actual call
     @#   settings, so it has to have the same structure of the data. See
     @#   Google::Gax#construct_settings for the structure of the data.
-    @#   Use the default config if not specified.
+    @#   client_config can specify a subset of the methods. If a method
+    @#   config is not specified, it falls back to the default config.
     @# @@param timeout [Numeric]
     @#   The default timeout, in seconds, for calls made through this client.
     @# @@param app_name [String]

--- a/src/test/java/com/google/api/codegen/testdata/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_library.baseline
@@ -136,8 +136,7 @@ class LibraryServiceApi(object):
             channel=None,
             ssl_creds=None,
             scopes=None,
-            retrying_override=None,
-            bundling_override=None,
+            client_config=None,
             timeout=_DEFAULT_TIMEOUT,
             app_name='gax',
             app_version=_GAX_VERSION):
@@ -150,18 +149,13 @@ class LibraryServiceApi(object):
             object through which to make calls.
           ssl_creds (:class:`grpc.beta.implementations.ClientCredentials`):
             A `ClientCredentials` for use with an SSL-enabled channel.
-          retrying_override (dict[string, :class:`google.gax.RetryOptions`]): A
-            dictionary that overrides default retrying settings.
-            ``retrying_override`` maps method names (e.g., ``'list_foo'``) to
-            custom RetryOptions objects, or to None. A value of None indicates
-            that the method in question should not retry.
-          bundling_override (dict[string, :class:`google.gax.BundleOptions`]): A
-            dictionary that overrides default bundling settings.
-            ``bundling_override`` maps bundling method names (e.g.,
-            'publish_foo') to custom BundleOptions objects, or to None. It is
-            invalid to have a key for a method that is not bundling-enabled. A
-            value of None indicates that the method in question should not
-            bundle.
+          client_config (dict):
+            The default client config for methods. When specified, the value is
+            passed to :method:`google.gax.construct_settings` to build the
+            actual call settings, so it has to have the same structure of
+            the data. See :method:`google.gax.construct_settings` for the
+            structure of the data.
+            Use the default config if not specified.
           timeout (int): The default timeout, in seconds, for calls made
             through this client
           app_name (string): The codename of the calling service.
@@ -172,15 +166,14 @@ class LibraryServiceApi(object):
         """
         if scopes is None:
             scopes = self._ALL_SCOPES
-        bundling_override = bundling_override or {}
-        retrying_override = retrying_override or {}
-        client_config = pkg_resources.resource_string(
-            __name__, 'library_service_client_config.json')
+        if not client_config:
+            client_config = json.loads(pkg_resources.resource_string(
+                __name__, 'library_service_client_config.json'))
         self._defaults = api_callable.construct_settings(
             'google.example.library.v1.LibraryService',
-            json.loads(client_config),
-            bundling_override,
-            retrying_override,
+            client_config,
+            {},
+            {},
             config.STATUS_CODE_NAMES,
             timeout,
             bundle_descriptors=self._BUNDLE_DESCRIPTORS,

--- a/src/test/java/com/google/api/codegen/testdata/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_library.baseline
@@ -150,13 +150,10 @@ class LibraryServiceApi(object):
           ssl_creds (:class:`grpc.beta.implementations.ClientCredentials`):
             A `ClientCredentials` for use with an SSL-enabled channel.
           client_config (dict):
-            The default client config for methods. When specified, the value is
-            passed to :method:`google.gax.construct_settings` to build the
-            actual call settings, so it has to have the same structure of
-            the data. See :method:`google.gax.construct_settings` for the
-            structure of the data.
-            client_config can specify a subset of the methods. If a method
-            config is not specified, it falls back to the default config.
+            A dictionary for call settings for each method. See
+            :method:`google.gax.construct_settings` for the structure of
+            this data. Falls back to the default config if not specified
+            or the specified config is missing data points.
           timeout (int): The default timeout, in seconds, for calls made
             through this client
           app_name (string): The codename of the calling service.
@@ -167,28 +164,18 @@ class LibraryServiceApi(object):
         """
         if scopes is None:
             scopes = self._ALL_SCOPES
+        if client_config is None:
+            client_config = {}
         default_client_config = json.loads(pkg_resources.resource_string(
             __name__, 'library_service_client_config.json'))
         self._defaults = api_callable.construct_settings(
             'google.example.library.v1.LibraryService',
             default_client_config,
-            {},
-            {},
+            client_config,
             config.STATUS_CODE_NAMES,
             timeout,
             bundle_descriptors=self._BUNDLE_DESCRIPTORS,
             page_descriptors=self._PAGE_DESCRIPTORS)
-        if client_config:
-            self._defaults.update(api_callable.construct_settings(
-                'google.example.library.v1.LibraryService',
-                client_config,
-                {},
-                {},
-                config.STATUS_CODE_NAMES,
-                timeout,
-                bundle_descriptors=self._BUNDLE_DESCRIPTORS,
-                page_descriptors=self._PAGE_DESCRIPTORS)
-            )
         goog_api_client = '{}/{} {} gax/{} python/{}'.format(
             app_name,
             app_version,

--- a/src/test/java/com/google/api/codegen/testdata/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_library.baseline
@@ -150,7 +150,7 @@ class LibraryServiceApi(object):
           ssl_creds (:class:`grpc.beta.implementations.ClientCredentials`):
             A `ClientCredentials` for use with an SSL-enabled channel.
           client_config (dict):
-            A dictionary for call settings for each method. See
+            A dictionary for call options for each method. See
             :method:`google.gax.construct_settings` for the structure of
             this data. Falls back to the default config if not specified
             or the specified config is missing data points.

--- a/src/test/java/com/google/api/codegen/testdata/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_library.baseline
@@ -155,7 +155,8 @@ class LibraryServiceApi(object):
             actual call settings, so it has to have the same structure of
             the data. See :method:`google.gax.construct_settings` for the
             structure of the data.
-            Use the default config if not specified.
+            client_config can specify a subset of the methods. If a method
+            config is not specified, it falls back to the default config.
           timeout (int): The default timeout, in seconds, for calls made
             through this client
           app_name (string): The codename of the calling service.
@@ -166,19 +167,28 @@ class LibraryServiceApi(object):
         """
         if scopes is None:
             scopes = self._ALL_SCOPES
-        if not client_config:
-            client_config = json.loads(pkg_resources.resource_string(
-                __name__, 'library_service_client_config.json'))
+        default_client_config = json.loads(pkg_resources.resource_string(
+            __name__, 'library_service_client_config.json'))
         self._defaults = api_callable.construct_settings(
             'google.example.library.v1.LibraryService',
-            client_config,
+            default_client_config,
             {},
             {},
             config.STATUS_CODE_NAMES,
             timeout,
             bundle_descriptors=self._BUNDLE_DESCRIPTORS,
-            page_descriptors=self._PAGE_DESCRIPTORS
-        )
+            page_descriptors=self._PAGE_DESCRIPTORS)
+        if client_config:
+            self._defaults.update(api_callable.construct_settings(
+                'google.example.library.v1.LibraryService',
+                client_config,
+                {},
+                {},
+                config.STATUS_CODE_NAMES,
+                timeout,
+                bundle_descriptors=self._BUNDLE_DESCRIPTORS,
+                page_descriptors=self._PAGE_DESCRIPTORS)
+            )
         goog_api_client = '{}/{} {} gax/{} python/{}'.format(
             app_name,
             app_version,

--- a/src/test/java/com/google/api/codegen/testdata/python_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_no_path_templates.baseline
@@ -76,7 +76,7 @@ class NoTemplatesServiceApi(object):
           ssl_creds (:class:`grpc.beta.implementations.ClientCredentials`):
             A `ClientCredentials` for use with an SSL-enabled channel.
           client_config (dict):
-            A dictionary for call settings for each method. See
+            A dictionary for call options for each method. See
             :method:`google.gax.construct_settings` for the structure of
             this data. Falls back to the default config if not specified
             or the specified config is missing data points.

--- a/src/test/java/com/google/api/codegen/testdata/python_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_no_path_templates.baseline
@@ -76,13 +76,10 @@ class NoTemplatesServiceApi(object):
           ssl_creds (:class:`grpc.beta.implementations.ClientCredentials`):
             A `ClientCredentials` for use with an SSL-enabled channel.
           client_config (dict):
-            The default client config for methods. When specified, the value is
-            passed to :method:`google.gax.construct_settings` to build the
-            actual call settings, so it has to have the same structure of
-            the data. See :method:`google.gax.construct_settings` for the
-            structure of the data.
-            client_config can specify a subset of the methods. If a method
-            config is not specified, it falls back to the default config.
+            A dictionary for call settings for each method. See
+            :method:`google.gax.construct_settings` for the structure of
+            this data. Falls back to the default config if not specified
+            or the specified config is missing data points.
           timeout (int): The default timeout, in seconds, for calls made
             through this client
           app_name (string): The codename of the calling service.
@@ -93,24 +90,16 @@ class NoTemplatesServiceApi(object):
         """
         if scopes is None:
             scopes = self._ALL_SCOPES
+        if client_config is None:
+            client_config = {}
         default_client_config = json.loads(pkg_resources.resource_string(
             __name__, 'no_templates_service_client_config.json'))
         self._defaults = api_callable.construct_settings(
             'google.example.v1.NoTemplatesService',
             default_client_config,
-            {},
-            {},
+            client_config,
             config.STATUS_CODE_NAMES,
             timeout)
-        if client_config:
-            self._defaults.update(api_callable.construct_settings(
-                'google.example.v1.NoTemplatesService',
-                client_config,
-                {},
-                {},
-                config.STATUS_CODE_NAMES,
-                timeout)
-            )
         goog_api_client = '{}/{} {} gax/{} python/{}'.format(
             app_name,
             app_version,

--- a/src/test/java/com/google/api/codegen/testdata/python_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_no_path_templates.baseline
@@ -62,8 +62,7 @@ class NoTemplatesServiceApi(object):
             channel=None,
             ssl_creds=None,
             scopes=None,
-            retrying_override=None,
-            bundling_override=None,
+            client_config=None,
             timeout=_DEFAULT_TIMEOUT,
             app_name='gax',
             app_version=_GAX_VERSION):
@@ -76,18 +75,13 @@ class NoTemplatesServiceApi(object):
             object through which to make calls.
           ssl_creds (:class:`grpc.beta.implementations.ClientCredentials`):
             A `ClientCredentials` for use with an SSL-enabled channel.
-          retrying_override (dict[string, :class:`google.gax.RetryOptions`]): A
-            dictionary that overrides default retrying settings.
-            ``retrying_override`` maps method names (e.g., ``'list_foo'``) to
-            custom RetryOptions objects, or to None. A value of None indicates
-            that the method in question should not retry.
-          bundling_override (dict[string, :class:`google.gax.BundleOptions`]): A
-            dictionary that overrides default bundling settings.
-            ``bundling_override`` maps bundling method names (e.g.,
-            'publish_foo') to custom BundleOptions objects, or to None. It is
-            invalid to have a key for a method that is not bundling-enabled. A
-            value of None indicates that the method in question should not
-            bundle.
+          client_config (dict):
+            The default client config for methods. When specified, the value is
+            passed to :method:`google.gax.construct_settings` to build the
+            actual call settings, so it has to have the same structure of
+            the data. See :method:`google.gax.construct_settings` for the
+            structure of the data.
+            Use the default config if not specified.
           timeout (int): The default timeout, in seconds, for calls made
             through this client
           app_name (string): The codename of the calling service.
@@ -98,15 +92,14 @@ class NoTemplatesServiceApi(object):
         """
         if scopes is None:
             scopes = self._ALL_SCOPES
-        bundling_override = bundling_override or {}
-        retrying_override = retrying_override or {}
-        client_config = pkg_resources.resource_string(
-            __name__, 'no_templates_service_client_config.json')
+        if not client_config:
+            client_config = json.loads(pkg_resources.resource_string(
+                __name__, 'no_templates_service_client_config.json'))
         self._defaults = api_callable.construct_settings(
             'google.example.v1.NoTemplatesService',
-            json.loads(client_config),
-            bundling_override,
-            retrying_override,
+            client_config,
+            {},
+            {},
             config.STATUS_CODE_NAMES,
             timeout
         )

--- a/src/test/java/com/google/api/codegen/testdata/python_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_no_path_templates.baseline
@@ -81,7 +81,8 @@ class NoTemplatesServiceApi(object):
             actual call settings, so it has to have the same structure of
             the data. See :method:`google.gax.construct_settings` for the
             structure of the data.
-            Use the default config if not specified.
+            client_config can specify a subset of the methods. If a method
+            config is not specified, it falls back to the default config.
           timeout (int): The default timeout, in seconds, for calls made
             through this client
           app_name (string): The codename of the calling service.
@@ -92,17 +93,24 @@ class NoTemplatesServiceApi(object):
         """
         if scopes is None:
             scopes = self._ALL_SCOPES
-        if not client_config:
-            client_config = json.loads(pkg_resources.resource_string(
-                __name__, 'no_templates_service_client_config.json'))
+        default_client_config = json.loads(pkg_resources.resource_string(
+            __name__, 'no_templates_service_client_config.json'))
         self._defaults = api_callable.construct_settings(
             'google.example.v1.NoTemplatesService',
-            client_config,
+            default_client_config,
             {},
             {},
             config.STATUS_CODE_NAMES,
-            timeout
-        )
+            timeout)
+        if client_config:
+            self._defaults.update(api_callable.construct_settings(
+                'google.example.v1.NoTemplatesService',
+                client_config,
+                {},
+                {},
+                config.STATUS_CODE_NAMES,
+                timeout)
+            )
         goog_api_client = '{}/{} {} gax/{} python/{}'.format(
             app_name,
             app_version,

--- a/src/test/java/com/google/api/codegen/testdata/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_library.baseline
@@ -128,18 +128,12 @@ module Google
           #   A Channel object through which to make calls.
           # @param ssl_creds [Grpc::ClientCredentials]
           #   A ClientCredentials for use with an SSL-enabled channel.
-          # @param retrying_override [Hash{String => RetryOptions}]
-          #   A Hash that overrides default retrying settings.
-          #   +retrying_override+ maps method names (e.g., +'list_foo'+) to
-          #   custom RetryOptions objects, or to nil. A value of nil indicates
-          #   that the method in question should not retry.
-          # @param bundling_override [Hash{String => BundleOptions}]
-          #   A Hash that overrides default bundling settings.
-          #   +bundling_override+ maps bundling method names (e.g.,
-          #   +'publish_foo'+) to custom BundleOptions objects, or to nil. It is
-          #   invalid to have a key for a method that is not bundling-enabled. A
-          #   value of nil indicates that the method in question should not
-          #   bundle.
+          # @param client_config[Hash]
+          #   The default client config for methods. When specified, the value is
+          #   passed to Google::Gax#construct_settings to build the actual call
+          #   settings, so it has to have the same structure of the data. See
+          #   Google::Gax#construct_settings for the structure of the data.
+          #   Use the default config if not specified.
           # @param timeout [Numeric]
           #   The default timeout, in seconds, for calls made through this client.
           # @param app_name [String]
@@ -152,24 +146,26 @@ module Google
             channel: nil,
             ssl_creds: nil,
             scopes: ALL_SCOPES,
-            retrying_override: {},
-            bundling_override: {},
+            client_config: nil,
             timeout: DEFAULT_TIMEOUT,
             app_name: 'gax',
             app_version: Google::Gax::VERSION)
-            client_config = Pathname.new(__dir__).join(
-              'library_service_client_config.json')
-            @defaults = client_config.open do |f|
-              Google::Gax.construct_settings(
-                'google.example.library.v1.LibraryService',
-                JSON.parse(f.read),
-                bundling_override,
-                retrying_override,
-                Google::Gax::Grpc::STATUS_CODE_NAMES,
-                timeout,
-                bundle_descriptors: BUNDLE_DESCRIPTORS,
-                page_descriptors: PAGE_DESCRIPTORS)
+            unless client_config
+              client_config_file = Pathname.new(__dir__).join(
+                'library_service_client_config.json')
+              client_config_file.open do |f|
+                client_config = JSON.parse(f.read)
+              end
             end
+            @defaults = Google::Gax.construct_settings(
+              'google.example.library.v1.LibraryService',
+              client_config,
+              {},
+              {},
+              Google::Gax::Grpc::STATUS_CODE_NAMES,
+              timeout,
+              bundle_descriptors: BUNDLE_DESCRIPTORS,
+              page_descriptors: PAGE_DESCRIPTORS)
             google_api_client = "#{app_name}/#{app_version} " \
               "#{CODE_GEN_NAME_VERSION} ruby/#{RUBY_VERSION}".freeze
             @headers = { :'x-goog-api-client' => google_api_client }

--- a/src/test/java/com/google/api/codegen/testdata/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_library.baseline
@@ -133,7 +133,8 @@ module Google
           #   passed to Google::Gax#construct_settings to build the actual call
           #   settings, so it has to have the same structure of the data. See
           #   Google::Gax#construct_settings for the structure of the data.
-          #   Use the default config if not specified.
+          #   client_config can specify a subset of the methods. If a method
+          #   config is not specified, it falls back to the default config.
           # @param timeout [Numeric]
           #   The default timeout, in seconds, for calls made through this client.
           # @param app_name [String]
@@ -150,22 +151,31 @@ module Google
             timeout: DEFAULT_TIMEOUT,
             app_name: 'gax',
             app_version: Google::Gax::VERSION)
-            unless client_config
-              client_config_file = Pathname.new(__dir__).join(
-                'library_service_client_config.json')
-              client_config_file.open do |f|
-                client_config = JSON.parse(f.read)
-              end
+            client_config_file = Pathname.new(__dir__).join(
+              'library_service_client_config.json')
+            client_config_file.open do |f|
+              @defaults = Google::Gax.construct_settings(
+                'google.example.library.v1.LibraryService',
+                JSON.parse(f.read),
+                {},
+                {},
+                Google::Gax::Grpc::STATUS_CODE_NAMES,
+                timeout,
+                bundle_descriptors: BUNDLE_DESCRIPTORS,
+                page_descriptors: PAGE_DESCRIPTORS)
             end
-            @defaults = Google::Gax.construct_settings(
-              'google.example.library.v1.LibraryService',
-              client_config,
-              {},
-              {},
-              Google::Gax::Grpc::STATUS_CODE_NAMES,
-              timeout,
-              bundle_descriptors: BUNDLE_DESCRIPTORS,
-              page_descriptors: PAGE_DESCRIPTORS)
+            if client_config
+              @defaults.update(Google::Gax.construct_settings(
+                'google.example.library.v1.LibraryService',
+                client_config,
+                {},
+                {},
+                Google::Gax::Grpc::STATUS_CODE_NAMES,
+                timeout,
+                bundle_descriptors: BUNDLE_DESCRIPTORS,
+                page_descriptors: PAGE_DESCRIPTORS)
+              )
+            end
             google_api_client = "#{app_name}/#{app_version} " \
               "#{CODE_GEN_NAME_VERSION} ruby/#{RUBY_VERSION}".freeze
             @headers = { :'x-goog-api-client' => google_api_client }

--- a/src/test/java/com/google/api/codegen/testdata/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_library.baseline
@@ -129,7 +129,7 @@ module Google
           # @param ssl_creds [Grpc::ClientCredentials]
           #   A ClientCredentials for use with an SSL-enabled channel.
           # @param client_config[Hash]
-          #   A Hash for call settings for each method. See
+          #   A Hash for call options for each method. See
           #   Google::Gax#construct_settings for the structure of
           #   this data. Falls back to the default config if not specified
           #   or the specified config is missing data points.

--- a/src/test/java/com/google/api/codegen/testdata/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_library.baseline
@@ -129,12 +129,10 @@ module Google
           # @param ssl_creds [Grpc::ClientCredentials]
           #   A ClientCredentials for use with an SSL-enabled channel.
           # @param client_config[Hash]
-          #   The default client config for methods. When specified, the value is
-          #   passed to Google::Gax#construct_settings to build the actual call
-          #   settings, so it has to have the same structure of the data. See
-          #   Google::Gax#construct_settings for the structure of the data.
-          #   client_config can specify a subset of the methods. If a method
-          #   config is not specified, it falls back to the default config.
+          #   A Hash for call settings for each method. See
+          #   Google::Gax#construct_settings for the structure of
+          #   this data. Falls back to the default config if not specified
+          #   or the specified config is missing data points.
           # @param timeout [Numeric]
           #   The default timeout, in seconds, for calls made through this client.
           # @param app_name [String]
@@ -147,34 +145,21 @@ module Google
             channel: nil,
             ssl_creds: nil,
             scopes: ALL_SCOPES,
-            client_config: nil,
+            client_config: {},
             timeout: DEFAULT_TIMEOUT,
             app_name: 'gax',
             app_version: Google::Gax::VERSION)
             client_config_file = Pathname.new(__dir__).join(
               'library_service_client_config.json')
-            client_config_file.open do |f|
-              @defaults = Google::Gax.construct_settings(
+            @defaults = client_config_file.open do |f|
+              Google::Gax.construct_settings(
                 'google.example.library.v1.LibraryService',
                 JSON.parse(f.read),
-                {},
-                {},
-                Google::Gax::Grpc::STATUS_CODE_NAMES,
-                timeout,
-                bundle_descriptors: BUNDLE_DESCRIPTORS,
-                page_descriptors: PAGE_DESCRIPTORS)
-            end
-            if client_config
-              @defaults.update(Google::Gax.construct_settings(
-                'google.example.library.v1.LibraryService',
                 client_config,
-                {},
-                {},
                 Google::Gax::Grpc::STATUS_CODE_NAMES,
                 timeout,
                 bundle_descriptors: BUNDLE_DESCRIPTORS,
                 page_descriptors: PAGE_DESCRIPTORS)
-              )
             end
             google_api_client = "#{app_name}/#{app_version} " \
               "#{CODE_GEN_NAME_VERSION} ruby/#{RUBY_VERSION}".freeze


### PR DESCRIPTION
This removes retrying_overrides and bundling_overrides, because
I think it's quite easy to modify the parameters before invoking
the constructor.

This fixes googleapis/gax-python#95 and googleapis/gax-ruby#5