### PR TITLE
Refactor Ruby/Python Comment fixers

### DIFF
--- a/src/main/java/com/google/api/codegen/CommentPatterns.java
+++ b/src/main/java/com/google/api/codegen/CommentPatterns.java
@@ -1,0 +1,31 @@
+/* Copyright 2016 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen;
+
+import java.util.regex.Pattern;
+
+/**
+ * Collects common regular expressions for formatting source comments to follow language-idiomatic
+ * style.
+ */
+public final class CommentPatterns {
+  public static final Pattern BACK_QUOTE_PATTERN = Pattern.compile("(?<!`)``?(?!`)");
+  public static final Pattern ABSOLUTE_LINK_PATTERN =
+      Pattern.compile("\\[([^\\]]+)\\]\\((\\p{Alpha}+:[^\\)]+)\\)");
+  public static final Pattern CLOUD_LINK_PATTERN =
+      Pattern.compile("\\[([^\\]]+)\\]\\(((?!\\p{Alpha}+:)[^\\)]+)\\)");
+  public static final Pattern PROTO_LINK_PATTERN = Pattern.compile("\\[([^\\]]+)\\]\\[[^\\]]*\\]");
+  public static final Pattern HEADLINE_PATTERN = Pattern.compile("^#+", Pattern.MULTILINE);
+}

--- a/src/main/java/com/google/api/codegen/py/PythonSphinxCommentFixer.java
+++ b/src/main/java/com/google/api/codegen/py/PythonSphinxCommentFixer.java
@@ -14,25 +14,22 @@
  */
 package com.google.api.codegen.py;
 
+import com.google.api.codegen.CommentPatterns;
+
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * Utility class for formatting python comments to follow Sphinx style.
  */
 public class PythonSphinxCommentFixer {
 
-  private static final Pattern SINGLE_BACK_QUOTE_PATTERN = Pattern.compile("(?<!`)`(?!`)");
-  private static final Pattern CLOUD_LINK_PATTERN =
-      Pattern.compile("\\[([^\\]]+)\\]\\(([^\\)]+)\\)");
-  private static final Pattern PROTO_LINK_PATTERN = Pattern.compile("\\[([^\\]]+)\\]\\[[^\\]]+\\]");
-
   /**
    * Returns a Sphinx-formatted comment string.
    */
   public static String sphinxify(String comment) {
-    comment = SINGLE_BACK_QUOTE_PATTERN.matcher(comment).replaceAll("``");
+    comment = CommentPatterns.BACK_QUOTE_PATTERN.matcher(comment).replaceAll("``");
     comment = sphinxifyProtoMarkdownLinks(comment);
+    comment = sphinxifyAbsoluteMarkdownLinks(comment);
     return sphinxifyCloudMarkdownLinks(comment);
   }
 
@@ -41,7 +38,7 @@ public class PythonSphinxCommentFixer {
    */
   private static String sphinxifyProtoMarkdownLinks(String comment) {
     StringBuffer sb = new StringBuffer();
-    Matcher m = PROTO_LINK_PATTERN.matcher(comment);
+    Matcher m = CommentPatterns.PROTO_LINK_PATTERN.matcher(comment);
     if (!m.find()) {
       return comment;
     }
@@ -53,11 +50,27 @@ public class PythonSphinxCommentFixer {
   }
 
   /**
+   * Returns a string with all absolute markdown links formatted to Sphinx style.
+   */
+  private static String sphinxifyAbsoluteMarkdownLinks(String comment) {
+    StringBuffer sb = new StringBuffer();
+    Matcher m = CommentPatterns.ABSOLUTE_LINK_PATTERN.matcher(comment);
+    if (!m.find()) {
+      return comment;
+    }
+    do {
+      m.appendReplacement(sb, String.format("`%s <%s>`_", m.group(1), m.group(2)));
+    } while (m.find());
+    m.appendTail(sb);
+    return sb.toString();
+  }
+
+  /**
    * Returns a string with all cloud markdown links formatted to Sphinx style.
    */
   private static String sphinxifyCloudMarkdownLinks(String comment) {
     StringBuffer sb = new StringBuffer();
-    Matcher m = CLOUD_LINK_PATTERN.matcher(comment);
+    Matcher m = CommentPatterns.CLOUD_LINK_PATTERN.matcher(comment);
     if (!m.find()) {
       return comment;
     }

--- a/src/test/java/com/google/api/codegen/testdata/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_library.baseline
@@ -44,6 +44,7 @@
 //   resources, named `shelves/*/books/*`
 //
 // Check out [cloud docs!](/library/example/link).
+// This is [not a cloud link](http://www.google.com).
 package library_service
 
 import (

--- a/src/test/java/com/google/api/codegen/testdata/java_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_main_library.baseline
@@ -82,6 +82,7 @@ import java.util.concurrent.ScheduledExecutorService;
  *   resources, named `shelves/&ast;/books/&ast;`
  *
  * Check out [cloud docs!](/library/example/link).
+ * This is [not a cloud link](http://www.google.com).
  *
  * <p>This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods. Sample code to get started:

--- a/src/test/java/com/google/api/codegen/testdata/library.proto
+++ b/src/test/java/com/google/api/codegen/testdata/library.proto
@@ -31,6 +31,7 @@ option java_package = "com.google.example.library.v1";
 //   resources, named `shelves/*/books/*`
 //
 // Check out [cloud docs!](/library/example/link).
+// This is [not a cloud link](http://www.google.com).
 //
 service LibraryService {
 

--- a/src/test/java/com/google/api/codegen/testdata/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_library.baseline
@@ -58,6 +58,7 @@ class LibraryServiceApi(object):
       resources, named ``shelves/*/books/*``
 
     Check out `cloud docs! <https://cloud.google.com/library/example/link>`_.
+    This is `not a cloud link <http://www.google.com>`_.
     """
 
     SERVICE_ADDRESS = 'library-example.googleapis.com'

--- a/src/test/java/com/google/api/codegen/testdata/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_library.baseline
@@ -44,6 +44,7 @@ module Google
         #   resources, named +shelves/*/books/*+
         #
         # Check out {cloud docs!}[https://cloud.google.com/library/example/link].
+        # This is {not a cloud link}[http://www.google.com].
         class LibraryServiceApi
           # The default address of the service.
           SERVICE_ADDRESS = 'library-example.googleapis.com'.freeze


### PR DESCRIPTION
Ruby and Python use similar regular expressions to make proto
comments idiomatic. Factor these regexes out into a utility class.