### PR TITLE
[discovery] Configuration not found should be an error

### DIFF
--- a/vgen/src/main/java/io/gapi/vgen/DiscoveryFragmentGeneratorApi.java
+++ b/vgen/src/main/java/io/gapi/vgen/DiscoveryFragmentGeneratorApi.java
@@ -141,8 +141,8 @@ public class DiscoveryFragmentGeneratorApi {
     for (String configFileName : configFileNames) {
       File file = findDataFile(configFileName);
       if (file == null) {
-        error("Cannot find configuration file '%s'.", configFileName);
-        continue;
+        throw new IllegalArgumentException(
+            String.format("Cannot find configuration file '%s'.", configFileName));
       }
       files.add(file);
     }


### PR DESCRIPTION
Previously when we cannot read from the configuration file,
an error message is printed to stderr and we keep going.
This commit changes this behavior so we will just fail out.