### PR TITLE
Minor Fixes to Go Discovery Sample Gen

### DIFF
--- a/src/main/resources/com/google/api/codegen/go/discovery_fragment.snip
+++ b/src/main/resources/com/google/api/codegen/go/discovery_fragment.snip
@@ -31,11 +31,13 @@ func main() {
   # TODO(pongad): Every API except autoscaler has the string as API.CloudPlatformScope, find out why
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := {@context.getApi.getName}.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
   {@initialize(method)}
@@ -51,12 +53,14 @@ func main() {
 @private compactCall(method)
   @if context.isResponseEmpty(method)
     if err = {@methodPath(method)}({@callArg(method)}).Context(ctx).Do(); err != nil {
-      _ = err // Handle error.
+      // TODO: Handle error.
+      _ = err
     }
   @else
     callResult, err := {@methodPath(method)}({@callArg(method)}).Context(ctx).Do()
     if err != nil {
-      _ = err // Handle error.
+      // TODO: Handle error.
+      _ = err
     }
     // doThingsWith(callResult)
     _ = callResult
@@ -79,7 +83,8 @@ func main() {
   @end
 
   if err = {@methodPath(method)}({@callArg(method)}).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 @end
 
@@ -95,7 +100,7 @@ func main() {
 
 @private initialize(method)
   @if context.getMethodParams(method)
-    // TODO: Change placeholders below to appropriate parameters values for the '{@context.getMethodName(method)}' method:
+    // TODO: Change placeholders below to appropriate parameter values for the '{@context.getMethodName(method)}' method:
 
   @end
   var (

--- a/src/main/resources/com/google/api/codegen/go/discovery_fragment.snip
+++ b/src/main/resources/com/google/api/codegen/go/discovery_fragment.snip
@@ -20,8 +20,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -29,16 +27,15 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
   # TODO(pongad): Every API except autoscaler has the string as API.CloudPlatformScope, find out why
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := {@context.getApi.getName}.New(client)
+  client, err := {@context.getApi.getName}.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   {@initialize(method)}
@@ -53,14 +50,13 @@ func main() {
 
 @private compactCall(method)
   @if context.isResponseEmpty(method)
-    err = {@methodPath(method)}({@callArg(method)}).Context(ctx).Do()
-    if err != nil {
-      log.Fatal(err)
+    if err = {@methodPath(method)}({@callArg(method)}).Context(ctx).Do(); err != nil {
+      _ = err // Handle error.
     }
   @else
     callResult, err := {@methodPath(method)}({@callArg(method)}).Context(ctx).Do()
     if err != nil {
-      log.Fatal(err)
+      _ = err // Handle error.
     }
     // doThingsWith(callResult)
     _ = callResult
@@ -82,14 +78,13 @@ func main() {
     }
   @end
 
-  err = {@methodPath(method)}({@callArg(method)}).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = {@methodPath(method)}({@callArg(method)}).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 @end
 
 @private methodPath(method)
-  service.{@resourcePath(method)}.{@context.lowerCamelToUpperCamel(context.getMethodName(method))}
+  client.{@resourcePath(method)}.{@context.lowerCamelToUpperCamel(context.getMethodName(method))}
 @end
 
 @private resourcePath(method)

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_appengine.v1beta5.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_appengine.v1beta5.json.baseline
@@ -12,8 +12,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -21,15 +19,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := appengine.New(client)
+  client, err := appengine.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -39,9 +36,9 @@ func main() {
 
   )
 
-  callResult, err := service.Apps.Get(appsId).Context(ctx).Do()
+  callResult, err := client.Apps.Get(appsId).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -59,8 +56,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -68,15 +63,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := appengine.New(client)
+  client, err := appengine.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -89,9 +83,9 @@ func main() {
 
   )
 
-  callResult, err := service.Apps.Operations.Get(appsId, operationsId).Context(ctx).Do()
+  callResult, err := client.Apps.Operations.Get(appsId, operationsId).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -109,8 +103,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -118,15 +110,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := appengine.New(client)
+  client, err := appengine.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -144,9 +135,8 @@ func main() {
     }
     return nil
   }
-  err = service.Apps.Operations.List(appsId).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Apps.Operations.List(appsId).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -162,8 +152,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -171,15 +159,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := appengine.New(client)
+  client, err := appengine.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -192,9 +179,9 @@ func main() {
 
   )
 
-  callResult, err := service.Apps.Services.Delete(appsId, servicesId).Context(ctx).Do()
+  callResult, err := client.Apps.Services.Delete(appsId, servicesId).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -212,8 +199,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -221,15 +206,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := appengine.New(client)
+  client, err := appengine.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -242,9 +226,9 @@ func main() {
 
   )
 
-  callResult, err := service.Apps.Services.Get(appsId, servicesId).Context(ctx).Do()
+  callResult, err := client.Apps.Services.Get(appsId, servicesId).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -262,8 +246,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -271,15 +253,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := appengine.New(client)
+  client, err := appengine.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -297,9 +278,8 @@ func main() {
     }
     return nil
   }
-  err = service.Apps.Services.List(appsId).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Apps.Services.List(appsId).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -315,8 +295,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -324,15 +302,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := appengine.New(client)
+  client, err := appengine.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'patch' method:
@@ -347,9 +324,9 @@ func main() {
     requestBody = &appengine.Service{}
   )
 
-  callResult, err := service.Apps.Services.Patch(appsId, servicesId, requestBody).Context(ctx).Do()
+  callResult, err := client.Apps.Services.Patch(appsId, servicesId, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -367,8 +344,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -376,15 +351,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := appengine.New(client)
+  client, err := appengine.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'create' method:
@@ -399,9 +373,9 @@ func main() {
     requestBody = &appengine.Version{}
   )
 
-  callResult, err := service.Apps.Services.Versions.Create(appsId, servicesId, requestBody).Context(ctx).Do()
+  callResult, err := client.Apps.Services.Versions.Create(appsId, servicesId, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -419,8 +393,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -428,15 +400,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := appengine.New(client)
+  client, err := appengine.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -452,9 +423,9 @@ func main() {
 
   )
 
-  callResult, err := service.Apps.Services.Versions.Delete(appsId, servicesId, versionsId).Context(ctx).Do()
+  callResult, err := client.Apps.Services.Versions.Delete(appsId, servicesId, versionsId).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -472,8 +443,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -481,15 +450,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := appengine.New(client)
+  client, err := appengine.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -505,9 +473,9 @@ func main() {
 
   )
 
-  callResult, err := service.Apps.Services.Versions.Get(appsId, servicesId, versionsId).Context(ctx).Do()
+  callResult, err := client.Apps.Services.Versions.Get(appsId, servicesId, versionsId).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -525,8 +493,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -534,15 +500,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := appengine.New(client)
+  client, err := appengine.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -566,9 +531,8 @@ func main() {
     }
     return nil
   }
-  err = service.Apps.Services.Versions.Instances.List(appsId, servicesId, versionsId).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Apps.Services.Versions.Instances.List(appsId, servicesId, versionsId).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -584,8 +548,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -593,15 +555,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := appengine.New(client)
+  client, err := appengine.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -622,9 +583,8 @@ func main() {
     }
     return nil
   }
-  err = service.Apps.Services.Versions.List(appsId, servicesId).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Apps.Services.Versions.List(appsId, servicesId).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -640,8 +600,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -649,15 +607,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := appengine.New(client)
+  client, err := appengine.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'patch' method:
@@ -675,9 +632,9 @@ func main() {
     requestBody = &appengine.Version{}
   )
 
-  callResult, err := service.Apps.Services.Versions.Patch(appsId, servicesId, versionsId, requestBody).Context(ctx).Do()
+  callResult, err := client.Apps.Services.Versions.Patch(appsId, servicesId, versionsId, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_appengine.v1beta5.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_appengine.v1beta5.json.baseline
@@ -22,14 +22,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := appengine.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Part of `name`. Name of the application to get. For example: "apps/myapp".
     appsId = ""
@@ -38,7 +40,8 @@ func main() {
 
   callResult, err := client.Apps.Get(appsId).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -66,14 +69,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := appengine.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Part of `name`. The name of the operation resource.
     appsId = ""
@@ -85,7 +90,8 @@ func main() {
 
   callResult, err := client.Apps.Operations.Get(appsId, operationsId).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -113,14 +119,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := appengine.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Part of `name`. The name of the operation collection.
     appsId = ""
@@ -136,7 +144,8 @@ func main() {
     return nil
   }
   if err = client.Apps.Operations.List(appsId).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -162,14 +171,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := appengine.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Part of `name`. Name of the resource requested. For example: "apps/myapp/services/default".
     appsId = ""
@@ -181,7 +192,8 @@ func main() {
 
   callResult, err := client.Apps.Services.Delete(appsId, servicesId).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -209,14 +221,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := appengine.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Part of `name`. Name of the resource requested. For example: "apps/myapp/services/default".
     appsId = ""
@@ -228,7 +242,8 @@ func main() {
 
   callResult, err := client.Apps.Services.Get(appsId, servicesId).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -256,14 +271,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := appengine.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Part of `name`. Name of the resource requested. For example: "apps/myapp".
     appsId = ""
@@ -279,7 +296,8 @@ func main() {
     return nil
   }
   if err = client.Apps.Services.List(appsId).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -305,14 +323,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := appengine.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'patch' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
   var (
     // Part of `name`. Name of the resource to update. For example: "apps/myapp/services/default".
     appsId = ""
@@ -326,7 +346,8 @@ func main() {
 
   callResult, err := client.Apps.Services.Patch(appsId, servicesId, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -354,14 +375,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := appengine.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'create' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'create' method:
   var (
     // Part of `name`. Name of the resource to update. For example: "apps/myapp/services/default".
     appsId = ""
@@ -375,7 +398,8 @@ func main() {
 
   callResult, err := client.Apps.Services.Versions.Create(appsId, servicesId, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -403,14 +427,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := appengine.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Part of `name`. Name of the resource requested. For example: "apps/myapp/services/default/versions/v1".
     appsId = ""
@@ -425,7 +451,8 @@ func main() {
 
   callResult, err := client.Apps.Services.Versions.Delete(appsId, servicesId, versionsId).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -453,14 +480,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := appengine.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Part of `name`. Name of the resource requested. For example: "apps/myapp/services/default/versions/v1".
     appsId = ""
@@ -475,7 +504,8 @@ func main() {
 
   callResult, err := client.Apps.Services.Versions.Get(appsId, servicesId, versionsId).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -503,14 +533,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := appengine.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Part of `name`. Name of the resource requested. For example: "apps/myapp/services/default/versions/v1".
     appsId = ""
@@ -532,7 +564,8 @@ func main() {
     return nil
   }
   if err = client.Apps.Services.Versions.Instances.List(appsId, servicesId, versionsId).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -558,14 +591,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := appengine.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Part of `name`. Name of the resource requested. For example: "apps/myapp/services/default".
     appsId = ""
@@ -584,7 +619,8 @@ func main() {
     return nil
   }
   if err = client.Apps.Services.Versions.List(appsId, servicesId).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -610,14 +646,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := appengine.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'patch' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
   var (
     // Part of `name`. Name of the resource to update. For example: "apps/myapp/services/default/versions/1".
     appsId = ""
@@ -634,7 +672,8 @@ func main() {
 
   callResult, err := client.Apps.Services.Versions.Patch(appsId, servicesId, versionsId, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_autoscaler.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_autoscaler.v1beta2.json.baseline
@@ -22,14 +22,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := autoscaler.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Project ID of Autoscaler resource.
     project = ""
@@ -44,7 +46,8 @@ func main() {
 
   callResult, err := client.Autoscalers.Delete(project, zone, autoscaler_).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -72,14 +75,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := autoscaler.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID of Autoscaler resource.
     project = ""
@@ -94,7 +99,8 @@ func main() {
 
   callResult, err := client.Autoscalers.Get(project, zone, autoscaler_).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -122,14 +128,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := autoscaler.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
   var (
     // Project ID of Autoscaler resource.
     project = ""
@@ -143,7 +151,8 @@ func main() {
 
   callResult, err := client.Autoscalers.Insert(project, zone, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -171,14 +180,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := autoscaler.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID of Autoscaler resource.
     project = ""
@@ -197,7 +208,8 @@ func main() {
     return nil
   }
   if err = client.Autoscalers.List(project, zone).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -223,14 +235,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := autoscaler.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'patch' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
   var (
     // Project ID of Autoscaler resource.
     project = ""
@@ -247,7 +261,8 @@ func main() {
 
   callResult, err := client.Autoscalers.Patch(project, zone, autoscaler_, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -275,14 +290,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := autoscaler.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
   var (
     // Project ID of Autoscaler resource.
     project = ""
@@ -299,7 +316,8 @@ func main() {
 
   callResult, err := client.Autoscalers.Update(project, zone, autoscaler_, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -327,14 +345,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := autoscaler.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
 
     project = ""
@@ -348,7 +368,8 @@ func main() {
   )
 
   if err = client.ZoneOperations.Delete(project, zone, operation).Context(ctx).Do(); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -374,14 +395,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := autoscaler.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
 
     project = ""
@@ -396,7 +419,8 @@ func main() {
 
   callResult, err := client.ZoneOperations.Get(project, zone, operation).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -424,14 +448,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := autoscaler.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
 
     project = ""
@@ -450,7 +476,8 @@ func main() {
     return nil
   }
   if err = client.ZoneOperations.List(project, zone).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -476,14 +503,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := autoscaler.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
 
     project = ""
@@ -499,6 +528,7 @@ func main() {
     return nil
   }
   if err = client.Zones.List(project).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_autoscaler.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_autoscaler.v1beta2.json.baseline
@@ -12,8 +12,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -21,15 +19,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := autoscaler.New(client)
+  client, err := autoscaler.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -45,9 +42,9 @@ func main() {
 
   )
 
-  callResult, err := service.Autoscalers.Delete(project, zone, autoscaler_).Context(ctx).Do()
+  callResult, err := client.Autoscalers.Delete(project, zone, autoscaler_).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -65,8 +62,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -74,15 +69,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := autoscaler.New(client)
+  client, err := autoscaler.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -98,9 +92,9 @@ func main() {
 
   )
 
-  callResult, err := service.Autoscalers.Get(project, zone, autoscaler_).Context(ctx).Do()
+  callResult, err := client.Autoscalers.Get(project, zone, autoscaler_).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -118,8 +112,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -127,15 +119,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := autoscaler.New(client)
+  client, err := autoscaler.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
@@ -150,9 +141,9 @@ func main() {
     requestBody = &autoscaler.Autoscaler{}
   )
 
-  callResult, err := service.Autoscalers.Insert(project, zone, requestBody).Context(ctx).Do()
+  callResult, err := client.Autoscalers.Insert(project, zone, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -170,8 +161,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -179,15 +168,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := autoscaler.New(client)
+  client, err := autoscaler.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -208,9 +196,8 @@ func main() {
     }
     return nil
   }
-  err = service.Autoscalers.List(project, zone).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Autoscalers.List(project, zone).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -226,8 +213,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -235,15 +220,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := autoscaler.New(client)
+  client, err := autoscaler.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'patch' method:
@@ -261,9 +245,9 @@ func main() {
     requestBody = &autoscaler.Autoscaler{}
   )
 
-  callResult, err := service.Autoscalers.Patch(project, zone, autoscaler_, requestBody).Context(ctx).Do()
+  callResult, err := client.Autoscalers.Patch(project, zone, autoscaler_, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -281,8 +265,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -290,15 +272,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := autoscaler.New(client)
+  client, err := autoscaler.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
@@ -316,9 +297,9 @@ func main() {
     requestBody = &autoscaler.Autoscaler{}
   )
 
-  callResult, err := service.Autoscalers.Update(project, zone, autoscaler_, requestBody).Context(ctx).Do()
+  callResult, err := client.Autoscalers.Update(project, zone, autoscaler_, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -336,8 +317,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -345,15 +324,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := autoscaler.New(client)
+  client, err := autoscaler.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -369,9 +347,8 @@ func main() {
 
   )
 
-  err = service.ZoneOperations.Delete(project, zone, operation).Context(ctx).Do()
-  if err != nil {
-    log.Fatal(err)
+  if err = client.ZoneOperations.Delete(project, zone, operation).Context(ctx).Do(); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -387,8 +364,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -396,15 +371,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := autoscaler.New(client)
+  client, err := autoscaler.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -420,9 +394,9 @@ func main() {
 
   )
 
-  callResult, err := service.ZoneOperations.Get(project, zone, operation).Context(ctx).Do()
+  callResult, err := client.ZoneOperations.Get(project, zone, operation).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -440,8 +414,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -449,15 +421,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := autoscaler.New(client)
+  client, err := autoscaler.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -478,9 +449,8 @@ func main() {
     }
     return nil
   }
-  err = service.ZoneOperations.List(project, zone).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.ZoneOperations.List(project, zone).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -496,8 +466,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -505,15 +473,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := autoscaler.New(client)
+  client, err := autoscaler.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -531,8 +498,7 @@ func main() {
     }
     return nil
   }
-  err = service.Zones.List(project).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Zones.List(project).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_bigquery.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_bigquery.v2.json.baseline
@@ -12,8 +12,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -21,15 +19,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := bigquery.New(client)
+  client, err := bigquery.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -42,9 +39,8 @@ func main() {
 
   )
 
-  err = service.Datasets.Delete(projectId, datasetId).Context(ctx).Do()
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Datasets.Delete(projectId, datasetId).Context(ctx).Do(); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -60,8 +56,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -69,15 +63,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := bigquery.New(client)
+  client, err := bigquery.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -90,9 +83,9 @@ func main() {
 
   )
 
-  callResult, err := service.Datasets.Get(projectId, datasetId).Context(ctx).Do()
+  callResult, err := client.Datasets.Get(projectId, datasetId).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -110,8 +103,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -119,15 +110,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := bigquery.New(client)
+  client, err := bigquery.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
@@ -139,9 +129,9 @@ func main() {
     requestBody = &bigquery.Dataset{}
   )
 
-  callResult, err := service.Datasets.Insert(projectId, requestBody).Context(ctx).Do()
+  callResult, err := client.Datasets.Insert(projectId, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -159,8 +149,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -168,15 +156,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := bigquery.New(client)
+  client, err := bigquery.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -194,9 +181,8 @@ func main() {
     }
     return nil
   }
-  err = service.Datasets.List(projectId).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Datasets.List(projectId).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -212,8 +198,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -221,15 +205,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := bigquery.New(client)
+  client, err := bigquery.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'patch' method:
@@ -244,9 +227,9 @@ func main() {
     requestBody = &bigquery.Dataset{}
   )
 
-  callResult, err := service.Datasets.Patch(projectId, datasetId, requestBody).Context(ctx).Do()
+  callResult, err := client.Datasets.Patch(projectId, datasetId, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -264,8 +247,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -273,15 +254,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := bigquery.New(client)
+  client, err := bigquery.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
@@ -296,9 +276,9 @@ func main() {
     requestBody = &bigquery.Dataset{}
   )
 
-  callResult, err := service.Datasets.Update(projectId, datasetId, requestBody).Context(ctx).Do()
+  callResult, err := client.Datasets.Update(projectId, datasetId, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -316,8 +296,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -325,15 +303,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := bigquery.New(client)
+  client, err := bigquery.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'cancel' method:
@@ -346,9 +323,9 @@ func main() {
 
   )
 
-  callResult, err := service.Jobs.Cancel(projectId, jobId).Context(ctx).Do()
+  callResult, err := client.Jobs.Cancel(projectId, jobId).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -366,8 +343,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -375,15 +350,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := bigquery.New(client)
+  client, err := bigquery.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -396,9 +370,9 @@ func main() {
 
   )
 
-  callResult, err := service.Jobs.Get(projectId, jobId).Context(ctx).Do()
+  callResult, err := client.Jobs.Get(projectId, jobId).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -416,8 +390,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -425,15 +397,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := bigquery.New(client)
+  client, err := bigquery.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'getQueryResults' method:
@@ -446,9 +417,9 @@ func main() {
 
   )
 
-  callResult, err := service.Jobs.GetQueryResults(projectId, jobId).Context(ctx).Do()
+  callResult, err := client.Jobs.GetQueryResults(projectId, jobId).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -466,8 +437,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -475,15 +444,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := bigquery.New(client)
+  client, err := bigquery.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
@@ -495,9 +463,9 @@ func main() {
     requestBody = &bigquery.Job{}
   )
 
-  callResult, err := service.Jobs.Insert(projectId, requestBody).Context(ctx).Do()
+  callResult, err := client.Jobs.Insert(projectId, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -515,8 +483,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -524,15 +490,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := bigquery.New(client)
+  client, err := bigquery.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -550,9 +515,8 @@ func main() {
     }
     return nil
   }
-  err = service.Jobs.List(projectId).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Jobs.List(projectId).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -568,8 +532,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -577,15 +539,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := bigquery.New(client)
+  client, err := bigquery.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'query' method:
@@ -597,9 +558,9 @@ func main() {
     requestBody = &bigquery.QueryRequest{}
   )
 
-  callResult, err := service.Jobs.Query(projectId, requestBody).Context(ctx).Do()
+  callResult, err := client.Jobs.Query(projectId, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -617,8 +578,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -626,15 +585,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := bigquery.New(client)
+  client, err := bigquery.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   var (
@@ -648,9 +606,8 @@ func main() {
     }
     return nil
   }
-  err = service.Projects.List().Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Projects.List().Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -666,8 +623,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -675,15 +630,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := bigquery.New(client)
+  client, err := bigquery.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'insertAll' method:
@@ -701,9 +655,9 @@ func main() {
     requestBody = &bigquery.TableDataInsertAllRequest{}
   )
 
-  callResult, err := service.Tabledata.InsertAll(projectId, datasetId, tableId, requestBody).Context(ctx).Do()
+  callResult, err := client.Tabledata.InsertAll(projectId, datasetId, tableId, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -721,8 +675,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -730,15 +682,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := bigquery.New(client)
+  client, err := bigquery.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -754,9 +705,9 @@ func main() {
 
   )
 
-  callResult, err := service.Tabledata.List(projectId, datasetId, tableId).Context(ctx).Do()
+  callResult, err := client.Tabledata.List(projectId, datasetId, tableId).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -774,8 +725,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -783,15 +732,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := bigquery.New(client)
+  client, err := bigquery.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -807,9 +755,8 @@ func main() {
 
   )
 
-  err = service.Tables.Delete(projectId, datasetId, tableId).Context(ctx).Do()
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Tables.Delete(projectId, datasetId, tableId).Context(ctx).Do(); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -825,8 +772,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -834,15 +779,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := bigquery.New(client)
+  client, err := bigquery.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -858,9 +802,9 @@ func main() {
 
   )
 
-  callResult, err := service.Tables.Get(projectId, datasetId, tableId).Context(ctx).Do()
+  callResult, err := client.Tables.Get(projectId, datasetId, tableId).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -878,8 +822,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -887,15 +829,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := bigquery.New(client)
+  client, err := bigquery.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
@@ -910,9 +851,9 @@ func main() {
     requestBody = &bigquery.Table{}
   )
 
-  callResult, err := service.Tables.Insert(projectId, datasetId, requestBody).Context(ctx).Do()
+  callResult, err := client.Tables.Insert(projectId, datasetId, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -930,8 +871,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -939,15 +878,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := bigquery.New(client)
+  client, err := bigquery.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -968,9 +906,8 @@ func main() {
     }
     return nil
   }
-  err = service.Tables.List(projectId, datasetId).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Tables.List(projectId, datasetId).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -986,8 +923,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -995,15 +930,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := bigquery.New(client)
+  client, err := bigquery.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'patch' method:
@@ -1021,9 +955,9 @@ func main() {
     requestBody = &bigquery.Table{}
   )
 
-  callResult, err := service.Tables.Patch(projectId, datasetId, tableId, requestBody).Context(ctx).Do()
+  callResult, err := client.Tables.Patch(projectId, datasetId, tableId, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1041,8 +975,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1050,15 +982,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := bigquery.New(client)
+  client, err := bigquery.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
@@ -1076,9 +1007,9 @@ func main() {
     requestBody = &bigquery.Table{}
   )
 
-  callResult, err := service.Tables.Update(projectId, datasetId, tableId, requestBody).Context(ctx).Do()
+  callResult, err := client.Tables.Update(projectId, datasetId, tableId, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_bigquery.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_bigquery.v2.json.baseline
@@ -22,14 +22,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := bigquery.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Project ID of the dataset being deleted
     projectId = ""
@@ -40,7 +42,8 @@ func main() {
   )
 
   if err = client.Datasets.Delete(projectId, datasetId).Context(ctx).Do(); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -66,14 +69,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := bigquery.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID of the requested dataset
     projectId = ""
@@ -85,7 +90,8 @@ func main() {
 
   callResult, err := client.Datasets.Get(projectId, datasetId).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -113,14 +119,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := bigquery.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
   var (
     // Project ID of the new dataset
     projectId = ""
@@ -131,7 +139,8 @@ func main() {
 
   callResult, err := client.Datasets.Insert(projectId, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -159,14 +168,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := bigquery.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID of the datasets to be listed
     projectId = ""
@@ -182,7 +193,8 @@ func main() {
     return nil
   }
   if err = client.Datasets.List(projectId).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -208,14 +220,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := bigquery.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'patch' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
   var (
     // Project ID of the dataset being updated
     projectId = ""
@@ -229,7 +243,8 @@ func main() {
 
   callResult, err := client.Datasets.Patch(projectId, datasetId, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -257,14 +272,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := bigquery.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
   var (
     // Project ID of the dataset being updated
     projectId = ""
@@ -278,7 +295,8 @@ func main() {
 
   callResult, err := client.Datasets.Update(projectId, datasetId, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -306,14 +324,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := bigquery.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'cancel' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'cancel' method:
   var (
     // [Required] Project ID of the job to cancel
     projectId = ""
@@ -325,7 +345,8 @@ func main() {
 
   callResult, err := client.Jobs.Cancel(projectId, jobId).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -353,14 +374,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := bigquery.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // [Required] Project ID of the requested job
     projectId = ""
@@ -372,7 +395,8 @@ func main() {
 
   callResult, err := client.Jobs.Get(projectId, jobId).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -400,14 +424,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := bigquery.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'getQueryResults' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'getQueryResults' method:
   var (
     // [Required] Project ID of the query job
     projectId = ""
@@ -419,7 +445,8 @@ func main() {
 
   callResult, err := client.Jobs.GetQueryResults(projectId, jobId).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -447,14 +474,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := bigquery.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
   var (
     // Project ID of the project that will be billed for the job
     projectId = ""
@@ -465,7 +494,8 @@ func main() {
 
   callResult, err := client.Jobs.Insert(projectId, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -493,14 +523,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := bigquery.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID of the jobs to list
     projectId = ""
@@ -516,7 +548,8 @@ func main() {
     return nil
   }
   if err = client.Jobs.List(projectId).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -542,14 +575,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := bigquery.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'query' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'query' method:
   var (
     // Project ID of the project billed for the query
     projectId = ""
@@ -560,7 +595,8 @@ func main() {
 
   callResult, err := client.Jobs.Query(projectId, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -588,11 +624,13 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := bigquery.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
   var (
@@ -607,7 +645,8 @@ func main() {
     return nil
   }
   if err = client.Projects.List().Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -633,14 +672,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := bigquery.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'insertAll' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'insertAll' method:
   var (
     // Project ID of the destination table.
     projectId = ""
@@ -657,7 +698,8 @@ func main() {
 
   callResult, err := client.Tabledata.InsertAll(projectId, datasetId, tableId, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -685,14 +727,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := bigquery.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID of the table to read
     projectId = ""
@@ -707,7 +751,8 @@ func main() {
 
   callResult, err := client.Tabledata.List(projectId, datasetId, tableId).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -735,14 +780,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := bigquery.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Project ID of the table to delete
     projectId = ""
@@ -756,7 +803,8 @@ func main() {
   )
 
   if err = client.Tables.Delete(projectId, datasetId, tableId).Context(ctx).Do(); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -782,14 +830,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := bigquery.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID of the requested table
     projectId = ""
@@ -804,7 +854,8 @@ func main() {
 
   callResult, err := client.Tables.Get(projectId, datasetId, tableId).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -832,14 +883,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := bigquery.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
   var (
     // Project ID of the new table
     projectId = ""
@@ -853,7 +906,8 @@ func main() {
 
   callResult, err := client.Tables.Insert(projectId, datasetId, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -881,14 +935,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := bigquery.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID of the tables to list
     projectId = ""
@@ -907,7 +963,8 @@ func main() {
     return nil
   }
   if err = client.Tables.List(projectId, datasetId).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -933,14 +990,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := bigquery.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'patch' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
   var (
     // Project ID of the table to update
     projectId = ""
@@ -957,7 +1016,8 @@ func main() {
 
   callResult, err := client.Tables.Patch(projectId, datasetId, tableId, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -985,14 +1045,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := bigquery.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
   var (
     // Project ID of the table to update
     projectId = ""
@@ -1009,7 +1071,8 @@ func main() {
 
   callResult, err := client.Tables.Update(projectId, datasetId, tableId, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudbilling.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudbilling.v1.json.baseline
@@ -12,8 +12,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -21,15 +19,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := cloudbilling.New(client)
+  client, err := cloudbilling.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -39,9 +36,9 @@ func main() {
 
   )
 
-  callResult, err := service.BillingAccounts.Get(name).Context(ctx).Do()
+  callResult, err := client.BillingAccounts.Get(name).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -59,8 +56,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -68,15 +63,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := cloudbilling.New(client)
+  client, err := cloudbilling.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   var (
@@ -90,9 +84,8 @@ func main() {
     }
     return nil
   }
-  err = service.BillingAccounts.List().Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.BillingAccounts.List().Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -108,8 +101,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -117,15 +108,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := cloudbilling.New(client)
+  client, err := cloudbilling.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -143,9 +133,8 @@ func main() {
     }
     return nil
   }
-  err = service.BillingAccounts.Projects.List(name).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.BillingAccounts.Projects.List(name).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -161,8 +150,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -170,15 +157,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := cloudbilling.New(client)
+  client, err := cloudbilling.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'getBillingInfo' method:
@@ -188,9 +174,9 @@ func main() {
 
   )
 
-  callResult, err := service.Projects.GetBillingInfo(name).Context(ctx).Do()
+  callResult, err := client.Projects.GetBillingInfo(name).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -208,8 +194,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -217,15 +201,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := cloudbilling.New(client)
+  client, err := cloudbilling.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'updateBillingInfo' method:
@@ -237,9 +220,9 @@ func main() {
     requestBody = &cloudbilling.ProjectBillingInfo{}
   )
 
-  callResult, err := service.Projects.UpdateBillingInfo(name, requestBody).Context(ctx).Do()
+  callResult, err := client.Projects.UpdateBillingInfo(name, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudbilling.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudbilling.v1.json.baseline
@@ -22,14 +22,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := cloudbilling.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // The resource name of the billing account to retrieve. For example, `billingAccounts/012345-567890-ABCDEF`.
     name = ""
@@ -38,7 +40,8 @@ func main() {
 
   callResult, err := client.BillingAccounts.Get(name).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -66,11 +69,13 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := cloudbilling.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
   var (
@@ -85,7 +90,8 @@ func main() {
     return nil
   }
   if err = client.BillingAccounts.List().Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -111,14 +117,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := cloudbilling.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // The resource name of the billing account associated with the projects that you want to list. For example, `billingAccounts/012345-567890-ABCDEF`.
     name = ""
@@ -134,7 +142,8 @@ func main() {
     return nil
   }
   if err = client.BillingAccounts.Projects.List(name).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -160,14 +169,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := cloudbilling.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'getBillingInfo' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'getBillingInfo' method:
   var (
     // The resource name of the project for which billing information is retrieved. For example, `projects/tokyo-rain-123`.
     name = ""
@@ -176,7 +187,8 @@ func main() {
 
   callResult, err := client.Projects.GetBillingInfo(name).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -204,14 +216,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := cloudbilling.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'updateBillingInfo' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'updateBillingInfo' method:
   var (
     // The resource name of the project associated with the billing information that you want to update. For example, `projects/tokyo-rain-123`.
     name = ""
@@ -222,7 +236,8 @@ func main() {
 
   callResult, err := client.Projects.UpdateBillingInfo(name, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_clouddebugger.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_clouddebugger.v2.json.baseline
@@ -22,14 +22,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := clouddebugger.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Identifies the debuggee.
     debuggeeId = ""
@@ -38,7 +40,8 @@ func main() {
 
   callResult, err := client.Controller.Debuggees.Breakpoints.List(debuggeeId).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -66,14 +69,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := clouddebugger.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
   var (
     // Identifies the debuggee being debugged.
     debuggeeId = ""
@@ -87,7 +92,8 @@ func main() {
 
   callResult, err := client.Controller.Debuggees.Breakpoints.Update(debuggeeId, id, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -115,14 +121,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := clouddebugger.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'register' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'register' method:
   var (
 
     requestBody = &clouddebugger.RegisterDebuggeeRequest{}
@@ -130,7 +138,8 @@ func main() {
 
   callResult, err := client.Controller.Debuggees.Register(requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -158,14 +167,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := clouddebugger.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // ID of the debuggee whose breakpoint to delete.
     debuggeeId = ""
@@ -177,7 +188,8 @@ func main() {
 
   callResult, err := client.Debugger.Debuggees.Breakpoints.Delete(debuggeeId, breakpointId).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -205,14 +217,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := clouddebugger.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // ID of the debuggee whose breakpoint to get.
     debuggeeId = ""
@@ -224,7 +238,8 @@ func main() {
 
   callResult, err := client.Debugger.Debuggees.Breakpoints.Get(debuggeeId, breakpointId).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -252,14 +267,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := clouddebugger.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // ID of the debuggee whose breakpoints to list.
     debuggeeId = ""
@@ -268,7 +285,8 @@ func main() {
 
   callResult, err := client.Debugger.Debuggees.Breakpoints.List(debuggeeId).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -296,14 +314,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := clouddebugger.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'set' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'set' method:
   var (
     // ID of the debuggee where the breakpoint is to be set.
     debuggeeId = ""
@@ -314,7 +334,8 @@ func main() {
 
   callResult, err := client.Debugger.Debuggees.Breakpoints.Set(debuggeeId, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -342,11 +363,13 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := clouddebugger.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
   var (
@@ -354,7 +377,8 @@ func main() {
 
   callResult, err := client.Debugger.Debuggees.List().Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_clouddebugger.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_clouddebugger.v2.json.baseline
@@ -12,8 +12,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -21,15 +19,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := clouddebugger.New(client)
+  client, err := clouddebugger.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -39,9 +36,9 @@ func main() {
 
   )
 
-  callResult, err := service.Controller.Debuggees.Breakpoints.List(debuggeeId).Context(ctx).Do()
+  callResult, err := client.Controller.Debuggees.Breakpoints.List(debuggeeId).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -59,8 +56,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -68,15 +63,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := clouddebugger.New(client)
+  client, err := clouddebugger.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
@@ -91,9 +85,9 @@ func main() {
     requestBody = &clouddebugger.UpdateActiveBreakpointRequest{}
   )
 
-  callResult, err := service.Controller.Debuggees.Breakpoints.Update(debuggeeId, id, requestBody).Context(ctx).Do()
+  callResult, err := client.Controller.Debuggees.Breakpoints.Update(debuggeeId, id, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -111,8 +105,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -120,15 +112,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := clouddebugger.New(client)
+  client, err := clouddebugger.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'register' method:
@@ -137,9 +128,9 @@ func main() {
     requestBody = &clouddebugger.RegisterDebuggeeRequest{}
   )
 
-  callResult, err := service.Controller.Debuggees.Register(requestBody).Context(ctx).Do()
+  callResult, err := client.Controller.Debuggees.Register(requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -157,8 +148,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -166,15 +155,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := clouddebugger.New(client)
+  client, err := clouddebugger.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -187,9 +175,9 @@ func main() {
 
   )
 
-  callResult, err := service.Debugger.Debuggees.Breakpoints.Delete(debuggeeId, breakpointId).Context(ctx).Do()
+  callResult, err := client.Debugger.Debuggees.Breakpoints.Delete(debuggeeId, breakpointId).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -207,8 +195,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -216,15 +202,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := clouddebugger.New(client)
+  client, err := clouddebugger.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -237,9 +222,9 @@ func main() {
 
   )
 
-  callResult, err := service.Debugger.Debuggees.Breakpoints.Get(debuggeeId, breakpointId).Context(ctx).Do()
+  callResult, err := client.Debugger.Debuggees.Breakpoints.Get(debuggeeId, breakpointId).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -257,8 +242,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -266,15 +249,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := clouddebugger.New(client)
+  client, err := clouddebugger.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -284,9 +266,9 @@ func main() {
 
   )
 
-  callResult, err := service.Debugger.Debuggees.Breakpoints.List(debuggeeId).Context(ctx).Do()
+  callResult, err := client.Debugger.Debuggees.Breakpoints.List(debuggeeId).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -304,8 +286,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -313,15 +293,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := clouddebugger.New(client)
+  client, err := clouddebugger.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'set' method:
@@ -333,9 +312,9 @@ func main() {
     requestBody = &clouddebugger.Breakpoint{}
   )
 
-  callResult, err := service.Debugger.Debuggees.Breakpoints.Set(debuggeeId, requestBody).Context(ctx).Do()
+  callResult, err := client.Debugger.Debuggees.Breakpoints.Set(debuggeeId, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -353,8 +332,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -362,23 +339,22 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := clouddebugger.New(client)
+  client, err := clouddebugger.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   var (
   )
 
-  callResult, err := service.Debugger.Debuggees.List().Context(ctx).Do()
+  callResult, err := client.Debugger.Debuggees.List().Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudmonitoring.v2beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudmonitoring.v2beta2.json.baseline
@@ -12,8 +12,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -21,15 +19,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := cloudmonitoring.New(client)
+  client, err := cloudmonitoring.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'create' method:
@@ -41,9 +38,9 @@ func main() {
     requestBody = &cloudmonitoring.MetricDescriptor{}
   )
 
-  callResult, err := service.MetricDescriptors.Create(project, requestBody).Context(ctx).Do()
+  callResult, err := client.MetricDescriptors.Create(project, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -61,8 +58,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -70,15 +65,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := cloudmonitoring.New(client)
+  client, err := cloudmonitoring.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -91,9 +85,9 @@ func main() {
 
   )
 
-  callResult, err := service.MetricDescriptors.Delete(project, metric).Context(ctx).Do()
+  callResult, err := client.MetricDescriptors.Delete(project, metric).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -111,8 +105,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -120,15 +112,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := cloudmonitoring.New(client)
+  client, err := cloudmonitoring.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -140,9 +131,9 @@ func main() {
     requestBody = &cloudmonitoring.ListMetricDescriptorsRequest{}
   )
 
-  callResult, err := service.MetricDescriptors.List(project, requestBody).Context(ctx).Do()
+  callResult, err := client.MetricDescriptors.List(project, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -160,8 +151,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -169,15 +158,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := cloudmonitoring.New(client)
+  client, err := cloudmonitoring.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -195,9 +183,9 @@ func main() {
     requestBody = &cloudmonitoring.ListTimeseriesRequest{}
   )
 
-  callResult, err := service.Timeseries.List(project, metric, youngest, requestBody).Context(ctx).Do()
+  callResult, err := client.Timeseries.List(project, metric, youngest, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -215,8 +203,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -224,15 +210,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := cloudmonitoring.New(client)
+  client, err := cloudmonitoring.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'write' method:
@@ -244,9 +229,9 @@ func main() {
     requestBody = &cloudmonitoring.WriteTimeseriesRequest{}
   )
 
-  callResult, err := service.Timeseries.Write(project, requestBody).Context(ctx).Do()
+  callResult, err := client.Timeseries.Write(project, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -264,8 +249,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -273,15 +256,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := cloudmonitoring.New(client)
+  client, err := cloudmonitoring.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -299,9 +281,9 @@ func main() {
     requestBody = &cloudmonitoring.ListTimeseriesDescriptorsRequest{}
   )
 
-  callResult, err := service.TimeseriesDescriptors.List(project, metric, youngest, requestBody).Context(ctx).Do()
+  callResult, err := client.TimeseriesDescriptors.List(project, metric, youngest, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudmonitoring.v2beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudmonitoring.v2beta2.json.baseline
@@ -22,14 +22,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := cloudmonitoring.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'create' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'create' method:
   var (
     // The project id. The value can be the numeric project ID or string-based project name.
     project = ""
@@ -40,7 +42,8 @@ func main() {
 
   callResult, err := client.MetricDescriptors.Create(project, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -68,14 +71,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := cloudmonitoring.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // The project ID to which the metric belongs.
     project = ""
@@ -87,7 +92,8 @@ func main() {
 
   callResult, err := client.MetricDescriptors.Delete(project, metric).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -115,14 +121,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := cloudmonitoring.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // The project id. The value can be the numeric project ID or string-based project name.
     project = ""
@@ -133,7 +141,8 @@ func main() {
 
   callResult, err := client.MetricDescriptors.List(project, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -161,14 +170,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := cloudmonitoring.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // The project ID to which this time series belongs. The value can be the numeric project ID or string-based project name.
     project = ""
@@ -185,7 +196,8 @@ func main() {
 
   callResult, err := client.Timeseries.List(project, metric, youngest, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -213,14 +225,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := cloudmonitoring.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'write' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'write' method:
   var (
     // The project ID. The value can be the numeric project ID or string-based project name.
     project = ""
@@ -231,7 +245,8 @@ func main() {
 
   callResult, err := client.Timeseries.Write(project, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -259,14 +274,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := cloudmonitoring.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // The project ID to which this time series belongs. The value can be the numeric project ID or string-based project name.
     project = ""
@@ -283,7 +300,8 @@ func main() {
 
   callResult, err := client.TimeseriesDescriptors.List(project, metric, youngest, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudresourcemanager.v1beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudresourcemanager.v1beta1.json.baseline
@@ -12,8 +12,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -21,15 +19,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := cloudresourcemanager.New(client)
+  client, err := cloudresourcemanager.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -39,9 +36,9 @@ func main() {
 
   )
 
-  callResult, err := service.Organizations.Get(organizationId).Context(ctx).Do()
+  callResult, err := client.Organizations.Get(organizationId).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -59,8 +56,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -68,15 +63,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := cloudresourcemanager.New(client)
+  client, err := cloudresourcemanager.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'getIamPolicy' method:
@@ -88,9 +82,9 @@ func main() {
     requestBody = &cloudresourcemanager.GetIamPolicyRequest{}
   )
 
-  callResult, err := service.Organizations.GetIamPolicy(resource, requestBody).Context(ctx).Do()
+  callResult, err := client.Organizations.GetIamPolicy(resource, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -108,8 +102,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -117,15 +109,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := cloudresourcemanager.New(client)
+  client, err := cloudresourcemanager.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   var (
@@ -139,9 +130,8 @@ func main() {
     }
     return nil
   }
-  err = service.Organizations.List().Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Organizations.List().Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -157,8 +147,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -166,15 +154,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := cloudresourcemanager.New(client)
+  client, err := cloudresourcemanager.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'setIamPolicy' method:
@@ -186,9 +173,9 @@ func main() {
     requestBody = &cloudresourcemanager.SetIamPolicyRequest{}
   )
 
-  callResult, err := service.Organizations.SetIamPolicy(resource, requestBody).Context(ctx).Do()
+  callResult, err := client.Organizations.SetIamPolicy(resource, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -206,8 +193,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -215,15 +200,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := cloudresourcemanager.New(client)
+  client, err := cloudresourcemanager.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'testIamPermissions' method:
@@ -235,9 +219,9 @@ func main() {
     requestBody = &cloudresourcemanager.TestIamPermissionsRequest{}
   )
 
-  callResult, err := service.Organizations.TestIamPermissions(resource, requestBody).Context(ctx).Do()
+  callResult, err := client.Organizations.TestIamPermissions(resource, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -255,8 +239,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -264,15 +246,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := cloudresourcemanager.New(client)
+  client, err := cloudresourcemanager.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
@@ -284,9 +265,9 @@ func main() {
     requestBody = &cloudresourcemanager.Organization{}
   )
 
-  callResult, err := service.Organizations.Update(organizationId, requestBody).Context(ctx).Do()
+  callResult, err := client.Organizations.Update(organizationId, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -304,8 +285,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -313,15 +292,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := cloudresourcemanager.New(client)
+  client, err := cloudresourcemanager.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'create' method:
@@ -330,9 +308,9 @@ func main() {
     requestBody = &cloudresourcemanager.Project{}
   )
 
-  callResult, err := service.Projects.Create(requestBody).Context(ctx).Do()
+  callResult, err := client.Projects.Create(requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -350,8 +328,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -359,15 +335,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := cloudresourcemanager.New(client)
+  client, err := cloudresourcemanager.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -377,9 +352,9 @@ func main() {
 
   )
 
-  callResult, err := service.Projects.Delete(projectId).Context(ctx).Do()
+  callResult, err := client.Projects.Delete(projectId).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -397,8 +372,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -406,15 +379,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := cloudresourcemanager.New(client)
+  client, err := cloudresourcemanager.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -424,9 +396,9 @@ func main() {
 
   )
 
-  callResult, err := service.Projects.Get(projectId).Context(ctx).Do()
+  callResult, err := client.Projects.Get(projectId).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -444,8 +416,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -453,15 +423,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := cloudresourcemanager.New(client)
+  client, err := cloudresourcemanager.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'getIamPolicy' method:
@@ -473,9 +442,9 @@ func main() {
     requestBody = &cloudresourcemanager.GetIamPolicyRequest{}
   )
 
-  callResult, err := service.Projects.GetIamPolicy(resource, requestBody).Context(ctx).Do()
+  callResult, err := client.Projects.GetIamPolicy(resource, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -493,8 +462,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -502,15 +469,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := cloudresourcemanager.New(client)
+  client, err := cloudresourcemanager.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   var (
@@ -524,9 +490,8 @@ func main() {
     }
     return nil
   }
-  err = service.Projects.List().Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Projects.List().Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -542,8 +507,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -551,15 +514,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := cloudresourcemanager.New(client)
+  client, err := cloudresourcemanager.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'setIamPolicy' method:
@@ -571,9 +533,9 @@ func main() {
     requestBody = &cloudresourcemanager.SetIamPolicyRequest{}
   )
 
-  callResult, err := service.Projects.SetIamPolicy(resource, requestBody).Context(ctx).Do()
+  callResult, err := client.Projects.SetIamPolicy(resource, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -591,8 +553,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -600,15 +560,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := cloudresourcemanager.New(client)
+  client, err := cloudresourcemanager.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'testIamPermissions' method:
@@ -620,9 +579,9 @@ func main() {
     requestBody = &cloudresourcemanager.TestIamPermissionsRequest{}
   )
 
-  callResult, err := service.Projects.TestIamPermissions(resource, requestBody).Context(ctx).Do()
+  callResult, err := client.Projects.TestIamPermissions(resource, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -640,8 +599,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -649,15 +606,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := cloudresourcemanager.New(client)
+  client, err := cloudresourcemanager.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'undelete' method:
@@ -669,9 +625,9 @@ func main() {
     requestBody = &cloudresourcemanager.UndeleteProjectRequest{}
   )
 
-  callResult, err := service.Projects.Undelete(projectId, requestBody).Context(ctx).Do()
+  callResult, err := client.Projects.Undelete(projectId, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -689,8 +645,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -698,15 +652,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := cloudresourcemanager.New(client)
+  client, err := cloudresourcemanager.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
@@ -718,9 +671,9 @@ func main() {
     requestBody = &cloudresourcemanager.Project{}
   )
 
-  callResult, err := service.Projects.Update(projectId, requestBody).Context(ctx).Do()
+  callResult, err := client.Projects.Update(projectId, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudresourcemanager.v1beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudresourcemanager.v1beta1.json.baseline
@@ -22,14 +22,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := cloudresourcemanager.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // The id of the Organization resource to fetch.
     organizationId = ""
@@ -38,7 +40,8 @@ func main() {
 
   callResult, err := client.Organizations.Get(organizationId).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -66,14 +69,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := cloudresourcemanager.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'getIamPolicy' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'getIamPolicy' method:
   var (
     // REQUIRED: The resource for which the policy is being requested. `resource` is usually specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in this value is resource specific and is specified in the `getIamPolicy` documentation.
     resource = ""
@@ -84,7 +89,8 @@ func main() {
 
   callResult, err := client.Organizations.GetIamPolicy(resource, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -112,11 +118,13 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := cloudresourcemanager.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
   var (
@@ -131,7 +139,8 @@ func main() {
     return nil
   }
   if err = client.Organizations.List().Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -157,14 +166,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := cloudresourcemanager.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'setIamPolicy' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'setIamPolicy' method:
   var (
     // REQUIRED: The resource for which the policy is being specified. `resource` is usually specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in this value is resource specific and is specified in the `setIamPolicy` documentation.
     resource = ""
@@ -175,7 +186,8 @@ func main() {
 
   callResult, err := client.Organizations.SetIamPolicy(resource, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -203,14 +215,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := cloudresourcemanager.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'testIamPermissions' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'testIamPermissions' method:
   var (
     // REQUIRED: The resource for which the policy detail is being requested. `resource` is usually specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in this value is resource specific and is specified in the `testIamPermissions` documentation.
     resource = ""
@@ -221,7 +235,8 @@ func main() {
 
   callResult, err := client.Organizations.TestIamPermissions(resource, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -249,14 +264,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := cloudresourcemanager.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
   var (
     // An immutable id for the Organization that is assigned on creation. This should be omitted when creating a new Organization. This field is read-only.
     organizationId = ""
@@ -267,7 +284,8 @@ func main() {
 
   callResult, err := client.Organizations.Update(organizationId, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -295,14 +313,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := cloudresourcemanager.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'create' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'create' method:
   var (
 
     requestBody = &cloudresourcemanager.Project{}
@@ -310,7 +330,8 @@ func main() {
 
   callResult, err := client.Projects.Create(requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -338,14 +359,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := cloudresourcemanager.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // The Project ID (for example, `foo-bar-123`). Required.
     projectId = ""
@@ -354,7 +377,8 @@ func main() {
 
   callResult, err := client.Projects.Delete(projectId).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -382,14 +406,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := cloudresourcemanager.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // The Project ID (for example, `my-project-123`). Required.
     projectId = ""
@@ -398,7 +424,8 @@ func main() {
 
   callResult, err := client.Projects.Get(projectId).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -426,14 +453,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := cloudresourcemanager.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'getIamPolicy' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'getIamPolicy' method:
   var (
     // REQUIRED: The resource for which the policy is being requested. `resource` is usually specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in this value is resource specific and is specified in the `getIamPolicy` documentation.
     resource = ""
@@ -444,7 +473,8 @@ func main() {
 
   callResult, err := client.Projects.GetIamPolicy(resource, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -472,11 +502,13 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := cloudresourcemanager.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
   var (
@@ -491,7 +523,8 @@ func main() {
     return nil
   }
   if err = client.Projects.List().Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -517,14 +550,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := cloudresourcemanager.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'setIamPolicy' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'setIamPolicy' method:
   var (
     // REQUIRED: The resource for which the policy is being specified. `resource` is usually specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in this value is resource specific and is specified in the `setIamPolicy` documentation.
     resource = ""
@@ -535,7 +570,8 @@ func main() {
 
   callResult, err := client.Projects.SetIamPolicy(resource, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -563,14 +599,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := cloudresourcemanager.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'testIamPermissions' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'testIamPermissions' method:
   var (
     // REQUIRED: The resource for which the policy detail is being requested. `resource` is usually specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in this value is resource specific and is specified in the `testIamPermissions` documentation.
     resource = ""
@@ -581,7 +619,8 @@ func main() {
 
   callResult, err := client.Projects.TestIamPermissions(resource, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -609,14 +648,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := cloudresourcemanager.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'undelete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'undelete' method:
   var (
     // The project ID (for example, `foo-bar-123`). Required.
     projectId = ""
@@ -627,7 +668,8 @@ func main() {
 
   callResult, err := client.Projects.Undelete(projectId, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -655,14 +697,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := cloudresourcemanager.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
   var (
     // The project ID (for example, `my-project-123`). Required.
     projectId = ""
@@ -673,7 +717,8 @@ func main() {
 
   callResult, err := client.Projects.Update(projectId, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudtrace.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudtrace.v1.json.baseline
@@ -12,8 +12,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -21,15 +19,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := cloudtrace.New(client)
+  client, err := cloudtrace.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'patchTraces' method:
@@ -41,9 +38,9 @@ func main() {
     requestBody = &cloudtrace.Traces{}
   )
 
-  callResult, err := service.Projects.PatchTraces(projectId, requestBody).Context(ctx).Do()
+  callResult, err := client.Projects.PatchTraces(projectId, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -61,8 +58,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -70,15 +65,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := cloudtrace.New(client)
+  client, err := cloudtrace.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -91,9 +85,9 @@ func main() {
 
   )
 
-  callResult, err := service.Projects.Traces.Get(projectId, traceId).Context(ctx).Do()
+  callResult, err := client.Projects.Traces.Get(projectId, traceId).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -111,8 +105,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -120,15 +112,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := cloudtrace.New(client)
+  client, err := cloudtrace.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -146,8 +137,7 @@ func main() {
     }
     return nil
   }
-  err = service.Projects.Traces.List(projectId).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Projects.Traces.List(projectId).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudtrace.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudtrace.v1.json.baseline
@@ -22,14 +22,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := cloudtrace.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'patchTraces' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'patchTraces' method:
   var (
     // ID of the Cloud project where the trace data is stored.
     projectId = ""
@@ -40,7 +42,8 @@ func main() {
 
   callResult, err := client.Projects.PatchTraces(projectId, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -68,14 +71,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := cloudtrace.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // ID of the Cloud project where the trace data is stored.
     projectId = ""
@@ -87,7 +92,8 @@ func main() {
 
   callResult, err := client.Projects.Traces.Get(projectId, traceId).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -115,14 +121,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := cloudtrace.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // ID of the Cloud project where the trace data is stored.
     projectId = ""
@@ -138,6 +146,7 @@ func main() {
     return nil
   }
   if err = client.Projects.Traces.List(projectId).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_clouduseraccounts.beta.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_clouduseraccounts.beta.json.baseline
@@ -12,8 +12,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -21,15 +19,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := clouduseraccounts.New(client)
+  client, err := clouduseraccounts.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -42,9 +39,8 @@ func main() {
 
   )
 
-  err = service.GlobalAccountsOperations.Delete(project, operation).Context(ctx).Do()
-  if err != nil {
-    log.Fatal(err)
+  if err = client.GlobalAccountsOperations.Delete(project, operation).Context(ctx).Do(); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -60,8 +56,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -69,15 +63,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := clouduseraccounts.New(client)
+  client, err := clouduseraccounts.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -90,9 +83,9 @@ func main() {
 
   )
 
-  callResult, err := service.GlobalAccountsOperations.Get(project, operation).Context(ctx).Do()
+  callResult, err := client.GlobalAccountsOperations.Get(project, operation).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -110,8 +103,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -119,15 +110,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := clouduseraccounts.New(client)
+  client, err := clouduseraccounts.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -145,9 +135,8 @@ func main() {
     }
     return nil
   }
-  err = service.GlobalAccountsOperations.List(project).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.GlobalAccountsOperations.List(project).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -163,8 +152,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -172,15 +159,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := clouduseraccounts.New(client)
+  client, err := clouduseraccounts.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'addMember' method:
@@ -195,9 +181,9 @@ func main() {
     requestBody = &clouduseraccounts.GroupsAddMemberRequest{}
   )
 
-  callResult, err := service.Groups.AddMember(project, groupName, requestBody).Context(ctx).Do()
+  callResult, err := client.Groups.AddMember(project, groupName, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -215,8 +201,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -224,15 +208,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := clouduseraccounts.New(client)
+  client, err := clouduseraccounts.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -245,9 +228,9 @@ func main() {
 
   )
 
-  callResult, err := service.Groups.Delete(project, groupName).Context(ctx).Do()
+  callResult, err := client.Groups.Delete(project, groupName).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -265,8 +248,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -274,15 +255,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := clouduseraccounts.New(client)
+  client, err := clouduseraccounts.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -295,9 +275,9 @@ func main() {
 
   )
 
-  callResult, err := service.Groups.Get(project, groupName).Context(ctx).Do()
+  callResult, err := client.Groups.Get(project, groupName).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -315,8 +295,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -324,15 +302,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := clouduseraccounts.New(client)
+  client, err := clouduseraccounts.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
@@ -344,9 +321,9 @@ func main() {
     requestBody = &clouduseraccounts.Group{}
   )
 
-  callResult, err := service.Groups.Insert(project, requestBody).Context(ctx).Do()
+  callResult, err := client.Groups.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -364,8 +341,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -373,15 +348,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := clouduseraccounts.New(client)
+  client, err := clouduseraccounts.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -399,9 +373,8 @@ func main() {
     }
     return nil
   }
-  err = service.Groups.List(project).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Groups.List(project).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -417,8 +390,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -426,15 +397,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := clouduseraccounts.New(client)
+  client, err := clouduseraccounts.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'removeMember' method:
@@ -449,9 +419,9 @@ func main() {
     requestBody = &clouduseraccounts.GroupsRemoveMemberRequest{}
   )
 
-  callResult, err := service.Groups.RemoveMember(project, groupName, requestBody).Context(ctx).Do()
+  callResult, err := client.Groups.RemoveMember(project, groupName, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -469,8 +439,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -478,15 +446,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := clouduseraccounts.New(client)
+  client, err := clouduseraccounts.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'getAuthorizedKeysView' method:
@@ -505,9 +472,9 @@ func main() {
 
   )
 
-  callResult, err := service.Linux.GetAuthorizedKeysView(project, zone, user, instance).Context(ctx).Do()
+  callResult, err := client.Linux.GetAuthorizedKeysView(project, zone, user, instance).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -525,8 +492,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -534,15 +499,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := clouduseraccounts.New(client)
+  client, err := clouduseraccounts.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'getLinuxAccountViews' method:
@@ -558,9 +522,9 @@ func main() {
 
   )
 
-  callResult, err := service.Linux.GetLinuxAccountViews(project, zone, instance).Context(ctx).Do()
+  callResult, err := client.Linux.GetLinuxAccountViews(project, zone, instance).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -578,8 +542,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -587,15 +549,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := clouduseraccounts.New(client)
+  client, err := clouduseraccounts.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'addPublicKey' method:
@@ -610,9 +571,9 @@ func main() {
     requestBody = &clouduseraccounts.PublicKey{}
   )
 
-  callResult, err := service.Users.AddPublicKey(project, user, requestBody).Context(ctx).Do()
+  callResult, err := client.Users.AddPublicKey(project, user, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -630,8 +591,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -639,15 +598,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := clouduseraccounts.New(client)
+  client, err := clouduseraccounts.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -660,9 +618,9 @@ func main() {
 
   )
 
-  callResult, err := service.Users.Delete(project, user).Context(ctx).Do()
+  callResult, err := client.Users.Delete(project, user).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -680,8 +638,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -689,15 +645,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := clouduseraccounts.New(client)
+  client, err := clouduseraccounts.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -710,9 +665,9 @@ func main() {
 
   )
 
-  callResult, err := service.Users.Get(project, user).Context(ctx).Do()
+  callResult, err := client.Users.Get(project, user).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -730,8 +685,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -739,15 +692,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := clouduseraccounts.New(client)
+  client, err := clouduseraccounts.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
@@ -759,9 +711,9 @@ func main() {
     requestBody = &clouduseraccounts.User{}
   )
 
-  callResult, err := service.Users.Insert(project, requestBody).Context(ctx).Do()
+  callResult, err := client.Users.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -779,8 +731,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -788,15 +738,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := clouduseraccounts.New(client)
+  client, err := clouduseraccounts.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -814,9 +763,8 @@ func main() {
     }
     return nil
   }
-  err = service.Users.List(project).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Users.List(project).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -832,8 +780,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -841,15 +787,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := clouduseraccounts.New(client)
+  client, err := clouduseraccounts.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'removePublicKey' method:
@@ -865,9 +810,9 @@ func main() {
 
   )
 
-  callResult, err := service.Users.RemovePublicKey(project, user, fingerprint).Context(ctx).Do()
+  callResult, err := client.Users.RemovePublicKey(project, user, fingerprint).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_clouduseraccounts.beta.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_clouduseraccounts.beta.json.baseline
@@ -22,14 +22,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := clouduseraccounts.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Project ID for this request.
     project = ""
@@ -40,7 +42,8 @@ func main() {
   )
 
   if err = client.GlobalAccountsOperations.Delete(project, operation).Context(ctx).Do(); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -66,14 +69,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := clouduseraccounts.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID for this request.
     project = ""
@@ -85,7 +90,8 @@ func main() {
 
   callResult, err := client.GlobalAccountsOperations.Get(project, operation).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -113,14 +119,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := clouduseraccounts.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID for this request.
     project = ""
@@ -136,7 +144,8 @@ func main() {
     return nil
   }
   if err = client.GlobalAccountsOperations.List(project).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -162,14 +171,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := clouduseraccounts.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'addMember' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'addMember' method:
   var (
     // Project ID for this request.
     project = ""
@@ -183,7 +194,8 @@ func main() {
 
   callResult, err := client.Groups.AddMember(project, groupName, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -211,14 +223,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := clouduseraccounts.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Project ID for this request.
     project = ""
@@ -230,7 +244,8 @@ func main() {
 
   callResult, err := client.Groups.Delete(project, groupName).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -258,14 +273,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := clouduseraccounts.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID for this request.
     project = ""
@@ -277,7 +294,8 @@ func main() {
 
   callResult, err := client.Groups.Get(project, groupName).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -305,14 +323,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := clouduseraccounts.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
   var (
     // Project ID for this request.
     project = ""
@@ -323,7 +343,8 @@ func main() {
 
   callResult, err := client.Groups.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -351,14 +372,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := clouduseraccounts.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID for this request.
     project = ""
@@ -374,7 +397,8 @@ func main() {
     return nil
   }
   if err = client.Groups.List(project).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -400,14 +424,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := clouduseraccounts.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'removeMember' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'removeMember' method:
   var (
     // Project ID for this request.
     project = ""
@@ -421,7 +447,8 @@ func main() {
 
   callResult, err := client.Groups.RemoveMember(project, groupName, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -449,14 +476,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := clouduseraccounts.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'getAuthorizedKeysView' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'getAuthorizedKeysView' method:
   var (
     // Project ID for this request.
     project = ""
@@ -474,7 +503,8 @@ func main() {
 
   callResult, err := client.Linux.GetAuthorizedKeysView(project, zone, user, instance).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -502,14 +532,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := clouduseraccounts.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'getLinuxAccountViews' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'getLinuxAccountViews' method:
   var (
     // Project ID for this request.
     project = ""
@@ -524,7 +556,8 @@ func main() {
 
   callResult, err := client.Linux.GetLinuxAccountViews(project, zone, instance).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -552,14 +585,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := clouduseraccounts.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'addPublicKey' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'addPublicKey' method:
   var (
     // Project ID for this request.
     project = ""
@@ -573,7 +608,8 @@ func main() {
 
   callResult, err := client.Users.AddPublicKey(project, user, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -601,14 +637,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := clouduseraccounts.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Project ID for this request.
     project = ""
@@ -620,7 +658,8 @@ func main() {
 
   callResult, err := client.Users.Delete(project, user).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -648,14 +687,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := clouduseraccounts.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID for this request.
     project = ""
@@ -667,7 +708,8 @@ func main() {
 
   callResult, err := client.Users.Get(project, user).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -695,14 +737,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := clouduseraccounts.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
   var (
     // Project ID for this request.
     project = ""
@@ -713,7 +757,8 @@ func main() {
 
   callResult, err := client.Users.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -741,14 +786,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := clouduseraccounts.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID for this request.
     project = ""
@@ -764,7 +811,8 @@ func main() {
     return nil
   }
   if err = client.Users.List(project).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -790,14 +838,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := clouduseraccounts.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'removePublicKey' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'removePublicKey' method:
   var (
     // Project ID for this request.
     project = ""
@@ -812,7 +862,8 @@ func main() {
 
   callResult, err := client.Users.RemovePublicKey(project, user, fingerprint).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_compute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_compute.v1.json.baseline
@@ -12,8 +12,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -21,15 +19,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'aggregatedList' method:
@@ -47,9 +44,8 @@ func main() {
     }
     return nil
   }
-  err = service.Addresses.AggregatedList(project).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Addresses.AggregatedList(project).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -65,8 +61,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -74,15 +68,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -98,9 +91,9 @@ func main() {
 
   )
 
-  callResult, err := service.Addresses.Delete(project, region, address).Context(ctx).Do()
+  callResult, err := client.Addresses.Delete(project, region, address).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -118,8 +111,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -127,15 +118,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -151,9 +141,9 @@ func main() {
 
   )
 
-  callResult, err := service.Addresses.Get(project, region, address).Context(ctx).Do()
+  callResult, err := client.Addresses.Get(project, region, address).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -171,8 +161,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -180,15 +168,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
@@ -203,9 +190,9 @@ func main() {
     requestBody = &compute.Address{}
   )
 
-  callResult, err := service.Addresses.Insert(project, region, requestBody).Context(ctx).Do()
+  callResult, err := client.Addresses.Insert(project, region, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -223,8 +210,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -232,15 +217,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -261,9 +245,8 @@ func main() {
     }
     return nil
   }
-  err = service.Addresses.List(project, region).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Addresses.List(project, region).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -279,8 +262,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -288,15 +269,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'aggregatedList' method:
@@ -314,9 +294,8 @@ func main() {
     }
     return nil
   }
-  err = service.Autoscalers.AggregatedList(project).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Autoscalers.AggregatedList(project).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -332,8 +311,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -341,15 +318,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -365,9 +341,9 @@ func main() {
 
   )
 
-  callResult, err := service.Autoscalers.Delete(project, zone, autoscaler).Context(ctx).Do()
+  callResult, err := client.Autoscalers.Delete(project, zone, autoscaler).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -385,8 +361,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -394,15 +368,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -418,9 +391,9 @@ func main() {
 
   )
 
-  callResult, err := service.Autoscalers.Get(project, zone, autoscaler).Context(ctx).Do()
+  callResult, err := client.Autoscalers.Get(project, zone, autoscaler).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -438,8 +411,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -447,15 +418,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
@@ -470,9 +440,9 @@ func main() {
     requestBody = &compute.Autoscaler{}
   )
 
-  callResult, err := service.Autoscalers.Insert(project, zone, requestBody).Context(ctx).Do()
+  callResult, err := client.Autoscalers.Insert(project, zone, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -490,8 +460,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -499,15 +467,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -528,9 +495,8 @@ func main() {
     }
     return nil
   }
-  err = service.Autoscalers.List(project, zone).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Autoscalers.List(project, zone).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -546,8 +512,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -555,15 +519,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'patch' method:
@@ -581,9 +544,9 @@ func main() {
     requestBody = &compute.Autoscaler{}
   )
 
-  callResult, err := service.Autoscalers.Patch(project, zone, autoscaler, requestBody).Context(ctx).Do()
+  callResult, err := client.Autoscalers.Patch(project, zone, autoscaler, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -601,8 +564,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -610,15 +571,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
@@ -633,9 +593,9 @@ func main() {
     requestBody = &compute.Autoscaler{}
   )
 
-  callResult, err := service.Autoscalers.Update(project, zone, requestBody).Context(ctx).Do()
+  callResult, err := client.Autoscalers.Update(project, zone, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -653,8 +613,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -662,15 +620,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -683,9 +640,9 @@ func main() {
 
   )
 
-  callResult, err := service.BackendServices.Delete(project, backendService).Context(ctx).Do()
+  callResult, err := client.BackendServices.Delete(project, backendService).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -703,8 +660,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -712,15 +667,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -733,9 +687,9 @@ func main() {
 
   )
 
-  callResult, err := service.BackendServices.Get(project, backendService).Context(ctx).Do()
+  callResult, err := client.BackendServices.Get(project, backendService).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -753,8 +707,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -762,15 +714,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'getHealth' method:
@@ -785,9 +736,9 @@ func main() {
     requestBody = &compute.ResourceGroupReference{}
   )
 
-  callResult, err := service.BackendServices.GetHealth(project, backendService, requestBody).Context(ctx).Do()
+  callResult, err := client.BackendServices.GetHealth(project, backendService, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -805,8 +756,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -814,15 +763,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
@@ -834,9 +782,9 @@ func main() {
     requestBody = &compute.BackendService{}
   )
 
-  callResult, err := service.BackendServices.Insert(project, requestBody).Context(ctx).Do()
+  callResult, err := client.BackendServices.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -854,8 +802,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -863,15 +809,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -889,9 +834,8 @@ func main() {
     }
     return nil
   }
-  err = service.BackendServices.List(project).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.BackendServices.List(project).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -907,8 +851,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -916,15 +858,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'patch' method:
@@ -939,9 +880,9 @@ func main() {
     requestBody = &compute.BackendService{}
   )
 
-  callResult, err := service.BackendServices.Patch(project, backendService, requestBody).Context(ctx).Do()
+  callResult, err := client.BackendServices.Patch(project, backendService, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -959,8 +900,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -968,15 +907,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
@@ -991,9 +929,9 @@ func main() {
     requestBody = &compute.BackendService{}
   )
 
-  callResult, err := service.BackendServices.Update(project, backendService, requestBody).Context(ctx).Do()
+  callResult, err := client.BackendServices.Update(project, backendService, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1011,8 +949,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1020,15 +956,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'aggregatedList' method:
@@ -1046,9 +981,8 @@ func main() {
     }
     return nil
   }
-  err = service.DiskTypes.AggregatedList(project).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.DiskTypes.AggregatedList(project).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -1064,8 +998,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1073,15 +1005,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -1097,9 +1028,9 @@ func main() {
 
   )
 
-  callResult, err := service.DiskTypes.Get(project, zone, diskType).Context(ctx).Do()
+  callResult, err := client.DiskTypes.Get(project, zone, diskType).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1117,8 +1048,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1126,15 +1055,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -1155,9 +1083,8 @@ func main() {
     }
     return nil
   }
-  err = service.DiskTypes.List(project, zone).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.DiskTypes.List(project, zone).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -1173,8 +1100,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1182,15 +1107,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'aggregatedList' method:
@@ -1208,9 +1132,8 @@ func main() {
     }
     return nil
   }
-  err = service.Disks.AggregatedList(project).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Disks.AggregatedList(project).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -1226,8 +1149,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1235,15 +1156,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'createSnapshot' method:
@@ -1261,9 +1181,9 @@ func main() {
     requestBody = &compute.Snapshot{}
   )
 
-  callResult, err := service.Disks.CreateSnapshot(project, zone, disk, requestBody).Context(ctx).Do()
+  callResult, err := client.Disks.CreateSnapshot(project, zone, disk, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1281,8 +1201,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1290,15 +1208,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -1314,9 +1231,9 @@ func main() {
 
   )
 
-  callResult, err := service.Disks.Delete(project, zone, disk).Context(ctx).Do()
+  callResult, err := client.Disks.Delete(project, zone, disk).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1334,8 +1251,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1343,15 +1258,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -1367,9 +1281,9 @@ func main() {
 
   )
 
-  callResult, err := service.Disks.Get(project, zone, disk).Context(ctx).Do()
+  callResult, err := client.Disks.Get(project, zone, disk).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1387,8 +1301,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1396,15 +1308,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
@@ -1419,9 +1330,9 @@ func main() {
     requestBody = &compute.Disk{}
   )
 
-  callResult, err := service.Disks.Insert(project, zone, requestBody).Context(ctx).Do()
+  callResult, err := client.Disks.Insert(project, zone, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1439,8 +1350,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1448,15 +1357,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -1477,9 +1385,8 @@ func main() {
     }
     return nil
   }
-  err = service.Disks.List(project, zone).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Disks.List(project, zone).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -1495,8 +1402,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1504,15 +1409,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -1525,9 +1429,9 @@ func main() {
 
   )
 
-  callResult, err := service.Firewalls.Delete(project, firewall).Context(ctx).Do()
+  callResult, err := client.Firewalls.Delete(project, firewall).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1545,8 +1449,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1554,15 +1456,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -1575,9 +1476,9 @@ func main() {
 
   )
 
-  callResult, err := service.Firewalls.Get(project, firewall).Context(ctx).Do()
+  callResult, err := client.Firewalls.Get(project, firewall).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1595,8 +1496,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1604,15 +1503,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
@@ -1624,9 +1522,9 @@ func main() {
     requestBody = &compute.Firewall{}
   )
 
-  callResult, err := service.Firewalls.Insert(project, requestBody).Context(ctx).Do()
+  callResult, err := client.Firewalls.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1644,8 +1542,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1653,15 +1549,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -1679,9 +1574,8 @@ func main() {
     }
     return nil
   }
-  err = service.Firewalls.List(project).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Firewalls.List(project).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -1697,8 +1591,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1706,15 +1598,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'patch' method:
@@ -1729,9 +1620,9 @@ func main() {
     requestBody = &compute.Firewall{}
   )
 
-  callResult, err := service.Firewalls.Patch(project, firewall, requestBody).Context(ctx).Do()
+  callResult, err := client.Firewalls.Patch(project, firewall, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1749,8 +1640,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1758,15 +1647,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
@@ -1781,9 +1669,9 @@ func main() {
     requestBody = &compute.Firewall{}
   )
 
-  callResult, err := service.Firewalls.Update(project, firewall, requestBody).Context(ctx).Do()
+  callResult, err := client.Firewalls.Update(project, firewall, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1801,8 +1689,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1810,15 +1696,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'aggregatedList' method:
@@ -1836,9 +1721,8 @@ func main() {
     }
     return nil
   }
-  err = service.ForwardingRules.AggregatedList(project).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.ForwardingRules.AggregatedList(project).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -1854,8 +1738,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1863,15 +1745,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -1887,9 +1768,9 @@ func main() {
 
   )
 
-  callResult, err := service.ForwardingRules.Delete(project, region, forwardingRule).Context(ctx).Do()
+  callResult, err := client.ForwardingRules.Delete(project, region, forwardingRule).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1907,8 +1788,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1916,15 +1795,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -1940,9 +1818,9 @@ func main() {
 
   )
 
-  callResult, err := service.ForwardingRules.Get(project, region, forwardingRule).Context(ctx).Do()
+  callResult, err := client.ForwardingRules.Get(project, region, forwardingRule).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1960,8 +1838,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1969,15 +1845,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
@@ -1992,9 +1867,9 @@ func main() {
     requestBody = &compute.ForwardingRule{}
   )
 
-  callResult, err := service.ForwardingRules.Insert(project, region, requestBody).Context(ctx).Do()
+  callResult, err := client.ForwardingRules.Insert(project, region, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -2012,8 +1887,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -2021,15 +1894,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -2050,9 +1922,8 @@ func main() {
     }
     return nil
   }
-  err = service.ForwardingRules.List(project, region).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.ForwardingRules.List(project, region).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -2068,8 +1939,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -2077,15 +1946,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'setTarget' method:
@@ -2103,9 +1971,9 @@ func main() {
     requestBody = &compute.TargetReference{}
   )
 
-  callResult, err := service.ForwardingRules.SetTarget(project, region, forwardingRule, requestBody).Context(ctx).Do()
+  callResult, err := client.ForwardingRules.SetTarget(project, region, forwardingRule, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -2123,8 +1991,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -2132,15 +1998,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -2153,9 +2018,9 @@ func main() {
 
   )
 
-  callResult, err := service.GlobalAddresses.Delete(project, address).Context(ctx).Do()
+  callResult, err := client.GlobalAddresses.Delete(project, address).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -2173,8 +2038,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -2182,15 +2045,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -2203,9 +2065,9 @@ func main() {
 
   )
 
-  callResult, err := service.GlobalAddresses.Get(project, address).Context(ctx).Do()
+  callResult, err := client.GlobalAddresses.Get(project, address).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -2223,8 +2085,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -2232,15 +2092,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
@@ -2252,9 +2111,9 @@ func main() {
     requestBody = &compute.Address{}
   )
 
-  callResult, err := service.GlobalAddresses.Insert(project, requestBody).Context(ctx).Do()
+  callResult, err := client.GlobalAddresses.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -2272,8 +2131,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -2281,15 +2138,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -2307,9 +2163,8 @@ func main() {
     }
     return nil
   }
-  err = service.GlobalAddresses.List(project).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.GlobalAddresses.List(project).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -2325,8 +2180,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -2334,15 +2187,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -2355,9 +2207,9 @@ func main() {
 
   )
 
-  callResult, err := service.GlobalForwardingRules.Delete(project, forwardingRule).Context(ctx).Do()
+  callResult, err := client.GlobalForwardingRules.Delete(project, forwardingRule).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -2375,8 +2227,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -2384,15 +2234,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -2405,9 +2254,9 @@ func main() {
 
   )
 
-  callResult, err := service.GlobalForwardingRules.Get(project, forwardingRule).Context(ctx).Do()
+  callResult, err := client.GlobalForwardingRules.Get(project, forwardingRule).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -2425,8 +2274,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -2434,15 +2281,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
@@ -2454,9 +2300,9 @@ func main() {
     requestBody = &compute.ForwardingRule{}
   )
 
-  callResult, err := service.GlobalForwardingRules.Insert(project, requestBody).Context(ctx).Do()
+  callResult, err := client.GlobalForwardingRules.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -2474,8 +2320,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -2483,15 +2327,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -2509,9 +2352,8 @@ func main() {
     }
     return nil
   }
-  err = service.GlobalForwardingRules.List(project).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.GlobalForwardingRules.List(project).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -2527,8 +2369,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -2536,15 +2376,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'setTarget' method:
@@ -2559,9 +2398,9 @@ func main() {
     requestBody = &compute.TargetReference{}
   )
 
-  callResult, err := service.GlobalForwardingRules.SetTarget(project, forwardingRule, requestBody).Context(ctx).Do()
+  callResult, err := client.GlobalForwardingRules.SetTarget(project, forwardingRule, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -2579,8 +2418,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -2588,15 +2425,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'aggregatedList' method:
@@ -2614,9 +2450,8 @@ func main() {
     }
     return nil
   }
-  err = service.GlobalOperations.AggregatedList(project).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.GlobalOperations.AggregatedList(project).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -2632,8 +2467,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -2641,15 +2474,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -2662,9 +2494,8 @@ func main() {
 
   )
 
-  err = service.GlobalOperations.Delete(project, operation).Context(ctx).Do()
-  if err != nil {
-    log.Fatal(err)
+  if err = client.GlobalOperations.Delete(project, operation).Context(ctx).Do(); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -2680,8 +2511,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -2689,15 +2518,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -2710,9 +2538,9 @@ func main() {
 
   )
 
-  callResult, err := service.GlobalOperations.Get(project, operation).Context(ctx).Do()
+  callResult, err := client.GlobalOperations.Get(project, operation).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -2730,8 +2558,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -2739,15 +2565,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -2765,9 +2590,8 @@ func main() {
     }
     return nil
   }
-  err = service.GlobalOperations.List(project).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.GlobalOperations.List(project).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -2783,8 +2607,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -2792,15 +2614,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -2813,9 +2634,9 @@ func main() {
 
   )
 
-  callResult, err := service.HttpHealthChecks.Delete(project, httpHealthCheck).Context(ctx).Do()
+  callResult, err := client.HttpHealthChecks.Delete(project, httpHealthCheck).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -2833,8 +2654,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -2842,15 +2661,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -2863,9 +2681,9 @@ func main() {
 
   )
 
-  callResult, err := service.HttpHealthChecks.Get(project, httpHealthCheck).Context(ctx).Do()
+  callResult, err := client.HttpHealthChecks.Get(project, httpHealthCheck).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -2883,8 +2701,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -2892,15 +2708,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
@@ -2912,9 +2727,9 @@ func main() {
     requestBody = &compute.HttpHealthCheck{}
   )
 
-  callResult, err := service.HttpHealthChecks.Insert(project, requestBody).Context(ctx).Do()
+  callResult, err := client.HttpHealthChecks.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -2932,8 +2747,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -2941,15 +2754,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -2967,9 +2779,8 @@ func main() {
     }
     return nil
   }
-  err = service.HttpHealthChecks.List(project).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.HttpHealthChecks.List(project).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -2985,8 +2796,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -2994,15 +2803,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'patch' method:
@@ -3017,9 +2825,9 @@ func main() {
     requestBody = &compute.HttpHealthCheck{}
   )
 
-  callResult, err := service.HttpHealthChecks.Patch(project, httpHealthCheck, requestBody).Context(ctx).Do()
+  callResult, err := client.HttpHealthChecks.Patch(project, httpHealthCheck, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -3037,8 +2845,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -3046,15 +2852,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
@@ -3069,9 +2874,9 @@ func main() {
     requestBody = &compute.HttpHealthCheck{}
   )
 
-  callResult, err := service.HttpHealthChecks.Update(project, httpHealthCheck, requestBody).Context(ctx).Do()
+  callResult, err := client.HttpHealthChecks.Update(project, httpHealthCheck, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -3089,8 +2894,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -3098,15 +2901,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -3119,9 +2921,9 @@ func main() {
 
   )
 
-  callResult, err := service.HttpsHealthChecks.Delete(project, httpsHealthCheck).Context(ctx).Do()
+  callResult, err := client.HttpsHealthChecks.Delete(project, httpsHealthCheck).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -3139,8 +2941,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -3148,15 +2948,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -3169,9 +2968,9 @@ func main() {
 
   )
 
-  callResult, err := service.HttpsHealthChecks.Get(project, httpsHealthCheck).Context(ctx).Do()
+  callResult, err := client.HttpsHealthChecks.Get(project, httpsHealthCheck).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -3189,8 +2988,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -3198,15 +2995,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
@@ -3218,9 +3014,9 @@ func main() {
     requestBody = &compute.HttpsHealthCheck{}
   )
 
-  callResult, err := service.HttpsHealthChecks.Insert(project, requestBody).Context(ctx).Do()
+  callResult, err := client.HttpsHealthChecks.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -3238,8 +3034,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -3247,15 +3041,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -3273,9 +3066,8 @@ func main() {
     }
     return nil
   }
-  err = service.HttpsHealthChecks.List(project).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.HttpsHealthChecks.List(project).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -3291,8 +3083,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -3300,15 +3090,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'patch' method:
@@ -3323,9 +3112,9 @@ func main() {
     requestBody = &compute.HttpsHealthCheck{}
   )
 
-  callResult, err := service.HttpsHealthChecks.Patch(project, httpsHealthCheck, requestBody).Context(ctx).Do()
+  callResult, err := client.HttpsHealthChecks.Patch(project, httpsHealthCheck, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -3343,8 +3132,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -3352,15 +3139,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
@@ -3375,9 +3161,9 @@ func main() {
     requestBody = &compute.HttpsHealthCheck{}
   )
 
-  callResult, err := service.HttpsHealthChecks.Update(project, httpsHealthCheck, requestBody).Context(ctx).Do()
+  callResult, err := client.HttpsHealthChecks.Update(project, httpsHealthCheck, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -3395,8 +3181,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -3404,15 +3188,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -3425,9 +3208,9 @@ func main() {
 
   )
 
-  callResult, err := service.Images.Delete(project, image).Context(ctx).Do()
+  callResult, err := client.Images.Delete(project, image).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -3445,8 +3228,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -3454,15 +3235,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'deprecate' method:
@@ -3477,9 +3257,9 @@ func main() {
     requestBody = &compute.DeprecationStatus{}
   )
 
-  callResult, err := service.Images.Deprecate(project, image, requestBody).Context(ctx).Do()
+  callResult, err := client.Images.Deprecate(project, image, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -3497,8 +3277,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -3506,15 +3284,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -3527,9 +3304,9 @@ func main() {
 
   )
 
-  callResult, err := service.Images.Get(project, image).Context(ctx).Do()
+  callResult, err := client.Images.Get(project, image).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -3547,8 +3324,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -3556,15 +3331,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
@@ -3576,9 +3350,9 @@ func main() {
     requestBody = &compute.Image{}
   )
 
-  callResult, err := service.Images.Insert(project, requestBody).Context(ctx).Do()
+  callResult, err := client.Images.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -3596,8 +3370,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -3605,15 +3377,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -3631,9 +3402,8 @@ func main() {
     }
     return nil
   }
-  err = service.Images.List(project).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Images.List(project).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -3649,8 +3419,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -3658,15 +3426,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'abandonInstances' method:
@@ -3684,9 +3451,9 @@ func main() {
     requestBody = &compute.InstanceGroupManagersAbandonInstancesRequest{}
   )
 
-  callResult, err := service.InstanceGroupManagers.AbandonInstances(project, zone, instanceGroupManager, requestBody).Context(ctx).Do()
+  callResult, err := client.InstanceGroupManagers.AbandonInstances(project, zone, instanceGroupManager, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -3704,8 +3471,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -3713,15 +3478,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'aggregatedList' method:
@@ -3739,9 +3503,8 @@ func main() {
     }
     return nil
   }
-  err = service.InstanceGroupManagers.AggregatedList(project).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.InstanceGroupManagers.AggregatedList(project).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -3757,8 +3520,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -3766,15 +3527,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -3790,9 +3550,9 @@ func main() {
 
   )
 
-  callResult, err := service.InstanceGroupManagers.Delete(project, zone, instanceGroupManager).Context(ctx).Do()
+  callResult, err := client.InstanceGroupManagers.Delete(project, zone, instanceGroupManager).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -3810,8 +3570,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -3819,15 +3577,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'deleteInstances' method:
@@ -3845,9 +3602,9 @@ func main() {
     requestBody = &compute.InstanceGroupManagersDeleteInstancesRequest{}
   )
 
-  callResult, err := service.InstanceGroupManagers.DeleteInstances(project, zone, instanceGroupManager, requestBody).Context(ctx).Do()
+  callResult, err := client.InstanceGroupManagers.DeleteInstances(project, zone, instanceGroupManager, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -3865,8 +3622,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -3874,15 +3629,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -3898,9 +3652,9 @@ func main() {
 
   )
 
-  callResult, err := service.InstanceGroupManagers.Get(project, zone, instanceGroupManager).Context(ctx).Do()
+  callResult, err := client.InstanceGroupManagers.Get(project, zone, instanceGroupManager).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -3918,8 +3672,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -3927,15 +3679,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
@@ -3950,9 +3701,9 @@ func main() {
     requestBody = &compute.InstanceGroupManager{}
   )
 
-  callResult, err := service.InstanceGroupManagers.Insert(project, zone, requestBody).Context(ctx).Do()
+  callResult, err := client.InstanceGroupManagers.Insert(project, zone, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -3970,8 +3721,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -3979,15 +3728,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -4008,9 +3756,8 @@ func main() {
     }
     return nil
   }
-  err = service.InstanceGroupManagers.List(project, zone).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.InstanceGroupManagers.List(project, zone).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -4026,8 +3773,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -4035,15 +3780,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'listManagedInstances' method:
@@ -4059,9 +3803,9 @@ func main() {
 
   )
 
-  callResult, err := service.InstanceGroupManagers.ListManagedInstances(project, zone, instanceGroupManager).Context(ctx).Do()
+  callResult, err := client.InstanceGroupManagers.ListManagedInstances(project, zone, instanceGroupManager).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -4079,8 +3823,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -4088,15 +3830,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'recreateInstances' method:
@@ -4114,9 +3855,9 @@ func main() {
     requestBody = &compute.InstanceGroupManagersRecreateInstancesRequest{}
   )
 
-  callResult, err := service.InstanceGroupManagers.RecreateInstances(project, zone, instanceGroupManager, requestBody).Context(ctx).Do()
+  callResult, err := client.InstanceGroupManagers.RecreateInstances(project, zone, instanceGroupManager, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -4134,8 +3875,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -4143,15 +3882,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'resize' method:
@@ -4170,9 +3908,9 @@ func main() {
 
   )
 
-  callResult, err := service.InstanceGroupManagers.Resize(project, zone, instanceGroupManager, size).Context(ctx).Do()
+  callResult, err := client.InstanceGroupManagers.Resize(project, zone, instanceGroupManager, size).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -4190,8 +3928,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -4199,15 +3935,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'setInstanceTemplate' method:
@@ -4225,9 +3960,9 @@ func main() {
     requestBody = &compute.InstanceGroupManagersSetInstanceTemplateRequest{}
   )
 
-  callResult, err := service.InstanceGroupManagers.SetInstanceTemplate(project, zone, instanceGroupManager, requestBody).Context(ctx).Do()
+  callResult, err := client.InstanceGroupManagers.SetInstanceTemplate(project, zone, instanceGroupManager, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -4245,8 +3980,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -4254,15 +3987,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'setTargetPools' method:
@@ -4280,9 +4012,9 @@ func main() {
     requestBody = &compute.InstanceGroupManagersSetTargetPoolsRequest{}
   )
 
-  callResult, err := service.InstanceGroupManagers.SetTargetPools(project, zone, instanceGroupManager, requestBody).Context(ctx).Do()
+  callResult, err := client.InstanceGroupManagers.SetTargetPools(project, zone, instanceGroupManager, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -4300,8 +4032,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -4309,15 +4039,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'addInstances' method:
@@ -4335,9 +4064,9 @@ func main() {
     requestBody = &compute.InstanceGroupsAddInstancesRequest{}
   )
 
-  callResult, err := service.InstanceGroups.AddInstances(project, zone, instanceGroup, requestBody).Context(ctx).Do()
+  callResult, err := client.InstanceGroups.AddInstances(project, zone, instanceGroup, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -4355,8 +4084,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -4364,15 +4091,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'aggregatedList' method:
@@ -4390,9 +4116,8 @@ func main() {
     }
     return nil
   }
-  err = service.InstanceGroups.AggregatedList(project).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.InstanceGroups.AggregatedList(project).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -4408,8 +4133,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -4417,15 +4140,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -4441,9 +4163,9 @@ func main() {
 
   )
 
-  callResult, err := service.InstanceGroups.Delete(project, zone, instanceGroup).Context(ctx).Do()
+  callResult, err := client.InstanceGroups.Delete(project, zone, instanceGroup).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -4461,8 +4183,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -4470,15 +4190,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -4494,9 +4213,9 @@ func main() {
 
   )
 
-  callResult, err := service.InstanceGroups.Get(project, zone, instanceGroup).Context(ctx).Do()
+  callResult, err := client.InstanceGroups.Get(project, zone, instanceGroup).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -4514,8 +4233,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -4523,15 +4240,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
@@ -4546,9 +4262,9 @@ func main() {
     requestBody = &compute.InstanceGroup{}
   )
 
-  callResult, err := service.InstanceGroups.Insert(project, zone, requestBody).Context(ctx).Do()
+  callResult, err := client.InstanceGroups.Insert(project, zone, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -4566,8 +4282,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -4575,15 +4289,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -4604,9 +4317,8 @@ func main() {
     }
     return nil
   }
-  err = service.InstanceGroups.List(project, zone).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.InstanceGroups.List(project, zone).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -4622,8 +4334,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -4631,15 +4341,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'listInstances' method:
@@ -4657,9 +4366,9 @@ func main() {
     requestBody = &compute.InstanceGroupsListInstancesRequest{}
   )
 
-  callResult, err := service.InstanceGroups.ListInstances(project, zone, instanceGroup, requestBody).Context(ctx).Do()
+  callResult, err := client.InstanceGroups.ListInstances(project, zone, instanceGroup, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -4677,8 +4386,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -4686,15 +4393,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'removeInstances' method:
@@ -4712,9 +4418,9 @@ func main() {
     requestBody = &compute.InstanceGroupsRemoveInstancesRequest{}
   )
 
-  callResult, err := service.InstanceGroups.RemoveInstances(project, zone, instanceGroup, requestBody).Context(ctx).Do()
+  callResult, err := client.InstanceGroups.RemoveInstances(project, zone, instanceGroup, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -4732,8 +4438,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -4741,15 +4445,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'setNamedPorts' method:
@@ -4767,9 +4470,9 @@ func main() {
     requestBody = &compute.InstanceGroupsSetNamedPortsRequest{}
   )
 
-  callResult, err := service.InstanceGroups.SetNamedPorts(project, zone, instanceGroup, requestBody).Context(ctx).Do()
+  callResult, err := client.InstanceGroups.SetNamedPorts(project, zone, instanceGroup, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -4787,8 +4490,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -4796,15 +4497,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -4817,9 +4517,9 @@ func main() {
 
   )
 
-  callResult, err := service.InstanceTemplates.Delete(project, instanceTemplate).Context(ctx).Do()
+  callResult, err := client.InstanceTemplates.Delete(project, instanceTemplate).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -4837,8 +4537,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -4846,15 +4544,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -4867,9 +4564,9 @@ func main() {
 
   )
 
-  callResult, err := service.InstanceTemplates.Get(project, instanceTemplate).Context(ctx).Do()
+  callResult, err := client.InstanceTemplates.Get(project, instanceTemplate).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -4887,8 +4584,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -4896,15 +4591,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
@@ -4916,9 +4610,9 @@ func main() {
     requestBody = &compute.InstanceTemplate{}
   )
 
-  callResult, err := service.InstanceTemplates.Insert(project, requestBody).Context(ctx).Do()
+  callResult, err := client.InstanceTemplates.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -4936,8 +4630,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -4945,15 +4637,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -4971,9 +4662,8 @@ func main() {
     }
     return nil
   }
-  err = service.InstanceTemplates.List(project).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.InstanceTemplates.List(project).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -4989,8 +4679,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -4998,15 +4686,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'addAccessConfig' method:
@@ -5027,9 +4714,9 @@ func main() {
     requestBody = &compute.AccessConfig{}
   )
 
-  callResult, err := service.Instances.AddAccessConfig(project, zone, instance, networkInterface, requestBody).Context(ctx).Do()
+  callResult, err := client.Instances.AddAccessConfig(project, zone, instance, networkInterface, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -5047,8 +4734,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -5056,15 +4741,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'aggregatedList' method:
@@ -5082,9 +4766,8 @@ func main() {
     }
     return nil
   }
-  err = service.Instances.AggregatedList(project).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Instances.AggregatedList(project).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -5100,8 +4783,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -5109,15 +4790,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'attachDisk' method:
@@ -5135,9 +4815,9 @@ func main() {
     requestBody = &compute.AttachedDisk{}
   )
 
-  callResult, err := service.Instances.AttachDisk(project, zone, instance, requestBody).Context(ctx).Do()
+  callResult, err := client.Instances.AttachDisk(project, zone, instance, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -5155,8 +4835,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -5164,15 +4842,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -5188,9 +4865,9 @@ func main() {
 
   )
 
-  callResult, err := service.Instances.Delete(project, zone, instance).Context(ctx).Do()
+  callResult, err := client.Instances.Delete(project, zone, instance).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -5208,8 +4885,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -5217,15 +4892,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'deleteAccessConfig' method:
@@ -5247,9 +4921,9 @@ func main() {
 
   )
 
-  callResult, err := service.Instances.DeleteAccessConfig(project, zone, instance, accessConfig, networkInterface).Context(ctx).Do()
+  callResult, err := client.Instances.DeleteAccessConfig(project, zone, instance, accessConfig, networkInterface).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -5267,8 +4941,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -5276,15 +4948,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'detachDisk' method:
@@ -5303,9 +4974,9 @@ func main() {
 
   )
 
-  callResult, err := service.Instances.DetachDisk(project, zone, instance, deviceName).Context(ctx).Do()
+  callResult, err := client.Instances.DetachDisk(project, zone, instance, deviceName).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -5323,8 +4994,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -5332,15 +5001,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -5356,9 +5024,9 @@ func main() {
 
   )
 
-  callResult, err := service.Instances.Get(project, zone, instance).Context(ctx).Do()
+  callResult, err := client.Instances.Get(project, zone, instance).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -5376,8 +5044,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -5385,15 +5051,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'getSerialPortOutput' method:
@@ -5409,9 +5074,9 @@ func main() {
 
   )
 
-  callResult, err := service.Instances.GetSerialPortOutput(project, zone, instance).Context(ctx).Do()
+  callResult, err := client.Instances.GetSerialPortOutput(project, zone, instance).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -5429,8 +5094,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -5438,15 +5101,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
@@ -5461,9 +5123,9 @@ func main() {
     requestBody = &compute.Instance{}
   )
 
-  callResult, err := service.Instances.Insert(project, zone, requestBody).Context(ctx).Do()
+  callResult, err := client.Instances.Insert(project, zone, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -5481,8 +5143,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -5490,15 +5150,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -5519,9 +5178,8 @@ func main() {
     }
     return nil
   }
-  err = service.Instances.List(project, zone).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Instances.List(project, zone).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -5537,8 +5195,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -5546,15 +5202,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'reset' method:
@@ -5570,9 +5225,9 @@ func main() {
 
   )
 
-  callResult, err := service.Instances.Reset(project, zone, instance).Context(ctx).Do()
+  callResult, err := client.Instances.Reset(project, zone, instance).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -5590,8 +5245,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -5599,15 +5252,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'setDiskAutoDelete' method:
@@ -5629,9 +5281,9 @@ func main() {
 
   )
 
-  callResult, err := service.Instances.SetDiskAutoDelete(project, zone, instance, autoDelete, deviceName).Context(ctx).Do()
+  callResult, err := client.Instances.SetDiskAutoDelete(project, zone, instance, autoDelete, deviceName).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -5649,8 +5301,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -5658,15 +5308,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'setMachineType' method:
@@ -5684,9 +5333,9 @@ func main() {
     requestBody = &compute.InstancesSetMachineTypeRequest{}
   )
 
-  callResult, err := service.Instances.SetMachineType(project, zone, instance, requestBody).Context(ctx).Do()
+  callResult, err := client.Instances.SetMachineType(project, zone, instance, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -5704,8 +5353,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -5713,15 +5360,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'setMetadata' method:
@@ -5739,9 +5385,9 @@ func main() {
     requestBody = &compute.Metadata{}
   )
 
-  callResult, err := service.Instances.SetMetadata(project, zone, instance, requestBody).Context(ctx).Do()
+  callResult, err := client.Instances.SetMetadata(project, zone, instance, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -5759,8 +5405,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -5768,15 +5412,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'setScheduling' method:
@@ -5794,9 +5437,9 @@ func main() {
     requestBody = &compute.Scheduling{}
   )
 
-  callResult, err := service.Instances.SetScheduling(project, zone, instance, requestBody).Context(ctx).Do()
+  callResult, err := client.Instances.SetScheduling(project, zone, instance, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -5814,8 +5457,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -5823,15 +5464,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'setTags' method:
@@ -5849,9 +5489,9 @@ func main() {
     requestBody = &compute.Tags{}
   )
 
-  callResult, err := service.Instances.SetTags(project, zone, instance, requestBody).Context(ctx).Do()
+  callResult, err := client.Instances.SetTags(project, zone, instance, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -5869,8 +5509,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -5878,15 +5516,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'start' method:
@@ -5902,9 +5539,9 @@ func main() {
 
   )
 
-  callResult, err := service.Instances.Start(project, zone, instance).Context(ctx).Do()
+  callResult, err := client.Instances.Start(project, zone, instance).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -5922,8 +5559,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -5931,15 +5566,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'stop' method:
@@ -5955,9 +5589,9 @@ func main() {
 
   )
 
-  callResult, err := service.Instances.Stop(project, zone, instance).Context(ctx).Do()
+  callResult, err := client.Instances.Stop(project, zone, instance).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -5975,8 +5609,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -5984,15 +5616,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -6005,9 +5636,9 @@ func main() {
 
   )
 
-  callResult, err := service.Licenses.Get(project, license).Context(ctx).Do()
+  callResult, err := client.Licenses.Get(project, license).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -6025,8 +5656,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -6034,15 +5663,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'aggregatedList' method:
@@ -6060,9 +5688,8 @@ func main() {
     }
     return nil
   }
-  err = service.MachineTypes.AggregatedList(project).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.MachineTypes.AggregatedList(project).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -6078,8 +5705,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -6087,15 +5712,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -6111,9 +5735,9 @@ func main() {
 
   )
 
-  callResult, err := service.MachineTypes.Get(project, zone, machineType).Context(ctx).Do()
+  callResult, err := client.MachineTypes.Get(project, zone, machineType).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -6131,8 +5755,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -6140,15 +5762,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -6169,9 +5790,8 @@ func main() {
     }
     return nil
   }
-  err = service.MachineTypes.List(project, zone).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.MachineTypes.List(project, zone).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -6187,8 +5807,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -6196,15 +5814,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -6217,9 +5834,9 @@ func main() {
 
   )
 
-  callResult, err := service.Networks.Delete(project, network).Context(ctx).Do()
+  callResult, err := client.Networks.Delete(project, network).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -6237,8 +5854,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -6246,15 +5861,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -6267,9 +5881,9 @@ func main() {
 
   )
 
-  callResult, err := service.Networks.Get(project, network).Context(ctx).Do()
+  callResult, err := client.Networks.Get(project, network).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -6287,8 +5901,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -6296,15 +5908,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
@@ -6316,9 +5927,9 @@ func main() {
     requestBody = &compute.Network{}
   )
 
-  callResult, err := service.Networks.Insert(project, requestBody).Context(ctx).Do()
+  callResult, err := client.Networks.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -6336,8 +5947,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -6345,15 +5954,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -6371,9 +5979,8 @@ func main() {
     }
     return nil
   }
-  err = service.Networks.List(project).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Networks.List(project).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -6389,8 +5996,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -6398,15 +6003,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -6416,9 +6020,9 @@ func main() {
 
   )
 
-  callResult, err := service.Projects.Get(project).Context(ctx).Do()
+  callResult, err := client.Projects.Get(project).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -6436,8 +6040,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -6445,15 +6047,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'moveDisk' method:
@@ -6465,9 +6066,9 @@ func main() {
     requestBody = &compute.DiskMoveRequest{}
   )
 
-  callResult, err := service.Projects.MoveDisk(project, requestBody).Context(ctx).Do()
+  callResult, err := client.Projects.MoveDisk(project, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -6485,8 +6086,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -6494,15 +6093,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'moveInstance' method:
@@ -6514,9 +6112,9 @@ func main() {
     requestBody = &compute.InstanceMoveRequest{}
   )
 
-  callResult, err := service.Projects.MoveInstance(project, requestBody).Context(ctx).Do()
+  callResult, err := client.Projects.MoveInstance(project, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -6534,8 +6132,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -6543,15 +6139,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'setCommonInstanceMetadata' method:
@@ -6563,9 +6158,9 @@ func main() {
     requestBody = &compute.Metadata{}
   )
 
-  callResult, err := service.Projects.SetCommonInstanceMetadata(project, requestBody).Context(ctx).Do()
+  callResult, err := client.Projects.SetCommonInstanceMetadata(project, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -6583,8 +6178,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -6592,15 +6185,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'setUsageExportBucket' method:
@@ -6612,9 +6204,9 @@ func main() {
     requestBody = &compute.UsageExportLocation{}
   )
 
-  callResult, err := service.Projects.SetUsageExportBucket(project, requestBody).Context(ctx).Do()
+  callResult, err := client.Projects.SetUsageExportBucket(project, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -6632,8 +6224,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -6641,15 +6231,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -6665,9 +6254,8 @@ func main() {
 
   )
 
-  err = service.RegionOperations.Delete(project, region, operation).Context(ctx).Do()
-  if err != nil {
-    log.Fatal(err)
+  if err = client.RegionOperations.Delete(project, region, operation).Context(ctx).Do(); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -6683,8 +6271,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -6692,15 +6278,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -6716,9 +6301,9 @@ func main() {
 
   )
 
-  callResult, err := service.RegionOperations.Get(project, region, operation).Context(ctx).Do()
+  callResult, err := client.RegionOperations.Get(project, region, operation).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -6736,8 +6321,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -6745,15 +6328,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -6774,9 +6356,8 @@ func main() {
     }
     return nil
   }
-  err = service.RegionOperations.List(project, region).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.RegionOperations.List(project, region).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -6792,8 +6373,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -6801,15 +6380,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -6822,9 +6400,9 @@ func main() {
 
   )
 
-  callResult, err := service.Regions.Get(project, region).Context(ctx).Do()
+  callResult, err := client.Regions.Get(project, region).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -6842,8 +6420,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -6851,15 +6427,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -6877,9 +6452,8 @@ func main() {
     }
     return nil
   }
-  err = service.Regions.List(project).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Regions.List(project).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -6895,8 +6469,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -6904,15 +6476,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -6925,9 +6496,9 @@ func main() {
 
   )
 
-  callResult, err := service.Routes.Delete(project, route).Context(ctx).Do()
+  callResult, err := client.Routes.Delete(project, route).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -6945,8 +6516,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -6954,15 +6523,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -6975,9 +6543,9 @@ func main() {
 
   )
 
-  callResult, err := service.Routes.Get(project, route).Context(ctx).Do()
+  callResult, err := client.Routes.Get(project, route).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -6995,8 +6563,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -7004,15 +6570,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
@@ -7024,9 +6589,9 @@ func main() {
     requestBody = &compute.Route{}
   )
 
-  callResult, err := service.Routes.Insert(project, requestBody).Context(ctx).Do()
+  callResult, err := client.Routes.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -7044,8 +6609,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -7053,15 +6616,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -7079,9 +6641,8 @@ func main() {
     }
     return nil
   }
-  err = service.Routes.List(project).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Routes.List(project).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -7097,8 +6658,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -7106,15 +6665,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -7127,9 +6685,9 @@ func main() {
 
   )
 
-  callResult, err := service.Snapshots.Delete(project, snapshot).Context(ctx).Do()
+  callResult, err := client.Snapshots.Delete(project, snapshot).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -7147,8 +6705,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -7156,15 +6712,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -7177,9 +6732,9 @@ func main() {
 
   )
 
-  callResult, err := service.Snapshots.Get(project, snapshot).Context(ctx).Do()
+  callResult, err := client.Snapshots.Get(project, snapshot).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -7197,8 +6752,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -7206,15 +6759,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -7232,9 +6784,8 @@ func main() {
     }
     return nil
   }
-  err = service.Snapshots.List(project).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Snapshots.List(project).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -7250,8 +6801,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -7259,15 +6808,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -7280,9 +6828,9 @@ func main() {
 
   )
 
-  callResult, err := service.SslCertificates.Delete(project, sslCertificate).Context(ctx).Do()
+  callResult, err := client.SslCertificates.Delete(project, sslCertificate).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -7300,8 +6848,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -7309,15 +6855,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -7330,9 +6875,9 @@ func main() {
 
   )
 
-  callResult, err := service.SslCertificates.Get(project, sslCertificate).Context(ctx).Do()
+  callResult, err := client.SslCertificates.Get(project, sslCertificate).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -7350,8 +6895,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -7359,15 +6902,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
@@ -7379,9 +6921,9 @@ func main() {
     requestBody = &compute.SslCertificate{}
   )
 
-  callResult, err := service.SslCertificates.Insert(project, requestBody).Context(ctx).Do()
+  callResult, err := client.SslCertificates.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -7399,8 +6941,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -7408,15 +6948,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -7434,9 +6973,8 @@ func main() {
     }
     return nil
   }
-  err = service.SslCertificates.List(project).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.SslCertificates.List(project).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -7452,8 +6990,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -7461,15 +6997,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'aggregatedList' method:
@@ -7487,9 +7022,8 @@ func main() {
     }
     return nil
   }
-  err = service.Subnetworks.AggregatedList(project).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Subnetworks.AggregatedList(project).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -7505,8 +7039,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -7514,15 +7046,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -7538,9 +7069,9 @@ func main() {
 
   )
 
-  callResult, err := service.Subnetworks.Delete(project, region, subnetwork).Context(ctx).Do()
+  callResult, err := client.Subnetworks.Delete(project, region, subnetwork).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -7558,8 +7089,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -7567,15 +7096,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -7591,9 +7119,9 @@ func main() {
 
   )
 
-  callResult, err := service.Subnetworks.Get(project, region, subnetwork).Context(ctx).Do()
+  callResult, err := client.Subnetworks.Get(project, region, subnetwork).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -7611,8 +7139,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -7620,15 +7146,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
@@ -7643,9 +7168,9 @@ func main() {
     requestBody = &compute.Subnetwork{}
   )
 
-  callResult, err := service.Subnetworks.Insert(project, region, requestBody).Context(ctx).Do()
+  callResult, err := client.Subnetworks.Insert(project, region, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -7663,8 +7188,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -7672,15 +7195,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -7701,9 +7223,8 @@ func main() {
     }
     return nil
   }
-  err = service.Subnetworks.List(project, region).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Subnetworks.List(project, region).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -7719,8 +7240,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -7728,15 +7247,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -7749,9 +7267,9 @@ func main() {
 
   )
 
-  callResult, err := service.TargetHttpProxies.Delete(project, targetHttpProxy).Context(ctx).Do()
+  callResult, err := client.TargetHttpProxies.Delete(project, targetHttpProxy).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -7769,8 +7287,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -7778,15 +7294,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -7799,9 +7314,9 @@ func main() {
 
   )
 
-  callResult, err := service.TargetHttpProxies.Get(project, targetHttpProxy).Context(ctx).Do()
+  callResult, err := client.TargetHttpProxies.Get(project, targetHttpProxy).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -7819,8 +7334,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -7828,15 +7341,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
@@ -7848,9 +7360,9 @@ func main() {
     requestBody = &compute.TargetHttpProxy{}
   )
 
-  callResult, err := service.TargetHttpProxies.Insert(project, requestBody).Context(ctx).Do()
+  callResult, err := client.TargetHttpProxies.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -7868,8 +7380,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -7877,15 +7387,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -7903,9 +7412,8 @@ func main() {
     }
     return nil
   }
-  err = service.TargetHttpProxies.List(project).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.TargetHttpProxies.List(project).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -7921,8 +7429,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -7930,15 +7436,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'setUrlMap' method:
@@ -7953,9 +7458,9 @@ func main() {
     requestBody = &compute.UrlMapReference{}
   )
 
-  callResult, err := service.TargetHttpProxies.SetUrlMap(project, targetHttpProxy, requestBody).Context(ctx).Do()
+  callResult, err := client.TargetHttpProxies.SetUrlMap(project, targetHttpProxy, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -7973,8 +7478,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -7982,15 +7485,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -8003,9 +7505,9 @@ func main() {
 
   )
 
-  callResult, err := service.TargetHttpsProxies.Delete(project, targetHttpsProxy).Context(ctx).Do()
+  callResult, err := client.TargetHttpsProxies.Delete(project, targetHttpsProxy).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -8023,8 +7525,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -8032,15 +7532,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -8053,9 +7552,9 @@ func main() {
 
   )
 
-  callResult, err := service.TargetHttpsProxies.Get(project, targetHttpsProxy).Context(ctx).Do()
+  callResult, err := client.TargetHttpsProxies.Get(project, targetHttpsProxy).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -8073,8 +7572,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -8082,15 +7579,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
@@ -8102,9 +7598,9 @@ func main() {
     requestBody = &compute.TargetHttpsProxy{}
   )
 
-  callResult, err := service.TargetHttpsProxies.Insert(project, requestBody).Context(ctx).Do()
+  callResult, err := client.TargetHttpsProxies.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -8122,8 +7618,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -8131,15 +7625,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -8157,9 +7650,8 @@ func main() {
     }
     return nil
   }
-  err = service.TargetHttpsProxies.List(project).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.TargetHttpsProxies.List(project).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -8175,8 +7667,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -8184,15 +7674,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'setSslCertificates' method:
@@ -8207,9 +7696,9 @@ func main() {
     requestBody = &compute.TargetHttpsProxiesSetSslCertificatesRequest{}
   )
 
-  callResult, err := service.TargetHttpsProxies.SetSslCertificates(project, targetHttpsProxy, requestBody).Context(ctx).Do()
+  callResult, err := client.TargetHttpsProxies.SetSslCertificates(project, targetHttpsProxy, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -8227,8 +7716,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -8236,15 +7723,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'setUrlMap' method:
@@ -8259,9 +7745,9 @@ func main() {
     requestBody = &compute.UrlMapReference{}
   )
 
-  callResult, err := service.TargetHttpsProxies.SetUrlMap(project, targetHttpsProxy, requestBody).Context(ctx).Do()
+  callResult, err := client.TargetHttpsProxies.SetUrlMap(project, targetHttpsProxy, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -8279,8 +7765,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -8288,15 +7772,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'aggregatedList' method:
@@ -8314,9 +7797,8 @@ func main() {
     }
     return nil
   }
-  err = service.TargetInstances.AggregatedList(project).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.TargetInstances.AggregatedList(project).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -8332,8 +7814,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -8341,15 +7821,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -8365,9 +7844,9 @@ func main() {
 
   )
 
-  callResult, err := service.TargetInstances.Delete(project, zone, targetInstance).Context(ctx).Do()
+  callResult, err := client.TargetInstances.Delete(project, zone, targetInstance).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -8385,8 +7864,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -8394,15 +7871,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -8418,9 +7894,9 @@ func main() {
 
   )
 
-  callResult, err := service.TargetInstances.Get(project, zone, targetInstance).Context(ctx).Do()
+  callResult, err := client.TargetInstances.Get(project, zone, targetInstance).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -8438,8 +7914,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -8447,15 +7921,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
@@ -8470,9 +7943,9 @@ func main() {
     requestBody = &compute.TargetInstance{}
   )
 
-  callResult, err := service.TargetInstances.Insert(project, zone, requestBody).Context(ctx).Do()
+  callResult, err := client.TargetInstances.Insert(project, zone, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -8490,8 +7963,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -8499,15 +7970,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -8528,9 +7998,8 @@ func main() {
     }
     return nil
   }
-  err = service.TargetInstances.List(project, zone).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.TargetInstances.List(project, zone).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -8546,8 +8015,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -8555,15 +8022,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'addHealthCheck' method:
@@ -8581,9 +8047,9 @@ func main() {
     requestBody = &compute.TargetPoolsAddHealthCheckRequest{}
   )
 
-  callResult, err := service.TargetPools.AddHealthCheck(project, region, targetPool, requestBody).Context(ctx).Do()
+  callResult, err := client.TargetPools.AddHealthCheck(project, region, targetPool, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -8601,8 +8067,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -8610,15 +8074,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'addInstance' method:
@@ -8636,9 +8099,9 @@ func main() {
     requestBody = &compute.TargetPoolsAddInstanceRequest{}
   )
 
-  callResult, err := service.TargetPools.AddInstance(project, region, targetPool, requestBody).Context(ctx).Do()
+  callResult, err := client.TargetPools.AddInstance(project, region, targetPool, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -8656,8 +8119,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -8665,15 +8126,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'aggregatedList' method:
@@ -8691,9 +8151,8 @@ func main() {
     }
     return nil
   }
-  err = service.TargetPools.AggregatedList(project).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.TargetPools.AggregatedList(project).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -8709,8 +8168,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -8718,15 +8175,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -8742,9 +8198,9 @@ func main() {
 
   )
 
-  callResult, err := service.TargetPools.Delete(project, region, targetPool).Context(ctx).Do()
+  callResult, err := client.TargetPools.Delete(project, region, targetPool).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -8762,8 +8218,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -8771,15 +8225,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -8795,9 +8248,9 @@ func main() {
 
   )
 
-  callResult, err := service.TargetPools.Get(project, region, targetPool).Context(ctx).Do()
+  callResult, err := client.TargetPools.Get(project, region, targetPool).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -8815,8 +8268,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -8824,15 +8275,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'getHealth' method:
@@ -8850,9 +8300,9 @@ func main() {
     requestBody = &compute.InstanceReference{}
   )
 
-  callResult, err := service.TargetPools.GetHealth(project, region, targetPool, requestBody).Context(ctx).Do()
+  callResult, err := client.TargetPools.GetHealth(project, region, targetPool, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -8870,8 +8320,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -8879,15 +8327,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
@@ -8902,9 +8349,9 @@ func main() {
     requestBody = &compute.TargetPool{}
   )
 
-  callResult, err := service.TargetPools.Insert(project, region, requestBody).Context(ctx).Do()
+  callResult, err := client.TargetPools.Insert(project, region, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -8922,8 +8369,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -8931,15 +8376,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -8960,9 +8404,8 @@ func main() {
     }
     return nil
   }
-  err = service.TargetPools.List(project, region).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.TargetPools.List(project, region).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -8978,8 +8421,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -8987,15 +8428,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'removeHealthCheck' method:
@@ -9013,9 +8453,9 @@ func main() {
     requestBody = &compute.TargetPoolsRemoveHealthCheckRequest{}
   )
 
-  callResult, err := service.TargetPools.RemoveHealthCheck(project, region, targetPool, requestBody).Context(ctx).Do()
+  callResult, err := client.TargetPools.RemoveHealthCheck(project, region, targetPool, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -9033,8 +8473,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -9042,15 +8480,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'removeInstance' method:
@@ -9068,9 +8505,9 @@ func main() {
     requestBody = &compute.TargetPoolsRemoveInstanceRequest{}
   )
 
-  callResult, err := service.TargetPools.RemoveInstance(project, region, targetPool, requestBody).Context(ctx).Do()
+  callResult, err := client.TargetPools.RemoveInstance(project, region, targetPool, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -9088,8 +8525,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -9097,15 +8532,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'setBackup' method:
@@ -9123,9 +8557,9 @@ func main() {
     requestBody = &compute.TargetReference{}
   )
 
-  callResult, err := service.TargetPools.SetBackup(project, region, targetPool, requestBody).Context(ctx).Do()
+  callResult, err := client.TargetPools.SetBackup(project, region, targetPool, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -9143,8 +8577,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -9152,15 +8584,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'aggregatedList' method:
@@ -9178,9 +8609,8 @@ func main() {
     }
     return nil
   }
-  err = service.TargetVpnGateways.AggregatedList(project).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.TargetVpnGateways.AggregatedList(project).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -9196,8 +8626,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -9205,15 +8633,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -9229,9 +8656,9 @@ func main() {
 
   )
 
-  callResult, err := service.TargetVpnGateways.Delete(project, region, targetVpnGateway).Context(ctx).Do()
+  callResult, err := client.TargetVpnGateways.Delete(project, region, targetVpnGateway).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -9249,8 +8676,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -9258,15 +8683,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -9282,9 +8706,9 @@ func main() {
 
   )
 
-  callResult, err := service.TargetVpnGateways.Get(project, region, targetVpnGateway).Context(ctx).Do()
+  callResult, err := client.TargetVpnGateways.Get(project, region, targetVpnGateway).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -9302,8 +8726,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -9311,15 +8733,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
@@ -9334,9 +8755,9 @@ func main() {
     requestBody = &compute.TargetVpnGateway{}
   )
 
-  callResult, err := service.TargetVpnGateways.Insert(project, region, requestBody).Context(ctx).Do()
+  callResult, err := client.TargetVpnGateways.Insert(project, region, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -9354,8 +8775,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -9363,15 +8782,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -9392,9 +8810,8 @@ func main() {
     }
     return nil
   }
-  err = service.TargetVpnGateways.List(project, region).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.TargetVpnGateways.List(project, region).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -9410,8 +8827,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -9419,15 +8834,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -9440,9 +8854,9 @@ func main() {
 
   )
 
-  callResult, err := service.UrlMaps.Delete(project, urlMap).Context(ctx).Do()
+  callResult, err := client.UrlMaps.Delete(project, urlMap).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -9460,8 +8874,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -9469,15 +8881,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -9490,9 +8901,9 @@ func main() {
 
   )
 
-  callResult, err := service.UrlMaps.Get(project, urlMap).Context(ctx).Do()
+  callResult, err := client.UrlMaps.Get(project, urlMap).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -9510,8 +8921,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -9519,15 +8928,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
@@ -9539,9 +8947,9 @@ func main() {
     requestBody = &compute.UrlMap{}
   )
 
-  callResult, err := service.UrlMaps.Insert(project, requestBody).Context(ctx).Do()
+  callResult, err := client.UrlMaps.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -9559,8 +8967,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -9568,15 +8974,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -9594,9 +8999,8 @@ func main() {
     }
     return nil
   }
-  err = service.UrlMaps.List(project).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.UrlMaps.List(project).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -9612,8 +9016,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -9621,15 +9023,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'patch' method:
@@ -9644,9 +9045,9 @@ func main() {
     requestBody = &compute.UrlMap{}
   )
 
-  callResult, err := service.UrlMaps.Patch(project, urlMap, requestBody).Context(ctx).Do()
+  callResult, err := client.UrlMaps.Patch(project, urlMap, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -9664,8 +9065,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -9673,15 +9072,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
@@ -9696,9 +9094,9 @@ func main() {
     requestBody = &compute.UrlMap{}
   )
 
-  callResult, err := service.UrlMaps.Update(project, urlMap, requestBody).Context(ctx).Do()
+  callResult, err := client.UrlMaps.Update(project, urlMap, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -9716,8 +9114,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -9725,15 +9121,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'validate' method:
@@ -9748,9 +9143,9 @@ func main() {
     requestBody = &compute.UrlMapsValidateRequest{}
   )
 
-  callResult, err := service.UrlMaps.Validate(project, urlMap, requestBody).Context(ctx).Do()
+  callResult, err := client.UrlMaps.Validate(project, urlMap, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -9768,8 +9163,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -9777,15 +9170,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'aggregatedList' method:
@@ -9803,9 +9195,8 @@ func main() {
     }
     return nil
   }
-  err = service.VpnTunnels.AggregatedList(project).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.VpnTunnels.AggregatedList(project).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -9821,8 +9212,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -9830,15 +9219,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -9854,9 +9242,9 @@ func main() {
 
   )
 
-  callResult, err := service.VpnTunnels.Delete(project, region, vpnTunnel).Context(ctx).Do()
+  callResult, err := client.VpnTunnels.Delete(project, region, vpnTunnel).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -9874,8 +9262,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -9883,15 +9269,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -9907,9 +9292,9 @@ func main() {
 
   )
 
-  callResult, err := service.VpnTunnels.Get(project, region, vpnTunnel).Context(ctx).Do()
+  callResult, err := client.VpnTunnels.Get(project, region, vpnTunnel).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -9927,8 +9312,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -9936,15 +9319,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
@@ -9959,9 +9341,9 @@ func main() {
     requestBody = &compute.VpnTunnel{}
   )
 
-  callResult, err := service.VpnTunnels.Insert(project, region, requestBody).Context(ctx).Do()
+  callResult, err := client.VpnTunnels.Insert(project, region, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -9979,8 +9361,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -9988,15 +9368,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -10017,9 +9396,8 @@ func main() {
     }
     return nil
   }
-  err = service.VpnTunnels.List(project, region).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.VpnTunnels.List(project, region).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -10035,8 +9413,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -10044,15 +9420,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -10068,9 +9443,8 @@ func main() {
 
   )
 
-  err = service.ZoneOperations.Delete(project, zone, operation).Context(ctx).Do()
-  if err != nil {
-    log.Fatal(err)
+  if err = client.ZoneOperations.Delete(project, zone, operation).Context(ctx).Do(); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -10086,8 +9460,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -10095,15 +9467,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -10119,9 +9490,9 @@ func main() {
 
   )
 
-  callResult, err := service.ZoneOperations.Get(project, zone, operation).Context(ctx).Do()
+  callResult, err := client.ZoneOperations.Get(project, zone, operation).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -10139,8 +9510,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -10148,15 +9517,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -10177,9 +9545,8 @@ func main() {
     }
     return nil
   }
-  err = service.ZoneOperations.List(project, zone).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.ZoneOperations.List(project, zone).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -10195,8 +9562,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -10204,15 +9569,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -10225,9 +9589,9 @@ func main() {
 
   )
 
-  callResult, err := service.Zones.Get(project, zone).Context(ctx).Do()
+  callResult, err := client.Zones.Get(project, zone).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -10245,8 +9609,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -10254,15 +9616,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := compute.New(client)
+  client, err := compute.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -10280,8 +9641,7 @@ func main() {
     }
     return nil
   }
-  err = service.Zones.List(project).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Zones.List(project).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_compute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_compute.v1.json.baseline
@@ -22,14 +22,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'aggregatedList' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
   var (
     // Project ID for this request.
     project = ""
@@ -45,7 +47,8 @@ func main() {
     return nil
   }
   if err = client.Addresses.AggregatedList(project).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -71,14 +74,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Project ID for this request.
     project = ""
@@ -93,7 +98,8 @@ func main() {
 
   callResult, err := client.Addresses.Delete(project, region, address).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -121,14 +127,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID for this request.
     project = ""
@@ -143,7 +151,8 @@ func main() {
 
   callResult, err := client.Addresses.Get(project, region, address).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -171,14 +180,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
   var (
     // Project ID for this request.
     project = ""
@@ -192,7 +203,8 @@ func main() {
 
   callResult, err := client.Addresses.Insert(project, region, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -220,14 +232,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID for this request.
     project = ""
@@ -246,7 +260,8 @@ func main() {
     return nil
   }
   if err = client.Addresses.List(project, region).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -272,14 +287,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'aggregatedList' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
   var (
     // Project ID for this request.
     project = ""
@@ -295,7 +312,8 @@ func main() {
     return nil
   }
   if err = client.Autoscalers.AggregatedList(project).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -321,14 +339,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Project ID for this request.
     project = ""
@@ -343,7 +363,8 @@ func main() {
 
   callResult, err := client.Autoscalers.Delete(project, zone, autoscaler).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -371,14 +392,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID for this request.
     project = ""
@@ -393,7 +416,8 @@ func main() {
 
   callResult, err := client.Autoscalers.Get(project, zone, autoscaler).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -421,14 +445,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
   var (
     // Project ID for this request.
     project = ""
@@ -442,7 +468,8 @@ func main() {
 
   callResult, err := client.Autoscalers.Insert(project, zone, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -470,14 +497,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID for this request.
     project = ""
@@ -496,7 +525,8 @@ func main() {
     return nil
   }
   if err = client.Autoscalers.List(project, zone).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -522,14 +552,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'patch' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
   var (
     // Project ID for this request.
     project = ""
@@ -546,7 +578,8 @@ func main() {
 
   callResult, err := client.Autoscalers.Patch(project, zone, autoscaler, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -574,14 +607,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
   var (
     // Project ID for this request.
     project = ""
@@ -595,7 +630,8 @@ func main() {
 
   callResult, err := client.Autoscalers.Update(project, zone, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -623,14 +659,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Project ID for this request.
     project = ""
@@ -642,7 +680,8 @@ func main() {
 
   callResult, err := client.BackendServices.Delete(project, backendService).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -670,14 +709,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID for this request.
     project = ""
@@ -689,7 +730,8 @@ func main() {
 
   callResult, err := client.BackendServices.Get(project, backendService).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -717,14 +759,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'getHealth' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'getHealth' method:
   var (
 
     project = ""
@@ -738,7 +782,8 @@ func main() {
 
   callResult, err := client.BackendServices.GetHealth(project, backendService, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -766,14 +811,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
   var (
     // Project ID for this request.
     project = ""
@@ -784,7 +831,8 @@ func main() {
 
   callResult, err := client.BackendServices.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -812,14 +860,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID for this request.
     project = ""
@@ -835,7 +885,8 @@ func main() {
     return nil
   }
   if err = client.BackendServices.List(project).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -861,14 +912,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'patch' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
   var (
     // Project ID for this request.
     project = ""
@@ -882,7 +935,8 @@ func main() {
 
   callResult, err := client.BackendServices.Patch(project, backendService, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -910,14 +964,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
   var (
     // Project ID for this request.
     project = ""
@@ -931,7 +987,8 @@ func main() {
 
   callResult, err := client.BackendServices.Update(project, backendService, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -959,14 +1016,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'aggregatedList' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
   var (
     // Project ID for this request.
     project = ""
@@ -982,7 +1041,8 @@ func main() {
     return nil
   }
   if err = client.DiskTypes.AggregatedList(project).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -1008,14 +1068,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID for this request.
     project = ""
@@ -1030,7 +1092,8 @@ func main() {
 
   callResult, err := client.DiskTypes.Get(project, zone, diskType).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1058,14 +1121,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID for this request.
     project = ""
@@ -1084,7 +1149,8 @@ func main() {
     return nil
   }
   if err = client.DiskTypes.List(project, zone).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -1110,14 +1176,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'aggregatedList' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
   var (
     // Project ID for this request.
     project = ""
@@ -1133,7 +1201,8 @@ func main() {
     return nil
   }
   if err = client.Disks.AggregatedList(project).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -1159,14 +1228,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'createSnapshot' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'createSnapshot' method:
   var (
     // Project ID for this request.
     project = ""
@@ -1183,7 +1254,8 @@ func main() {
 
   callResult, err := client.Disks.CreateSnapshot(project, zone, disk, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1211,14 +1283,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Project ID for this request.
     project = ""
@@ -1233,7 +1307,8 @@ func main() {
 
   callResult, err := client.Disks.Delete(project, zone, disk).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1261,14 +1336,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID for this request.
     project = ""
@@ -1283,7 +1360,8 @@ func main() {
 
   callResult, err := client.Disks.Get(project, zone, disk).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1311,14 +1389,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
   var (
     // Project ID for this request.
     project = ""
@@ -1332,7 +1412,8 @@ func main() {
 
   callResult, err := client.Disks.Insert(project, zone, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1360,14 +1441,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID for this request.
     project = ""
@@ -1386,7 +1469,8 @@ func main() {
     return nil
   }
   if err = client.Disks.List(project, zone).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -1412,14 +1496,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Project ID for this request.
     project = ""
@@ -1431,7 +1517,8 @@ func main() {
 
   callResult, err := client.Firewalls.Delete(project, firewall).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1459,14 +1546,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID for this request.
     project = ""
@@ -1478,7 +1567,8 @@ func main() {
 
   callResult, err := client.Firewalls.Get(project, firewall).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1506,14 +1596,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
   var (
     // Project ID for this request.
     project = ""
@@ -1524,7 +1616,8 @@ func main() {
 
   callResult, err := client.Firewalls.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1552,14 +1645,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID for this request.
     project = ""
@@ -1575,7 +1670,8 @@ func main() {
     return nil
   }
   if err = client.Firewalls.List(project).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -1601,14 +1697,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'patch' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
   var (
     // Project ID for this request.
     project = ""
@@ -1622,7 +1720,8 @@ func main() {
 
   callResult, err := client.Firewalls.Patch(project, firewall, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1650,14 +1749,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
   var (
     // Project ID for this request.
     project = ""
@@ -1671,7 +1772,8 @@ func main() {
 
   callResult, err := client.Firewalls.Update(project, firewall, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1699,14 +1801,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'aggregatedList' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
   var (
     // Project ID for this request.
     project = ""
@@ -1722,7 +1826,8 @@ func main() {
     return nil
   }
   if err = client.ForwardingRules.AggregatedList(project).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -1748,14 +1853,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Project ID for this request.
     project = ""
@@ -1770,7 +1877,8 @@ func main() {
 
   callResult, err := client.ForwardingRules.Delete(project, region, forwardingRule).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1798,14 +1906,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID for this request.
     project = ""
@@ -1820,7 +1930,8 @@ func main() {
 
   callResult, err := client.ForwardingRules.Get(project, region, forwardingRule).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1848,14 +1959,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
   var (
     // Project ID for this request.
     project = ""
@@ -1869,7 +1982,8 @@ func main() {
 
   callResult, err := client.ForwardingRules.Insert(project, region, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1897,14 +2011,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID for this request.
     project = ""
@@ -1923,7 +2039,8 @@ func main() {
     return nil
   }
   if err = client.ForwardingRules.List(project, region).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -1949,14 +2066,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'setTarget' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'setTarget' method:
   var (
     // Project ID for this request.
     project = ""
@@ -1973,7 +2092,8 @@ func main() {
 
   callResult, err := client.ForwardingRules.SetTarget(project, region, forwardingRule, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -2001,14 +2121,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Project ID for this request.
     project = ""
@@ -2020,7 +2142,8 @@ func main() {
 
   callResult, err := client.GlobalAddresses.Delete(project, address).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -2048,14 +2171,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID for this request.
     project = ""
@@ -2067,7 +2192,8 @@ func main() {
 
   callResult, err := client.GlobalAddresses.Get(project, address).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -2095,14 +2221,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
   var (
     // Project ID for this request.
     project = ""
@@ -2113,7 +2241,8 @@ func main() {
 
   callResult, err := client.GlobalAddresses.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -2141,14 +2270,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID for this request.
     project = ""
@@ -2164,7 +2295,8 @@ func main() {
     return nil
   }
   if err = client.GlobalAddresses.List(project).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -2190,14 +2322,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Project ID for this request.
     project = ""
@@ -2209,7 +2343,8 @@ func main() {
 
   callResult, err := client.GlobalForwardingRules.Delete(project, forwardingRule).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -2237,14 +2372,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID for this request.
     project = ""
@@ -2256,7 +2393,8 @@ func main() {
 
   callResult, err := client.GlobalForwardingRules.Get(project, forwardingRule).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -2284,14 +2422,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
   var (
     // Project ID for this request.
     project = ""
@@ -2302,7 +2442,8 @@ func main() {
 
   callResult, err := client.GlobalForwardingRules.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -2330,14 +2471,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID for this request.
     project = ""
@@ -2353,7 +2496,8 @@ func main() {
     return nil
   }
   if err = client.GlobalForwardingRules.List(project).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -2379,14 +2523,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'setTarget' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'setTarget' method:
   var (
     // Project ID for this request.
     project = ""
@@ -2400,7 +2546,8 @@ func main() {
 
   callResult, err := client.GlobalForwardingRules.SetTarget(project, forwardingRule, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -2428,14 +2575,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'aggregatedList' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
   var (
     // Project ID for this request.
     project = ""
@@ -2451,7 +2600,8 @@ func main() {
     return nil
   }
   if err = client.GlobalOperations.AggregatedList(project).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -2477,14 +2627,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Project ID for this request.
     project = ""
@@ -2495,7 +2647,8 @@ func main() {
   )
 
   if err = client.GlobalOperations.Delete(project, operation).Context(ctx).Do(); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -2521,14 +2674,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID for this request.
     project = ""
@@ -2540,7 +2695,8 @@ func main() {
 
   callResult, err := client.GlobalOperations.Get(project, operation).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -2568,14 +2724,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID for this request.
     project = ""
@@ -2591,7 +2749,8 @@ func main() {
     return nil
   }
   if err = client.GlobalOperations.List(project).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -2617,14 +2776,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Project ID for this request.
     project = ""
@@ -2636,7 +2797,8 @@ func main() {
 
   callResult, err := client.HttpHealthChecks.Delete(project, httpHealthCheck).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -2664,14 +2826,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID for this request.
     project = ""
@@ -2683,7 +2847,8 @@ func main() {
 
   callResult, err := client.HttpHealthChecks.Get(project, httpHealthCheck).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -2711,14 +2876,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
   var (
     // Project ID for this request.
     project = ""
@@ -2729,7 +2896,8 @@ func main() {
 
   callResult, err := client.HttpHealthChecks.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -2757,14 +2925,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID for this request.
     project = ""
@@ -2780,7 +2950,8 @@ func main() {
     return nil
   }
   if err = client.HttpHealthChecks.List(project).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -2806,14 +2977,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'patch' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
   var (
     // Project ID for this request.
     project = ""
@@ -2827,7 +3000,8 @@ func main() {
 
   callResult, err := client.HttpHealthChecks.Patch(project, httpHealthCheck, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -2855,14 +3029,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
   var (
     // Project ID for this request.
     project = ""
@@ -2876,7 +3052,8 @@ func main() {
 
   callResult, err := client.HttpHealthChecks.Update(project, httpHealthCheck, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -2904,14 +3081,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Project ID for this request.
     project = ""
@@ -2923,7 +3102,8 @@ func main() {
 
   callResult, err := client.HttpsHealthChecks.Delete(project, httpsHealthCheck).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -2951,14 +3131,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID for this request.
     project = ""
@@ -2970,7 +3152,8 @@ func main() {
 
   callResult, err := client.HttpsHealthChecks.Get(project, httpsHealthCheck).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -2998,14 +3181,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
   var (
     // Project ID for this request.
     project = ""
@@ -3016,7 +3201,8 @@ func main() {
 
   callResult, err := client.HttpsHealthChecks.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -3044,14 +3230,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID for this request.
     project = ""
@@ -3067,7 +3255,8 @@ func main() {
     return nil
   }
   if err = client.HttpsHealthChecks.List(project).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -3093,14 +3282,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'patch' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
   var (
     // Project ID for this request.
     project = ""
@@ -3114,7 +3305,8 @@ func main() {
 
   callResult, err := client.HttpsHealthChecks.Patch(project, httpsHealthCheck, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -3142,14 +3334,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
   var (
     // Project ID for this request.
     project = ""
@@ -3163,7 +3357,8 @@ func main() {
 
   callResult, err := client.HttpsHealthChecks.Update(project, httpsHealthCheck, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -3191,14 +3386,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Project ID for this request.
     project = ""
@@ -3210,7 +3407,8 @@ func main() {
 
   callResult, err := client.Images.Delete(project, image).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -3238,14 +3436,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'deprecate' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'deprecate' method:
   var (
     // Project ID for this request.
     project = ""
@@ -3259,7 +3459,8 @@ func main() {
 
   callResult, err := client.Images.Deprecate(project, image, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -3287,14 +3488,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID for this request.
     project = ""
@@ -3306,7 +3509,8 @@ func main() {
 
   callResult, err := client.Images.Get(project, image).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -3334,14 +3538,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
   var (
     // Project ID for this request.
     project = ""
@@ -3352,7 +3558,8 @@ func main() {
 
   callResult, err := client.Images.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -3380,14 +3587,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID for this request.
     project = ""
@@ -3403,7 +3612,8 @@ func main() {
     return nil
   }
   if err = client.Images.List(project).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -3429,14 +3639,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'abandonInstances' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'abandonInstances' method:
   var (
     // Project ID for this request.
     project = ""
@@ -3453,7 +3665,8 @@ func main() {
 
   callResult, err := client.InstanceGroupManagers.AbandonInstances(project, zone, instanceGroupManager, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -3481,14 +3694,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'aggregatedList' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
   var (
     // Project ID for this request.
     project = ""
@@ -3504,7 +3719,8 @@ func main() {
     return nil
   }
   if err = client.InstanceGroupManagers.AggregatedList(project).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -3530,14 +3746,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Project ID for this request.
     project = ""
@@ -3552,7 +3770,8 @@ func main() {
 
   callResult, err := client.InstanceGroupManagers.Delete(project, zone, instanceGroupManager).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -3580,14 +3799,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'deleteInstances' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'deleteInstances' method:
   var (
     // Project ID for this request.
     project = ""
@@ -3604,7 +3825,8 @@ func main() {
 
   callResult, err := client.InstanceGroupManagers.DeleteInstances(project, zone, instanceGroupManager, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -3632,14 +3854,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID for this request.
     project = ""
@@ -3654,7 +3878,8 @@ func main() {
 
   callResult, err := client.InstanceGroupManagers.Get(project, zone, instanceGroupManager).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -3682,14 +3907,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
   var (
     // Project ID for this request.
     project = ""
@@ -3703,7 +3930,8 @@ func main() {
 
   callResult, err := client.InstanceGroupManagers.Insert(project, zone, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -3731,14 +3959,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID for this request.
     project = ""
@@ -3757,7 +3987,8 @@ func main() {
     return nil
   }
   if err = client.InstanceGroupManagers.List(project, zone).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -3783,14 +4014,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'listManagedInstances' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'listManagedInstances' method:
   var (
     // Project ID for this request.
     project = ""
@@ -3805,7 +4038,8 @@ func main() {
 
   callResult, err := client.InstanceGroupManagers.ListManagedInstances(project, zone, instanceGroupManager).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -3833,14 +4067,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'recreateInstances' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'recreateInstances' method:
   var (
     // Project ID for this request.
     project = ""
@@ -3857,7 +4093,8 @@ func main() {
 
   callResult, err := client.InstanceGroupManagers.RecreateInstances(project, zone, instanceGroupManager, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -3885,14 +4122,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'resize' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'resize' method:
   var (
     // Project ID for this request.
     project = ""
@@ -3910,7 +4149,8 @@ func main() {
 
   callResult, err := client.InstanceGroupManagers.Resize(project, zone, instanceGroupManager, size).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -3938,14 +4178,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'setInstanceTemplate' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'setInstanceTemplate' method:
   var (
     // Project ID for this request.
     project = ""
@@ -3962,7 +4204,8 @@ func main() {
 
   callResult, err := client.InstanceGroupManagers.SetInstanceTemplate(project, zone, instanceGroupManager, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -3990,14 +4233,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'setTargetPools' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'setTargetPools' method:
   var (
     // Project ID for this request.
     project = ""
@@ -4014,7 +4259,8 @@ func main() {
 
   callResult, err := client.InstanceGroupManagers.SetTargetPools(project, zone, instanceGroupManager, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -4042,14 +4288,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'addInstances' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'addInstances' method:
   var (
     // Project ID for this request.
     project = ""
@@ -4066,7 +4314,8 @@ func main() {
 
   callResult, err := client.InstanceGroups.AddInstances(project, zone, instanceGroup, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -4094,14 +4343,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'aggregatedList' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
   var (
     // Project ID for this request.
     project = ""
@@ -4117,7 +4368,8 @@ func main() {
     return nil
   }
   if err = client.InstanceGroups.AggregatedList(project).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -4143,14 +4395,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Project ID for this request.
     project = ""
@@ -4165,7 +4419,8 @@ func main() {
 
   callResult, err := client.InstanceGroups.Delete(project, zone, instanceGroup).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -4193,14 +4448,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID for this request.
     project = ""
@@ -4215,7 +4472,8 @@ func main() {
 
   callResult, err := client.InstanceGroups.Get(project, zone, instanceGroup).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -4243,14 +4501,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
   var (
     // Project ID for this request.
     project = ""
@@ -4264,7 +4524,8 @@ func main() {
 
   callResult, err := client.InstanceGroups.Insert(project, zone, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -4292,14 +4553,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID for this request.
     project = ""
@@ -4318,7 +4581,8 @@ func main() {
     return nil
   }
   if err = client.InstanceGroups.List(project, zone).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -4344,14 +4608,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'listInstances' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'listInstances' method:
   var (
     // Project ID for this request.
     project = ""
@@ -4368,7 +4634,8 @@ func main() {
 
   callResult, err := client.InstanceGroups.ListInstances(project, zone, instanceGroup, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -4396,14 +4663,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'removeInstances' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'removeInstances' method:
   var (
     // Project ID for this request.
     project = ""
@@ -4420,7 +4689,8 @@ func main() {
 
   callResult, err := client.InstanceGroups.RemoveInstances(project, zone, instanceGroup, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -4448,14 +4718,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'setNamedPorts' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'setNamedPorts' method:
   var (
     // Project ID for this request.
     project = ""
@@ -4472,7 +4744,8 @@ func main() {
 
   callResult, err := client.InstanceGroups.SetNamedPorts(project, zone, instanceGroup, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -4500,14 +4773,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Project ID for this request.
     project = ""
@@ -4519,7 +4794,8 @@ func main() {
 
   callResult, err := client.InstanceTemplates.Delete(project, instanceTemplate).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -4547,14 +4823,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID for this request.
     project = ""
@@ -4566,7 +4844,8 @@ func main() {
 
   callResult, err := client.InstanceTemplates.Get(project, instanceTemplate).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -4594,14 +4873,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
   var (
     // Project ID for this request.
     project = ""
@@ -4612,7 +4893,8 @@ func main() {
 
   callResult, err := client.InstanceTemplates.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -4640,14 +4922,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID for this request.
     project = ""
@@ -4663,7 +4947,8 @@ func main() {
     return nil
   }
   if err = client.InstanceTemplates.List(project).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -4689,14 +4974,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'addAccessConfig' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'addAccessConfig' method:
   var (
     // Project ID for this request.
     project = ""
@@ -4716,7 +5003,8 @@ func main() {
 
   callResult, err := client.Instances.AddAccessConfig(project, zone, instance, networkInterface, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -4744,14 +5032,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'aggregatedList' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
   var (
     // Project ID for this request.
     project = ""
@@ -4767,7 +5057,8 @@ func main() {
     return nil
   }
   if err = client.Instances.AggregatedList(project).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -4793,14 +5084,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'attachDisk' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'attachDisk' method:
   var (
     // Project ID for this request.
     project = ""
@@ -4817,7 +5110,8 @@ func main() {
 
   callResult, err := client.Instances.AttachDisk(project, zone, instance, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -4845,14 +5139,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Project ID for this request.
     project = ""
@@ -4867,7 +5163,8 @@ func main() {
 
   callResult, err := client.Instances.Delete(project, zone, instance).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -4895,14 +5192,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'deleteAccessConfig' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'deleteAccessConfig' method:
   var (
     // Project ID for this request.
     project = ""
@@ -4923,7 +5222,8 @@ func main() {
 
   callResult, err := client.Instances.DeleteAccessConfig(project, zone, instance, accessConfig, networkInterface).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -4951,14 +5251,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'detachDisk' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'detachDisk' method:
   var (
     // Project ID for this request.
     project = ""
@@ -4976,7 +5278,8 @@ func main() {
 
   callResult, err := client.Instances.DetachDisk(project, zone, instance, deviceName).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -5004,14 +5307,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID for this request.
     project = ""
@@ -5026,7 +5331,8 @@ func main() {
 
   callResult, err := client.Instances.Get(project, zone, instance).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -5054,14 +5360,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'getSerialPortOutput' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'getSerialPortOutput' method:
   var (
     // Project ID for this request.
     project = ""
@@ -5076,7 +5384,8 @@ func main() {
 
   callResult, err := client.Instances.GetSerialPortOutput(project, zone, instance).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -5104,14 +5413,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
   var (
     // Project ID for this request.
     project = ""
@@ -5125,7 +5436,8 @@ func main() {
 
   callResult, err := client.Instances.Insert(project, zone, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -5153,14 +5465,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID for this request.
     project = ""
@@ -5179,7 +5493,8 @@ func main() {
     return nil
   }
   if err = client.Instances.List(project, zone).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -5205,14 +5520,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'reset' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'reset' method:
   var (
     // Project ID for this request.
     project = ""
@@ -5227,7 +5544,8 @@ func main() {
 
   callResult, err := client.Instances.Reset(project, zone, instance).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -5255,14 +5573,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'setDiskAutoDelete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'setDiskAutoDelete' method:
   var (
     // Project ID for this request.
     project = ""
@@ -5283,7 +5603,8 @@ func main() {
 
   callResult, err := client.Instances.SetDiskAutoDelete(project, zone, instance, autoDelete, deviceName).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -5311,14 +5632,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'setMachineType' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'setMachineType' method:
   var (
     // Project ID for this request.
     project = ""
@@ -5335,7 +5658,8 @@ func main() {
 
   callResult, err := client.Instances.SetMachineType(project, zone, instance, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -5363,14 +5687,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'setMetadata' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'setMetadata' method:
   var (
     // Project ID for this request.
     project = ""
@@ -5387,7 +5713,8 @@ func main() {
 
   callResult, err := client.Instances.SetMetadata(project, zone, instance, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -5415,14 +5742,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'setScheduling' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'setScheduling' method:
   var (
     // Project ID for this request.
     project = ""
@@ -5439,7 +5768,8 @@ func main() {
 
   callResult, err := client.Instances.SetScheduling(project, zone, instance, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -5467,14 +5797,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'setTags' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'setTags' method:
   var (
     // Project ID for this request.
     project = ""
@@ -5491,7 +5823,8 @@ func main() {
 
   callResult, err := client.Instances.SetTags(project, zone, instance, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -5519,14 +5852,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'start' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'start' method:
   var (
     // Project ID for this request.
     project = ""
@@ -5541,7 +5876,8 @@ func main() {
 
   callResult, err := client.Instances.Start(project, zone, instance).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -5569,14 +5905,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'stop' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'stop' method:
   var (
     // Project ID for this request.
     project = ""
@@ -5591,7 +5929,8 @@ func main() {
 
   callResult, err := client.Instances.Stop(project, zone, instance).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -5619,14 +5958,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID for this request.
     project = ""
@@ -5638,7 +5979,8 @@ func main() {
 
   callResult, err := client.Licenses.Get(project, license).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -5666,14 +6008,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'aggregatedList' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
   var (
     // Project ID for this request.
     project = ""
@@ -5689,7 +6033,8 @@ func main() {
     return nil
   }
   if err = client.MachineTypes.AggregatedList(project).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -5715,14 +6060,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID for this request.
     project = ""
@@ -5737,7 +6084,8 @@ func main() {
 
   callResult, err := client.MachineTypes.Get(project, zone, machineType).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -5765,14 +6113,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID for this request.
     project = ""
@@ -5791,7 +6141,8 @@ func main() {
     return nil
   }
   if err = client.MachineTypes.List(project, zone).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -5817,14 +6168,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Project ID for this request.
     project = ""
@@ -5836,7 +6189,8 @@ func main() {
 
   callResult, err := client.Networks.Delete(project, network).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -5864,14 +6218,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID for this request.
     project = ""
@@ -5883,7 +6239,8 @@ func main() {
 
   callResult, err := client.Networks.Get(project, network).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -5911,14 +6268,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
   var (
     // Project ID for this request.
     project = ""
@@ -5929,7 +6288,8 @@ func main() {
 
   callResult, err := client.Networks.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -5957,14 +6317,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID for this request.
     project = ""
@@ -5980,7 +6342,8 @@ func main() {
     return nil
   }
   if err = client.Networks.List(project).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -6006,14 +6369,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID for this request.
     project = ""
@@ -6022,7 +6387,8 @@ func main() {
 
   callResult, err := client.Projects.Get(project).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -6050,14 +6416,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'moveDisk' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'moveDisk' method:
   var (
     // Project ID for this request.
     project = ""
@@ -6068,7 +6436,8 @@ func main() {
 
   callResult, err := client.Projects.MoveDisk(project, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -6096,14 +6465,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'moveInstance' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'moveInstance' method:
   var (
     // Project ID for this request.
     project = ""
@@ -6114,7 +6485,8 @@ func main() {
 
   callResult, err := client.Projects.MoveInstance(project, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -6142,14 +6514,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'setCommonInstanceMetadata' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'setCommonInstanceMetadata' method:
   var (
     // Project ID for this request.
     project = ""
@@ -6160,7 +6534,8 @@ func main() {
 
   callResult, err := client.Projects.SetCommonInstanceMetadata(project, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -6188,14 +6563,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'setUsageExportBucket' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'setUsageExportBucket' method:
   var (
     // Project ID for this request.
     project = ""
@@ -6206,7 +6583,8 @@ func main() {
 
   callResult, err := client.Projects.SetUsageExportBucket(project, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -6234,14 +6612,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Project ID for this request.
     project = ""
@@ -6255,7 +6635,8 @@ func main() {
   )
 
   if err = client.RegionOperations.Delete(project, region, operation).Context(ctx).Do(); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -6281,14 +6662,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID for this request.
     project = ""
@@ -6303,7 +6686,8 @@ func main() {
 
   callResult, err := client.RegionOperations.Get(project, region, operation).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -6331,14 +6715,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID for this request.
     project = ""
@@ -6357,7 +6743,8 @@ func main() {
     return nil
   }
   if err = client.RegionOperations.List(project, region).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -6383,14 +6770,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID for this request.
     project = ""
@@ -6402,7 +6791,8 @@ func main() {
 
   callResult, err := client.Regions.Get(project, region).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -6430,14 +6820,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID for this request.
     project = ""
@@ -6453,7 +6845,8 @@ func main() {
     return nil
   }
   if err = client.Regions.List(project).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -6479,14 +6872,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Project ID for this request.
     project = ""
@@ -6498,7 +6893,8 @@ func main() {
 
   callResult, err := client.Routes.Delete(project, route).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -6526,14 +6922,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID for this request.
     project = ""
@@ -6545,7 +6943,8 @@ func main() {
 
   callResult, err := client.Routes.Get(project, route).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -6573,14 +6972,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
   var (
     // Project ID for this request.
     project = ""
@@ -6591,7 +6992,8 @@ func main() {
 
   callResult, err := client.Routes.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -6619,14 +7021,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID for this request.
     project = ""
@@ -6642,7 +7046,8 @@ func main() {
     return nil
   }
   if err = client.Routes.List(project).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -6668,14 +7073,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Project ID for this request.
     project = ""
@@ -6687,7 +7094,8 @@ func main() {
 
   callResult, err := client.Snapshots.Delete(project, snapshot).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -6715,14 +7123,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID for this request.
     project = ""
@@ -6734,7 +7144,8 @@ func main() {
 
   callResult, err := client.Snapshots.Get(project, snapshot).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -6762,14 +7173,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID for this request.
     project = ""
@@ -6785,7 +7198,8 @@ func main() {
     return nil
   }
   if err = client.Snapshots.List(project).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -6811,14 +7225,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Project ID for this request.
     project = ""
@@ -6830,7 +7246,8 @@ func main() {
 
   callResult, err := client.SslCertificates.Delete(project, sslCertificate).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -6858,14 +7275,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID for this request.
     project = ""
@@ -6877,7 +7296,8 @@ func main() {
 
   callResult, err := client.SslCertificates.Get(project, sslCertificate).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -6905,14 +7325,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
   var (
     // Project ID for this request.
     project = ""
@@ -6923,7 +7345,8 @@ func main() {
 
   callResult, err := client.SslCertificates.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -6951,14 +7374,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID for this request.
     project = ""
@@ -6974,7 +7399,8 @@ func main() {
     return nil
   }
   if err = client.SslCertificates.List(project).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -7000,14 +7426,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'aggregatedList' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
   var (
     // Project ID for this request.
     project = ""
@@ -7023,7 +7451,8 @@ func main() {
     return nil
   }
   if err = client.Subnetworks.AggregatedList(project).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -7049,14 +7478,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Project ID for this request.
     project = ""
@@ -7071,7 +7502,8 @@ func main() {
 
   callResult, err := client.Subnetworks.Delete(project, region, subnetwork).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -7099,14 +7531,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID for this request.
     project = ""
@@ -7121,7 +7555,8 @@ func main() {
 
   callResult, err := client.Subnetworks.Get(project, region, subnetwork).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -7149,14 +7584,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
   var (
     // Project ID for this request.
     project = ""
@@ -7170,7 +7607,8 @@ func main() {
 
   callResult, err := client.Subnetworks.Insert(project, region, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -7198,14 +7636,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID for this request.
     project = ""
@@ -7224,7 +7664,8 @@ func main() {
     return nil
   }
   if err = client.Subnetworks.List(project, region).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -7250,14 +7691,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Project ID for this request.
     project = ""
@@ -7269,7 +7712,8 @@ func main() {
 
   callResult, err := client.TargetHttpProxies.Delete(project, targetHttpProxy).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -7297,14 +7741,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID for this request.
     project = ""
@@ -7316,7 +7762,8 @@ func main() {
 
   callResult, err := client.TargetHttpProxies.Get(project, targetHttpProxy).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -7344,14 +7791,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
   var (
     // Project ID for this request.
     project = ""
@@ -7362,7 +7811,8 @@ func main() {
 
   callResult, err := client.TargetHttpProxies.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -7390,14 +7840,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID for this request.
     project = ""
@@ -7413,7 +7865,8 @@ func main() {
     return nil
   }
   if err = client.TargetHttpProxies.List(project).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -7439,14 +7892,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'setUrlMap' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'setUrlMap' method:
   var (
     // Project ID for this request.
     project = ""
@@ -7460,7 +7915,8 @@ func main() {
 
   callResult, err := client.TargetHttpProxies.SetUrlMap(project, targetHttpProxy, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -7488,14 +7944,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Project ID for this request.
     project = ""
@@ -7507,7 +7965,8 @@ func main() {
 
   callResult, err := client.TargetHttpsProxies.Delete(project, targetHttpsProxy).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -7535,14 +7994,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID for this request.
     project = ""
@@ -7554,7 +8015,8 @@ func main() {
 
   callResult, err := client.TargetHttpsProxies.Get(project, targetHttpsProxy).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -7582,14 +8044,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
   var (
     // Project ID for this request.
     project = ""
@@ -7600,7 +8064,8 @@ func main() {
 
   callResult, err := client.TargetHttpsProxies.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -7628,14 +8093,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID for this request.
     project = ""
@@ -7651,7 +8118,8 @@ func main() {
     return nil
   }
   if err = client.TargetHttpsProxies.List(project).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -7677,14 +8145,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'setSslCertificates' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'setSslCertificates' method:
   var (
     // Project ID for this request.
     project = ""
@@ -7698,7 +8168,8 @@ func main() {
 
   callResult, err := client.TargetHttpsProxies.SetSslCertificates(project, targetHttpsProxy, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -7726,14 +8197,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'setUrlMap' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'setUrlMap' method:
   var (
     // Project ID for this request.
     project = ""
@@ -7747,7 +8220,8 @@ func main() {
 
   callResult, err := client.TargetHttpsProxies.SetUrlMap(project, targetHttpsProxy, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -7775,14 +8249,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'aggregatedList' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
   var (
     // Project ID for this request.
     project = ""
@@ -7798,7 +8274,8 @@ func main() {
     return nil
   }
   if err = client.TargetInstances.AggregatedList(project).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -7824,14 +8301,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Project ID for this request.
     project = ""
@@ -7846,7 +8325,8 @@ func main() {
 
   callResult, err := client.TargetInstances.Delete(project, zone, targetInstance).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -7874,14 +8354,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID for this request.
     project = ""
@@ -7896,7 +8378,8 @@ func main() {
 
   callResult, err := client.TargetInstances.Get(project, zone, targetInstance).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -7924,14 +8407,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
   var (
     // Project ID for this request.
     project = ""
@@ -7945,7 +8430,8 @@ func main() {
 
   callResult, err := client.TargetInstances.Insert(project, zone, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -7973,14 +8459,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID for this request.
     project = ""
@@ -7999,7 +8487,8 @@ func main() {
     return nil
   }
   if err = client.TargetInstances.List(project, zone).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -8025,14 +8514,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'addHealthCheck' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'addHealthCheck' method:
   var (
     // Project ID for this request.
     project = ""
@@ -8049,7 +8540,8 @@ func main() {
 
   callResult, err := client.TargetPools.AddHealthCheck(project, region, targetPool, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -8077,14 +8569,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'addInstance' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'addInstance' method:
   var (
     // Project ID for this request.
     project = ""
@@ -8101,7 +8595,8 @@ func main() {
 
   callResult, err := client.TargetPools.AddInstance(project, region, targetPool, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -8129,14 +8624,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'aggregatedList' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
   var (
     // Project ID for this request.
     project = ""
@@ -8152,7 +8649,8 @@ func main() {
     return nil
   }
   if err = client.TargetPools.AggregatedList(project).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -8178,14 +8676,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Project ID for this request.
     project = ""
@@ -8200,7 +8700,8 @@ func main() {
 
   callResult, err := client.TargetPools.Delete(project, region, targetPool).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -8228,14 +8729,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID for this request.
     project = ""
@@ -8250,7 +8753,8 @@ func main() {
 
   callResult, err := client.TargetPools.Get(project, region, targetPool).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -8278,14 +8782,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'getHealth' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'getHealth' method:
   var (
     // Project ID for this request.
     project = ""
@@ -8302,7 +8808,8 @@ func main() {
 
   callResult, err := client.TargetPools.GetHealth(project, region, targetPool, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -8330,14 +8837,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
   var (
     // Project ID for this request.
     project = ""
@@ -8351,7 +8860,8 @@ func main() {
 
   callResult, err := client.TargetPools.Insert(project, region, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -8379,14 +8889,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID for this request.
     project = ""
@@ -8405,7 +8917,8 @@ func main() {
     return nil
   }
   if err = client.TargetPools.List(project, region).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -8431,14 +8944,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'removeHealthCheck' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'removeHealthCheck' method:
   var (
     // Project ID for this request.
     project = ""
@@ -8455,7 +8970,8 @@ func main() {
 
   callResult, err := client.TargetPools.RemoveHealthCheck(project, region, targetPool, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -8483,14 +8999,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'removeInstance' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'removeInstance' method:
   var (
     // Project ID for this request.
     project = ""
@@ -8507,7 +9025,8 @@ func main() {
 
   callResult, err := client.TargetPools.RemoveInstance(project, region, targetPool, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -8535,14 +9054,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'setBackup' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'setBackup' method:
   var (
     // Project ID for this request.
     project = ""
@@ -8559,7 +9080,8 @@ func main() {
 
   callResult, err := client.TargetPools.SetBackup(project, region, targetPool, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -8587,14 +9109,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'aggregatedList' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
   var (
     // Project ID for this request.
     project = ""
@@ -8610,7 +9134,8 @@ func main() {
     return nil
   }
   if err = client.TargetVpnGateways.AggregatedList(project).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -8636,14 +9161,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Project ID for this request.
     project = ""
@@ -8658,7 +9185,8 @@ func main() {
 
   callResult, err := client.TargetVpnGateways.Delete(project, region, targetVpnGateway).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -8686,14 +9214,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID for this request.
     project = ""
@@ -8708,7 +9238,8 @@ func main() {
 
   callResult, err := client.TargetVpnGateways.Get(project, region, targetVpnGateway).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -8736,14 +9267,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
   var (
     // Project ID for this request.
     project = ""
@@ -8757,7 +9290,8 @@ func main() {
 
   callResult, err := client.TargetVpnGateways.Insert(project, region, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -8785,14 +9319,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID for this request.
     project = ""
@@ -8811,7 +9347,8 @@ func main() {
     return nil
   }
   if err = client.TargetVpnGateways.List(project, region).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -8837,14 +9374,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Project ID for this request.
     project = ""
@@ -8856,7 +9395,8 @@ func main() {
 
   callResult, err := client.UrlMaps.Delete(project, urlMap).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -8884,14 +9424,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID for this request.
     project = ""
@@ -8903,7 +9445,8 @@ func main() {
 
   callResult, err := client.UrlMaps.Get(project, urlMap).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -8931,14 +9474,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
   var (
     // Project ID for this request.
     project = ""
@@ -8949,7 +9494,8 @@ func main() {
 
   callResult, err := client.UrlMaps.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -8977,14 +9523,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID for this request.
     project = ""
@@ -9000,7 +9548,8 @@ func main() {
     return nil
   }
   if err = client.UrlMaps.List(project).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -9026,14 +9575,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'patch' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
   var (
     // Project ID for this request.
     project = ""
@@ -9047,7 +9598,8 @@ func main() {
 
   callResult, err := client.UrlMaps.Patch(project, urlMap, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -9075,14 +9627,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
   var (
     // Project ID for this request.
     project = ""
@@ -9096,7 +9650,8 @@ func main() {
 
   callResult, err := client.UrlMaps.Update(project, urlMap, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -9124,14 +9679,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'validate' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'validate' method:
   var (
     // Project ID for this request.
     project = ""
@@ -9145,7 +9702,8 @@ func main() {
 
   callResult, err := client.UrlMaps.Validate(project, urlMap, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -9173,14 +9731,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'aggregatedList' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
   var (
     // Project ID for this request.
     project = ""
@@ -9196,7 +9756,8 @@ func main() {
     return nil
   }
   if err = client.VpnTunnels.AggregatedList(project).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -9222,14 +9783,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Project ID for this request.
     project = ""
@@ -9244,7 +9807,8 @@ func main() {
 
   callResult, err := client.VpnTunnels.Delete(project, region, vpnTunnel).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -9272,14 +9836,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID for this request.
     project = ""
@@ -9294,7 +9860,8 @@ func main() {
 
   callResult, err := client.VpnTunnels.Get(project, region, vpnTunnel).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -9322,14 +9889,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
   var (
     // Project ID for this request.
     project = ""
@@ -9343,7 +9912,8 @@ func main() {
 
   callResult, err := client.VpnTunnels.Insert(project, region, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -9371,14 +9941,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID for this request.
     project = ""
@@ -9397,7 +9969,8 @@ func main() {
     return nil
   }
   if err = client.VpnTunnels.List(project, region).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -9423,14 +9996,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Project ID for this request.
     project = ""
@@ -9444,7 +10019,8 @@ func main() {
   )
 
   if err = client.ZoneOperations.Delete(project, zone, operation).Context(ctx).Do(); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -9470,14 +10046,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID for this request.
     project = ""
@@ -9492,7 +10070,8 @@ func main() {
 
   callResult, err := client.ZoneOperations.Get(project, zone, operation).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -9520,14 +10099,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID for this request.
     project = ""
@@ -9546,7 +10127,8 @@ func main() {
     return nil
   }
   if err = client.ZoneOperations.List(project, zone).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -9572,14 +10154,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID for this request.
     project = ""
@@ -9591,7 +10175,8 @@ func main() {
 
   callResult, err := client.Zones.Get(project, zone).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -9619,14 +10204,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := compute.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID for this request.
     project = ""
@@ -9642,6 +10229,7 @@ func main() {
     return nil
   }
   if err = client.Zones.List(project).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_container.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_container.v1.json.baseline
@@ -22,14 +22,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := container.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'create' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'create' method:
   var (
     // The Google Developers Console [project ID or project number](https://developers.google.com/console/help/new/#projectnumber).
     projectId = ""
@@ -43,7 +45,8 @@ func main() {
 
   callResult, err := client.Projects.Zones.Clusters.Create(projectId, zone, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -71,14 +74,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := container.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // The Google Developers Console [project ID or project number](https://developers.google.com/console/help/new/#projectnumber).
     projectId = ""
@@ -93,7 +98,8 @@ func main() {
 
   callResult, err := client.Projects.Zones.Clusters.Delete(projectId, zone, clusterId).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -121,14 +127,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := container.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // The Google Developers Console [project ID or project number](https://developers.google.com/console/help/new/#projectnumber).
     projectId = ""
@@ -143,7 +151,8 @@ func main() {
 
   callResult, err := client.Projects.Zones.Clusters.Get(projectId, zone, clusterId).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -171,14 +180,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := container.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // The Google Developers Console [project ID or project number](https://developers.google.com/console/help/new/#projectnumber).
     projectId = ""
@@ -190,7 +201,8 @@ func main() {
 
   callResult, err := client.Projects.Zones.Clusters.List(projectId, zone).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -218,14 +230,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := container.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
   var (
     // The Google Developers Console [project ID or project number](https://developers.google.com/console/help/new/#projectnumber).
     projectId = ""
@@ -242,7 +256,8 @@ func main() {
 
   callResult, err := client.Projects.Zones.Clusters.Update(projectId, zone, clusterId, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -270,14 +285,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := container.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'getServerconfig' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'getServerconfig' method:
   var (
     // The Google Developers Console [project ID or project number](https://developers.google.com/console/help/new/#projectnumber).
     projectId = ""
@@ -289,7 +306,8 @@ func main() {
 
   callResult, err := client.Projects.Zones.GetServerconfig(projectId, zone).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -317,14 +335,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := container.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // The Google Developers Console [project ID or project number](https://developers.google.com/console/help/new/#projectnumber).
     projectId = ""
@@ -339,7 +359,8 @@ func main() {
 
   callResult, err := client.Projects.Zones.Operations.Get(projectId, zone, operationId).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -367,14 +388,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := container.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // The Google Developers Console [project ID or project number](https://developers.google.com/console/help/new/#projectnumber).
     projectId = ""
@@ -386,7 +409,8 @@ func main() {
 
   callResult, err := client.Projects.Zones.Operations.List(projectId, zone).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_container.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_container.v1.json.baseline
@@ -12,8 +12,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -21,15 +19,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := container.New(client)
+  client, err := container.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'create' method:
@@ -44,9 +41,9 @@ func main() {
     requestBody = &container.CreateClusterRequest{}
   )
 
-  callResult, err := service.Projects.Zones.Clusters.Create(projectId, zone, requestBody).Context(ctx).Do()
+  callResult, err := client.Projects.Zones.Clusters.Create(projectId, zone, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -64,8 +61,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -73,15 +68,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := container.New(client)
+  client, err := container.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -97,9 +91,9 @@ func main() {
 
   )
 
-  callResult, err := service.Projects.Zones.Clusters.Delete(projectId, zone, clusterId).Context(ctx).Do()
+  callResult, err := client.Projects.Zones.Clusters.Delete(projectId, zone, clusterId).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -117,8 +111,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -126,15 +118,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := container.New(client)
+  client, err := container.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -150,9 +141,9 @@ func main() {
 
   )
 
-  callResult, err := service.Projects.Zones.Clusters.Get(projectId, zone, clusterId).Context(ctx).Do()
+  callResult, err := client.Projects.Zones.Clusters.Get(projectId, zone, clusterId).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -170,8 +161,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -179,15 +168,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := container.New(client)
+  client, err := container.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -200,9 +188,9 @@ func main() {
 
   )
 
-  callResult, err := service.Projects.Zones.Clusters.List(projectId, zone).Context(ctx).Do()
+  callResult, err := client.Projects.Zones.Clusters.List(projectId, zone).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -220,8 +208,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -229,15 +215,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := container.New(client)
+  client, err := container.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
@@ -255,9 +240,9 @@ func main() {
     requestBody = &container.UpdateClusterRequest{}
   )
 
-  callResult, err := service.Projects.Zones.Clusters.Update(projectId, zone, clusterId, requestBody).Context(ctx).Do()
+  callResult, err := client.Projects.Zones.Clusters.Update(projectId, zone, clusterId, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -275,8 +260,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -284,15 +267,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := container.New(client)
+  client, err := container.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'getServerconfig' method:
@@ -305,9 +287,9 @@ func main() {
 
   )
 
-  callResult, err := service.Projects.Zones.GetServerconfig(projectId, zone).Context(ctx).Do()
+  callResult, err := client.Projects.Zones.GetServerconfig(projectId, zone).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -325,8 +307,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -334,15 +314,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := container.New(client)
+  client, err := container.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -358,9 +337,9 @@ func main() {
 
   )
 
-  callResult, err := service.Projects.Zones.Operations.Get(projectId, zone, operationId).Context(ctx).Do()
+  callResult, err := client.Projects.Zones.Operations.Get(projectId, zone, operationId).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -378,8 +357,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -387,15 +364,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := container.New(client)
+  client, err := container.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -408,9 +384,9 @@ func main() {
 
   )
 
-  callResult, err := service.Projects.Zones.Operations.List(projectId, zone).Context(ctx).Do()
+  callResult, err := client.Projects.Zones.Operations.List(projectId, zone).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_dataflow.v1b3.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_dataflow.v1b3.json.baseline
@@ -22,14 +22,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := dataflow.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'create' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'create' method:
   var (
     // The project which owns the job.
     projectId = ""
@@ -40,7 +42,8 @@ func main() {
 
   callResult, err := client.Projects.Jobs.Create(projectId, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -68,14 +71,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := dataflow.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // The project which owns the job.
     projectId = ""
@@ -87,7 +92,8 @@ func main() {
 
   callResult, err := client.Projects.Jobs.Get(projectId, jobId).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -115,14 +121,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := dataflow.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'getMetrics' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'getMetrics' method:
   var (
     // A project id.
     projectId = ""
@@ -134,7 +142,8 @@ func main() {
 
   callResult, err := client.Projects.Jobs.GetMetrics(projectId, jobId).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -162,14 +171,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := dataflow.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // The project which owns the jobs.
     projectId = ""
@@ -185,7 +196,8 @@ func main() {
     return nil
   }
   if err = client.Projects.Jobs.List(projectId).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -211,14 +223,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := dataflow.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // A project id.
     projectId = ""
@@ -237,7 +251,8 @@ func main() {
     return nil
   }
   if err = client.Projects.Jobs.Messages.List(projectId, jobId).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -263,14 +278,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := dataflow.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
   var (
     // The project which owns the job.
     projectId = ""
@@ -284,7 +301,8 @@ func main() {
 
   callResult, err := client.Projects.Jobs.Update(projectId, jobId, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -312,14 +330,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := dataflow.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'lease' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'lease' method:
   var (
     // Identifies the project this worker belongs to.
     projectId = ""
@@ -333,7 +353,8 @@ func main() {
 
   callResult, err := client.Projects.Jobs.WorkItems.Lease(projectId, jobId, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -361,14 +382,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := dataflow.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'reportStatus' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'reportStatus' method:
   var (
     // The project which owns the WorkItem's job.
     projectId = ""
@@ -382,7 +405,8 @@ func main() {
 
   callResult, err := client.Projects.Jobs.WorkItems.ReportStatus(projectId, jobId, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -410,14 +434,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := dataflow.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'workerMessages' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'workerMessages' method:
   var (
     // The project to send the WorkerMessages to.
     projectId = ""
@@ -428,7 +454,8 @@ func main() {
 
   callResult, err := client.Projects.WorkerMessages(projectId, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_dataflow.v1b3.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_dataflow.v1b3.json.baseline
@@ -12,8 +12,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -21,15 +19,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := dataflow.New(client)
+  client, err := dataflow.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'create' method:
@@ -41,9 +38,9 @@ func main() {
     requestBody = &dataflow.Job{}
   )
 
-  callResult, err := service.Projects.Jobs.Create(projectId, requestBody).Context(ctx).Do()
+  callResult, err := client.Projects.Jobs.Create(projectId, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -61,8 +58,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -70,15 +65,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := dataflow.New(client)
+  client, err := dataflow.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -91,9 +85,9 @@ func main() {
 
   )
 
-  callResult, err := service.Projects.Jobs.Get(projectId, jobId).Context(ctx).Do()
+  callResult, err := client.Projects.Jobs.Get(projectId, jobId).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -111,8 +105,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -120,15 +112,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := dataflow.New(client)
+  client, err := dataflow.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'getMetrics' method:
@@ -141,9 +132,9 @@ func main() {
 
   )
 
-  callResult, err := service.Projects.Jobs.GetMetrics(projectId, jobId).Context(ctx).Do()
+  callResult, err := client.Projects.Jobs.GetMetrics(projectId, jobId).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -161,8 +152,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -170,15 +159,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := dataflow.New(client)
+  client, err := dataflow.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -196,9 +184,8 @@ func main() {
     }
     return nil
   }
-  err = service.Projects.Jobs.List(projectId).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Projects.Jobs.List(projectId).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -214,8 +201,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -223,15 +208,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := dataflow.New(client)
+  client, err := dataflow.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -252,9 +236,8 @@ func main() {
     }
     return nil
   }
-  err = service.Projects.Jobs.Messages.List(projectId, jobId).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Projects.Jobs.Messages.List(projectId, jobId).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -270,8 +253,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -279,15 +260,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := dataflow.New(client)
+  client, err := dataflow.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
@@ -302,9 +282,9 @@ func main() {
     requestBody = &dataflow.Job{}
   )
 
-  callResult, err := service.Projects.Jobs.Update(projectId, jobId, requestBody).Context(ctx).Do()
+  callResult, err := client.Projects.Jobs.Update(projectId, jobId, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -322,8 +302,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -331,15 +309,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := dataflow.New(client)
+  client, err := dataflow.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'lease' method:
@@ -354,9 +331,9 @@ func main() {
     requestBody = &dataflow.LeaseWorkItemRequest{}
   )
 
-  callResult, err := service.Projects.Jobs.WorkItems.Lease(projectId, jobId, requestBody).Context(ctx).Do()
+  callResult, err := client.Projects.Jobs.WorkItems.Lease(projectId, jobId, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -374,8 +351,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -383,15 +358,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := dataflow.New(client)
+  client, err := dataflow.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'reportStatus' method:
@@ -406,9 +380,9 @@ func main() {
     requestBody = &dataflow.ReportWorkItemStatusRequest{}
   )
 
-  callResult, err := service.Projects.Jobs.WorkItems.ReportStatus(projectId, jobId, requestBody).Context(ctx).Do()
+  callResult, err := client.Projects.Jobs.WorkItems.ReportStatus(projectId, jobId, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -426,8 +400,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -435,15 +407,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := dataflow.New(client)
+  client, err := dataflow.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'workerMessages' method:
@@ -455,9 +426,9 @@ func main() {
     requestBody = &dataflow.SendWorkerMessagesRequest{}
   )
 
-  callResult, err := service.Projects.WorkerMessages(projectId, requestBody).Context(ctx).Do()
+  callResult, err := client.Projects.WorkerMessages(projectId, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_dataproc.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_dataproc.v1.json.baseline
@@ -22,14 +22,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := dataproc.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'download' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'download' method:
   var (
     // Name of the media that is being downloaded. See ByteStream.ReadRequest.resource_name.
     resourceName = ""
@@ -38,7 +40,8 @@ func main() {
 
   callResult, err := client.Media.Download(resourceName).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -66,14 +69,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := dataproc.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'upload' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'upload' method:
   var (
     // Name of the media that is being downloaded. See ByteStream.ReadRequest.resource_name.
     resourceName = ""
@@ -84,7 +89,8 @@ func main() {
 
   callResult, err := client.Media.Upload(resourceName, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -112,14 +118,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := dataproc.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'create' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'create' method:
   var (
     // [Required] The ID of the Google Cloud Platform project that the cluster belongs to.
     projectId = ""
@@ -133,7 +141,8 @@ func main() {
 
   callResult, err := client.Projects.Regions.Clusters.Create(projectId, region, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -161,14 +170,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := dataproc.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // [Required] The ID of the Google Cloud Platform project that the cluster belongs to.
     projectId = ""
@@ -183,7 +194,8 @@ func main() {
 
   callResult, err := client.Projects.Regions.Clusters.Delete(projectId, region, clusterName).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -211,14 +223,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := dataproc.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'diagnose' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'diagnose' method:
   var (
     // [Required] The ID of the Google Cloud Platform project that the cluster belongs to.
     projectId = ""
@@ -235,7 +249,8 @@ func main() {
 
   callResult, err := client.Projects.Regions.Clusters.Diagnose(projectId, region, clusterName, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -263,14 +278,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := dataproc.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // [Required] The ID of the Google Cloud Platform project that the cluster belongs to.
     projectId = ""
@@ -285,7 +302,8 @@ func main() {
 
   callResult, err := client.Projects.Regions.Clusters.Get(projectId, region, clusterName).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -313,14 +331,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := dataproc.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // [Required] The ID of the Google Cloud Platform project that the cluster belongs to.
     projectId = ""
@@ -339,7 +359,8 @@ func main() {
     return nil
   }
   if err = client.Projects.Regions.Clusters.List(projectId, region).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -365,14 +386,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := dataproc.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'patch' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
   var (
     // [Required] The ID of the Google Cloud Platform project the cluster belongs to.
     projectId = ""
@@ -389,7 +412,8 @@ func main() {
 
   callResult, err := client.Projects.Regions.Clusters.Patch(projectId, region, clusterName, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -417,14 +441,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := dataproc.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'cancel' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'cancel' method:
   var (
     // [Required] The ID of the Google Cloud Platform project that the job belongs to.
     projectId = ""
@@ -441,7 +467,8 @@ func main() {
 
   callResult, err := client.Projects.Regions.Jobs.Cancel(projectId, region, jobId, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -469,14 +496,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := dataproc.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // [Required] The ID of the Google Cloud Platform project that the job belongs to.
     projectId = ""
@@ -491,7 +520,8 @@ func main() {
 
   callResult, err := client.Projects.Regions.Jobs.Delete(projectId, region, jobId).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -519,14 +549,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := dataproc.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // [Required] The ID of the Google Cloud Platform project that the job belongs to.
     projectId = ""
@@ -541,7 +573,8 @@ func main() {
 
   callResult, err := client.Projects.Regions.Jobs.Get(projectId, region, jobId).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -569,14 +602,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := dataproc.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // [Required] The ID of the Google Cloud Platform project that the job belongs to.
     projectId = ""
@@ -595,7 +630,8 @@ func main() {
     return nil
   }
   if err = client.Projects.Regions.Jobs.List(projectId, region).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -621,14 +657,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := dataproc.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'submit' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'submit' method:
   var (
     // [Required] The ID of the Google Cloud Platform project that the job belongs to.
     projectId = ""
@@ -642,7 +680,8 @@ func main() {
 
   callResult, err := client.Projects.Regions.Jobs.Submit(projectId, region, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -670,14 +709,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := dataproc.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'cancel' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'cancel' method:
   var (
     // The name of the operation resource to be cancelled.
     name = ""
@@ -686,7 +727,8 @@ func main() {
 
   callResult, err := client.Projects.Regions.Operations.Cancel(name).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -714,14 +756,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := dataproc.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // The name of the operation resource to be deleted.
     name = ""
@@ -730,7 +774,8 @@ func main() {
 
   callResult, err := client.Projects.Regions.Operations.Delete(name).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -758,14 +803,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := dataproc.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // The name of the operation resource.
     name = ""
@@ -774,7 +821,8 @@ func main() {
 
   callResult, err := client.Projects.Regions.Operations.Get(name).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -802,14 +850,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := dataproc.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // The name of the operation collection.
     name = ""
@@ -825,6 +875,7 @@ func main() {
     return nil
   }
   if err = client.Projects.Regions.Operations.List(name).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_dataproc.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_dataproc.v1.json.baseline
@@ -12,8 +12,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -21,15 +19,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := dataproc.New(client)
+  client, err := dataproc.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'download' method:
@@ -39,9 +36,9 @@ func main() {
 
   )
 
-  callResult, err := service.Media.Download(resourceName).Context(ctx).Do()
+  callResult, err := client.Media.Download(resourceName).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -59,8 +56,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -68,15 +63,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := dataproc.New(client)
+  client, err := dataproc.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'upload' method:
@@ -88,9 +82,9 @@ func main() {
     requestBody = &dataproc.Media{}
   )
 
-  callResult, err := service.Media.Upload(resourceName, requestBody).Context(ctx).Do()
+  callResult, err := client.Media.Upload(resourceName, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -108,8 +102,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -117,15 +109,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := dataproc.New(client)
+  client, err := dataproc.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'create' method:
@@ -140,9 +131,9 @@ func main() {
     requestBody = &dataproc.Cluster{}
   )
 
-  callResult, err := service.Projects.Regions.Clusters.Create(projectId, region, requestBody).Context(ctx).Do()
+  callResult, err := client.Projects.Regions.Clusters.Create(projectId, region, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -160,8 +151,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -169,15 +158,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := dataproc.New(client)
+  client, err := dataproc.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -193,9 +181,9 @@ func main() {
 
   )
 
-  callResult, err := service.Projects.Regions.Clusters.Delete(projectId, region, clusterName).Context(ctx).Do()
+  callResult, err := client.Projects.Regions.Clusters.Delete(projectId, region, clusterName).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -213,8 +201,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -222,15 +208,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := dataproc.New(client)
+  client, err := dataproc.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'diagnose' method:
@@ -248,9 +233,9 @@ func main() {
     requestBody = &dataproc.DiagnoseClusterRequest{}
   )
 
-  callResult, err := service.Projects.Regions.Clusters.Diagnose(projectId, region, clusterName, requestBody).Context(ctx).Do()
+  callResult, err := client.Projects.Regions.Clusters.Diagnose(projectId, region, clusterName, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -268,8 +253,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -277,15 +260,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := dataproc.New(client)
+  client, err := dataproc.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -301,9 +283,9 @@ func main() {
 
   )
 
-  callResult, err := service.Projects.Regions.Clusters.Get(projectId, region, clusterName).Context(ctx).Do()
+  callResult, err := client.Projects.Regions.Clusters.Get(projectId, region, clusterName).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -321,8 +303,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -330,15 +310,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := dataproc.New(client)
+  client, err := dataproc.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -359,9 +338,8 @@ func main() {
     }
     return nil
   }
-  err = service.Projects.Regions.Clusters.List(projectId, region).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Projects.Regions.Clusters.List(projectId, region).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -377,8 +355,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -386,15 +362,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := dataproc.New(client)
+  client, err := dataproc.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'patch' method:
@@ -412,9 +387,9 @@ func main() {
     requestBody = &dataproc.Cluster{}
   )
 
-  callResult, err := service.Projects.Regions.Clusters.Patch(projectId, region, clusterName, requestBody).Context(ctx).Do()
+  callResult, err := client.Projects.Regions.Clusters.Patch(projectId, region, clusterName, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -432,8 +407,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -441,15 +414,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := dataproc.New(client)
+  client, err := dataproc.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'cancel' method:
@@ -467,9 +439,9 @@ func main() {
     requestBody = &dataproc.CancelJobRequest{}
   )
 
-  callResult, err := service.Projects.Regions.Jobs.Cancel(projectId, region, jobId, requestBody).Context(ctx).Do()
+  callResult, err := client.Projects.Regions.Jobs.Cancel(projectId, region, jobId, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -487,8 +459,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -496,15 +466,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := dataproc.New(client)
+  client, err := dataproc.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -520,9 +489,9 @@ func main() {
 
   )
 
-  callResult, err := service.Projects.Regions.Jobs.Delete(projectId, region, jobId).Context(ctx).Do()
+  callResult, err := client.Projects.Regions.Jobs.Delete(projectId, region, jobId).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -540,8 +509,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -549,15 +516,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := dataproc.New(client)
+  client, err := dataproc.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -573,9 +539,9 @@ func main() {
 
   )
 
-  callResult, err := service.Projects.Regions.Jobs.Get(projectId, region, jobId).Context(ctx).Do()
+  callResult, err := client.Projects.Regions.Jobs.Get(projectId, region, jobId).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -593,8 +559,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -602,15 +566,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := dataproc.New(client)
+  client, err := dataproc.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -631,9 +594,8 @@ func main() {
     }
     return nil
   }
-  err = service.Projects.Regions.Jobs.List(projectId, region).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Projects.Regions.Jobs.List(projectId, region).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -649,8 +611,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -658,15 +618,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := dataproc.New(client)
+  client, err := dataproc.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'submit' method:
@@ -681,9 +640,9 @@ func main() {
     requestBody = &dataproc.SubmitJobRequest{}
   )
 
-  callResult, err := service.Projects.Regions.Jobs.Submit(projectId, region, requestBody).Context(ctx).Do()
+  callResult, err := client.Projects.Regions.Jobs.Submit(projectId, region, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -701,8 +660,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -710,15 +667,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := dataproc.New(client)
+  client, err := dataproc.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'cancel' method:
@@ -728,9 +684,9 @@ func main() {
 
   )
 
-  callResult, err := service.Projects.Regions.Operations.Cancel(name).Context(ctx).Do()
+  callResult, err := client.Projects.Regions.Operations.Cancel(name).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -748,8 +704,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -757,15 +711,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := dataproc.New(client)
+  client, err := dataproc.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -775,9 +728,9 @@ func main() {
 
   )
 
-  callResult, err := service.Projects.Regions.Operations.Delete(name).Context(ctx).Do()
+  callResult, err := client.Projects.Regions.Operations.Delete(name).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -795,8 +748,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -804,15 +755,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := dataproc.New(client)
+  client, err := dataproc.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -822,9 +772,9 @@ func main() {
 
   )
 
-  callResult, err := service.Projects.Regions.Operations.Get(name).Context(ctx).Do()
+  callResult, err := client.Projects.Regions.Operations.Get(name).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -842,8 +792,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -851,15 +799,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := dataproc.New(client)
+  client, err := dataproc.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -877,8 +824,7 @@ func main() {
     }
     return nil
   }
-  err = service.Projects.Regions.Operations.List(name).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Projects.Regions.Operations.List(name).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_datastore.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_datastore.v1beta2.json.baseline
@@ -12,8 +12,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -21,15 +19,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := datastore.New(client)
+  client, err := datastore.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'allocateIds' method:
@@ -41,9 +38,9 @@ func main() {
     requestBody = &datastore.AllocateIdsRequest{}
   )
 
-  callResult, err := service.Datasets.AllocateIds(datasetId, requestBody).Context(ctx).Do()
+  callResult, err := client.Datasets.AllocateIds(datasetId, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -61,8 +58,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -70,15 +65,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := datastore.New(client)
+  client, err := datastore.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'beginTransaction' method:
@@ -90,9 +84,9 @@ func main() {
     requestBody = &datastore.BeginTransactionRequest{}
   )
 
-  callResult, err := service.Datasets.BeginTransaction(datasetId, requestBody).Context(ctx).Do()
+  callResult, err := client.Datasets.BeginTransaction(datasetId, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -110,8 +104,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -119,15 +111,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := datastore.New(client)
+  client, err := datastore.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'commit' method:
@@ -139,9 +130,9 @@ func main() {
     requestBody = &datastore.CommitRequest{}
   )
 
-  callResult, err := service.Datasets.Commit(datasetId, requestBody).Context(ctx).Do()
+  callResult, err := client.Datasets.Commit(datasetId, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -159,8 +150,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -168,15 +157,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := datastore.New(client)
+  client, err := datastore.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'lookup' method:
@@ -188,9 +176,9 @@ func main() {
     requestBody = &datastore.LookupRequest{}
   )
 
-  callResult, err := service.Datasets.Lookup(datasetId, requestBody).Context(ctx).Do()
+  callResult, err := client.Datasets.Lookup(datasetId, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -208,8 +196,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -217,15 +203,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := datastore.New(client)
+  client, err := datastore.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'rollback' method:
@@ -237,9 +222,9 @@ func main() {
     requestBody = &datastore.RollbackRequest{}
   )
 
-  callResult, err := service.Datasets.Rollback(datasetId, requestBody).Context(ctx).Do()
+  callResult, err := client.Datasets.Rollback(datasetId, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -257,8 +242,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -266,15 +249,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := datastore.New(client)
+  client, err := datastore.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'runQuery' method:
@@ -286,9 +268,9 @@ func main() {
     requestBody = &datastore.RunQueryRequest{}
   )
 
-  callResult, err := service.Datasets.RunQuery(datasetId, requestBody).Context(ctx).Do()
+  callResult, err := client.Datasets.RunQuery(datasetId, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_datastore.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_datastore.v1beta2.json.baseline
@@ -22,14 +22,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := datastore.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'allocateIds' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'allocateIds' method:
   var (
     // Identifies the dataset.
     datasetId = ""
@@ -40,7 +42,8 @@ func main() {
 
   callResult, err := client.Datasets.AllocateIds(datasetId, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -68,14 +71,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := datastore.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'beginTransaction' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'beginTransaction' method:
   var (
     // Identifies the dataset.
     datasetId = ""
@@ -86,7 +91,8 @@ func main() {
 
   callResult, err := client.Datasets.BeginTransaction(datasetId, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -114,14 +120,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := datastore.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'commit' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'commit' method:
   var (
     // Identifies the dataset.
     datasetId = ""
@@ -132,7 +140,8 @@ func main() {
 
   callResult, err := client.Datasets.Commit(datasetId, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -160,14 +169,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := datastore.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'lookup' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'lookup' method:
   var (
     // Identifies the dataset.
     datasetId = ""
@@ -178,7 +189,8 @@ func main() {
 
   callResult, err := client.Datasets.Lookup(datasetId, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -206,14 +218,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := datastore.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'rollback' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'rollback' method:
   var (
     // Identifies the dataset.
     datasetId = ""
@@ -224,7 +238,8 @@ func main() {
 
   callResult, err := client.Datasets.Rollback(datasetId, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -252,14 +267,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := datastore.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'runQuery' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'runQuery' method:
   var (
     // Identifies the dataset.
     datasetId = ""
@@ -270,7 +287,8 @@ func main() {
 
   callResult, err := client.Datasets.RunQuery(datasetId, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_deploymentmanager.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_deploymentmanager.v2.json.baseline
@@ -22,14 +22,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := deploymentmanager.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'cancelPreview' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'cancelPreview' method:
   var (
     // The project ID for this request.
     project = ""
@@ -43,7 +45,8 @@ func main() {
 
   callResult, err := client.Deployments.CancelPreview(project, deployment, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -71,14 +74,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := deploymentmanager.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // The project ID for this request.
     project = ""
@@ -90,7 +95,8 @@ func main() {
 
   callResult, err := client.Deployments.Delete(project, deployment).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -118,14 +124,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := deploymentmanager.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // The project ID for this request.
     project = ""
@@ -137,7 +145,8 @@ func main() {
 
   callResult, err := client.Deployments.Get(project, deployment).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -165,14 +174,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := deploymentmanager.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
   var (
     // The project ID for this request.
     project = ""
@@ -183,7 +194,8 @@ func main() {
 
   callResult, err := client.Deployments.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -211,14 +223,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := deploymentmanager.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // The project ID for this request.
     project = ""
@@ -234,7 +248,8 @@ func main() {
     return nil
   }
   if err = client.Deployments.List(project).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -260,14 +275,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := deploymentmanager.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'patch' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
   var (
     // The project ID for this request.
     project = ""
@@ -281,7 +298,8 @@ func main() {
 
   callResult, err := client.Deployments.Patch(project, deployment, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -309,14 +327,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := deploymentmanager.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'stop' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'stop' method:
   var (
     // The project ID for this request.
     project = ""
@@ -330,7 +350,8 @@ func main() {
 
   callResult, err := client.Deployments.Stop(project, deployment, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -358,14 +379,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := deploymentmanager.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
   var (
     // The project ID for this request.
     project = ""
@@ -379,7 +402,8 @@ func main() {
 
   callResult, err := client.Deployments.Update(project, deployment, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -407,14 +431,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := deploymentmanager.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // The project ID for this request.
     project = ""
@@ -429,7 +455,8 @@ func main() {
 
   callResult, err := client.Manifests.Get(project, deployment, manifest).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -457,14 +484,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := deploymentmanager.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // The project ID for this request.
     project = ""
@@ -483,7 +512,8 @@ func main() {
     return nil
   }
   if err = client.Manifests.List(project, deployment).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -509,14 +539,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := deploymentmanager.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // The project ID for this request.
     project = ""
@@ -528,7 +560,8 @@ func main() {
 
   callResult, err := client.Operations.Get(project, operation).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -556,14 +589,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := deploymentmanager.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // The project ID for this request.
     project = ""
@@ -579,7 +614,8 @@ func main() {
     return nil
   }
   if err = client.Operations.List(project).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -605,14 +641,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := deploymentmanager.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // The project ID for this request.
     project = ""
@@ -627,7 +665,8 @@ func main() {
 
   callResult, err := client.Resources.Get(project, deployment, resource).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -655,14 +694,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := deploymentmanager.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // The project ID for this request.
     project = ""
@@ -681,7 +722,8 @@ func main() {
     return nil
   }
   if err = client.Resources.List(project, deployment).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -707,14 +749,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := deploymentmanager.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // The project ID for this request.
     project = ""
@@ -730,6 +774,7 @@ func main() {
     return nil
   }
   if err = client.Types.List(project).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_deploymentmanager.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_deploymentmanager.v2.json.baseline
@@ -12,8 +12,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -21,15 +19,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := deploymentmanager.New(client)
+  client, err := deploymentmanager.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'cancelPreview' method:
@@ -44,9 +41,9 @@ func main() {
     requestBody = &deploymentmanager.DeploymentsCancelPreviewRequest{}
   )
 
-  callResult, err := service.Deployments.CancelPreview(project, deployment, requestBody).Context(ctx).Do()
+  callResult, err := client.Deployments.CancelPreview(project, deployment, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -64,8 +61,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -73,15 +68,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := deploymentmanager.New(client)
+  client, err := deploymentmanager.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -94,9 +88,9 @@ func main() {
 
   )
 
-  callResult, err := service.Deployments.Delete(project, deployment).Context(ctx).Do()
+  callResult, err := client.Deployments.Delete(project, deployment).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -114,8 +108,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -123,15 +115,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := deploymentmanager.New(client)
+  client, err := deploymentmanager.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -144,9 +135,9 @@ func main() {
 
   )
 
-  callResult, err := service.Deployments.Get(project, deployment).Context(ctx).Do()
+  callResult, err := client.Deployments.Get(project, deployment).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -164,8 +155,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -173,15 +162,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := deploymentmanager.New(client)
+  client, err := deploymentmanager.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
@@ -193,9 +181,9 @@ func main() {
     requestBody = &deploymentmanager.Deployment{}
   )
 
-  callResult, err := service.Deployments.Insert(project, requestBody).Context(ctx).Do()
+  callResult, err := client.Deployments.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -213,8 +201,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -222,15 +208,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := deploymentmanager.New(client)
+  client, err := deploymentmanager.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -248,9 +233,8 @@ func main() {
     }
     return nil
   }
-  err = service.Deployments.List(project).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Deployments.List(project).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -266,8 +250,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -275,15 +257,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := deploymentmanager.New(client)
+  client, err := deploymentmanager.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'patch' method:
@@ -298,9 +279,9 @@ func main() {
     requestBody = &deploymentmanager.Deployment{}
   )
 
-  callResult, err := service.Deployments.Patch(project, deployment, requestBody).Context(ctx).Do()
+  callResult, err := client.Deployments.Patch(project, deployment, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -318,8 +299,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -327,15 +306,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := deploymentmanager.New(client)
+  client, err := deploymentmanager.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'stop' method:
@@ -350,9 +328,9 @@ func main() {
     requestBody = &deploymentmanager.DeploymentsStopRequest{}
   )
 
-  callResult, err := service.Deployments.Stop(project, deployment, requestBody).Context(ctx).Do()
+  callResult, err := client.Deployments.Stop(project, deployment, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -370,8 +348,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -379,15 +355,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := deploymentmanager.New(client)
+  client, err := deploymentmanager.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
@@ -402,9 +377,9 @@ func main() {
     requestBody = &deploymentmanager.Deployment{}
   )
 
-  callResult, err := service.Deployments.Update(project, deployment, requestBody).Context(ctx).Do()
+  callResult, err := client.Deployments.Update(project, deployment, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -422,8 +397,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -431,15 +404,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := deploymentmanager.New(client)
+  client, err := deploymentmanager.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -455,9 +427,9 @@ func main() {
 
   )
 
-  callResult, err := service.Manifests.Get(project, deployment, manifest).Context(ctx).Do()
+  callResult, err := client.Manifests.Get(project, deployment, manifest).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -475,8 +447,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -484,15 +454,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := deploymentmanager.New(client)
+  client, err := deploymentmanager.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -513,9 +482,8 @@ func main() {
     }
     return nil
   }
-  err = service.Manifests.List(project, deployment).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Manifests.List(project, deployment).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -531,8 +499,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -540,15 +506,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := deploymentmanager.New(client)
+  client, err := deploymentmanager.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -561,9 +526,9 @@ func main() {
 
   )
 
-  callResult, err := service.Operations.Get(project, operation).Context(ctx).Do()
+  callResult, err := client.Operations.Get(project, operation).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -581,8 +546,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -590,15 +553,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := deploymentmanager.New(client)
+  client, err := deploymentmanager.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -616,9 +578,8 @@ func main() {
     }
     return nil
   }
-  err = service.Operations.List(project).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Operations.List(project).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -634,8 +595,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -643,15 +602,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := deploymentmanager.New(client)
+  client, err := deploymentmanager.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -667,9 +625,9 @@ func main() {
 
   )
 
-  callResult, err := service.Resources.Get(project, deployment, resource).Context(ctx).Do()
+  callResult, err := client.Resources.Get(project, deployment, resource).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -687,8 +645,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -696,15 +652,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := deploymentmanager.New(client)
+  client, err := deploymentmanager.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -725,9 +680,8 @@ func main() {
     }
     return nil
   }
-  err = service.Resources.List(project, deployment).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Resources.List(project, deployment).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -743,8 +697,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -752,15 +704,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := deploymentmanager.New(client)
+  client, err := deploymentmanager.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -778,8 +729,7 @@ func main() {
     }
     return nil
   }
-  err = service.Types.List(project).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Types.List(project).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_dns.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_dns.v1.json.baseline
@@ -22,14 +22,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := dns.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'create' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'create' method:
   var (
     // Identifies the project addressed by this request.
     project = ""
@@ -43,7 +45,8 @@ func main() {
 
   callResult, err := client.Changes.Create(project, managedZone, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -71,14 +74,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := dns.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Identifies the project addressed by this request.
     project = ""
@@ -93,7 +98,8 @@ func main() {
 
   callResult, err := client.Changes.Get(project, managedZone, changeId).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -121,14 +127,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := dns.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Identifies the project addressed by this request.
     project = ""
@@ -147,7 +155,8 @@ func main() {
     return nil
   }
   if err = client.Changes.List(project, managedZone).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -173,14 +182,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := dns.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'create' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'create' method:
   var (
     // Identifies the project addressed by this request.
     project = ""
@@ -191,7 +202,8 @@ func main() {
 
   callResult, err := client.ManagedZones.Create(project, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -219,14 +231,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := dns.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Identifies the project addressed by this request.
     project = ""
@@ -237,7 +251,8 @@ func main() {
   )
 
   if err = client.ManagedZones.Delete(project, managedZone).Context(ctx).Do(); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -263,14 +278,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := dns.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Identifies the project addressed by this request.
     project = ""
@@ -282,7 +299,8 @@ func main() {
 
   callResult, err := client.ManagedZones.Get(project, managedZone).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -310,14 +328,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := dns.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Identifies the project addressed by this request.
     project = ""
@@ -333,7 +353,8 @@ func main() {
     return nil
   }
   if err = client.ManagedZones.List(project).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -359,14 +380,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := dns.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Identifies the project addressed by this request.
     project = ""
@@ -375,7 +398,8 @@ func main() {
 
   callResult, err := client.Projects.Get(project).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -403,14 +427,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := dns.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Identifies the project addressed by this request.
     project = ""
@@ -429,6 +455,7 @@ func main() {
     return nil
   }
   if err = client.ResourceRecordSets.List(project, managedZone).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_dns.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_dns.v1.json.baseline
@@ -12,8 +12,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -21,15 +19,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := dns.New(client)
+  client, err := dns.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'create' method:
@@ -44,9 +41,9 @@ func main() {
     requestBody = &dns.Change{}
   )
 
-  callResult, err := service.Changes.Create(project, managedZone, requestBody).Context(ctx).Do()
+  callResult, err := client.Changes.Create(project, managedZone, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -64,8 +61,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -73,15 +68,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := dns.New(client)
+  client, err := dns.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -97,9 +91,9 @@ func main() {
 
   )
 
-  callResult, err := service.Changes.Get(project, managedZone, changeId).Context(ctx).Do()
+  callResult, err := client.Changes.Get(project, managedZone, changeId).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -117,8 +111,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -126,15 +118,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := dns.New(client)
+  client, err := dns.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -155,9 +146,8 @@ func main() {
     }
     return nil
   }
-  err = service.Changes.List(project, managedZone).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Changes.List(project, managedZone).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -173,8 +163,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -182,15 +170,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := dns.New(client)
+  client, err := dns.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'create' method:
@@ -202,9 +189,9 @@ func main() {
     requestBody = &dns.ManagedZone{}
   )
 
-  callResult, err := service.ManagedZones.Create(project, requestBody).Context(ctx).Do()
+  callResult, err := client.ManagedZones.Create(project, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -222,8 +209,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -231,15 +216,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := dns.New(client)
+  client, err := dns.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -252,9 +236,8 @@ func main() {
 
   )
 
-  err = service.ManagedZones.Delete(project, managedZone).Context(ctx).Do()
-  if err != nil {
-    log.Fatal(err)
+  if err = client.ManagedZones.Delete(project, managedZone).Context(ctx).Do(); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -270,8 +253,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -279,15 +260,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := dns.New(client)
+  client, err := dns.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -300,9 +280,9 @@ func main() {
 
   )
 
-  callResult, err := service.ManagedZones.Get(project, managedZone).Context(ctx).Do()
+  callResult, err := client.ManagedZones.Get(project, managedZone).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -320,8 +300,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -329,15 +307,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := dns.New(client)
+  client, err := dns.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -355,9 +332,8 @@ func main() {
     }
     return nil
   }
-  err = service.ManagedZones.List(project).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.ManagedZones.List(project).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -373,8 +349,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -382,15 +356,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := dns.New(client)
+  client, err := dns.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -400,9 +373,9 @@ func main() {
 
   )
 
-  callResult, err := service.Projects.Get(project).Context(ctx).Do()
+  callResult, err := client.Projects.Get(project).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -420,8 +393,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -429,15 +400,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := dns.New(client)
+  client, err := dns.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -458,8 +428,7 @@ func main() {
     }
     return nil
   }
-  err = service.ResourceRecordSets.List(project, managedZone).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.ResourceRecordSets.List(project, managedZone).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_logging.v2beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_logging.v2beta1.json.baseline
@@ -12,8 +12,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -21,15 +19,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := logging.New(client)
+  client, err := logging.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -38,9 +35,9 @@ func main() {
     requestBody = &logging.ListLogEntriesRequest{}
   )
 
-  callResult, err := service.Entries.List(requestBody).Context(ctx).Do()
+  callResult, err := client.Entries.List(requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -58,8 +55,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -67,15 +62,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := logging.New(client)
+  client, err := logging.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'write' method:
@@ -84,9 +78,9 @@ func main() {
     requestBody = &logging.WriteLogEntriesRequest{}
   )
 
-  callResult, err := service.Entries.Write(requestBody).Context(ctx).Do()
+  callResult, err := client.Entries.Write(requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -104,8 +98,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -113,15 +105,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := logging.New(client)
+  client, err := logging.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   var (
@@ -135,9 +126,8 @@ func main() {
     }
     return nil
   }
-  err = service.MonitoredResourceDescriptors.List().Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.MonitoredResourceDescriptors.List().Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -153,8 +143,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -162,15 +150,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := logging.New(client)
+  client, err := logging.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -180,9 +167,9 @@ func main() {
 
   )
 
-  callResult, err := service.Projects.Logs.Delete(logName).Context(ctx).Do()
+  callResult, err := client.Projects.Logs.Delete(logName).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -200,8 +187,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -209,15 +194,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := logging.New(client)
+  client, err := logging.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'create' method:
@@ -229,9 +213,9 @@ func main() {
     requestBody = &logging.LogMetric{}
   )
 
-  callResult, err := service.Projects.Metrics.Create(projectName, requestBody).Context(ctx).Do()
+  callResult, err := client.Projects.Metrics.Create(projectName, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -249,8 +233,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -258,15 +240,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := logging.New(client)
+  client, err := logging.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -276,9 +257,9 @@ func main() {
 
   )
 
-  callResult, err := service.Projects.Metrics.Delete(metricName).Context(ctx).Do()
+  callResult, err := client.Projects.Metrics.Delete(metricName).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -296,8 +277,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -305,15 +284,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := logging.New(client)
+  client, err := logging.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -323,9 +301,9 @@ func main() {
 
   )
 
-  callResult, err := service.Projects.Metrics.Get(metricName).Context(ctx).Do()
+  callResult, err := client.Projects.Metrics.Get(metricName).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -343,8 +321,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -352,15 +328,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := logging.New(client)
+  client, err := logging.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -378,9 +353,8 @@ func main() {
     }
     return nil
   }
-  err = service.Projects.Metrics.List(projectName).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Projects.Metrics.List(projectName).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -396,8 +370,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -405,15 +377,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := logging.New(client)
+  client, err := logging.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
@@ -425,9 +396,9 @@ func main() {
     requestBody = &logging.LogMetric{}
   )
 
-  callResult, err := service.Projects.Metrics.Update(metricName, requestBody).Context(ctx).Do()
+  callResult, err := client.Projects.Metrics.Update(metricName, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -445,8 +416,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -454,15 +423,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := logging.New(client)
+  client, err := logging.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'create' method:
@@ -474,9 +442,9 @@ func main() {
     requestBody = &logging.LogSink{}
   )
 
-  callResult, err := service.Projects.Sinks.Create(projectName, requestBody).Context(ctx).Do()
+  callResult, err := client.Projects.Sinks.Create(projectName, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -494,8 +462,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -503,15 +469,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := logging.New(client)
+  client, err := logging.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -521,9 +486,9 @@ func main() {
 
   )
 
-  callResult, err := service.Projects.Sinks.Delete(sinkName).Context(ctx).Do()
+  callResult, err := client.Projects.Sinks.Delete(sinkName).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -541,8 +506,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -550,15 +513,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := logging.New(client)
+  client, err := logging.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -568,9 +530,9 @@ func main() {
 
   )
 
-  callResult, err := service.Projects.Sinks.Get(sinkName).Context(ctx).Do()
+  callResult, err := client.Projects.Sinks.Get(sinkName).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -588,8 +550,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -597,15 +557,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := logging.New(client)
+  client, err := logging.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -623,9 +582,8 @@ func main() {
     }
     return nil
   }
-  err = service.Projects.Sinks.List(projectName).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Projects.Sinks.List(projectName).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -641,8 +599,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -650,15 +606,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := logging.New(client)
+  client, err := logging.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
@@ -670,9 +625,9 @@ func main() {
     requestBody = &logging.LogSink{}
   )
 
-  callResult, err := service.Projects.Sinks.Update(sinkName, requestBody).Context(ctx).Do()
+  callResult, err := client.Projects.Sinks.Update(sinkName, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_logging.v2beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_logging.v2beta1.json.baseline
@@ -22,14 +22,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := logging.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
 
     requestBody = &logging.ListLogEntriesRequest{}
@@ -37,7 +39,8 @@ func main() {
 
   callResult, err := client.Entries.List(requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -65,14 +68,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := logging.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'write' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'write' method:
   var (
 
     requestBody = &logging.WriteLogEntriesRequest{}
@@ -80,7 +85,8 @@ func main() {
 
   callResult, err := client.Entries.Write(requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -108,11 +114,13 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := logging.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
   var (
@@ -127,7 +135,8 @@ func main() {
     return nil
   }
   if err = client.MonitoredResourceDescriptors.List().Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -153,14 +162,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := logging.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Required. The resource name of the log to delete. Example: `"projects/my-project/logs/syslog"`.
     logName = ""
@@ -169,7 +180,8 @@ func main() {
 
   callResult, err := client.Projects.Logs.Delete(logName).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -197,14 +209,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := logging.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'create' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'create' method:
   var (
     // The resource name of the project in which to create the metric. Example: `"projects/my-project-id"`. The new metric must be provided in the request.
     projectName = ""
@@ -215,7 +229,8 @@ func main() {
 
   callResult, err := client.Projects.Metrics.Create(projectName, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -243,14 +258,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := logging.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // The resource name of the metric to delete. Example: `"projects/my-project-id/metrics/my-metric-id"`.
     metricName = ""
@@ -259,7 +276,8 @@ func main() {
 
   callResult, err := client.Projects.Metrics.Delete(metricName).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -287,14 +305,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := logging.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // The resource name of the desired metric. Example: `"projects/my-project-id/metrics/my-metric-id"`.
     metricName = ""
@@ -303,7 +323,8 @@ func main() {
 
   callResult, err := client.Projects.Metrics.Get(metricName).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -331,14 +352,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := logging.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Required. The resource name of the project containing the metrics. Example: `"projects/my-project-id"`.
     projectName = ""
@@ -354,7 +377,8 @@ func main() {
     return nil
   }
   if err = client.Projects.Metrics.List(projectName).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -380,14 +404,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := logging.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
   var (
     // The resource name of the metric to update. Example: `"projects/my-project-id/metrics/my-metric-id"`. The updated metric must be provided in the request and have the same identifier that is specified in `metricName`. If the metric does not exist, it is created.
     metricName = ""
@@ -398,7 +424,8 @@ func main() {
 
   callResult, err := client.Projects.Metrics.Update(metricName, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -426,14 +453,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := logging.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'create' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'create' method:
   var (
     // The resource name of the project in which to create the sink. Example: `"projects/my-project-id"`. The new sink must be provided in the request.
     projectName = ""
@@ -444,7 +473,8 @@ func main() {
 
   callResult, err := client.Projects.Sinks.Create(projectName, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -472,14 +502,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := logging.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // The resource name of the sink to delete. Example: `"projects/my-project-id/sinks/my-sink-id"`.
     sinkName = ""
@@ -488,7 +520,8 @@ func main() {
 
   callResult, err := client.Projects.Sinks.Delete(sinkName).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -516,14 +549,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := logging.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // The resource name of the sink to return. Example: `"projects/my-project-id/sinks/my-sink-id"`.
     sinkName = ""
@@ -532,7 +567,8 @@ func main() {
 
   callResult, err := client.Projects.Sinks.Get(sinkName).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -560,14 +596,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := logging.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Required. The resource name of the project containing the sinks. Example: `"projects/my-logging-project"`, `"projects/01234567890"`.
     projectName = ""
@@ -583,7 +621,8 @@ func main() {
     return nil
   }
   if err = client.Projects.Sinks.List(projectName).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -609,14 +648,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := logging.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
   var (
     // The resource name of the sink to update. Example: `"projects/my-project-id/sinks/my-sink-id"`. The updated sink must be provided in the request and have the same name that is specified in `sinkName`. If the sink does not exist, it is created.
     sinkName = ""
@@ -627,7 +668,8 @@ func main() {
 
   callResult, err := client.Projects.Sinks.Update(sinkName, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_prediction.v1.6.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_prediction.v1.6.json.baseline
@@ -12,8 +12,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -21,15 +19,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := prediction.New(client)
+  client, err := prediction.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'predict' method:
@@ -44,9 +41,9 @@ func main() {
     requestBody = &prediction.Input{}
   )
 
-  callResult, err := service.Hostedmodels.Predict(project, hostedModelName, requestBody).Context(ctx).Do()
+  callResult, err := client.Hostedmodels.Predict(project, hostedModelName, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -64,8 +61,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -73,15 +68,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := prediction.New(client)
+  client, err := prediction.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'analyze' method:
@@ -94,9 +88,9 @@ func main() {
 
   )
 
-  callResult, err := service.Trainedmodels.Analyze(project, id).Context(ctx).Do()
+  callResult, err := client.Trainedmodels.Analyze(project, id).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -114,8 +108,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -123,15 +115,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := prediction.New(client)
+  client, err := prediction.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -144,9 +135,8 @@ func main() {
 
   )
 
-  err = service.Trainedmodels.Delete(project, id).Context(ctx).Do()
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Trainedmodels.Delete(project, id).Context(ctx).Do(); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -162,8 +152,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -171,15 +159,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := prediction.New(client)
+  client, err := prediction.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -192,9 +179,9 @@ func main() {
 
   )
 
-  callResult, err := service.Trainedmodels.Get(project, id).Context(ctx).Do()
+  callResult, err := client.Trainedmodels.Get(project, id).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -212,8 +199,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -221,15 +206,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := prediction.New(client)
+  client, err := prediction.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
@@ -241,9 +225,9 @@ func main() {
     requestBody = &prediction.Insert{}
   )
 
-  callResult, err := service.Trainedmodels.Insert(project, requestBody).Context(ctx).Do()
+  callResult, err := client.Trainedmodels.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -261,8 +245,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -270,15 +252,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := prediction.New(client)
+  client, err := prediction.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -296,9 +277,8 @@ func main() {
     }
     return nil
   }
-  err = service.Trainedmodels.List(project).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Trainedmodels.List(project).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -314,8 +294,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -323,15 +301,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := prediction.New(client)
+  client, err := prediction.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'predict' method:
@@ -346,9 +323,9 @@ func main() {
     requestBody = &prediction.Input{}
   )
 
-  callResult, err := service.Trainedmodels.Predict(project, id, requestBody).Context(ctx).Do()
+  callResult, err := client.Trainedmodels.Predict(project, id, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -366,8 +343,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -375,15 +350,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := prediction.New(client)
+  client, err := prediction.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
@@ -398,9 +372,9 @@ func main() {
     requestBody = &prediction.Update{}
   )
 
-  callResult, err := service.Trainedmodels.Update(project, id, requestBody).Context(ctx).Do()
+  callResult, err := client.Trainedmodels.Update(project, id, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_prediction.v1.6.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_prediction.v1.6.json.baseline
@@ -22,14 +22,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := prediction.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'predict' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'predict' method:
   var (
     // The project associated with the model.
     project = ""
@@ -43,7 +45,8 @@ func main() {
 
   callResult, err := client.Hostedmodels.Predict(project, hostedModelName, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -71,14 +74,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := prediction.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'analyze' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'analyze' method:
   var (
     // The project associated with the model.
     project = ""
@@ -90,7 +95,8 @@ func main() {
 
   callResult, err := client.Trainedmodels.Analyze(project, id).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -118,14 +124,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := prediction.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // The project associated with the model.
     project = ""
@@ -136,7 +144,8 @@ func main() {
   )
 
   if err = client.Trainedmodels.Delete(project, id).Context(ctx).Do(); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -162,14 +171,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := prediction.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // The project associated with the model.
     project = ""
@@ -181,7 +192,8 @@ func main() {
 
   callResult, err := client.Trainedmodels.Get(project, id).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -209,14 +221,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := prediction.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
   var (
     // The project associated with the model.
     project = ""
@@ -227,7 +241,8 @@ func main() {
 
   callResult, err := client.Trainedmodels.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -255,14 +270,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := prediction.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // The project associated with the model.
     project = ""
@@ -278,7 +295,8 @@ func main() {
     return nil
   }
   if err = client.Trainedmodels.List(project).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -304,14 +322,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := prediction.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'predict' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'predict' method:
   var (
     // The project associated with the model.
     project = ""
@@ -325,7 +345,8 @@ func main() {
 
   callResult, err := client.Trainedmodels.Predict(project, id, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -353,14 +374,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := prediction.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
   var (
     // The project associated with the model.
     project = ""
@@ -374,7 +397,8 @@ func main() {
 
   callResult, err := client.Trainedmodels.Update(project, id, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_pubsub.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_pubsub.v1.json.baseline
@@ -22,14 +22,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := pubsub.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'acknowledge' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'acknowledge' method:
   var (
     // The subscription whose message is being acknowledged.
     subscription = ""
@@ -40,7 +42,8 @@ func main() {
 
   callResult, err := client.Projects.Subscriptions.Acknowledge(subscription, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -68,14 +71,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := pubsub.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'create' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'create' method:
   var (
     // The name of the subscription. It must have the format `"projects/{project}/subscriptions/{subscription}"`. `{subscription}` must start with a letter, and contain only letters (`[A-Za-z]`), numbers (`[0-9]`), dashes (`-`), underscores (`_`), periods (`.`), tildes (`~`), plus (`+`) or percent signs (`%`). It must be between 3 and 255 characters in length, and it must not start with `"goog"`.
     name = ""
@@ -86,7 +91,8 @@ func main() {
 
   callResult, err := client.Projects.Subscriptions.Create(name, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -114,14 +120,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := pubsub.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // The subscription to delete.
     subscription = ""
@@ -130,7 +138,8 @@ func main() {
 
   callResult, err := client.Projects.Subscriptions.Delete(subscription).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -158,14 +167,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := pubsub.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // The name of the subscription to get.
     subscription = ""
@@ -174,7 +185,8 @@ func main() {
 
   callResult, err := client.Projects.Subscriptions.Get(subscription).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -202,14 +214,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := pubsub.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'getIamPolicy' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'getIamPolicy' method:
   var (
     // REQUIRED: The resource for which policy is being requested. `resource` is usually specified as a path, such as, `projects/{project}/zones/{zone}/disks/{disk}`. The format for the path specified in this value is resource specific and is specified in the documentation for the respective GetIamPolicy rpc.
     resource = ""
@@ -218,7 +232,8 @@ func main() {
 
   callResult, err := client.Projects.Subscriptions.GetIamPolicy(resource).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -246,14 +261,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := pubsub.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // The name of the cloud project that subscriptions belong to.
     project = ""
@@ -269,7 +286,8 @@ func main() {
     return nil
   }
   if err = client.Projects.Subscriptions.List(project).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -295,14 +313,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := pubsub.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'modifyAckDeadline' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'modifyAckDeadline' method:
   var (
     // The name of the subscription.
     subscription = ""
@@ -313,7 +333,8 @@ func main() {
 
   callResult, err := client.Projects.Subscriptions.ModifyAckDeadline(subscription, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -341,14 +362,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := pubsub.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'modifyPushConfig' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'modifyPushConfig' method:
   var (
     // The name of the subscription.
     subscription = ""
@@ -359,7 +382,8 @@ func main() {
 
   callResult, err := client.Projects.Subscriptions.ModifyPushConfig(subscription, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -387,14 +411,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := pubsub.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'pull' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'pull' method:
   var (
     // The subscription from which messages should be pulled.
     subscription = ""
@@ -405,7 +431,8 @@ func main() {
 
   callResult, err := client.Projects.Subscriptions.Pull(subscription, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -433,14 +460,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := pubsub.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'setIamPolicy' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'setIamPolicy' method:
   var (
     // REQUIRED: The resource for which policy is being specified. `resource` is usually specified as a path, such as, `projects/{project}/zones/{zone}/disks/{disk}`. The format for the path specified in this value is resource specific and is specified in the documentation for the respective SetIamPolicy rpc.
     resource = ""
@@ -451,7 +480,8 @@ func main() {
 
   callResult, err := client.Projects.Subscriptions.SetIamPolicy(resource, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -479,14 +509,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := pubsub.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'testIamPermissions' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'testIamPermissions' method:
   var (
     // REQUIRED: The resource for which policy detail is being requested. `resource` is usually specified as a path, such as, `projects/{project}/zones/{zone}/disks/{disk}`. The format for the path specified in this value is resource specific and is specified in the documentation for the respective TestIamPermissions rpc.
     resource = ""
@@ -497,7 +529,8 @@ func main() {
 
   callResult, err := client.Projects.Subscriptions.TestIamPermissions(resource, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -525,14 +558,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := pubsub.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'create' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'create' method:
   var (
     // The name of the topic. It must have the format `"projects/{project}/topics/{topic}"`. `{topic}` must start with a letter, and contain only letters (`[A-Za-z]`), numbers (`[0-9]`), dashes (`-`), underscores (`_`), periods (`.`), tildes (`~`), plus (`+`) or percent signs (`%`). It must be between 3 and 255 characters in length, and it must not start with `"goog"`.
     name = ""
@@ -543,7 +578,8 @@ func main() {
 
   callResult, err := client.Projects.Topics.Create(name, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -571,14 +607,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := pubsub.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Name of the topic to delete.
     topic = ""
@@ -587,7 +625,8 @@ func main() {
 
   callResult, err := client.Projects.Topics.Delete(topic).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -615,14 +654,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := pubsub.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // The name of the topic to get.
     topic = ""
@@ -631,7 +672,8 @@ func main() {
 
   callResult, err := client.Projects.Topics.Get(topic).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -659,14 +701,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := pubsub.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'getIamPolicy' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'getIamPolicy' method:
   var (
     // REQUIRED: The resource for which policy is being requested. `resource` is usually specified as a path, such as, `projects/{project}/zones/{zone}/disks/{disk}`. The format for the path specified in this value is resource specific and is specified in the documentation for the respective GetIamPolicy rpc.
     resource = ""
@@ -675,7 +719,8 @@ func main() {
 
   callResult, err := client.Projects.Topics.GetIamPolicy(resource).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -703,14 +748,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := pubsub.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // The name of the cloud project that topics belong to.
     project = ""
@@ -726,7 +773,8 @@ func main() {
     return nil
   }
   if err = client.Projects.Topics.List(project).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -752,14 +800,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := pubsub.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'publish' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'publish' method:
   var (
     // The messages in the request will be published on this topic.
     topic = ""
@@ -770,7 +820,8 @@ func main() {
 
   callResult, err := client.Projects.Topics.Publish(topic, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -798,14 +849,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := pubsub.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'setIamPolicy' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'setIamPolicy' method:
   var (
     // REQUIRED: The resource for which policy is being specified. `resource` is usually specified as a path, such as, `projects/{project}/zones/{zone}/disks/{disk}`. The format for the path specified in this value is resource specific and is specified in the documentation for the respective SetIamPolicy rpc.
     resource = ""
@@ -816,7 +869,8 @@ func main() {
 
   callResult, err := client.Projects.Topics.SetIamPolicy(resource, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -844,14 +898,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := pubsub.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // The name of the topic that subscriptions are attached to.
     topic = ""
@@ -867,7 +923,8 @@ func main() {
     return nil
   }
   if err = client.Projects.Topics.Subscriptions.List(topic).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -893,14 +950,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := pubsub.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'testIamPermissions' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'testIamPermissions' method:
   var (
     // REQUIRED: The resource for which policy detail is being requested. `resource` is usually specified as a path, such as, `projects/{project}/zones/{zone}/disks/{disk}`. The format for the path specified in this value is resource specific and is specified in the documentation for the respective TestIamPermissions rpc.
     resource = ""
@@ -911,7 +970,8 @@ func main() {
 
   callResult, err := client.Projects.Topics.TestIamPermissions(resource, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_pubsub.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_pubsub.v1.json.baseline
@@ -12,8 +12,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -21,15 +19,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := pubsub.New(client)
+  client, err := pubsub.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'acknowledge' method:
@@ -41,9 +38,9 @@ func main() {
     requestBody = &pubsub.AcknowledgeRequest{}
   )
 
-  callResult, err := service.Projects.Subscriptions.Acknowledge(subscription, requestBody).Context(ctx).Do()
+  callResult, err := client.Projects.Subscriptions.Acknowledge(subscription, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -61,8 +58,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -70,15 +65,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := pubsub.New(client)
+  client, err := pubsub.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'create' method:
@@ -90,9 +84,9 @@ func main() {
     requestBody = &pubsub.Subscription{}
   )
 
-  callResult, err := service.Projects.Subscriptions.Create(name, requestBody).Context(ctx).Do()
+  callResult, err := client.Projects.Subscriptions.Create(name, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -110,8 +104,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -119,15 +111,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := pubsub.New(client)
+  client, err := pubsub.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -137,9 +128,9 @@ func main() {
 
   )
 
-  callResult, err := service.Projects.Subscriptions.Delete(subscription).Context(ctx).Do()
+  callResult, err := client.Projects.Subscriptions.Delete(subscription).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -157,8 +148,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -166,15 +155,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := pubsub.New(client)
+  client, err := pubsub.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -184,9 +172,9 @@ func main() {
 
   )
 
-  callResult, err := service.Projects.Subscriptions.Get(subscription).Context(ctx).Do()
+  callResult, err := client.Projects.Subscriptions.Get(subscription).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -204,8 +192,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -213,15 +199,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := pubsub.New(client)
+  client, err := pubsub.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'getIamPolicy' method:
@@ -231,9 +216,9 @@ func main() {
 
   )
 
-  callResult, err := service.Projects.Subscriptions.GetIamPolicy(resource).Context(ctx).Do()
+  callResult, err := client.Projects.Subscriptions.GetIamPolicy(resource).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -251,8 +236,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -260,15 +243,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := pubsub.New(client)
+  client, err := pubsub.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -286,9 +268,8 @@ func main() {
     }
     return nil
   }
-  err = service.Projects.Subscriptions.List(project).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Projects.Subscriptions.List(project).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -304,8 +285,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -313,15 +292,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := pubsub.New(client)
+  client, err := pubsub.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'modifyAckDeadline' method:
@@ -333,9 +311,9 @@ func main() {
     requestBody = &pubsub.ModifyAckDeadlineRequest{}
   )
 
-  callResult, err := service.Projects.Subscriptions.ModifyAckDeadline(subscription, requestBody).Context(ctx).Do()
+  callResult, err := client.Projects.Subscriptions.ModifyAckDeadline(subscription, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -353,8 +331,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -362,15 +338,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := pubsub.New(client)
+  client, err := pubsub.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'modifyPushConfig' method:
@@ -382,9 +357,9 @@ func main() {
     requestBody = &pubsub.ModifyPushConfigRequest{}
   )
 
-  callResult, err := service.Projects.Subscriptions.ModifyPushConfig(subscription, requestBody).Context(ctx).Do()
+  callResult, err := client.Projects.Subscriptions.ModifyPushConfig(subscription, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -402,8 +377,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -411,15 +384,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := pubsub.New(client)
+  client, err := pubsub.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'pull' method:
@@ -431,9 +403,9 @@ func main() {
     requestBody = &pubsub.PullRequest{}
   )
 
-  callResult, err := service.Projects.Subscriptions.Pull(subscription, requestBody).Context(ctx).Do()
+  callResult, err := client.Projects.Subscriptions.Pull(subscription, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -451,8 +423,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -460,15 +430,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := pubsub.New(client)
+  client, err := pubsub.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'setIamPolicy' method:
@@ -480,9 +449,9 @@ func main() {
     requestBody = &pubsub.SetIamPolicyRequest{}
   )
 
-  callResult, err := service.Projects.Subscriptions.SetIamPolicy(resource, requestBody).Context(ctx).Do()
+  callResult, err := client.Projects.Subscriptions.SetIamPolicy(resource, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -500,8 +469,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -509,15 +476,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := pubsub.New(client)
+  client, err := pubsub.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'testIamPermissions' method:
@@ -529,9 +495,9 @@ func main() {
     requestBody = &pubsub.TestIamPermissionsRequest{}
   )
 
-  callResult, err := service.Projects.Subscriptions.TestIamPermissions(resource, requestBody).Context(ctx).Do()
+  callResult, err := client.Projects.Subscriptions.TestIamPermissions(resource, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -549,8 +515,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -558,15 +522,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := pubsub.New(client)
+  client, err := pubsub.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'create' method:
@@ -578,9 +541,9 @@ func main() {
     requestBody = &pubsub.Topic{}
   )
 
-  callResult, err := service.Projects.Topics.Create(name, requestBody).Context(ctx).Do()
+  callResult, err := client.Projects.Topics.Create(name, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -598,8 +561,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -607,15 +568,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := pubsub.New(client)
+  client, err := pubsub.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -625,9 +585,9 @@ func main() {
 
   )
 
-  callResult, err := service.Projects.Topics.Delete(topic).Context(ctx).Do()
+  callResult, err := client.Projects.Topics.Delete(topic).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -645,8 +605,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -654,15 +612,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := pubsub.New(client)
+  client, err := pubsub.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -672,9 +629,9 @@ func main() {
 
   )
 
-  callResult, err := service.Projects.Topics.Get(topic).Context(ctx).Do()
+  callResult, err := client.Projects.Topics.Get(topic).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -692,8 +649,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -701,15 +656,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := pubsub.New(client)
+  client, err := pubsub.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'getIamPolicy' method:
@@ -719,9 +673,9 @@ func main() {
 
   )
 
-  callResult, err := service.Projects.Topics.GetIamPolicy(resource).Context(ctx).Do()
+  callResult, err := client.Projects.Topics.GetIamPolicy(resource).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -739,8 +693,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -748,15 +700,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := pubsub.New(client)
+  client, err := pubsub.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -774,9 +725,8 @@ func main() {
     }
     return nil
   }
-  err = service.Projects.Topics.List(project).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Projects.Topics.List(project).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -792,8 +742,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -801,15 +749,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := pubsub.New(client)
+  client, err := pubsub.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'publish' method:
@@ -821,9 +768,9 @@ func main() {
     requestBody = &pubsub.PublishRequest{}
   )
 
-  callResult, err := service.Projects.Topics.Publish(topic, requestBody).Context(ctx).Do()
+  callResult, err := client.Projects.Topics.Publish(topic, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -841,8 +788,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -850,15 +795,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := pubsub.New(client)
+  client, err := pubsub.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'setIamPolicy' method:
@@ -870,9 +814,9 @@ func main() {
     requestBody = &pubsub.SetIamPolicyRequest{}
   )
 
-  callResult, err := service.Projects.Topics.SetIamPolicy(resource, requestBody).Context(ctx).Do()
+  callResult, err := client.Projects.Topics.SetIamPolicy(resource, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -890,8 +834,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -899,15 +841,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := pubsub.New(client)
+  client, err := pubsub.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -925,9 +866,8 @@ func main() {
     }
     return nil
   }
-  err = service.Projects.Topics.Subscriptions.List(topic).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Projects.Topics.Subscriptions.List(topic).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -943,8 +883,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -952,15 +890,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := pubsub.New(client)
+  client, err := pubsub.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'testIamPermissions' method:
@@ -972,9 +909,9 @@ func main() {
     requestBody = &pubsub.TestIamPermissionsRequest{}
   )
 
-  callResult, err := service.Projects.Topics.TestIamPermissions(resource, requestBody).Context(ctx).Do()
+  callResult, err := client.Projects.Topics.TestIamPermissions(resource, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_replicapoolupdater.v1beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_replicapoolupdater.v1beta1.json.baseline
@@ -22,14 +22,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := replicapoolupdater.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'cancel' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'cancel' method:
   var (
     // The Google Developers Console project name.
     project = ""
@@ -44,7 +46,8 @@ func main() {
 
   callResult, err := client.RollingUpdates.Cancel(project, zone, rollingUpdate).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -72,14 +75,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := replicapoolupdater.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // The Google Developers Console project name.
     project = ""
@@ -94,7 +99,8 @@ func main() {
 
   callResult, err := client.RollingUpdates.Get(project, zone, rollingUpdate).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -122,14 +128,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := replicapoolupdater.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
   var (
     // The Google Developers Console project name.
     project = ""
@@ -143,7 +151,8 @@ func main() {
 
   callResult, err := client.RollingUpdates.Insert(project, zone, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -171,14 +180,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := replicapoolupdater.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // The Google Developers Console project name.
     project = ""
@@ -197,7 +208,8 @@ func main() {
     return nil
   }
   if err = client.RollingUpdates.List(project, zone).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -223,14 +235,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := replicapoolupdater.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'listInstanceUpdates' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'listInstanceUpdates' method:
   var (
     // The Google Developers Console project name.
     project = ""
@@ -252,7 +266,8 @@ func main() {
     return nil
   }
   if err = client.RollingUpdates.ListInstanceUpdates(project, zone, rollingUpdate).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -278,14 +293,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := replicapoolupdater.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'pause' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'pause' method:
   var (
     // The Google Developers Console project name.
     project = ""
@@ -300,7 +317,8 @@ func main() {
 
   callResult, err := client.RollingUpdates.Pause(project, zone, rollingUpdate).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -328,14 +346,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := replicapoolupdater.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'resume' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'resume' method:
   var (
     // The Google Developers Console project name.
     project = ""
@@ -350,7 +370,8 @@ func main() {
 
   callResult, err := client.RollingUpdates.Resume(project, zone, rollingUpdate).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -378,14 +399,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := replicapoolupdater.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'rollback' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'rollback' method:
   var (
     // The Google Developers Console project name.
     project = ""
@@ -400,7 +423,8 @@ func main() {
 
   callResult, err := client.RollingUpdates.Rollback(project, zone, rollingUpdate).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -428,14 +452,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := replicapoolupdater.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Name of the project scoping this request.
     project = ""
@@ -450,7 +476,8 @@ func main() {
 
   callResult, err := client.ZoneOperations.Get(project, zone, operation).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -478,14 +505,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := replicapoolupdater.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Name of the project scoping this request.
     project = ""
@@ -504,6 +533,7 @@ func main() {
     return nil
   }
   if err = client.ZoneOperations.List(project, zone).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_replicapoolupdater.v1beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_replicapoolupdater.v1beta1.json.baseline
@@ -12,8 +12,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -21,15 +19,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := replicapoolupdater.New(client)
+  client, err := replicapoolupdater.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'cancel' method:
@@ -45,9 +42,9 @@ func main() {
 
   )
 
-  callResult, err := service.RollingUpdates.Cancel(project, zone, rollingUpdate).Context(ctx).Do()
+  callResult, err := client.RollingUpdates.Cancel(project, zone, rollingUpdate).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -65,8 +62,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -74,15 +69,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := replicapoolupdater.New(client)
+  client, err := replicapoolupdater.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -98,9 +92,9 @@ func main() {
 
   )
 
-  callResult, err := service.RollingUpdates.Get(project, zone, rollingUpdate).Context(ctx).Do()
+  callResult, err := client.RollingUpdates.Get(project, zone, rollingUpdate).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -118,8 +112,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -127,15 +119,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := replicapoolupdater.New(client)
+  client, err := replicapoolupdater.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
@@ -150,9 +141,9 @@ func main() {
     requestBody = &replicapoolupdater.RollingUpdate{}
   )
 
-  callResult, err := service.RollingUpdates.Insert(project, zone, requestBody).Context(ctx).Do()
+  callResult, err := client.RollingUpdates.Insert(project, zone, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -170,8 +161,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -179,15 +168,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := replicapoolupdater.New(client)
+  client, err := replicapoolupdater.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -208,9 +196,8 @@ func main() {
     }
     return nil
   }
-  err = service.RollingUpdates.List(project, zone).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.RollingUpdates.List(project, zone).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -226,8 +213,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -235,15 +220,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := replicapoolupdater.New(client)
+  client, err := replicapoolupdater.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'listInstanceUpdates' method:
@@ -267,9 +251,8 @@ func main() {
     }
     return nil
   }
-  err = service.RollingUpdates.ListInstanceUpdates(project, zone, rollingUpdate).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.RollingUpdates.ListInstanceUpdates(project, zone, rollingUpdate).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -285,8 +268,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -294,15 +275,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := replicapoolupdater.New(client)
+  client, err := replicapoolupdater.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'pause' method:
@@ -318,9 +298,9 @@ func main() {
 
   )
 
-  callResult, err := service.RollingUpdates.Pause(project, zone, rollingUpdate).Context(ctx).Do()
+  callResult, err := client.RollingUpdates.Pause(project, zone, rollingUpdate).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -338,8 +318,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -347,15 +325,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := replicapoolupdater.New(client)
+  client, err := replicapoolupdater.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'resume' method:
@@ -371,9 +348,9 @@ func main() {
 
   )
 
-  callResult, err := service.RollingUpdates.Resume(project, zone, rollingUpdate).Context(ctx).Do()
+  callResult, err := client.RollingUpdates.Resume(project, zone, rollingUpdate).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -391,8 +368,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -400,15 +375,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := replicapoolupdater.New(client)
+  client, err := replicapoolupdater.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'rollback' method:
@@ -424,9 +398,9 @@ func main() {
 
   )
 
-  callResult, err := service.RollingUpdates.Rollback(project, zone, rollingUpdate).Context(ctx).Do()
+  callResult, err := client.RollingUpdates.Rollback(project, zone, rollingUpdate).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -444,8 +418,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -453,15 +425,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := replicapoolupdater.New(client)
+  client, err := replicapoolupdater.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -477,9 +448,9 @@ func main() {
 
   )
 
-  callResult, err := service.ZoneOperations.Get(project, zone, operation).Context(ctx).Do()
+  callResult, err := client.ZoneOperations.Get(project, zone, operation).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -497,8 +468,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -506,15 +475,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := replicapoolupdater.New(client)
+  client, err := replicapoolupdater.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -535,8 +503,7 @@ func main() {
     }
     return nil
   }
-  err = service.ZoneOperations.List(project, zone).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.ZoneOperations.List(project, zone).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_sqladmin.v1beta4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_sqladmin.v1beta4.json.baseline
@@ -22,14 +22,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := sqladmin.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Project ID of the project that contains the instance.
     project = ""
@@ -44,7 +46,8 @@ func main() {
 
   callResult, err := client.BackupRuns.Delete(project, instance, id).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -72,14 +75,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := sqladmin.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID of the project that contains the instance.
     project = ""
@@ -94,7 +99,8 @@ func main() {
 
   callResult, err := client.BackupRuns.Get(project, instance, id).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -122,14 +128,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := sqladmin.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID of the project that contains the instance.
     project = ""
@@ -148,7 +156,8 @@ func main() {
     return nil
   }
   if err = client.BackupRuns.List(project, instance).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -174,14 +183,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := sqladmin.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Project ID of the project that contains the instance.
     project = ""
@@ -196,7 +207,8 @@ func main() {
 
   callResult, err := client.Databases.Delete(project, instance, database).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -224,14 +236,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := sqladmin.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID of the project that contains the instance.
     project = ""
@@ -246,7 +260,8 @@ func main() {
 
   callResult, err := client.Databases.Get(project, instance, database).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -274,14 +289,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := sqladmin.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
   var (
     // Project ID of the project that contains the instance.
     project = ""
@@ -295,7 +312,8 @@ func main() {
 
   callResult, err := client.Databases.Insert(project, instance, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -323,14 +341,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := sqladmin.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID of the project for which to list Cloud SQL instances.
     project = ""
@@ -342,7 +362,8 @@ func main() {
 
   callResult, err := client.Databases.List(project, instance).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -370,14 +391,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := sqladmin.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'patch' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
   var (
     // Project ID of the project that contains the instance.
     project = ""
@@ -394,7 +417,8 @@ func main() {
 
   callResult, err := client.Databases.Patch(project, instance, database, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -422,14 +446,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := sqladmin.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
   var (
     // Project ID of the project that contains the instance.
     project = ""
@@ -446,7 +472,8 @@ func main() {
 
   callResult, err := client.Databases.Update(project, instance, database, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -474,11 +501,13 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := sqladmin.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
   var (
@@ -486,7 +515,8 @@ func main() {
 
   callResult, err := client.Flags.List().Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -514,14 +544,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := sqladmin.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'clone' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'clone' method:
   var (
     // Project ID of the source as well as the clone Cloud SQL instance.
     project = ""
@@ -535,7 +567,8 @@ func main() {
 
   callResult, err := client.Instances.Clone(project, instance, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -563,14 +596,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := sqladmin.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Project ID of the project that contains the instance to be deleted.
     project = ""
@@ -582,7 +617,8 @@ func main() {
 
   callResult, err := client.Instances.Delete(project, instance).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -610,14 +646,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := sqladmin.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'export' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'export' method:
   var (
     // Project ID of the project that contains the instance to be exported.
     project = ""
@@ -631,7 +669,8 @@ func main() {
 
   callResult, err := client.Instances.Export(project, instance, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -659,14 +698,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := sqladmin.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'failover' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'failover' method:
   var (
     // ID of the project that contains the read replica.
     project = ""
@@ -680,7 +721,8 @@ func main() {
 
   callResult, err := client.Instances.Failover(project, instance, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -708,14 +750,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := sqladmin.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID of the project that contains the instance.
     project = ""
@@ -727,7 +771,8 @@ func main() {
 
   callResult, err := client.Instances.Get(project, instance).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -755,14 +800,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := sqladmin.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'import' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'import' method:
   var (
     // Project ID of the project that contains the instance.
     project = ""
@@ -776,7 +823,8 @@ func main() {
 
   callResult, err := client.Instances.Import(project, instance, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -804,14 +852,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := sqladmin.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
   var (
     // Project ID of the project to which the newly created Cloud SQL instances should belong.
     project = ""
@@ -822,7 +872,8 @@ func main() {
 
   callResult, err := client.Instances.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -850,14 +901,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := sqladmin.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID of the project for which to list Cloud SQL instances.
     project = ""
@@ -873,7 +926,8 @@ func main() {
     return nil
   }
   if err = client.Instances.List(project).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -899,14 +953,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := sqladmin.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'patch' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
   var (
     // Project ID of the project that contains the instance.
     project = ""
@@ -920,7 +976,8 @@ func main() {
 
   callResult, err := client.Instances.Patch(project, instance, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -948,14 +1005,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := sqladmin.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'promoteReplica' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'promoteReplica' method:
   var (
     // ID of the project that contains the read replica.
     project = ""
@@ -967,7 +1026,8 @@ func main() {
 
   callResult, err := client.Instances.PromoteReplica(project, instance).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -995,14 +1055,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := sqladmin.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'resetSslConfig' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'resetSslConfig' method:
   var (
     // Project ID of the project that contains the instance.
     project = ""
@@ -1014,7 +1076,8 @@ func main() {
 
   callResult, err := client.Instances.ResetSslConfig(project, instance).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1042,14 +1105,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := sqladmin.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'restart' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'restart' method:
   var (
     // Project ID of the project that contains the instance to be restarted.
     project = ""
@@ -1061,7 +1126,8 @@ func main() {
 
   callResult, err := client.Instances.Restart(project, instance).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1089,14 +1155,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := sqladmin.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'restoreBackup' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'restoreBackup' method:
   var (
     // Project ID of the project that contains the instance.
     project = ""
@@ -1110,7 +1178,8 @@ func main() {
 
   callResult, err := client.Instances.RestoreBackup(project, instance, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1138,14 +1207,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := sqladmin.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'startReplica' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'startReplica' method:
   var (
     // ID of the project that contains the read replica.
     project = ""
@@ -1157,7 +1228,8 @@ func main() {
 
   callResult, err := client.Instances.StartReplica(project, instance).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1185,14 +1257,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := sqladmin.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'stopReplica' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'stopReplica' method:
   var (
     // ID of the project that contains the read replica.
     project = ""
@@ -1204,7 +1278,8 @@ func main() {
 
   callResult, err := client.Instances.StopReplica(project, instance).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1232,14 +1307,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := sqladmin.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
   var (
     // Project ID of the project that contains the instance.
     project = ""
@@ -1253,7 +1330,8 @@ func main() {
 
   callResult, err := client.Instances.Update(project, instance, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1281,14 +1359,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := sqladmin.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID of the project that contains the instance.
     project = ""
@@ -1300,7 +1380,8 @@ func main() {
 
   callResult, err := client.Operations.Get(project, operation).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1328,14 +1409,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := sqladmin.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID of the project that contains the instance.
     project = ""
@@ -1354,7 +1437,8 @@ func main() {
     return nil
   }
   if err = client.Operations.List(project, instance).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -1380,14 +1464,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := sqladmin.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'createEphemeral' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'createEphemeral' method:
   var (
     // Project ID of the Cloud SQL project.
     project = ""
@@ -1401,7 +1487,8 @@ func main() {
 
   callResult, err := client.SslCerts.CreateEphemeral(project, instance, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1429,14 +1516,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := sqladmin.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Project ID of the project that contains the instance to be deleted.
     project = ""
@@ -1451,7 +1540,8 @@ func main() {
 
   callResult, err := client.SslCerts.Delete(project, instance, sha1Fingerprint).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1479,14 +1569,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := sqladmin.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Project ID of the project that contains the instance.
     project = ""
@@ -1501,7 +1593,8 @@ func main() {
 
   callResult, err := client.SslCerts.Get(project, instance, sha1Fingerprint).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1529,14 +1622,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := sqladmin.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
   var (
     // Project ID of the project to which the newly created Cloud SQL instances should belong.
     project = ""
@@ -1550,7 +1645,8 @@ func main() {
 
   callResult, err := client.SslCerts.Insert(project, instance, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1578,14 +1674,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := sqladmin.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID of the project for which to list Cloud SQL instances.
     project = ""
@@ -1597,7 +1695,8 @@ func main() {
 
   callResult, err := client.SslCerts.List(project, instance).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1625,14 +1724,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := sqladmin.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID of the project for which to list tiers.
     project = ""
@@ -1641,7 +1742,8 @@ func main() {
 
   callResult, err := client.Tiers.List(project).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1669,14 +1771,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := sqladmin.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Project ID of the project that contains the instance.
     project = ""
@@ -1694,7 +1798,8 @@ func main() {
 
   callResult, err := client.Users.Delete(project, instance, host, name).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1722,14 +1827,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := sqladmin.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
   var (
     // Project ID of the project that contains the instance.
     project = ""
@@ -1743,7 +1850,8 @@ func main() {
 
   callResult, err := client.Users.Insert(project, instance, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1771,14 +1879,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := sqladmin.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Project ID of the project that contains the instance.
     project = ""
@@ -1790,7 +1900,8 @@ func main() {
 
   callResult, err := client.Users.List(project, instance).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1818,14 +1929,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := sqladmin.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
   var (
     // Project ID of the project that contains the instance.
     project = ""
@@ -1845,7 +1958,8 @@ func main() {
 
   callResult, err := client.Users.Update(project, instance, host, name, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_sqladmin.v1beta4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_sqladmin.v1beta4.json.baseline
@@ -12,8 +12,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -21,15 +19,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := sqladmin.New(client)
+  client, err := sqladmin.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -45,9 +42,9 @@ func main() {
 
   )
 
-  callResult, err := service.BackupRuns.Delete(project, instance, id).Context(ctx).Do()
+  callResult, err := client.BackupRuns.Delete(project, instance, id).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -65,8 +62,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -74,15 +69,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := sqladmin.New(client)
+  client, err := sqladmin.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -98,9 +92,9 @@ func main() {
 
   )
 
-  callResult, err := service.BackupRuns.Get(project, instance, id).Context(ctx).Do()
+  callResult, err := client.BackupRuns.Get(project, instance, id).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -118,8 +112,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -127,15 +119,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := sqladmin.New(client)
+  client, err := sqladmin.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -156,9 +147,8 @@ func main() {
     }
     return nil
   }
-  err = service.BackupRuns.List(project, instance).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.BackupRuns.List(project, instance).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -174,8 +164,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -183,15 +171,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := sqladmin.New(client)
+  client, err := sqladmin.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -207,9 +194,9 @@ func main() {
 
   )
 
-  callResult, err := service.Databases.Delete(project, instance, database).Context(ctx).Do()
+  callResult, err := client.Databases.Delete(project, instance, database).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -227,8 +214,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -236,15 +221,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := sqladmin.New(client)
+  client, err := sqladmin.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -260,9 +244,9 @@ func main() {
 
   )
 
-  callResult, err := service.Databases.Get(project, instance, database).Context(ctx).Do()
+  callResult, err := client.Databases.Get(project, instance, database).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -280,8 +264,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -289,15 +271,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := sqladmin.New(client)
+  client, err := sqladmin.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
@@ -312,9 +293,9 @@ func main() {
     requestBody = &sqladmin.Database{}
   )
 
-  callResult, err := service.Databases.Insert(project, instance, requestBody).Context(ctx).Do()
+  callResult, err := client.Databases.Insert(project, instance, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -332,8 +313,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -341,15 +320,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := sqladmin.New(client)
+  client, err := sqladmin.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -362,9 +340,9 @@ func main() {
 
   )
 
-  callResult, err := service.Databases.List(project, instance).Context(ctx).Do()
+  callResult, err := client.Databases.List(project, instance).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -382,8 +360,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -391,15 +367,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := sqladmin.New(client)
+  client, err := sqladmin.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'patch' method:
@@ -417,9 +392,9 @@ func main() {
     requestBody = &sqladmin.Database{}
   )
 
-  callResult, err := service.Databases.Patch(project, instance, database, requestBody).Context(ctx).Do()
+  callResult, err := client.Databases.Patch(project, instance, database, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -437,8 +412,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -446,15 +419,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := sqladmin.New(client)
+  client, err := sqladmin.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
@@ -472,9 +444,9 @@ func main() {
     requestBody = &sqladmin.Database{}
   )
 
-  callResult, err := service.Databases.Update(project, instance, database, requestBody).Context(ctx).Do()
+  callResult, err := client.Databases.Update(project, instance, database, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -492,8 +464,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -501,23 +471,22 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := sqladmin.New(client)
+  client, err := sqladmin.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   var (
   )
 
-  callResult, err := service.Flags.List().Context(ctx).Do()
+  callResult, err := client.Flags.List().Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -535,8 +504,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -544,15 +511,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := sqladmin.New(client)
+  client, err := sqladmin.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'clone' method:
@@ -567,9 +533,9 @@ func main() {
     requestBody = &sqladmin.InstancesCloneRequest{}
   )
 
-  callResult, err := service.Instances.Clone(project, instance, requestBody).Context(ctx).Do()
+  callResult, err := client.Instances.Clone(project, instance, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -587,8 +553,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -596,15 +560,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := sqladmin.New(client)
+  client, err := sqladmin.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -617,9 +580,9 @@ func main() {
 
   )
 
-  callResult, err := service.Instances.Delete(project, instance).Context(ctx).Do()
+  callResult, err := client.Instances.Delete(project, instance).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -637,8 +600,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -646,15 +607,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := sqladmin.New(client)
+  client, err := sqladmin.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'export' method:
@@ -669,9 +629,9 @@ func main() {
     requestBody = &sqladmin.InstancesExportRequest{}
   )
 
-  callResult, err := service.Instances.Export(project, instance, requestBody).Context(ctx).Do()
+  callResult, err := client.Instances.Export(project, instance, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -689,8 +649,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -698,15 +656,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := sqladmin.New(client)
+  client, err := sqladmin.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'failover' method:
@@ -721,9 +678,9 @@ func main() {
     requestBody = &sqladmin.InstancesFailoverRequest{}
   )
 
-  callResult, err := service.Instances.Failover(project, instance, requestBody).Context(ctx).Do()
+  callResult, err := client.Instances.Failover(project, instance, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -741,8 +698,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -750,15 +705,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := sqladmin.New(client)
+  client, err := sqladmin.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -771,9 +725,9 @@ func main() {
 
   )
 
-  callResult, err := service.Instances.Get(project, instance).Context(ctx).Do()
+  callResult, err := client.Instances.Get(project, instance).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -791,8 +745,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -800,15 +752,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := sqladmin.New(client)
+  client, err := sqladmin.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'import' method:
@@ -823,9 +774,9 @@ func main() {
     requestBody = &sqladmin.InstancesImportRequest{}
   )
 
-  callResult, err := service.Instances.Import(project, instance, requestBody).Context(ctx).Do()
+  callResult, err := client.Instances.Import(project, instance, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -843,8 +794,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -852,15 +801,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := sqladmin.New(client)
+  client, err := sqladmin.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
@@ -872,9 +820,9 @@ func main() {
     requestBody = &sqladmin.DatabaseInstance{}
   )
 
-  callResult, err := service.Instances.Insert(project, requestBody).Context(ctx).Do()
+  callResult, err := client.Instances.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -892,8 +840,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -901,15 +847,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := sqladmin.New(client)
+  client, err := sqladmin.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -927,9 +872,8 @@ func main() {
     }
     return nil
   }
-  err = service.Instances.List(project).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Instances.List(project).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -945,8 +889,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -954,15 +896,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := sqladmin.New(client)
+  client, err := sqladmin.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'patch' method:
@@ -977,9 +918,9 @@ func main() {
     requestBody = &sqladmin.DatabaseInstance{}
   )
 
-  callResult, err := service.Instances.Patch(project, instance, requestBody).Context(ctx).Do()
+  callResult, err := client.Instances.Patch(project, instance, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -997,8 +938,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1006,15 +945,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := sqladmin.New(client)
+  client, err := sqladmin.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'promoteReplica' method:
@@ -1027,9 +965,9 @@ func main() {
 
   )
 
-  callResult, err := service.Instances.PromoteReplica(project, instance).Context(ctx).Do()
+  callResult, err := client.Instances.PromoteReplica(project, instance).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1047,8 +985,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1056,15 +992,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := sqladmin.New(client)
+  client, err := sqladmin.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'resetSslConfig' method:
@@ -1077,9 +1012,9 @@ func main() {
 
   )
 
-  callResult, err := service.Instances.ResetSslConfig(project, instance).Context(ctx).Do()
+  callResult, err := client.Instances.ResetSslConfig(project, instance).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1097,8 +1032,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1106,15 +1039,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := sqladmin.New(client)
+  client, err := sqladmin.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'restart' method:
@@ -1127,9 +1059,9 @@ func main() {
 
   )
 
-  callResult, err := service.Instances.Restart(project, instance).Context(ctx).Do()
+  callResult, err := client.Instances.Restart(project, instance).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1147,8 +1079,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1156,15 +1086,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := sqladmin.New(client)
+  client, err := sqladmin.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'restoreBackup' method:
@@ -1179,9 +1108,9 @@ func main() {
     requestBody = &sqladmin.InstancesRestoreBackupRequest{}
   )
 
-  callResult, err := service.Instances.RestoreBackup(project, instance, requestBody).Context(ctx).Do()
+  callResult, err := client.Instances.RestoreBackup(project, instance, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1199,8 +1128,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1208,15 +1135,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := sqladmin.New(client)
+  client, err := sqladmin.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'startReplica' method:
@@ -1229,9 +1155,9 @@ func main() {
 
   )
 
-  callResult, err := service.Instances.StartReplica(project, instance).Context(ctx).Do()
+  callResult, err := client.Instances.StartReplica(project, instance).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1249,8 +1175,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1258,15 +1182,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := sqladmin.New(client)
+  client, err := sqladmin.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'stopReplica' method:
@@ -1279,9 +1202,9 @@ func main() {
 
   )
 
-  callResult, err := service.Instances.StopReplica(project, instance).Context(ctx).Do()
+  callResult, err := client.Instances.StopReplica(project, instance).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1299,8 +1222,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1308,15 +1229,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := sqladmin.New(client)
+  client, err := sqladmin.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
@@ -1331,9 +1251,9 @@ func main() {
     requestBody = &sqladmin.DatabaseInstance{}
   )
 
-  callResult, err := service.Instances.Update(project, instance, requestBody).Context(ctx).Do()
+  callResult, err := client.Instances.Update(project, instance, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1351,8 +1271,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1360,15 +1278,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := sqladmin.New(client)
+  client, err := sqladmin.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -1381,9 +1298,9 @@ func main() {
 
   )
 
-  callResult, err := service.Operations.Get(project, operation).Context(ctx).Do()
+  callResult, err := client.Operations.Get(project, operation).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1401,8 +1318,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1410,15 +1325,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := sqladmin.New(client)
+  client, err := sqladmin.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -1439,9 +1353,8 @@ func main() {
     }
     return nil
   }
-  err = service.Operations.List(project, instance).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Operations.List(project, instance).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -1457,8 +1370,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1466,15 +1377,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := sqladmin.New(client)
+  client, err := sqladmin.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'createEphemeral' method:
@@ -1489,9 +1399,9 @@ func main() {
     requestBody = &sqladmin.SslCertsCreateEphemeralRequest{}
   )
 
-  callResult, err := service.SslCerts.CreateEphemeral(project, instance, requestBody).Context(ctx).Do()
+  callResult, err := client.SslCerts.CreateEphemeral(project, instance, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1509,8 +1419,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1518,15 +1426,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := sqladmin.New(client)
+  client, err := sqladmin.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -1542,9 +1449,9 @@ func main() {
 
   )
 
-  callResult, err := service.SslCerts.Delete(project, instance, sha1Fingerprint).Context(ctx).Do()
+  callResult, err := client.SslCerts.Delete(project, instance, sha1Fingerprint).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1562,8 +1469,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1571,15 +1476,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := sqladmin.New(client)
+  client, err := sqladmin.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -1595,9 +1499,9 @@ func main() {
 
   )
 
-  callResult, err := service.SslCerts.Get(project, instance, sha1Fingerprint).Context(ctx).Do()
+  callResult, err := client.SslCerts.Get(project, instance, sha1Fingerprint).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1615,8 +1519,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1624,15 +1526,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := sqladmin.New(client)
+  client, err := sqladmin.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
@@ -1647,9 +1548,9 @@ func main() {
     requestBody = &sqladmin.SslCertsInsertRequest{}
   )
 
-  callResult, err := service.SslCerts.Insert(project, instance, requestBody).Context(ctx).Do()
+  callResult, err := client.SslCerts.Insert(project, instance, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1667,8 +1568,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1676,15 +1575,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := sqladmin.New(client)
+  client, err := sqladmin.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -1697,9 +1595,9 @@ func main() {
 
   )
 
-  callResult, err := service.SslCerts.List(project, instance).Context(ctx).Do()
+  callResult, err := client.SslCerts.List(project, instance).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1717,8 +1615,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1726,15 +1622,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := sqladmin.New(client)
+  client, err := sqladmin.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -1744,9 +1639,9 @@ func main() {
 
   )
 
-  callResult, err := service.Tiers.List(project).Context(ctx).Do()
+  callResult, err := client.Tiers.List(project).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1764,8 +1659,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1773,15 +1666,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := sqladmin.New(client)
+  client, err := sqladmin.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -1800,9 +1692,9 @@ func main() {
 
   )
 
-  callResult, err := service.Users.Delete(project, instance, host, name).Context(ctx).Do()
+  callResult, err := client.Users.Delete(project, instance, host, name).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1820,8 +1712,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1829,15 +1719,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := sqladmin.New(client)
+  client, err := sqladmin.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
@@ -1852,9 +1741,9 @@ func main() {
     requestBody = &sqladmin.User{}
   )
 
-  callResult, err := service.Users.Insert(project, instance, requestBody).Context(ctx).Do()
+  callResult, err := client.Users.Insert(project, instance, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1872,8 +1761,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1881,15 +1768,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := sqladmin.New(client)
+  client, err := sqladmin.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -1902,9 +1788,9 @@ func main() {
 
   )
 
-  callResult, err := service.Users.List(project, instance).Context(ctx).Do()
+  callResult, err := client.Users.List(project, instance).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1922,8 +1808,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1931,15 +1815,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := sqladmin.New(client)
+  client, err := sqladmin.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
@@ -1960,9 +1843,9 @@ func main() {
     requestBody = &sqladmin.User{}
   )
 
-  callResult, err := service.Users.Update(project, instance, host, name, requestBody).Context(ctx).Do()
+  callResult, err := client.Users.Update(project, instance, host, name, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_storage.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_storage.v1.json.baseline
@@ -12,8 +12,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -21,15 +19,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storage.New(client)
+  client, err := storage.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -42,9 +39,8 @@ func main() {
 
   )
 
-  err = service.BucketAccessControls.Delete(bucket, entity).Context(ctx).Do()
-  if err != nil {
-    log.Fatal(err)
+  if err = client.BucketAccessControls.Delete(bucket, entity).Context(ctx).Do(); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -60,8 +56,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -69,15 +63,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storage.New(client)
+  client, err := storage.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -90,9 +83,9 @@ func main() {
 
   )
 
-  callResult, err := service.BucketAccessControls.Get(bucket, entity).Context(ctx).Do()
+  callResult, err := client.BucketAccessControls.Get(bucket, entity).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -110,8 +103,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -119,15 +110,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storage.New(client)
+  client, err := storage.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
@@ -139,9 +129,9 @@ func main() {
     requestBody = &storage.BucketAccessControl{}
   )
 
-  callResult, err := service.BucketAccessControls.Insert(bucket, requestBody).Context(ctx).Do()
+  callResult, err := client.BucketAccessControls.Insert(bucket, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -159,8 +149,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -168,15 +156,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storage.New(client)
+  client, err := storage.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -186,9 +173,9 @@ func main() {
 
   )
 
-  callResult, err := service.BucketAccessControls.List(bucket).Context(ctx).Do()
+  callResult, err := client.BucketAccessControls.List(bucket).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -206,8 +193,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -215,15 +200,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storage.New(client)
+  client, err := storage.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'patch' method:
@@ -238,9 +222,9 @@ func main() {
     requestBody = &storage.BucketAccessControl{}
   )
 
-  callResult, err := service.BucketAccessControls.Patch(bucket, entity, requestBody).Context(ctx).Do()
+  callResult, err := client.BucketAccessControls.Patch(bucket, entity, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -258,8 +242,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -267,15 +249,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storage.New(client)
+  client, err := storage.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
@@ -290,9 +271,9 @@ func main() {
     requestBody = &storage.BucketAccessControl{}
   )
 
-  callResult, err := service.BucketAccessControls.Update(bucket, entity, requestBody).Context(ctx).Do()
+  callResult, err := client.BucketAccessControls.Update(bucket, entity, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -310,8 +291,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -319,15 +298,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storage.New(client)
+  client, err := storage.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -337,9 +315,8 @@ func main() {
 
   )
 
-  err = service.Buckets.Delete(bucket).Context(ctx).Do()
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Buckets.Delete(bucket).Context(ctx).Do(); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -355,8 +332,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -364,15 +339,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storage.New(client)
+  client, err := storage.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -382,9 +356,9 @@ func main() {
 
   )
 
-  callResult, err := service.Buckets.Get(bucket).Context(ctx).Do()
+  callResult, err := client.Buckets.Get(bucket).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -402,8 +376,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -411,15 +383,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storage.New(client)
+  client, err := storage.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
@@ -431,9 +402,9 @@ func main() {
     requestBody = &storage.Bucket{}
   )
 
-  callResult, err := service.Buckets.Insert(project, requestBody).Context(ctx).Do()
+  callResult, err := client.Buckets.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -451,8 +422,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -460,15 +429,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storage.New(client)
+  client, err := storage.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -486,9 +454,8 @@ func main() {
     }
     return nil
   }
-  err = service.Buckets.List(project).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Buckets.List(project).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -504,8 +471,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -513,15 +478,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storage.New(client)
+  client, err := storage.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'patch' method:
@@ -533,9 +497,9 @@ func main() {
     requestBody = &storage.Bucket{}
   )
 
-  callResult, err := service.Buckets.Patch(bucket, requestBody).Context(ctx).Do()
+  callResult, err := client.Buckets.Patch(bucket, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -553,8 +517,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -562,15 +524,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storage.New(client)
+  client, err := storage.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
@@ -582,9 +543,9 @@ func main() {
     requestBody = &storage.Bucket{}
   )
 
-  callResult, err := service.Buckets.Update(bucket, requestBody).Context(ctx).Do()
+  callResult, err := client.Buckets.Update(bucket, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -602,8 +563,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -611,15 +570,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storage.New(client)
+  client, err := storage.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'stop' method:
@@ -628,9 +586,8 @@ func main() {
     requestBody = &storage.Channel{}
   )
 
-  err = service.Channels.Stop(requestBody).Context(ctx).Do()
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Channels.Stop(requestBody).Context(ctx).Do(); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -646,8 +603,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -655,15 +610,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storage.New(client)
+  client, err := storage.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -676,9 +630,8 @@ func main() {
 
   )
 
-  err = service.DefaultObjectAccessControls.Delete(bucket, entity).Context(ctx).Do()
-  if err != nil {
-    log.Fatal(err)
+  if err = client.DefaultObjectAccessControls.Delete(bucket, entity).Context(ctx).Do(); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -694,8 +647,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -703,15 +654,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storage.New(client)
+  client, err := storage.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -724,9 +674,9 @@ func main() {
 
   )
 
-  callResult, err := service.DefaultObjectAccessControls.Get(bucket, entity).Context(ctx).Do()
+  callResult, err := client.DefaultObjectAccessControls.Get(bucket, entity).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -744,8 +694,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -753,15 +701,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storage.New(client)
+  client, err := storage.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
@@ -773,9 +720,9 @@ func main() {
     requestBody = &storage.ObjectAccessControl{}
   )
 
-  callResult, err := service.DefaultObjectAccessControls.Insert(bucket, requestBody).Context(ctx).Do()
+  callResult, err := client.DefaultObjectAccessControls.Insert(bucket, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -793,8 +740,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -802,15 +747,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storage.New(client)
+  client, err := storage.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -820,9 +764,9 @@ func main() {
 
   )
 
-  callResult, err := service.DefaultObjectAccessControls.List(bucket).Context(ctx).Do()
+  callResult, err := client.DefaultObjectAccessControls.List(bucket).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -840,8 +784,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -849,15 +791,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storage.New(client)
+  client, err := storage.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'patch' method:
@@ -872,9 +813,9 @@ func main() {
     requestBody = &storage.ObjectAccessControl{}
   )
 
-  callResult, err := service.DefaultObjectAccessControls.Patch(bucket, entity, requestBody).Context(ctx).Do()
+  callResult, err := client.DefaultObjectAccessControls.Patch(bucket, entity, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -892,8 +833,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -901,15 +840,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storage.New(client)
+  client, err := storage.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
@@ -924,9 +862,9 @@ func main() {
     requestBody = &storage.ObjectAccessControl{}
   )
 
-  callResult, err := service.DefaultObjectAccessControls.Update(bucket, entity, requestBody).Context(ctx).Do()
+  callResult, err := client.DefaultObjectAccessControls.Update(bucket, entity, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -944,8 +882,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -953,15 +889,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storage.New(client)
+  client, err := storage.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -977,9 +912,8 @@ func main() {
 
   )
 
-  err = service.ObjectAccessControls.Delete(bucket, object, entity).Context(ctx).Do()
-  if err != nil {
-    log.Fatal(err)
+  if err = client.ObjectAccessControls.Delete(bucket, object, entity).Context(ctx).Do(); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -995,8 +929,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1004,15 +936,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storage.New(client)
+  client, err := storage.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -1028,9 +959,9 @@ func main() {
 
   )
 
-  callResult, err := service.ObjectAccessControls.Get(bucket, object, entity).Context(ctx).Do()
+  callResult, err := client.ObjectAccessControls.Get(bucket, object, entity).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1048,8 +979,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1057,15 +986,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storage.New(client)
+  client, err := storage.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
@@ -1080,9 +1008,9 @@ func main() {
     requestBody = &storage.ObjectAccessControl{}
   )
 
-  callResult, err := service.ObjectAccessControls.Insert(bucket, object, requestBody).Context(ctx).Do()
+  callResult, err := client.ObjectAccessControls.Insert(bucket, object, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1100,8 +1028,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1109,15 +1035,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storage.New(client)
+  client, err := storage.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -1130,9 +1055,9 @@ func main() {
 
   )
 
-  callResult, err := service.ObjectAccessControls.List(bucket, object).Context(ctx).Do()
+  callResult, err := client.ObjectAccessControls.List(bucket, object).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1150,8 +1075,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1159,15 +1082,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storage.New(client)
+  client, err := storage.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'patch' method:
@@ -1185,9 +1107,9 @@ func main() {
     requestBody = &storage.ObjectAccessControl{}
   )
 
-  callResult, err := service.ObjectAccessControls.Patch(bucket, object, entity, requestBody).Context(ctx).Do()
+  callResult, err := client.ObjectAccessControls.Patch(bucket, object, entity, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1205,8 +1127,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1214,15 +1134,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storage.New(client)
+  client, err := storage.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
@@ -1240,9 +1159,9 @@ func main() {
     requestBody = &storage.ObjectAccessControl{}
   )
 
-  callResult, err := service.ObjectAccessControls.Update(bucket, object, entity, requestBody).Context(ctx).Do()
+  callResult, err := client.ObjectAccessControls.Update(bucket, object, entity, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1260,8 +1179,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1269,15 +1186,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storage.New(client)
+  client, err := storage.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'compose' method:
@@ -1292,9 +1208,9 @@ func main() {
     requestBody = &storage.ComposeRequest{}
   )
 
-  callResult, err := service.Objects.Compose(destinationBucket, destinationObject, requestBody).Context(ctx).Do()
+  callResult, err := client.Objects.Compose(destinationBucket, destinationObject, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1312,8 +1228,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1321,15 +1235,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storage.New(client)
+  client, err := storage.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'copy' method:
@@ -1350,9 +1263,9 @@ func main() {
     requestBody = &storage.Object{}
   )
 
-  callResult, err := service.Objects.Copy(sourceBucket, sourceObject, destinationBucket, destinationObject, requestBody).Context(ctx).Do()
+  callResult, err := client.Objects.Copy(sourceBucket, sourceObject, destinationBucket, destinationObject, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1370,8 +1283,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1379,15 +1290,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storage.New(client)
+  client, err := storage.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -1400,9 +1310,8 @@ func main() {
 
   )
 
-  err = service.Objects.Delete(bucket, object).Context(ctx).Do()
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Objects.Delete(bucket, object).Context(ctx).Do(); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -1418,8 +1327,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1427,15 +1334,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storage.New(client)
+  client, err := storage.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -1448,9 +1354,9 @@ func main() {
 
   )
 
-  callResult, err := service.Objects.Get(bucket, object).Context(ctx).Do()
+  callResult, err := client.Objects.Get(bucket, object).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1468,8 +1374,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1477,15 +1381,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storage.New(client)
+  client, err := storage.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
@@ -1497,9 +1400,9 @@ func main() {
     requestBody = &storage.Object{}
   )
 
-  callResult, err := service.Objects.Insert(bucket, requestBody).Context(ctx).Do()
+  callResult, err := client.Objects.Insert(bucket, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1517,8 +1420,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1526,15 +1427,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storage.New(client)
+  client, err := storage.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -1552,9 +1452,8 @@ func main() {
     }
     return nil
   }
-  err = service.Objects.List(bucket).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Objects.List(bucket).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -1570,8 +1469,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1579,15 +1476,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storage.New(client)
+  client, err := storage.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'patch' method:
@@ -1602,9 +1498,9 @@ func main() {
     requestBody = &storage.Object{}
   )
 
-  callResult, err := service.Objects.Patch(bucket, object, requestBody).Context(ctx).Do()
+  callResult, err := client.Objects.Patch(bucket, object, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1622,8 +1518,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1631,15 +1525,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storage.New(client)
+  client, err := storage.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'rewrite' method:
@@ -1660,9 +1553,9 @@ func main() {
     requestBody = &storage.Object{}
   )
 
-  callResult, err := service.Objects.Rewrite(sourceBucket, sourceObject, destinationBucket, destinationObject, requestBody).Context(ctx).Do()
+  callResult, err := client.Objects.Rewrite(sourceBucket, sourceObject, destinationBucket, destinationObject, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1680,8 +1573,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1689,15 +1580,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storage.New(client)
+  client, err := storage.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
@@ -1712,9 +1602,9 @@ func main() {
     requestBody = &storage.Object{}
   )
 
-  callResult, err := service.Objects.Update(bucket, object, requestBody).Context(ctx).Do()
+  callResult, err := client.Objects.Update(bucket, object, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1732,8 +1622,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -1741,15 +1629,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storage.New(client)
+  client, err := storage.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'watchAll' method:
@@ -1761,9 +1648,9 @@ func main() {
     requestBody = &storage.Channel{}
   )
 
-  callResult, err := service.Objects.WatchAll(bucket, requestBody).Context(ctx).Do()
+  callResult, err := client.Objects.WatchAll(bucket, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_storage.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_storage.v1.json.baseline
@@ -22,14 +22,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storage.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Name of a bucket.
     bucket = ""
@@ -40,7 +42,8 @@ func main() {
   )
 
   if err = client.BucketAccessControls.Delete(bucket, entity).Context(ctx).Do(); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -66,14 +69,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storage.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Name of a bucket.
     bucket = ""
@@ -85,7 +90,8 @@ func main() {
 
   callResult, err := client.BucketAccessControls.Get(bucket, entity).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -113,14 +119,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storage.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
   var (
     // Name of a bucket.
     bucket = ""
@@ -131,7 +139,8 @@ func main() {
 
   callResult, err := client.BucketAccessControls.Insert(bucket, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -159,14 +168,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storage.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Name of a bucket.
     bucket = ""
@@ -175,7 +186,8 @@ func main() {
 
   callResult, err := client.BucketAccessControls.List(bucket).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -203,14 +215,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storage.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'patch' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
   var (
     // Name of a bucket.
     bucket = ""
@@ -224,7 +238,8 @@ func main() {
 
   callResult, err := client.BucketAccessControls.Patch(bucket, entity, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -252,14 +267,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storage.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
   var (
     // Name of a bucket.
     bucket = ""
@@ -273,7 +290,8 @@ func main() {
 
   callResult, err := client.BucketAccessControls.Update(bucket, entity, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -301,14 +319,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storage.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Name of a bucket.
     bucket = ""
@@ -316,7 +336,8 @@ func main() {
   )
 
   if err = client.Buckets.Delete(bucket).Context(ctx).Do(); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -342,14 +363,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storage.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Name of a bucket.
     bucket = ""
@@ -358,7 +381,8 @@ func main() {
 
   callResult, err := client.Buckets.Get(bucket).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -386,14 +410,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storage.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
   var (
     // A valid API project identifier.
     project = ""
@@ -404,7 +430,8 @@ func main() {
 
   callResult, err := client.Buckets.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -432,14 +459,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storage.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // A valid API project identifier.
     project = ""
@@ -455,7 +484,8 @@ func main() {
     return nil
   }
   if err = client.Buckets.List(project).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -481,14 +511,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storage.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'patch' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
   var (
     // Name of a bucket.
     bucket = ""
@@ -499,7 +531,8 @@ func main() {
 
   callResult, err := client.Buckets.Patch(bucket, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -527,14 +560,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storage.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
   var (
     // Name of a bucket.
     bucket = ""
@@ -545,7 +580,8 @@ func main() {
 
   callResult, err := client.Buckets.Update(bucket, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -573,21 +609,24 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storage.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'stop' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'stop' method:
   var (
 
     requestBody = &storage.Channel{}
   )
 
   if err = client.Channels.Stop(requestBody).Context(ctx).Do(); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -613,14 +652,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storage.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Name of a bucket.
     bucket = ""
@@ -631,7 +672,8 @@ func main() {
   )
 
   if err = client.DefaultObjectAccessControls.Delete(bucket, entity).Context(ctx).Do(); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -657,14 +699,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storage.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Name of a bucket.
     bucket = ""
@@ -676,7 +720,8 @@ func main() {
 
   callResult, err := client.DefaultObjectAccessControls.Get(bucket, entity).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -704,14 +749,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storage.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
   var (
     // Name of a bucket.
     bucket = ""
@@ -722,7 +769,8 @@ func main() {
 
   callResult, err := client.DefaultObjectAccessControls.Insert(bucket, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -750,14 +798,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storage.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Name of a bucket.
     bucket = ""
@@ -766,7 +816,8 @@ func main() {
 
   callResult, err := client.DefaultObjectAccessControls.List(bucket).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -794,14 +845,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storage.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'patch' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
   var (
     // Name of a bucket.
     bucket = ""
@@ -815,7 +868,8 @@ func main() {
 
   callResult, err := client.DefaultObjectAccessControls.Patch(bucket, entity, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -843,14 +897,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storage.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
   var (
     // Name of a bucket.
     bucket = ""
@@ -864,7 +920,8 @@ func main() {
 
   callResult, err := client.DefaultObjectAccessControls.Update(bucket, entity, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -892,14 +949,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storage.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Name of a bucket.
     bucket = ""
@@ -913,7 +972,8 @@ func main() {
   )
 
   if err = client.ObjectAccessControls.Delete(bucket, object, entity).Context(ctx).Do(); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -939,14 +999,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storage.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Name of a bucket.
     bucket = ""
@@ -961,7 +1023,8 @@ func main() {
 
   callResult, err := client.ObjectAccessControls.Get(bucket, object, entity).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -989,14 +1052,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storage.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
   var (
     // Name of a bucket.
     bucket = ""
@@ -1010,7 +1075,8 @@ func main() {
 
   callResult, err := client.ObjectAccessControls.Insert(bucket, object, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1038,14 +1104,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storage.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Name of a bucket.
     bucket = ""
@@ -1057,7 +1125,8 @@ func main() {
 
   callResult, err := client.ObjectAccessControls.List(bucket, object).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1085,14 +1154,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storage.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'patch' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
   var (
     // Name of a bucket.
     bucket = ""
@@ -1109,7 +1180,8 @@ func main() {
 
   callResult, err := client.ObjectAccessControls.Patch(bucket, object, entity, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1137,14 +1209,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storage.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
   var (
     // Name of a bucket.
     bucket = ""
@@ -1161,7 +1235,8 @@ func main() {
 
   callResult, err := client.ObjectAccessControls.Update(bucket, object, entity, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1189,14 +1264,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storage.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'compose' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'compose' method:
   var (
     // Name of the bucket in which to store the new object.
     destinationBucket = ""
@@ -1210,7 +1287,8 @@ func main() {
 
   callResult, err := client.Objects.Compose(destinationBucket, destinationObject, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1238,14 +1316,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storage.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'copy' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'copy' method:
   var (
     // Name of the bucket in which to find the source object.
     sourceBucket = ""
@@ -1265,7 +1345,8 @@ func main() {
 
   callResult, err := client.Objects.Copy(sourceBucket, sourceObject, destinationBucket, destinationObject, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1293,14 +1374,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storage.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // Name of the bucket in which the object resides.
     bucket = ""
@@ -1311,7 +1394,8 @@ func main() {
   )
 
   if err = client.Objects.Delete(bucket, object).Context(ctx).Do(); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -1337,14 +1421,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storage.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // Name of the bucket in which the object resides.
     bucket = ""
@@ -1356,7 +1442,8 @@ func main() {
 
   callResult, err := client.Objects.Get(bucket, object).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1384,14 +1471,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storage.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
   var (
     // Name of the bucket in which to store the new object. Overrides the provided object metadata's bucket value, if any.
     bucket = ""
@@ -1402,7 +1491,8 @@ func main() {
 
   callResult, err := client.Objects.Insert(bucket, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1430,14 +1520,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storage.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // Name of the bucket in which to look for objects.
     bucket = ""
@@ -1453,7 +1545,8 @@ func main() {
     return nil
   }
   if err = client.Objects.List(bucket).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -1479,14 +1572,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storage.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'patch' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
   var (
     // Name of the bucket in which the object resides.
     bucket = ""
@@ -1500,7 +1595,8 @@ func main() {
 
   callResult, err := client.Objects.Patch(bucket, object, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1528,14 +1624,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storage.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'rewrite' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'rewrite' method:
   var (
     // Name of the bucket in which to find the source object.
     sourceBucket = ""
@@ -1555,7 +1653,8 @@ func main() {
 
   callResult, err := client.Objects.Rewrite(sourceBucket, sourceObject, destinationBucket, destinationObject, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1583,14 +1682,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storage.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
   var (
     // Name of the bucket in which the object resides.
     bucket = ""
@@ -1604,7 +1705,8 @@ func main() {
 
   callResult, err := client.Objects.Update(bucket, object, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -1632,14 +1734,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storage.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'watchAll' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'watchAll' method:
   var (
     // Name of the bucket in which to look for objects.
     bucket = ""
@@ -1650,7 +1754,8 @@ func main() {
 
   callResult, err := client.Objects.WatchAll(bucket, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_storagetransfer.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_storagetransfer.v1.json.baseline
@@ -22,11 +22,13 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storagetransfer.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
   var (
@@ -34,7 +36,8 @@ func main() {
 
   callResult, err := client.V1.GetGoogleServiceAccount().Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -62,14 +65,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storagetransfer.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // The ID of the Google Developers Console project that the Google service account is associated with. Required.
     projectId = ""
@@ -78,7 +83,8 @@ func main() {
 
   callResult, err := client.GoogleServiceAccounts.Get(projectId).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -106,14 +112,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storagetransfer.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'create' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'create' method:
   var (
 
     requestBody = &storagetransfer.TransferJob{}
@@ -121,7 +129,8 @@ func main() {
 
   callResult, err := client.TransferJobs.Create(requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -149,14 +158,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storagetransfer.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // The job to get. Required.
     jobName = ""
@@ -165,7 +176,8 @@ func main() {
 
   callResult, err := client.TransferJobs.Get(jobName).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -193,11 +205,13 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storagetransfer.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
   var (
@@ -212,7 +226,8 @@ func main() {
     return nil
   }
   if err = client.TransferJobs.List().Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -238,14 +253,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storagetransfer.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'patch' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
   var (
     // The name of job to update. Required.
     jobName = ""
@@ -256,7 +273,8 @@ func main() {
 
   callResult, err := client.TransferJobs.Patch(jobName, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -284,14 +302,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storagetransfer.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'cancel' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'cancel' method:
   var (
     // The name of the operation resource to be cancelled.
     name = ""
@@ -300,7 +320,8 @@ func main() {
 
   callResult, err := client.TransferOperations.Cancel(name).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -328,14 +349,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storagetransfer.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // The name of the operation resource to be deleted.
     name = ""
@@ -344,7 +367,8 @@ func main() {
 
   callResult, err := client.TransferOperations.Delete(name).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -372,14 +396,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storagetransfer.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // The name of the operation resource.
     name = ""
@@ -388,7 +414,8 @@ func main() {
 
   callResult, err := client.TransferOperations.Get(name).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -416,14 +443,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storagetransfer.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // The value `transferOperations`.
     name = ""
@@ -439,7 +468,8 @@ func main() {
     return nil
   }
   if err = client.TransferOperations.List(name).Pages(ctx, fn); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -465,14 +495,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storagetransfer.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'pause' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'pause' method:
   var (
     // The name of the transfer operation. Required.
     name = ""
@@ -483,7 +515,8 @@ func main() {
 
   callResult, err := client.TransferOperations.Pause(name, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -511,14 +544,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := storagetransfer.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'resume' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'resume' method:
   var (
     // The name of the transfer operation. Required.
     name = ""
@@ -529,7 +564,8 @@ func main() {
 
   callResult, err := client.TransferOperations.Resume(name, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_storagetransfer.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_storagetransfer.v1.json.baseline
@@ -12,8 +12,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -21,23 +19,22 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storagetransfer.New(client)
+  client, err := storagetransfer.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   var (
   )
 
-  callResult, err := service.V1.GetGoogleServiceAccount().Context(ctx).Do()
+  callResult, err := client.V1.GetGoogleServiceAccount().Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -55,8 +52,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -64,15 +59,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storagetransfer.New(client)
+  client, err := storagetransfer.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -82,9 +76,9 @@ func main() {
 
   )
 
-  callResult, err := service.GoogleServiceAccounts.Get(projectId).Context(ctx).Do()
+  callResult, err := client.GoogleServiceAccounts.Get(projectId).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -102,8 +96,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -111,15 +103,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storagetransfer.New(client)
+  client, err := storagetransfer.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'create' method:
@@ -128,9 +119,9 @@ func main() {
     requestBody = &storagetransfer.TransferJob{}
   )
 
-  callResult, err := service.TransferJobs.Create(requestBody).Context(ctx).Do()
+  callResult, err := client.TransferJobs.Create(requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -148,8 +139,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -157,15 +146,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storagetransfer.New(client)
+  client, err := storagetransfer.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -175,9 +163,9 @@ func main() {
 
   )
 
-  callResult, err := service.TransferJobs.Get(jobName).Context(ctx).Do()
+  callResult, err := client.TransferJobs.Get(jobName).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -195,8 +183,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -204,15 +190,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storagetransfer.New(client)
+  client, err := storagetransfer.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   var (
@@ -226,9 +211,8 @@ func main() {
     }
     return nil
   }
-  err = service.TransferJobs.List().Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.TransferJobs.List().Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -244,8 +228,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -253,15 +235,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storagetransfer.New(client)
+  client, err := storagetransfer.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'patch' method:
@@ -273,9 +254,9 @@ func main() {
     requestBody = &storagetransfer.UpdateTransferJobRequest{}
   )
 
-  callResult, err := service.TransferJobs.Patch(jobName, requestBody).Context(ctx).Do()
+  callResult, err := client.TransferJobs.Patch(jobName, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -293,8 +274,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -302,15 +281,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storagetransfer.New(client)
+  client, err := storagetransfer.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'cancel' method:
@@ -320,9 +298,9 @@ func main() {
 
   )
 
-  callResult, err := service.TransferOperations.Cancel(name).Context(ctx).Do()
+  callResult, err := client.TransferOperations.Cancel(name).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -340,8 +318,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -349,15 +325,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storagetransfer.New(client)
+  client, err := storagetransfer.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -367,9 +342,9 @@ func main() {
 
   )
 
-  callResult, err := service.TransferOperations.Delete(name).Context(ctx).Do()
+  callResult, err := client.TransferOperations.Delete(name).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -387,8 +362,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -396,15 +369,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storagetransfer.New(client)
+  client, err := storagetransfer.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -414,9 +386,9 @@ func main() {
 
   )
 
-  callResult, err := service.TransferOperations.Get(name).Context(ctx).Do()
+  callResult, err := client.TransferOperations.Get(name).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -434,8 +406,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -443,15 +413,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storagetransfer.New(client)
+  client, err := storagetransfer.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -469,9 +438,8 @@ func main() {
     }
     return nil
   }
-  err = service.TransferOperations.List(name).Pages(ctx, fn)
-  if err != nil {
-    log.Fatal(err)
+  if err = client.TransferOperations.List(name).Pages(ctx, fn); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -487,8 +455,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -496,15 +462,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storagetransfer.New(client)
+  client, err := storagetransfer.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'pause' method:
@@ -516,9 +481,9 @@ func main() {
     requestBody = &storagetransfer.PauseTransferOperationRequest{}
   )
 
-  callResult, err := service.TransferOperations.Pause(name, requestBody).Context(ctx).Do()
+  callResult, err := client.TransferOperations.Pause(name, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -536,8 +501,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -545,15 +508,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := storagetransfer.New(client)
+  client, err := storagetransfer.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'resume' method:
@@ -565,9 +527,9 @@ func main() {
     requestBody = &storagetransfer.ResumeTransferOperationRequest{}
   )
 
-  callResult, err := service.TransferOperations.Resume(name, requestBody).Context(ctx).Do()
+  callResult, err := client.TransferOperations.Resume(name, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_taskqueue.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_taskqueue.v1beta2.json.baseline
@@ -22,14 +22,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := taskqueue.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // The project under which the queue lies.
     project = ""
@@ -41,7 +43,8 @@ func main() {
 
   callResult, err := client.Taskqueues.Get(project, taskqueue_).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -69,14 +72,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := taskqueue.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
   var (
     // The project under which the queue lies.
     project = ""
@@ -90,7 +95,8 @@ func main() {
   )
 
   if err = client.Tasks.Delete(project, taskqueue_, task).Context(ctx).Do(); err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 }
 package main
@@ -116,14 +122,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := taskqueue.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
   var (
     // The project under which the queue lies.
     project = ""
@@ -138,7 +146,8 @@ func main() {
 
   callResult, err := client.Tasks.Get(project, taskqueue_, task).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -166,14 +175,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := taskqueue.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
   var (
     // The project under which the queue lies
     project = ""
@@ -187,7 +198,8 @@ func main() {
 
   callResult, err := client.Tasks.Insert(project, taskqueue_, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -215,14 +227,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := taskqueue.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'lease' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'lease' method:
   var (
     // The project under which the queue lies.
     project = ""
@@ -240,7 +254,8 @@ func main() {
 
   callResult, err := client.Tasks.Lease(project, taskqueue_, numTasks, leaseSecs).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -268,14 +283,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := taskqueue.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // The project under which the queue lies.
     project = ""
@@ -287,7 +304,8 @@ func main() {
 
   callResult, err := client.Tasks.List(project, taskqueue_).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -315,14 +333,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := taskqueue.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'patch' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
   var (
     // The project under which the queue lies.
     project = ""
@@ -342,7 +362,8 @@ func main() {
 
   callResult, err := client.Tasks.Patch(project, taskqueue_, task, newLeaseSeconds, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -370,14 +391,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := taskqueue.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
   var (
     // The project under which the queue lies.
     project = ""
@@ -397,7 +420,8 @@ func main() {
 
   callResult, err := client.Tasks.Update(project, taskqueue_, task, newLeaseSeconds, requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_taskqueue.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_taskqueue.v1beta2.json.baseline
@@ -12,8 +12,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -21,15 +19,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := taskqueue.New(client)
+  client, err := taskqueue.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -42,9 +39,9 @@ func main() {
 
   )
 
-  callResult, err := service.Taskqueues.Get(project, taskqueue_).Context(ctx).Do()
+  callResult, err := client.Taskqueues.Get(project, taskqueue_).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -62,8 +59,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -71,15 +66,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := taskqueue.New(client)
+  client, err := taskqueue.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'delete' method:
@@ -95,9 +89,8 @@ func main() {
 
   )
 
-  err = service.Tasks.Delete(project, taskqueue_, task).Context(ctx).Do()
-  if err != nil {
-    log.Fatal(err)
+  if err = client.Tasks.Delete(project, taskqueue_, task).Context(ctx).Do(); err != nil {
+    _ = err // Handle error.
   }
 }
 package main
@@ -113,8 +106,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -122,15 +113,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := taskqueue.New(client)
+  client, err := taskqueue.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'get' method:
@@ -146,9 +136,9 @@ func main() {
 
   )
 
-  callResult, err := service.Tasks.Get(project, taskqueue_, task).Context(ctx).Do()
+  callResult, err := client.Tasks.Get(project, taskqueue_, task).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -166,8 +156,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -175,15 +163,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := taskqueue.New(client)
+  client, err := taskqueue.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'insert' method:
@@ -198,9 +185,9 @@ func main() {
     requestBody = &taskqueue.Task{}
   )
 
-  callResult, err := service.Tasks.Insert(project, taskqueue_, requestBody).Context(ctx).Do()
+  callResult, err := client.Tasks.Insert(project, taskqueue_, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -218,8 +205,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -227,15 +212,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := taskqueue.New(client)
+  client, err := taskqueue.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'lease' method:
@@ -254,9 +238,9 @@ func main() {
 
   )
 
-  callResult, err := service.Tasks.Lease(project, taskqueue_, numTasks, leaseSecs).Context(ctx).Do()
+  callResult, err := client.Tasks.Lease(project, taskqueue_, numTasks, leaseSecs).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -274,8 +258,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -283,15 +265,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := taskqueue.New(client)
+  client, err := taskqueue.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -304,9 +285,9 @@ func main() {
 
   )
 
-  callResult, err := service.Tasks.List(project, taskqueue_).Context(ctx).Do()
+  callResult, err := client.Tasks.List(project, taskqueue_).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -324,8 +305,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -333,15 +312,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := taskqueue.New(client)
+  client, err := taskqueue.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'patch' method:
@@ -362,9 +340,9 @@ func main() {
     requestBody = &taskqueue.Task{}
   )
 
-  callResult, err := service.Tasks.Patch(project, taskqueue_, task, newLeaseSeconds, requestBody).Context(ctx).Do()
+  callResult, err := client.Tasks.Patch(project, taskqueue_, task, newLeaseSeconds, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -382,8 +360,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -391,15 +367,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := taskqueue.New(client)
+  client, err := taskqueue.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'update' method:
@@ -420,9 +395,9 @@ func main() {
     requestBody = &taskqueue.Task{}
   )
 
-  callResult, err := service.Tasks.Update(project, taskqueue_, task, newLeaseSeconds, requestBody).Context(ctx).Do()
+  callResult, err := client.Tasks.Update(project, taskqueue_, task, newLeaseSeconds, requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_translate.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_translate.v2.json.baseline
@@ -22,14 +22,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := translate.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // The text to detect
     q = []string{}
@@ -38,7 +40,8 @@ func main() {
 
   callResult, err := client.Detections.List(q).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -66,11 +69,13 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := translate.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
   var (
@@ -78,7 +83,8 @@ func main() {
 
   callResult, err := client.Languages.List().Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -106,14 +112,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := translate.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
   var (
     // The text to translate
     q = []string{}
@@ -125,7 +133,8 @@ func main() {
 
   callResult, err := client.Translations.List(q, target).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_translate.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_translate.v2.json.baseline
@@ -12,8 +12,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -21,15 +19,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := translate.New(client)
+  client, err := translate.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -39,9 +36,9 @@ func main() {
 
   )
 
-  callResult, err := service.Detections.List(q).Context(ctx).Do()
+  callResult, err := client.Detections.List(q).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -59,8 +56,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -68,23 +63,22 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := translate.New(client)
+  client, err := translate.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   var (
   )
 
-  callResult, err := service.Languages.List().Context(ctx).Do()
+  callResult, err := client.Languages.List().Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult
@@ -102,8 +96,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -111,15 +103,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := translate.New(client)
+  client, err := translate.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'list' method:
@@ -132,9 +123,9 @@ func main() {
 
   )
 
-  callResult, err := service.Translations.List(q, target).Context(ctx).Do()
+  callResult, err := client.Translations.List(q, target).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_vision.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_vision.v1.json.baseline
@@ -12,8 +12,6 @@ package main
 //    'go get golang.org/x/oauth2/google'
 
 import (
-  "log"
-
   "golang.org/x/net/context"
   "golang.org/x/oauth2/google"
 
@@ -21,15 +19,14 @@ import (
 )
 
 func main() {
-  // Use oauth2.NoContext if there isn't a good context to pass in.
   ctx := context.Background()
-  client, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
+  httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
-  service, err := vision.New(client)
+  client, err := vision.New(httpClient)
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
 
   // TODO: Change placeholders below to appropriate parameters values for the 'annotate' method:
@@ -38,9 +35,9 @@ func main() {
     requestBody = &vision.BatchAnnotateImagesRequest{}
   )
 
-  callResult, err := service.Images.Annotate(requestBody).Context(ctx).Do()
+  callResult, err := client.Images.Annotate(requestBody).Context(ctx).Do()
   if err != nil {
-    log.Fatal(err)
+    _ = err // Handle error.
   }
   // doThingsWith(callResult)
   _ = callResult

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_vision.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_vision.v1.json.baseline
@@ -22,14 +22,16 @@ func main() {
   ctx := context.Background()
   httpClient, err := google.DefaultClient(ctx, "https://www.googleapis.com/auth/cloud-platform")
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   client, err := vision.New(httpClient)
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
 
-  // TODO: Change placeholders below to appropriate parameters values for the 'annotate' method:
+  // TODO: Change placeholders below to appropriate parameter values for the 'annotate' method:
   var (
 
     requestBody = &vision.BatchAnnotateImagesRequest{}
@@ -37,7 +39,8 @@ func main() {
 
   callResult, err := client.Images.Annotate(requestBody).Context(ctx).Do()
   if err != nil {
-    _ = err // Handle error.
+    // TODO: Handle error.
+    _ = err
   }
   // doThingsWith(callResult)
   _ = callResult


### PR DESCRIPTION
The HTTP client is renamed from "client" to "httpClient" and
"service" is renamed to "client". Fixes #114.

Remove the comment about oauth2.NoContext. Fixes #112.

Comment that an error should be handled instead of log.Fatal(err).
Fixes #116.