### PR TITLE
Sphinxify all Python comments

### DIFF
--- a/src/main/java/com/google/api/codegen/py/PythonGapicContext.java
+++ b/src/main/java/com/google/api/codegen/py/PythonGapicContext.java
@@ -103,8 +103,7 @@ public class PythonGapicContext extends GapicContext {
     if (!element.hasAttribute(ElementDocumentationAttribute.KEY)) {
       return ImmutableList.<String>of("");
     }
-    return pythonCommon.convertToCommentedBlock(
-        PythonSphinxCommentFixer.sphinxify(DocumentationUtil.getScopedDescription(element)));
+    return pythonCommon.convertToCommentedBlock(getSphinxifiedScopedDescription(element));
   }
 
   /**
@@ -154,7 +153,7 @@ public class PythonGapicContext extends GapicContext {
     String comment =
         String.format(
             "  %s (%s)", field.getSimpleName(), fieldTypeCardinalityComment(field, importHandler));
-    String paramComment = DocumentationUtil.getScopedDescription(field);
+    String paramComment = getSphinxifiedScopedDescription(field);
     if (!Strings.isNullOrEmpty(paramComment)) {
       if (paramComment.charAt(paramComment.length() - 1) == '\n') {
         paramComment = paramComment.substring(0, paramComment.length() - 1);
@@ -179,7 +178,7 @@ public class PythonGapicContext extends GapicContext {
     // Generate comment contents
     StringBuilder contentBuilder = new StringBuilder();
     if (msg.hasAttribute(ElementDocumentationAttribute.KEY)) {
-      contentBuilder.append(DocumentationUtil.getScopedDescription(msg));
+      contentBuilder.append(getSphinxifiedScopedDescription(msg));
       if (!Strings.isNullOrEmpty(paramTypes)) {
         contentBuilder.append("\n\n");
       }
@@ -238,8 +237,7 @@ public class PythonGapicContext extends GapicContext {
     // Generate comment contents
     StringBuilder contentBuilder = new StringBuilder();
     if (msg.hasAttribute(ElementDocumentationAttribute.KEY)) {
-      String sphinxified =
-          PythonSphinxCommentFixer.sphinxify(DocumentationUtil.getScopedDescription(msg));
+      String sphinxified = getSphinxifiedScopedDescription(msg);
       sphinxified = sphinxified.trim();
       contentBuilder.append(sphinxified.replaceAll("\\s*\\n\\s*", "\n"));
       if (!Strings.isNullOrEmpty(paramTypes)) {
@@ -295,5 +293,9 @@ public class PythonGapicContext extends GapicContext {
       default:
         return false;
     }
+  }
+
+  private String getSphinxifiedScopedDescription(ProtoElement element) {
+    return PythonSphinxCommentFixer.sphinxify(DocumentationUtil.getScopedDescription(element));
   }
 }

--- a/src/test/java/com/google/api/codegen/testdata/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_library.baseline
@@ -616,15 +616,15 @@ class FieldMask(object):
 
 class Any(object):
     """
-    `Any` contains an arbitrary serialized message along with a URL
+    ``Any`` contains an arbitrary serialized message along with a URL
     that describes the type of the serialized message.
 
 
     # JSON
 
-    The JSON representation of an `Any` value uses the regular
+    The JSON representation of an ``Any`` value uses the regular
     representation of the deserialized, embedded message, with an
-    additional field `@type` which contains the type URL. Example:
+    additional field ``@type`` which contains the type URL. Example:
 
         package google.profile;
         message Person {
@@ -640,8 +640,8 @@ class Any(object):
 
     If the embedded message type is well-known and has a custom JSON
     representation, that representation will be embedded adding a field
-    `value` which holds the custom JSON in addition to the `@type`
-    field. Example (for message [google.protobuf.Duration][google.protobuf.Duration]):
+    ``value`` which holds the custom JSON in addition to the ``@type``
+    field. Example (for message ``google.protobuf.Duration``):
 
         {
           "@type": "type.googleapis.com/google.protobuf.Duration",
@@ -652,13 +652,13 @@ class Any(object):
       type_url (string): A URL/resource name whose content describes the type of the
         serialized message.
 
-        For URLs which use the schema `http`, `https`, or no schema, the
+        For URLs which use the schema ``http``, ``https``, or no schema, the
         following restrictions and interpretations apply:
 
-        * If no schema is provided, `https` is assumed.
+        * If no schema is provided, ``https`` is assumed.
         * The last segment of the URL's path must represent the fully
-          qualified name of the type (as in `path/google.protobuf.Duration`).
-        * An HTTP GET on the URL must yield a [google.protobuf.Type][]
+          qualified name of the type (as in ``path/google.protobuf.Duration``).
+        * An HTTP GET on the URL must yield a ``google.protobuf.Type``
           value in binary format, or produce an error.
         * Applications are allowed to cache lookup results based on the
           URL, or have them precompiled into a binary to avoid any
@@ -666,7 +666,7 @@ class Any(object):
           on changes to types. (Use versioned type names to manage
           breaking changes.)
 
-        Schemas other than `http`, `https` (or the empty schema) might be
+        Schemas other than ``http``, ``https`` (or the empty schema) might be
         used with implementation specific semantics.
       value (bytes): Must be valid serialized data of the above specified type.
 
@@ -737,9 +737,9 @@ class Duration(object):
         to +315,576,000,000 inclusive.
       nanos (int32): Signed fractions of a second at nanosecond resolution of the span
         of time. Durations less than one second are represented with a 0
-        `seconds` field and a positive or negative `nanos` field. For durations
-        of one second or more, a non-zero value for the `nanos` field must be
-        of the same sign as the `seconds` field. Must be from -999,999,999
+        ``seconds`` field and a positive or negative ``nanos`` field. For durations
+        of one second or more, a non-zero value for the ``nanos`` field must be
+        of the same sign as the ``seconds`` field. Must be from -999,999,999
         to +999,999,999 inclusive.
 
     """
@@ -763,14 +763,14 @@ class Duration(object):
 
 class FieldMask(object):
     """
-    `FieldMask` represents a set of symbolic field paths, for example:
+    ``FieldMask`` represents a set of symbolic field paths, for example:
 
         paths: "f.a"
         paths: "f.b.d"
 
-    Here `f` represents a field in some root message, `a` and `b`
-    fields in the message found in `f`, and `d` a field found in the
-    message in `f.b`.
+    Here ``f`` represents a field in some root message, ``a`` and ``b``
+    fields in the message found in ``f``, and ``d`` a field found in the
+    message in ``f.b``.
 
     Field masks are used to specify a subset of fields that should be
     returned by a get operation or modified by an update operation.
@@ -873,7 +873,7 @@ class FieldMask(object):
           string address = 2;
         }
 
-    In proto a field mask for `Profile` may look as such:
+    In proto a field mask for ``Profile`` may look as such:
 
         mask {
           paths: "user.display_name"
@@ -920,15 +920,15 @@ class Timestamp(object):
     0001-01-01T00:00:00Z to 9999-12-31T23:59:59.999999999Z.
     By restricting to that range, we ensure that we can convert to
     and from  RFC 3339 date strings.
-    See [https://www.ietf.org/rfc/rfc3339.txt](https://www.ietf.org/rfc/rfc3339.txt).
+    See `https://www.ietf.org/rfc/rfc3339.txt <https://www.ietf.org/rfc/rfc3339.txt>`_.
 
-    Example 1: Compute Timestamp from POSIX `time()`.
+    Example 1: Compute Timestamp from POSIX ``time()``.
 
         Timestamp timestamp;
         timestamp.set_seconds(time(NULL));
         timestamp.set_nanos(0);
 
-    Example 2: Compute Timestamp from POSIX `gettimeofday()`.
+    Example 2: Compute Timestamp from POSIX ``gettimeofday()``.
 
         struct timeval tv;
         gettimeofday(&tv, NULL);
@@ -937,7 +937,7 @@ class Timestamp(object):
         timestamp.set_seconds(tv.tv_sec);
         timestamp.set_nanos(tv.tv_usec * 1000);
 
-    Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
+    Example 3: Compute Timestamp from Win32 ``GetSystemTimeAsFileTime()``.
 
         FILETIME ft;
         GetSystemTimeAsFileTime(&ft);
@@ -949,7 +949,7 @@ class Timestamp(object):
         timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
         timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
 
-    Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
+    Example 4: Compute Timestamp from Java ``System.currentTimeMillis()``.
 
         long millis = System.currentTimeMillis();
 
@@ -994,9 +994,9 @@ class Timestamp(object):
 
 class DoubleValue(object):
     """
-    Wrapper message for `double`.
+    Wrapper message for ``double``.
 
-    The JSON representation for `DoubleValue` is JSON number.
+    The JSON representation for ``DoubleValue`` is JSON number.
 
     Attributes:
       value (double): The double value.
@@ -1007,9 +1007,9 @@ class DoubleValue(object):
 
 class FloatValue(object):
     """
-    Wrapper message for `float`.
+    Wrapper message for ``float``.
 
-    The JSON representation for `FloatValue` is JSON number.
+    The JSON representation for ``FloatValue`` is JSON number.
 
     Attributes:
       value (float): The float value.
@@ -1020,9 +1020,9 @@ class FloatValue(object):
 
 class Int64Value(object):
     """
-    Wrapper message for `int64`.
+    Wrapper message for ``int64``.
 
-    The JSON representation for `Int64Value` is JSON string.
+    The JSON representation for ``Int64Value`` is JSON string.
 
     Attributes:
       value (int64): The int64 value.
@@ -1033,9 +1033,9 @@ class Int64Value(object):
 
 class UInt64Value(object):
     """
-    Wrapper message for `uint64`.
+    Wrapper message for ``uint64``.
 
-    The JSON representation for `UInt64Value` is JSON string.
+    The JSON representation for ``UInt64Value`` is JSON string.
 
     Attributes:
       value (uint64): The uint64 value.
@@ -1046,9 +1046,9 @@ class UInt64Value(object):
 
 class Int32Value(object):
     """
-    Wrapper message for `int32`.
+    Wrapper message for ``int32``.
 
-    The JSON representation for `Int32Value` is JSON number.
+    The JSON representation for ``Int32Value`` is JSON number.
 
     Attributes:
       value (int32): The int32 value.
@@ -1059,9 +1059,9 @@ class Int32Value(object):
 
 class UInt32Value(object):
     """
-    Wrapper message for `uint32`.
+    Wrapper message for ``uint32``.
 
-    The JSON representation for `UInt32Value` is JSON number.
+    The JSON representation for ``UInt32Value`` is JSON number.
 
     Attributes:
       value (uint32): The uint32 value.
@@ -1072,9 +1072,9 @@ class UInt32Value(object):
 
 class BoolValue(object):
     """
-    Wrapper message for `bool`.
+    Wrapper message for ``bool``.
 
-    The JSON representation for `BoolValue` is JSON `true` and `false`.
+    The JSON representation for ``BoolValue`` is JSON ``true`` and ``false``.
 
     Attributes:
       value (bool): The bool value.
@@ -1085,9 +1085,9 @@ class BoolValue(object):
 
 class StringValue(object):
     """
-    Wrapper message for `string`.
+    Wrapper message for ``string``.
 
-    The JSON representation for `StringValue` is JSON string.
+    The JSON representation for ``StringValue`` is JSON string.
 
     Attributes:
       value (string): The string value.
@@ -1098,9 +1098,9 @@ class StringValue(object):
 
 class BytesValue(object):
     """
-    Wrapper message for `bytes`.
+    Wrapper message for ``bytes``.
 
-    The JSON representation for `BytesValue` is JSON string.
+    The JSON representation for ``BytesValue`` is JSON string.
 
     Attributes:
       value (bytes): The bytes value.
@@ -1138,7 +1138,7 @@ class Book(object):
 
     Attributes:
       name (string): The resource name of the book.
-        Book names have the form `shelves/{shelf_id}/books/{book_id}`.
+        Book names have the form ``shelves/{shelf_id}/books/{book_id}``.
       author (string): The name of the book author.
       title (string): The title of the book.
       read (bool): Value indicating whether the book has been read.
@@ -1192,7 +1192,7 @@ class Shelf(object):
 
     Attributes:
       name (string): The resource name of the shelf.
-        Shelf names have the form `shelves/{shelf_id}`.
+        Shelf names have the form ``shelves/{shelf_id}``.
       theme (string): The theme of the shelf
       internal_theme (string): Internal theme that is visible to trusted testers only.
 
@@ -1244,8 +1244,8 @@ class ListShelvesRequest(object):
         If unspecified, server will pick an appropriate default.
       page_token (string): A token identifying a page of results the server should return.
         Typically, this is the value of
-        [ListShelvesResponse.next_page_token][google.example.library.v1.ListShelvesResponse.next_page_token]
-        returned from the previous call to `ListShelves` method.
+        ``ListShelvesResponse.next_page_token``
+        returned from the previous call to ``ListShelves`` method.
 
     """
     pass
@@ -1259,8 +1259,8 @@ class ListShelvesResponse(object):
       shelves (list[:class:`google.example.library.v1.library_pb2.Shelf`]): The list of shelves.
       next_page_token (string): A token to retrieve next page of results.
         Pass this value in the
-        [ListShelvesRequest.page_token][google.example.library.v1.ListShelvesRequest.page_token]
-        field in the subsequent call to `ListShelves` method to retrieve the next
+        ``ListShelvesRequest.page_token``
+        field in the subsequent call to ``ListShelves`` method to retrieve the next
         page of results.
 
     """
@@ -1348,8 +1348,8 @@ class ListBooksRequest(object):
         If unspecified, server will pick an appropriate default.
       page_token (string): A token identifying a page of results the server should return.
         Typically, this is the value of
-        [ListBooksResponse.next_page_token][google.example.library.v1.ListBooksResponse.next_page_token].
-        returned from the previous call to `ListBooks` method.
+        ``ListBooksResponse.next_page_token``.
+        returned from the previous call to ``ListBooks`` method.
       filter (string): To test python built-in wrapping.
 
     """
@@ -1364,8 +1364,8 @@ class ListBooksResponse(object):
       books (list[:class:`google.example.library.v1.library_pb2.Book`]): The list of books.
       next_page_token (string): A token to retrieve next page of results.
         Pass this value in the
-        [ListBooksRequest.page_token][google.example.library.v1.ListBooksRequest.page_token]
-        field in the subsequent call to `ListBooks` method to retrieve the next
+        ``ListBooksRequest.page_token``
+        field in the subsequent call to ``ListBooks`` method to retrieve the next
         page of results.
 
     """


### PR DESCRIPTION
Previously there were still uses of the raw proto comment strings.
Instead, introduce a helper method that wraps the function that gets
proto comments and sphinxifies them.

Fixes googleapis/gax-python#83