### PR TITLE
Refactor language providers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 bin
 build
 .gradle
+vgen/src-gen
 
 # Eclipse
 .apt_generated
@@ -9,3 +10,6 @@ build
 .factorypath
 .project
 .settings
+
+# emacs/gEdit autosave files
+*~

--- a/vgen/src/main/java/io/gapi/vgen/DiscoveryFragmentGenerator.java
+++ b/vgen/src/main/java/io/gapi/vgen/DiscoveryFragmentGenerator.java
@@ -48,12 +48,15 @@ public class DiscoveryFragmentGenerator {
 
     ApiaryConfig apiaryConfig = discovery.getConfig();
 
+    // TODO: Support multiple templates; don't hard-code the zero-index here.
+    Preconditions.checkArgument(configProto.getTemplatesCount() == 1);
     DiscoveryLanguageProvider languageProvider =
-        GeneratorBuilderUtil.createLanguageProvider(
-            configProto.getLanguageProvider(),
+        GeneratorBuilderUtil.createClass(
+            configProto.getTemplates(0).getLanguageProvider(),
             DiscoveryLanguageProvider.class,
             new Class<?>[] {Service.class, ApiaryConfig.class},
             new Object[] {discovery.getService(), apiaryConfig},
+            "discovery language provider",
             new GeneratorBuilderUtil.ErrorReporter() {
               @Override
               public void error(String message, Object... args) {

--- a/vgen/src/main/java/io/gapi/vgen/DiscoveryFragmentGeneratorApi.java
+++ b/vgen/src/main/java/io/gapi/vgen/DiscoveryFragmentGeneratorApi.java
@@ -19,6 +19,7 @@ import com.google.api.tools.framework.model.testing.SimpleDiag;
 import com.google.api.tools.framework.tools.ToolOptions;
 import com.google.api.tools.framework.tools.ToolOptions.Option;
 import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.ArrayListMultimap;
@@ -101,7 +102,10 @@ public class DiscoveryFragmentGeneratorApi {
     }
 
     Multimap<Method, GeneratedResult> docs = ArrayListMultimap.create();
-    for (String snippetInputName : configProto.getFragmentFilesList()) {
+    
+    // TODO: Support multiple templates; don't hard-code the zero-index here.
+    Preconditions.checkArgument(configProto.getTemplatesCount() == 1);
+    for (String snippetInputName : configProto.getTemplates(0).getSnippetFilesList()) {
       SnippetDescriptor snippetDescriptor = new SnippetDescriptor(snippetInputName);
       Map<Method, GeneratedResult> code = generator.generateFragments(snippetDescriptor);
       if (code == null) {

--- a/vgen/src/main/java/io/gapi/vgen/FragmentGenerator.java
+++ b/vgen/src/main/java/io/gapi/vgen/FragmentGenerator.java
@@ -14,62 +14,25 @@
  */
 package io.gapi.vgen;
 
-import com.google.api.tools.framework.model.Interface;
 import com.google.api.tools.framework.model.Method;
-import com.google.api.tools.framework.model.stages.Merged;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Multimap;
 
 import java.io.IOException;
-import java.util.Map;
-
-import javax.annotation.Nullable;
 
 /**
  * Fragment generator.
  */
 public class FragmentGenerator {
 
-  private final GapicLanguageProvider provider;
+  private final GapicLanguageProvider<Method> provider;
 
-  public FragmentGenerator(GapicLanguageProvider provider) {
+  public FragmentGenerator(GapicLanguageProvider<Method> provider) {
     this.provider = Preconditions.checkNotNull(provider);
   }
 
-  public static FragmentGenerator create(GapicLanguageProvider provider) {
+  public static FragmentGenerator create(GapicLanguageProvider<Method> provider) {
     return new FragmentGenerator(provider);
-  }
-
-  /**
-   * Generates fragments for the model. Returns a map from each method to a fragment for the method.
-   * Returns null if generation failed.
-   */
-  @Nullable
-  public Map<Method, GeneratedResult> generateFragments(SnippetDescriptor snippetDescriptor) {
-    // Establish required stage for generation.
-    provider.getModel().establishStage(Merged.KEY);
-    if (provider.getModel().getErrorCount() > 0) {
-      return null;
-    }
-
-    // Run the generator for each method of each service.
-    ImmutableMap.Builder<Method, GeneratedResult> generated = ImmutableMap.builder();
-    for (Interface iface : provider.getModel().getSymbolTable().getInterfaces()) {
-      if (!iface.isReachable()) {
-        continue;
-      }
-      for (Method method : iface.getMethods()) {
-        GeneratedResult result = provider.generateFragments(method, snippetDescriptor);
-        generated.put(method, result);
-      }
-    }
-
-    // Return result.
-    if (provider.getModel().getErrorCount() > 0) {
-      return null;
-    }
-    return generated.build();
   }
 
   /**

--- a/vgen/src/main/java/io/gapi/vgen/InputElementView.java
+++ b/vgen/src/main/java/io/gapi/vgen/InputElementView.java
@@ -16,31 +16,11 @@ package io.gapi.vgen;
 
 import com.google.api.tools.framework.model.Model;
 import com.google.api.tools.framework.model.ProtoElement;
-import com.google.common.collect.Multimap;
-
-import java.io.IOException;
 
 /**
- * A GapicLanguageProvider performs code or fragment generation using on a proto-based Model for a
- * particular language.
+ * An implementation of InputElementProvider is a strategy object, encapsulating a strategy for
+ * retrieving a ProtoElement from a model.
  */
-public interface GapicLanguageProvider<InputElementT extends ProtoElement> {
-
-  Model getModel();
-
-  /**
-   * Gets the view of the model.
-   */
-  public InputElementView<InputElementT> getView();
-
-  /**
-   * Runs code generation.
-   */
-  GeneratedResult generate(InputElementT element, SnippetDescriptor snippetDescriptor);
-
-  /**
-   * Outputs the given elements to the given output path.
-   */
-  <Element> void output(String outputPath, Multimap<Element, GeneratedResult> elements)
-      throws IOException;
+public interface InputElementView<InputElementT extends ProtoElement> {
+  public Iterable<InputElementT> getElementIterable(Model model);
 }

--- a/vgen/src/main/java/io/gapi/vgen/InterfaceView.java
+++ b/vgen/src/main/java/io/gapi/vgen/InterfaceView.java
@@ -1,0 +1,41 @@
+/* Copyright 2016 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gapi.vgen;
+
+import com.google.api.tools.framework.model.Interface;
+import com.google.api.tools.framework.model.Model;
+
+import java.util.ArrayList;
+
+/**
+ * An interface-based view of model, consisting of a strategy for getting the interfaces of the
+ * model.
+ */
+public class InterfaceView implements InputElementView<Interface> {
+
+  /**
+   * Gets the reachable interfaces of the model.
+   */
+  @Override
+  public Iterable<Interface> getElementIterable(Model model) {
+    ArrayList<Interface> interfaces = new ArrayList<>();
+    for (Interface iface : model.getSymbolTable().getInterfaces()) {
+      if (iface.isReachable()) {
+        interfaces.add(iface);
+      }
+    }
+    return interfaces;
+  }
+}

--- a/vgen/src/main/java/io/gapi/vgen/MethodView.java
+++ b/vgen/src/main/java/io/gapi/vgen/MethodView.java
@@ -1,0 +1,44 @@
+/* Copyright 2016 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gapi.vgen;
+
+import com.google.api.tools.framework.model.Interface;
+import com.google.api.tools.framework.model.Method;
+import com.google.api.tools.framework.model.Model;
+
+import java.util.ArrayList;
+
+/**
+ * An method-based view of model, consisting of a strategy for getting the methods of the model.
+ */
+public class MethodView implements InputElementView<Method> {
+
+  /**
+   * Gets the reachable methods of the model.
+   */
+  @Override
+  public Iterable<Method> getElementIterable(Model model) {
+    ArrayList<Method> methods = new ArrayList<>();
+    for (Interface iface : model.getSymbolTable().getInterfaces()) {
+      if (!iface.isReachable()) {
+        continue;
+      }
+      for (Method method : iface.getMethods()) {
+        methods.add(method);
+      }
+    }
+    return methods;
+  }
+}

--- a/vgen/src/main/java/io/gapi/vgen/ProtoElementComparator.java
+++ b/vgen/src/main/java/io/gapi/vgen/ProtoElementComparator.java
@@ -1,0 +1,35 @@
+/* Copyright 2016 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gapi.vgen;
+
+import com.google.api.tools.framework.model.ProtoElement;
+
+import java.util.Comparator;
+
+/**
+ * A comparator for ProtoElements for, e.g., ensuring determinism in test output.
+ */
+public class ProtoElementComparator implements Comparator<ProtoElement> {
+
+  @Override
+  public int compare(ProtoElement elt1, ProtoElement elt2) {
+    int simple = elt1.getFile().getSimpleName().compareTo(elt2.getFile().getSimpleName());
+    if (simple == 0) {
+      return elt1.getFullName().compareTo(elt2.getFullName());
+    } else {
+      return simple;
+    }
+  }
+}

--- a/vgen/src/main/java/io/gapi/vgen/ProtoFileView.java
+++ b/vgen/src/main/java/io/gapi/vgen/ProtoFileView.java
@@ -1,0 +1,69 @@
+/* Copyright 2016 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gapi.vgen;
+
+import com.google.api.tools.framework.model.Field;
+import com.google.api.tools.framework.model.Interface;
+import com.google.api.tools.framework.model.MessageType;
+import com.google.api.tools.framework.model.Method;
+import com.google.api.tools.framework.model.Model;
+import com.google.api.tools.framework.model.ProtoFile;
+import com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Type;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * A file-based view of model, consisting of a strategy for getting the protocol buffer files from
+ * which the model was constructed.
+ */
+public class ProtoFileView implements InputElementView<ProtoFile> {
+
+  /**
+   * Gets the ProtoFile objects in which the fields of the reachable methods in the model are
+   * defined.
+   */
+  @Override
+  public Iterable<ProtoFile> getElementIterable(Model model) {
+    Set<ProtoFile> files = new HashSet<>();
+    for (Interface iface : model.getSymbolTable().getInterfaces()) {
+      if (!iface.isReachable()) {
+        continue;
+      }
+      for (Method method : iface.getMethods()) {
+        if (!method.isReachable()) {
+          continue;
+        }
+        for (Field field : method.getInputType().getMessageType().getFields()) {
+          files.addAll(protoFiles(field));
+        }
+      }
+    }
+    return files;
+  }
+
+  private Set<ProtoFile> protoFiles(Field field) {
+    Set<ProtoFile> fields = new HashSet<ProtoFile>();
+    if (field.getType().getKind() != Type.TYPE_MESSAGE) {
+      return fields;
+    }
+    MessageType messageType = field.getType().getMessageType();
+    fields.add(messageType.getFile());
+    for (Field f : messageType.getNonCyclicFields()) {
+      fields.addAll(protoFiles(f));
+    }
+    return fields;
+  }
+}

--- a/vgen/src/main/java/io/gapi/vgen/csharp/CSharpInterfaceView.java
+++ b/vgen/src/main/java/io/gapi/vgen/csharp/CSharpInterfaceView.java
@@ -1,0 +1,29 @@
+/* Copyright 2016 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gapi.vgen.csharp;
+
+import com.google.api.tools.framework.model.Interface;
+import com.google.api.tools.framework.model.ProtoFile;
+
+import io.gapi.vgen.InterfaceView;
+
+public class CSharpInterfaceView extends InterfaceView
+    implements CSharpProtoElementView<Interface> {
+
+  @Override
+  public ProtoFile getNamespaceFile(Interface service) {
+    return service.getFile();
+  }
+}

--- a/vgen/src/main/java/io/gapi/vgen/csharp/CSharpMethodView.java
+++ b/vgen/src/main/java/io/gapi/vgen/csharp/CSharpMethodView.java
@@ -1,0 +1,29 @@
+/* Copyright 2016 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gapi.vgen.csharp;
+
+import com.google.api.tools.framework.model.Method;
+import com.google.api.tools.framework.model.ProtoFile;
+
+import io.gapi.vgen.MethodView;
+
+public class CSharpMethodView extends MethodView
+    implements CSharpProtoElementView<Method> {
+
+  @Override
+  public ProtoFile getNamespaceFile(Method method) {
+    return method.getParent().getFile();
+  }
+}

--- a/vgen/src/main/java/io/gapi/vgen/csharp/CSharpProtoElementView.java
+++ b/vgen/src/main/java/io/gapi/vgen/csharp/CSharpProtoElementView.java
@@ -1,0 +1,25 @@
+/* Copyright 2016 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gapi.vgen.csharp;
+
+import com.google.api.tools.framework.model.ProtoElement;
+import com.google.api.tools.framework.model.ProtoFile;
+
+import io.gapi.vgen.InputElementView;
+
+public interface CSharpProtoElementView<InputElementT extends ProtoElement>
+    extends InputElementView<InputElementT> {
+  public ProtoFile getNamespaceFile(InputElementT t);
+}

--- a/vgen/src/main/java/io/gapi/vgen/go/GoGapicLanguageProvider.java
+++ b/vgen/src/main/java/io/gapi/vgen/go/GoGapicLanguageProvider.java
@@ -14,15 +14,14 @@
  */
 package io.gapi.vgen.go;
 
-import com.google.api.tools.framework.model.Interface;
-import com.google.api.tools.framework.model.Method;
 import com.google.api.tools.framework.model.Model;
-import com.google.api.tools.framework.model.ProtoFile;
+import com.google.api.tools.framework.model.ProtoElement;
 import com.google.common.collect.Multimap;
 
 import io.gapi.vgen.ApiConfig;
 import io.gapi.vgen.GapicLanguageProvider;
 import io.gapi.vgen.GeneratedResult;
+import io.gapi.vgen.InputElementView;
 import io.gapi.vgen.SnippetDescriptor;
 
 import java.io.IOException;
@@ -30,14 +29,18 @@ import java.io.IOException;
 /**
  * The LanguageProvider which runs Gapic code generation for Go.
  */
-public class GoGapicLanguageProvider implements GapicLanguageProvider {
+public class GoGapicLanguageProvider<InputElementT extends ProtoElement>
+    implements GapicLanguageProvider<InputElementT> {
 
   private final GoGapicContext context;
   private final GoLanguageProvider provider;
+  private InputElementView<InputElementT> view;
 
-  public GoGapicLanguageProvider(Model model, ApiConfig apiConfig) {
+  public GoGapicLanguageProvider(
+      Model model, ApiConfig apiConfig, InputElementView<InputElementT> view) {
     this.context = new GoGapicContext(model, apiConfig);
     this.provider = new GoLanguageProvider();
+    this.view = view;
   }
 
   @Override
@@ -52,17 +55,12 @@ public class GoGapicLanguageProvider implements GapicLanguageProvider {
   }
 
   @Override
-  public GeneratedResult generateCode(Interface service, SnippetDescriptor snippetDescriptor) {
-    return provider.generate(service, snippetDescriptor, context);
+  public GeneratedResult generate(InputElementT element, SnippetDescriptor snippetDescriptor) {
+    return provider.generate(element, snippetDescriptor, context);
   }
 
   @Override
-  public GeneratedResult generateFragments(Method method, SnippetDescriptor snippetDescriptor) {
-    return provider.generate(method, snippetDescriptor, context);
-  }
-
-  @Override
-  public GeneratedResult generateDoc(ProtoFile file, SnippetDescriptor descriptor) {
-    return null;
-  }
+  public InputElementView<InputElementT> getView() {
+    return view;
+    }
 }

--- a/vgen/src/main/java/io/gapi/vgen/java/JavaGapicLanguageProvider.java
+++ b/vgen/src/main/java/io/gapi/vgen/java/JavaGapicLanguageProvider.java
@@ -14,15 +14,14 @@
  */
 package io.gapi.vgen.java;
 
-import com.google.api.tools.framework.model.Interface;
-import com.google.api.tools.framework.model.Method;
 import com.google.api.tools.framework.model.Model;
-import com.google.api.tools.framework.model.ProtoFile;
+import com.google.api.tools.framework.model.ProtoElement;
 import com.google.common.collect.Multimap;
 
 import io.gapi.vgen.ApiConfig;
 import io.gapi.vgen.GapicLanguageProvider;
 import io.gapi.vgen.GeneratedResult;
+import io.gapi.vgen.InputElementView;
 import io.gapi.vgen.SnippetDescriptor;
 
 import java.io.IOException;
@@ -30,14 +29,18 @@ import java.io.IOException;
 /**
  * The LanguageProvider which runs Gapic code generation for Java.
  */
-public class JavaGapicLanguageProvider implements GapicLanguageProvider {
+public class JavaGapicLanguageProvider<InputElementT extends ProtoElement>
+    implements GapicLanguageProvider<InputElementT> {
 
   private final JavaGapicContext context;
   private final JavaLanguageProvider provider;
+  private InputElementView<InputElementT> view;
 
-  public JavaGapicLanguageProvider(Model model, ApiConfig apiConfig) {
+  public JavaGapicLanguageProvider(
+      Model model, ApiConfig apiConfig, InputElementView<InputElementT> view) {
     this.context = new JavaGapicContext(model, apiConfig);
     this.provider = new JavaLanguageProvider();
+    this.view = view;
   }
 
   @Override
@@ -53,18 +56,12 @@ public class JavaGapicLanguageProvider implements GapicLanguageProvider {
   }
 
   @Override
-  public GeneratedResult generateCode(Interface service, SnippetDescriptor snippetDescriptor) {
-    return provider.generate(
-        service, snippetDescriptor, context, context.getApiConfig().getPackageName() + ".");
+  public InputElementView<InputElementT> getView() {
+    return view;
   }
 
   @Override
-  public GeneratedResult generateFragments(Method method, SnippetDescriptor snippetDescriptor) {
-    return provider.generate(method, snippetDescriptor, context);
-  }
-
-  @Override
-  public GeneratedResult generateDoc(ProtoFile file, SnippetDescriptor descriptor) {
-    return null;
+  public GeneratedResult generate(InputElementT element, SnippetDescriptor snippetDescriptor) {
+    return provider.generate(element, snippetDescriptor, context);
   }
 }

--- a/vgen/src/main/java/io/gapi/vgen/php/PhpGapicLanguageProvider.java
+++ b/vgen/src/main/java/io/gapi/vgen/php/PhpGapicLanguageProvider.java
@@ -14,15 +14,14 @@
  */
 package io.gapi.vgen.php;
 
-import com.google.api.tools.framework.model.Interface;
-import com.google.api.tools.framework.model.Method;
 import com.google.api.tools.framework.model.Model;
-import com.google.api.tools.framework.model.ProtoFile;
+import com.google.api.tools.framework.model.ProtoElement;
 import com.google.common.collect.Multimap;
 
 import io.gapi.vgen.ApiConfig;
 import io.gapi.vgen.GapicLanguageProvider;
 import io.gapi.vgen.GeneratedResult;
+import io.gapi.vgen.InputElementView;
 import io.gapi.vgen.SnippetDescriptor;
 
 import java.io.IOException;
@@ -30,14 +29,18 @@ import java.io.IOException;
 /**
  * The LanguageProvider which runs Gapic code generation for PHP.
  */
-public class PhpGapicLanguageProvider implements GapicLanguageProvider {
+public class PhpGapicLanguageProvider<InputElementT extends ProtoElement>
+    implements GapicLanguageProvider<InputElementT> {
 
   private final PhpGapicContext context;
   private final PhpLanguageProvider provider;
+  private InputElementView<InputElementT> view;
 
-  public PhpGapicLanguageProvider(Model model, ApiConfig apiConfig) {
+  public PhpGapicLanguageProvider(
+      Model model, ApiConfig apiConfig, InputElementView<InputElementT> view) {
     this.context = new PhpGapicContext(model, apiConfig);
     this.provider = new PhpLanguageProvider();
+    this.view = view;
   }
 
   @Override
@@ -53,17 +56,12 @@ public class PhpGapicLanguageProvider implements GapicLanguageProvider {
   }
 
   @Override
-  public GeneratedResult generateDoc(ProtoFile file, SnippetDescriptor snippetDescriptor) {
-    return provider.generate(file, snippetDescriptor, context);
+  public GeneratedResult generate(InputElementT element, SnippetDescriptor snippetDescriptor) {
+    return provider.generate(element, snippetDescriptor, context);
   }
 
   @Override
-  public GeneratedResult generateCode(Interface service, SnippetDescriptor snippetDescriptor) {
-    return provider.generate(service, snippetDescriptor, context);
-  }
-
-  @Override
-  public GeneratedResult generateFragments(Method method, SnippetDescriptor snippetDescriptor) {
-    return provider.generate(method, snippetDescriptor, context);
+  public InputElementView<InputElementT> getView() {
+    return view;
   }
 }

--- a/vgen/src/main/java/io/gapi/vgen/py/PythonInputElementView.java
+++ b/vgen/src/main/java/io/gapi/vgen/py/PythonInputElementView.java
@@ -1,0 +1,29 @@
+/* Copyright 2016 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gapi.vgen.py;
+
+import com.google.api.tools.framework.model.ProtoElement;
+import com.google.common.collect.ImmutableMap;
+
+import io.gapi.vgen.InputElementView;
+
+public interface PythonInputElementView<InputElementT extends ProtoElement>
+    extends InputElementView<InputElementT> {
+  public PythonImportHandler getImportHandler(InputElementT t, PythonGapicContext context);
+
+  public ImmutableMap<String, Object> getGlobalMap(InputElementT element);
+
+  public String getPathPrefix(PythonGapicContext context);
+}

--- a/vgen/src/main/java/io/gapi/vgen/py/PythonInterfaceView.java
+++ b/vgen/src/main/java/io/gapi/vgen/py/PythonInterfaceView.java
@@ -1,0 +1,39 @@
+/* Copyright 2016 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gapi.vgen.py;
+
+import com.google.api.tools.framework.model.Interface;
+import com.google.common.collect.ImmutableMap;
+
+import io.gapi.vgen.InterfaceView;
+
+public class PythonInterfaceView extends InterfaceView
+    implements PythonInputElementView<Interface> {
+
+  @Override
+  public PythonImportHandler getImportHandler(Interface iface, PythonGapicContext context) {
+    return new PythonImportHandler(iface, context.getApiConfig().getInterfaceConfig(iface));
+  }
+
+  @Override
+  public ImmutableMap<String, Object> getGlobalMap(Interface iface) {
+    return ImmutableMap.of("pyproto", (Object) new PythonProtoElements());
+  }
+
+  @Override
+  public String getPathPrefix(PythonGapicContext context) {
+    return PythonProtoElements.packagePathPrefix(context);
+  }
+}

--- a/vgen/src/main/java/io/gapi/vgen/py/PythonProtoElements.java
+++ b/vgen/src/main/java/io/gapi/vgen/py/PythonProtoElements.java
@@ -16,6 +16,7 @@ package io.gapi.vgen.py;
 
 import com.google.api.tools.framework.model.MessageType;
 import com.google.api.tools.framework.model.ProtoElement;
+import com.google.common.base.Strings;
 
 public class PythonProtoElements {
   /**
@@ -55,5 +56,18 @@ public class PythonProtoElements {
       prefix = parent.getSimpleName() + "." + prefix;
     }
     return prefix;
+  }
+
+  /**
+   * Converts the dot-separated Python package name from the GAPIC config to a slash-separated
+   * directory structure.
+   */
+  public static String packagePathPrefix(PythonGapicContext context) {
+    String packageName = context.getApiConfig().getPackageName();
+    if (Strings.isNullOrEmpty(packageName)) {
+      return "";
+    } else {
+      return packageName.replace('.', '/') + "/";
+    }
   }
 }

--- a/vgen/src/main/java/io/gapi/vgen/py/PythonProtoFileView.java
+++ b/vgen/src/main/java/io/gapi/vgen/py/PythonProtoFileView.java
@@ -1,0 +1,39 @@
+/* Copyright 2016 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.gapi.vgen.py;
+
+import com.google.api.tools.framework.model.ProtoFile;
+import com.google.common.collect.ImmutableMap;
+
+import io.gapi.vgen.ProtoFileView;
+
+public class PythonProtoFileView extends ProtoFileView
+    implements PythonInputElementView<ProtoFile> {
+
+  @Override
+  public PythonImportHandler getImportHandler(ProtoFile file, PythonGapicContext context) {
+    return new PythonImportHandler(file);
+  }
+
+  @Override
+  public ImmutableMap<String, Object> getGlobalMap(ProtoFile file) {
+    return ImmutableMap.of("file", (Object) file);
+  }
+
+  @Override
+  public String getPathPrefix(PythonGapicContext context) {
+    return "";
+  }
+}

--- a/vgen/src/main/java/io/gapi/vgen/ruby/RubyGapicLanguageProvider.java
+++ b/vgen/src/main/java/io/gapi/vgen/ruby/RubyGapicLanguageProvider.java
@@ -14,16 +14,15 @@
  */
 package io.gapi.vgen.ruby;
 
-import com.google.api.tools.framework.model.Interface;
-import com.google.api.tools.framework.model.Method;
 import com.google.api.tools.framework.model.Model;
-import com.google.api.tools.framework.model.ProtoFile;
+import com.google.api.tools.framework.model.ProtoElement;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Multimap;
 
 import io.gapi.vgen.ApiConfig;
-import io.gapi.vgen.GeneratedResult;
 import io.gapi.vgen.GapicLanguageProvider;
+import io.gapi.vgen.GeneratedResult;
+import io.gapi.vgen.InputElementView;
 import io.gapi.vgen.SnippetDescriptor;
 
 import java.io.IOException;
@@ -32,14 +31,18 @@ import java.util.ArrayList;
 /**
  * The LanguageProvider which runs Gapic code generation for Ruby.
  */
-public class RubyGapicLanguageProvider implements GapicLanguageProvider {
+public class RubyGapicLanguageProvider<InputElementT extends ProtoElement>
+    implements GapicLanguageProvider<InputElementT> {
 
   private final RubyGapicContext context;
   private final RubyLanguageProvider provider;
+  private InputElementView<InputElementT> view;
 
-  public RubyGapicLanguageProvider(Model model, ApiConfig apiConfig) {
+  public RubyGapicLanguageProvider(
+      Model model, ApiConfig apiConfig, InputElementView<InputElementT> view) {
     this.context = new RubyGapicContext(model, apiConfig);
     this.provider = new RubyLanguageProvider();
+    this.view = view;
   }
 
   @Override
@@ -64,17 +67,12 @@ public class RubyGapicLanguageProvider implements GapicLanguageProvider {
   }
 
   @Override
-  public GeneratedResult generateDoc(ProtoFile file, SnippetDescriptor snippetDescriptor) {
-    return provider.generate(file, snippetDescriptor, context);
+  public GeneratedResult generate(InputElementT element, SnippetDescriptor snippetDescriptor) {
+    return provider.generate(element, snippetDescriptor, context);
   }
 
   @Override
-  public GeneratedResult generateCode(Interface service, SnippetDescriptor snippetDescriptor) {
-    return provider.generate(service, snippetDescriptor, context);
-  }
-
-  @Override
-  public GeneratedResult generateFragments(Method method, SnippetDescriptor snippetDescriptor) {
-    return provider.generate(method, snippetDescriptor, context);
+  public InputElementView<InputElementT> getView() {
+    return view;
   }
 }

--- a/vgen/src/main/proto/io/gapi/vgen/config.proto
+++ b/vgen/src/main/proto/io/gapi/vgen/config.proto
@@ -13,9 +13,13 @@ option java_package = "io.gapi.vgen";
 // Example of a YAML configuration:
 //
 //     type: io.gapi.vgen.ConfigProto
-//     language_provider: io.gapi.vgen.java.JavaLanguageProvider
-//     snippet_files: main.snip
-//     fragment_files: fragment.snip
+//     templates:
+//     - language_provider: io.gapi.vgen.java.JavaLanguageProvider
+//       input_element_view: io.gapi.vgen.InterfaceView
+//       snippet_files: main.snip
+//     - language_provider: io.gapi.vgen.java.JavaFragmentsLanguageProvider
+//       input_element_view: io.gapi.vgen.MethodView
+//       snippet_files: fragment.snip
 //     interfaces:
 //     - name: google.example.library.v1.LibraryService
 //       collections:
@@ -65,9 +69,31 @@ option java_package = "io.gapi.vgen";
 //       ...
 //     ...
 message ConfigProto {
+  repeated TemplateProto templates = 3;
+
+  // The settings of generated code in a specific language.
+  map<string, LanguageSettingsProto> language_settings = 4;
+
+  // The language of the generated code.
+  string language = 5;
+
+  // A list of API interface configurations.
+  repeated InterfaceConfigProto interfaces = 10;
+
+  // Whether or not we should generate code samples.
+  // This flag should go away as the feature matures.
+  bool generate_samples = 15;
+}
+
+message TemplateProto {
   // The fully qualified name of the Java class of the language
   // provider. Must be provided.
   string language_provider = 1;
+
+  // The fully qualified name of the Java class of the input element
+  // view. The given class must view elements of the type expected by
+  // `language_provider`. Must be provided.
+  string input_element_view = 3;
 
   // The snippet template files used for generation. Each file is used
   // to produce one output file. If the snippet file name is simple
@@ -76,30 +102,6 @@ message ConfigProto {
   // `/`, it is looked up in the file system. Defaults to a singleton
   // list with the entry `main.snip`.
   repeated string snippet_files = 2;
-
-  // The settings of generated code in a specific language.
-  map<string, LanguageSettingsProto> language_settings = 4;
-
-  // The language of the generated code.
-  string language = 5;
-
-  // The snippet template files used for fragment generation. Each file is used
-  // to produce one example snippet for each method. If the snippet file name is
-  // simple (does not contain a `/`), it is looked up as a resource relative to
-  // the package of the language provider class. If it contains a `/`, it is
-  // looked up in the file system.
-  repeated string fragment_files = 6;
-
-  // The snippet template files used for doc generation. Intended to generate
-  // proto docs in PythonLanguageProvider.
-  repeated string doc_snippet_files = 7;
-
-  // A list of API interface configurations.
-  repeated InterfaceConfigProto interfaces = 10;
-
-  // Whether or not we should generate code samples.
-  // This flag should go away as the feature matures.
-  bool generate_samples = 15;
 }
 
 message LanguageSettingsProto {

--- a/vgen/src/main/resources/io/gapi/vgen/csharp/csharp_gapic.yaml
+++ b/vgen/src/main/resources/io/gapi/vgen/csharp/csharp_gapic.yaml
@@ -1,5 +1,7 @@
 type: io.gapi.vgen.ConfigProto
 language: csharp
-language_provider: io.gapi.vgen.csharp.CSharpGapicLanguageProvider
-snippet_files:
-- wrapper.snip
+templates:
+- language_provider: io.gapi.vgen.csharp.CSharpGapicLanguageProvider
+  input_element_view: io.gapi.vgen.csharp.CSharpInterfaceView
+  snippet_files:
+  - wrapper.snip

--- a/vgen/src/main/resources/io/gapi/vgen/go/go_discovery_gapic.yaml
+++ b/vgen/src/main/resources/io/gapi/vgen/go/go_discovery_gapic.yaml
@@ -1,4 +1,7 @@
 type: io.gapi.vgen.ConfigProto
-language_provider: io.gapi.vgen.go.GoDiscoveryLanguageProvider
-fragment_files:
-- discovery_fragment.snip
+language: go
+templates:
+- language_provider: io.gapi.vgen.go.GoDiscoveryLanguageProvider
+  input_element_view: io.gapi.vgen.MethodView
+  snippet_files:
+  - discovery_fragment.snip

--- a/vgen/src/main/resources/io/gapi/vgen/go/go_gapic.yaml
+++ b/vgen/src/main/resources/io/gapi/vgen/go/go_gapic.yaml
@@ -1,6 +1,8 @@
 type: io.gapi.vgen.ConfigProto
 language: go
-language_provider: io.gapi.vgen.go.GoGapicLanguageProvider
-snippet_files:
-- main.snip
-- doc.snip
+templates:
+- language_provider: io.gapi.vgen.go.GoGapicLanguageProvider
+  input_element_view: io.gapi.vgen.InterfaceView
+  snippet_files:
+  - main.snip
+  - doc.snip

--- a/vgen/src/main/resources/io/gapi/vgen/java/java_discovery_gapic.yaml
+++ b/vgen/src/main/resources/io/gapi/vgen/java/java_discovery_gapic.yaml
@@ -1,4 +1,7 @@
 type: io.gapi.vgen.ConfigProto
-language_provider: io.gapi.vgen.java.JavaDiscoveryLanguageProvider
-fragment_files:
-- discovery_fragment.snip
+language: java
+templates:
+- language_provider: io.gapi.vgen.java.JavaDiscoveryLanguageProvider
+  input_element_view: io.gapi.vgen.MethodView
+  snippet_files:
+  - discovery_fragment.snip

--- a/vgen/src/main/resources/io/gapi/vgen/java/java_gapic_fragment.yaml
+++ b/vgen/src/main/resources/io/gapi/vgen/java/java_gapic_fragment.yaml
@@ -2,7 +2,6 @@ type: io.gapi.vgen.ConfigProto
 language: java
 templates:
 - language_provider: io.gapi.vgen.java.JavaGapicLanguageProvider
-  input_element_view: io.gapi.vgen.InterfaceView
+  input_element_view: io.gapi.vgen.MethodView
   snippet_files:
-  - main.snip
-  - settings.snip
+  - fragment.snip

--- a/vgen/src/main/resources/io/gapi/vgen/nodejs/nodejs_discovery_gapic.yaml
+++ b/vgen/src/main/resources/io/gapi/vgen/nodejs/nodejs_discovery_gapic.yaml
@@ -1,4 +1,7 @@
 type: io.gapi.vgen.ConfigProto
-language_provider: io.gapi.vgen.nodejs.NodeJSDiscoveryLanguageProvider
-fragment_files:
-- discovery_fragment.snip
+language: nodejs
+templates:
+- language_provider: io.gapi.vgen.nodejs.NodeJSDiscoveryLanguageProvider
+  input_element_view: io.gapi.vgen.InterfaceView
+  snippet_files:
+  - discovery_fragment.snip

--- a/vgen/src/main/resources/io/gapi/vgen/php/php_discovery_gapic.yaml
+++ b/vgen/src/main/resources/io/gapi/vgen/php/php_discovery_gapic.yaml
@@ -1,4 +1,7 @@
 type: io.gapi.vgen.ConfigProto
-language_provider: io.gapi.vgen.php.PhpDiscoveryLanguageProvider
-fragment_files:
-- discovery_fragment.snip
+language: php
+templates:
+- language_provider: io.gapi.vgen.php.PhpDiscoveryLanguageProvider
+  input_element_view: io.gapi.vgen.MethodView
+  snippet_files:
+  - discovery_fragment.snip

--- a/vgen/src/main/resources/io/gapi/vgen/php/php_gapic.yaml
+++ b/vgen/src/main/resources/io/gapi/vgen/php/php_gapic.yaml
@@ -1,5 +1,7 @@
 type: io.gapi.vgen.ConfigProto
 language: php
-language_provider: io.gapi.vgen.php.PhpGapicLanguageProvider
-snippet_files:
-- main.snip
+templates:
+- language_provider: io.gapi.vgen.php.PhpGapicLanguageProvider
+  input_element_view: io.gapi.vgen.InterfaceView
+  snippet_files:
+  - main.snip

--- a/vgen/src/main/resources/io/gapi/vgen/py/python_gapic.yaml
+++ b/vgen/src/main/resources/io/gapi/vgen/py/python_gapic.yaml
@@ -1,7 +1,11 @@
 type: io.gapi.vgen.ConfigProto
 language: python
-language_provider: io.gapi.vgen.py.PythonGapicLanguageProvider
-snippet_files:
-- main.snip
-doc_snippet_files:
-- message.snip
+templates:
+- language_provider: io.gapi.vgen.py.PythonGapicLanguageProvider
+  input_element_view: io.gapi.vgen.py.PythonInterfaceView
+  snippet_files:
+  - main.snip
+- language_provider: io.gapi.vgen.py.PythonGapicLanguageProvider
+  input_element_view: io.gapi.vgen.py.PythonProtoFileView
+  snippet_files:
+  - message.snip

--- a/vgen/src/main/resources/io/gapi/vgen/ruby/ruby_gapic.yaml
+++ b/vgen/src/main/resources/io/gapi/vgen/ruby/ruby_gapic.yaml
@@ -1,7 +1,11 @@
 type: io.gapi.vgen.ConfigProto
 language: ruby
-language_provider: io.gapi.vgen.ruby.RubyGapicLanguageProvider
-snippet_files:
-- main.snip
-doc_snippet_files:
-- message.snip
+templates:
+- language_provider: io.gapi.vgen.ruby.RubyGapicLanguageProvider
+  input_element_view: io.gapi.vgen.InterfaceView
+  snippet_files:
+  - main.snip
+- language_provider: io.gapi.vgen.ruby.RubyGapicLanguageProvider
+  input_element_view: io.gapi.vgen.ProtoFileView
+  snippet_files:
+  - message.snip

--- a/vgen/src/test/java/io/gapi/vgen/CSharpCodeGeneratorTest.java
+++ b/vgen/src/test/java/io/gapi/vgen/CSharpCodeGeneratorTest.java
@@ -29,8 +29,13 @@ import java.util.List;
 @RunWith(Parameterized.class)
 public class CSharpCodeGeneratorTest extends CodeGeneratorTestBase {
 
-  public CSharpCodeGeneratorTest(String name, String[] gapicConfigFileNames, String snippetName) {
-    super(name, gapicConfigFileNames, snippetName);
+  public CSharpCodeGeneratorTest(
+      String name,
+      String[] gapicConfigFileNames,
+      String providerName,
+      String viewName,
+      String snippetName) {
+    super(name, gapicConfigFileNames, providerName, viewName, snippetName);
     getTestDataLocator().addTestDataSource(io.gapi.vgen.csharp.CSharpGapicContext.class, "");
   }
 
@@ -46,7 +51,11 @@ public class CSharpCodeGeneratorTest extends CodeGeneratorTestBase {
     // append to list values.)
     return ImmutableList.of(
         new Object[] {
-          "csharp_wrapper", new String[] {"library_gapic.yaml", "csharp_gapic.yaml"}, "wrapper.snip"
+          "csharp_wrapper",
+          new String[] {"library_gapic.yaml", "csharp_gapic.yaml"},
+          "io.gapi.vgen.csharp.CSharpGapicLanguageProvider",
+          "io.gapi.vgen.csharp.CSharpInterfaceView",
+          "wrapper.snip"
         });
   }
 

--- a/vgen/src/test/java/io/gapi/vgen/DiscoveryFragmentGeneratorTestBase.java
+++ b/vgen/src/test/java/io/gapi/vgen/DiscoveryFragmentGeneratorTestBase.java
@@ -35,7 +35,7 @@ public abstract class DiscoveryFragmentGeneratorTestBase extends DiscoveryGenera
 
   @Override
   protected Object run() {
-    String snippetInputName = config.getFragmentFilesList().get(0);
+    String snippetInputName = config.getTemplates(0).getSnippetFiles(0);
     SnippetDescriptor resourceDescriptor = new SnippetDescriptor(snippetInputName);
     Map<Method, GeneratedResult> result =
         DiscoveryFragmentGenerator.create(config, discoveryImporter)

--- a/vgen/src/test/java/io/gapi/vgen/DiscoveryGeneratorTestBase.java
+++ b/vgen/src/test/java/io/gapi/vgen/DiscoveryGeneratorTestBase.java
@@ -31,7 +31,6 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -47,21 +46,27 @@ public abstract class DiscoveryGeneratorTestBase extends ConfigBaselineTestCase 
   private final String name;
   private final String discoveryDocFileName;
   private final String[] gapicConfigFileNames;
+  private final String gapicLanguageProviderName;
   private final String snippetName;
   protected ConfigProto config;
   protected DiscoveryImporter discoveryImporter;
 
   public DiscoveryGeneratorTestBase(
-      String name, String discoveryDocFileName, String[] gapicConfigFileNames, String snippetName) {
+      String name,
+      String discoveryDocFileName,
+      String[] gapicConfigFileNames,
+      String gapicLanguageProviderName,
+      String snippetName) {
     this.name = name;
     this.discoveryDocFileName = discoveryDocFileName;
     this.gapicConfigFileNames = gapicConfigFileNames;
+    this.gapicLanguageProviderName = gapicLanguageProviderName;
     this.snippetName = snippetName;
   }
 
   public DiscoveryGeneratorTestBase(
       String name, String discoveryDocFileName, String[] gapicConfigFileNames) {
-    this(name, discoveryDocFileName, gapicConfigFileNames, null);
+    this(name, discoveryDocFileName, gapicConfigFileNames, null, null);
   }
 
   protected void setupDiscovery() {
@@ -138,10 +143,15 @@ public abstract class DiscoveryGeneratorTestBase extends ConfigBaselineTestCase 
       return null;
     }
 
-    if (snippetName != null) {
+    // TODO: this has exactly the same pattern as GeneratorTestBase; opportunity to refactor
+    if (gapicLanguageProviderName != null && snippetName != null) {
       // Filtering can be made more sophisticated later if required
-      configProto =
-          configProto.toBuilder().clearSnippetFiles().addSnippetFiles(snippetName).build();
+      TemplateProto template =
+          TemplateProto.newBuilder()
+              .setLanguageProvider(gapicLanguageProviderName)
+              .addSnippetFiles(snippetName)
+              .build();
+      configProto = configProto.toBuilder().clearTemplates().addTemplates(template).build();
     }
 
     return configProto;

--- a/vgen/src/test/java/io/gapi/vgen/FragmentGeneratorTestBase.java
+++ b/vgen/src/test/java/io/gapi/vgen/FragmentGeneratorTestBase.java
@@ -15,7 +15,7 @@
 package io.gapi.vgen;
 
 import com.google.api.tools.framework.model.Diag;
-import com.google.api.tools.framework.model.Method;
+import com.google.api.tools.framework.model.ProtoElement;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -34,12 +34,11 @@ public abstract class FragmentGeneratorTestBase extends GeneratorTestBase {
 
   @Override
   protected Object run() {
-    GapicLanguageProvider languageProvider =
-        GeneratorBuilderUtil.createLanguageProvider(config, model);
-    String snippetInputName = config.getFragmentFilesList().get(0);
+    TemplateProto template = config.getTemplates(0);
+    CodeGenerator generator = CodeGenerator.create(config, template, model);
+    String snippetInputName = template.getSnippetFiles(0);
     SnippetDescriptor resourceDescriptor = new SnippetDescriptor(snippetInputName);
-    Map<Method, GeneratedResult> result =
-        FragmentGenerator.create(languageProvider).generateFragments(resourceDescriptor);
+    Map<ProtoElement, GeneratedResult> result = generator.generate(resourceDescriptor);
     if (result == null) {
       // Report diagnosis to baseline file.
       for (Diag diag : model.getDiags()) {

--- a/vgen/src/test/java/io/gapi/vgen/GeneratorTestBase.java
+++ b/vgen/src/test/java/io/gapi/vgen/GeneratorTestBase.java
@@ -40,17 +40,26 @@ public abstract class GeneratorTestBase extends ConfigBaselineTestCase {
 
   private final String name;
   private final String[] gapicConfigFileNames;
+  private final String gapicLanguageProviderName;
   private final String snippetName;
+  private String viewName;
   protected ConfigProto config;
 
-  public GeneratorTestBase(String name, String[] gapicConfigFileNames, String snippetName) {
+  public GeneratorTestBase(
+      String name,
+      String[] gapicConfigFileNames,
+      String gapicLanguageProviderName,
+      String viewName,
+      String snippetName) {
     this.name = name;
     this.gapicConfigFileNames = gapicConfigFileNames;
+    this.gapicLanguageProviderName = gapicLanguageProviderName;
+    this.viewName = viewName;
     this.snippetName = snippetName;
   }
 
   public GeneratorTestBase(String name, String[] gapicConfigFileNames) {
-    this(name, gapicConfigFileNames, null);
+    this(name, gapicConfigFileNames, null, null, null);
   }
 
   @Override
@@ -105,10 +114,15 @@ public abstract class GeneratorTestBase extends ConfigBaselineTestCase {
     ConfigProto configProto =
         (ConfigProto) MultiYamlReader.read(model, inputNames, inputs, supportedConfigTypes);
 
-    if (snippetName != null) {
+    if (gapicLanguageProviderName != null && snippetName != null && viewName != null) {
       // Filtering can be made more sophisticated later if required
-      configProto =
-          configProto.toBuilder().clearSnippetFiles().addSnippetFiles(snippetName).build();
+      TemplateProto template =
+          TemplateProto.newBuilder()
+              .setLanguageProvider(gapicLanguageProviderName)
+              .setInputElementView(viewName)
+              .addSnippetFiles(snippetName)
+              .build();
+      configProto = configProto.toBuilder().clearTemplates().addTemplates(template).build();
     }
 
     return configProto;

--- a/vgen/src/test/java/io/gapi/vgen/GoCodeGeneratorTest.java
+++ b/vgen/src/test/java/io/gapi/vgen/GoCodeGeneratorTest.java
@@ -14,6 +14,7 @@
  */
 package io.gapi.vgen;
 
+import com.google.api.tools.framework.snippet.Doc;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.truth.Truth;
@@ -54,13 +55,19 @@ public class GoCodeGeneratorTest extends CodeGeneratorTestBase {
   protected Object run() {
     // GoLanguageGenerator should generate two files -- one for the class, and
     // the other for "doc.go" which holds package doc.
-    GeneratedResult codeResult = generateForSnippet(0);
-    GeneratedResult docResult = generateForSnippet(1);
+    List<GeneratedResult> codeResult = generateForTemplate(0, 0);
+    List<GeneratedResult> docsResult = generateForTemplate(0, 1);
     Truth.assertThat(codeResult).isNotNull();
-    Truth.assertThat(docResult).isNotNull();
-    return ImmutableMap.of(
-        codeResult.getFilename(), codeResult.getDoc(),
-        docResult.getFilename(), docResult.getDoc());
+    Truth.assertThat(docsResult).isNotNull();
+
+    ImmutableMap.Builder<String, Doc> builder = new ImmutableMap.Builder<String, Doc>();
+    for (GeneratedResult result : codeResult) {
+      builder.put(result.getFilename(), result.getDoc());
+    }
+    for (GeneratedResult result : docsResult) {
+      builder.put(result.getFilename(), result.getDoc());
+    }
+    return builder.build();
   }
 
   // Tests

--- a/vgen/src/test/java/io/gapi/vgen/JavaCodeGeneratorTest.java
+++ b/vgen/src/test/java/io/gapi/vgen/JavaCodeGeneratorTest.java
@@ -29,8 +29,13 @@ import java.util.List;
 @RunWith(Parameterized.class)
 public class JavaCodeGeneratorTest extends CodeGeneratorTestBase {
 
-  public JavaCodeGeneratorTest(String name, String[] gapicConfigFileNames, String snippetName) {
-    super(name, gapicConfigFileNames, snippetName);
+  public JavaCodeGeneratorTest(
+      String name,
+      String[] gapicConfigFileNames,
+      String providerName,
+      String viewName,
+      String snippetName) {
+    super(name, gapicConfigFileNames, providerName, viewName, snippetName);
     getTestDataLocator().addTestDataSource(io.gapi.vgen.java.JavaGapicContext.class, "");
   }
 
@@ -42,10 +47,18 @@ public class JavaCodeGeneratorTest extends CodeGeneratorTestBase {
   public static List<Object[]> testedConfigs() {
     return ImmutableList.of(
         new Object[] {
-          "java_main", new String[] {"java_gapic.yaml", "library_gapic.yaml"}, "main.snip"
+          "java_main",
+          new String[] {"java_gapic.yaml", "library_gapic.yaml"},
+          "io.gapi.vgen.java.JavaGapicLanguageProvider",
+          "io.gapi.vgen.InterfaceView",
+          "main.snip"
         },
         new Object[] {
-          "java_settings", new String[] {"java_gapic.yaml", "library_gapic.yaml"}, "settings.snip"
+          "java_settings",
+          new String[] {"java_gapic.yaml", "library_gapic.yaml"},
+          "io.gapi.vgen.java.JavaGapicLanguageProvider",
+          "io.gapi.vgen.InterfaceView",
+          "settings.snip"
         });
   }
 

--- a/vgen/src/test/java/io/gapi/vgen/JavaFragmentGeneratorTest.java
+++ b/vgen/src/test/java/io/gapi/vgen/JavaFragmentGeneratorTest.java
@@ -43,7 +43,7 @@ public class JavaFragmentGeneratorTest extends FragmentGeneratorTestBase {
         new Object[] {
           "java_fragments",
           new String[] {
-            "io/gapi/vgen/java/java_gapic.yaml", "library_gapic.yaml",
+            "io/gapi/vgen/java/java_gapic_fragment.yaml", "library_gapic.yaml",
           }
         });
   }

--- a/vgen/src/test/java/io/gapi/vgen/PythonCodeGeneratorTest.java
+++ b/vgen/src/test/java/io/gapi/vgen/PythonCodeGeneratorTest.java
@@ -53,13 +53,16 @@ public class PythonCodeGeneratorTest {
     @Override
     protected Object run() {
       // Should generate one file for the class, and a list of files for the protos
-      GeneratedResult codeResult = generateForSnippet(0);
-      List<GeneratedResult> docsResult = generateForDocSnippet(0);
+      List<GeneratedResult> codeResult = generateForTemplate(0, 0);
+      List<GeneratedResult> docsResult = generateForTemplate(1, 0);
+
       Truth.assertThat(codeResult).isNotNull();
       Truth.assertThat(docsResult).isNotNull();
 
       ImmutableMap.Builder<String, Doc> builder = new ImmutableMap.Builder<String, Doc>();
-      builder.put(codeResult.getFilename(), codeResult.getDoc());
+      for (GeneratedResult result : codeResult) {
+        builder.put(result.getFilename(), result.getDoc());
+      }
       for (GeneratedResult result : docsResult) {
         builder.put(result.getFilename(), result.getDoc());
       }
@@ -97,13 +100,15 @@ public class PythonCodeGeneratorTest {
 
     @Override
     protected Object run() {
-      GeneratedResult codeResult = generateForSnippet(0);
-      List<GeneratedResult> docsResult = generateForDocSnippet(0);
+      List<GeneratedResult> codeResult = generateForTemplate(0, 0);
+      List<GeneratedResult> docsResult = generateForTemplate(1, 0);
       Truth.assertThat(codeResult).isNotNull();
       Truth.assertThat(docsResult).isNotNull();
 
       ImmutableMap.Builder<String, Doc> builder = new ImmutableMap.Builder<String, Doc>();
-      builder.put(codeResult.getFilename(), codeResult.getDoc());
+      for (GeneratedResult result : codeResult) {
+        builder.put(result.getFilename(), result.getDoc());
+      }
       for (GeneratedResult result : docsResult) {
         builder.put(result.getFilename(), result.getDoc());
       }

--- a/vgen/src/test/java/io/gapi/vgen/RubyCodeGeneratorTest.java
+++ b/vgen/src/test/java/io/gapi/vgen/RubyCodeGeneratorTest.java
@@ -54,13 +54,15 @@ public class RubyCodeGeneratorTest extends CodeGeneratorTestBase {
   @Override
   protected Object run() {
     // Should generate one file for the class, and a list of files for the protos
-    GeneratedResult codeResult = generateForSnippet(0);
-    List<GeneratedResult> docsResult = generateForDocSnippet(0);
+    List<GeneratedResult> codeResult = generateForTemplate(0, 0);
+    List<GeneratedResult> docsResult = generateForTemplate(1, 0);
     Truth.assertThat(codeResult).isNotNull();
     Truth.assertThat(docsResult).isNotNull();
 
     ImmutableMap.Builder<String, Doc> builder = new ImmutableMap.Builder<String, Doc>();
-    builder.put(codeResult.getFilename(), codeResult.getDoc());
+    for (GeneratedResult result : codeResult) {
+      builder.put(result.getFilename(), result.getDoc());
+    }
     for (GeneratedResult result : docsResult) {
       builder.put(result.getFilename(), result.getDoc());
     }


### PR DESCRIPTION
Each language provider instance now represents a single template
(i.e. code, doc, or fragment) for a given language. It has an internal
strategy object (*Viewing) to encapsulate template-specific generation
details. The structure of the language provider is simplified to have
a single generate method, corresponding to the generation of a single
template.

The structure of the GAPIC config YAML files has changed to push the
snippet definitions down to a per-template level, to avoid the
explosion of keys for various types of snippet files.

Pre-push hook installed.

Change-Id: Id682441e1b8a3f3209974e0d3ee3642d5a6ce610