### PR TITLE
Unflake verifyLicense

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -339,7 +339,7 @@ task runDiscoGen(type: JavaExec) {
 }
 
 task verifyLicense << {
-  def licenseText = new File(System.getProperty('user.dir'), 'license-header-javadoc.txt').text
+  def licenseText = new File(rootProject.rootDir, 'license-header-javadoc.txt').text
   def srcFiles = []
   sourceSets
       .collectMany{it.allJava.getSrcDirs()}


### PR DESCRIPTION
Previously verifyLicense looks for license-header-javadoc.txt by
looking in the process's working directory. This will most likely
work if the build is manually run.
When run by other programs such as an IDE, the working directory might
be different, causing the check to fail.

This commit looks for the license header within the project's root
directory instead. This should work generally.