### PR TITLE
Fix Go Discovery Generation

### DIFF
--- a/src/main/java/com/google/api/codegen/DiscoveryContext.java
+++ b/src/main/java/com/google/api/codegen/DiscoveryContext.java
@@ -136,7 +136,8 @@ public abstract class DiscoveryContext extends CodegenContext {
   }
 
   public boolean isResponseEmpty(Method method) {
-    return method.getResponseTypeUrl().equals(DiscoveryImporter.EMPTY_TYPE_NAME);
+    String typeUrl = method.getResponseTypeUrl();
+    return typeUrl.equals(DiscoveryImporter.EMPTY_TYPE_NAME) || typeUrl.equals("Empty");
   }
 
   public boolean isPageStreaming(Method method) {

--- a/src/main/java/com/google/api/codegen/DiscoveryImporter.java
+++ b/src/main/java/com/google/api/codegen/DiscoveryImporter.java
@@ -409,11 +409,6 @@ public class DiscoveryImporter {
       return EMPTY_TYPE_NAME;
     }
     return response.get("$ref").asText();
-    // String typeUrl = response.get("$ref").asText();
-    // if (typeUrl.equals("Empty")) {
-    //   return EMPTY_TYPE_NAME;
-    // }
-    // return typeUrl;
   }
 
   /**

--- a/src/main/java/com/google/api/codegen/DiscoveryImporter.java
+++ b/src/main/java/com/google/api/codegen/DiscoveryImporter.java
@@ -408,11 +408,12 @@ public class DiscoveryImporter {
     if (response == null) {
       return EMPTY_TYPE_NAME;
     }
-    String typeUrl = response.get("$ref").asText();
-    if (typeUrl.equals("Empty")) {
-      return EMPTY_TYPE_NAME;
-    }
-    return typeUrl;
+    return response.get("$ref").asText();
+    // String typeUrl = response.get("$ref").asText();
+    // if (typeUrl.equals("Empty")) {
+    //   return EMPTY_TYPE_NAME;
+    // }
+    // return typeUrl;
   }
 
   /**

--- a/src/main/java/com/google/api/codegen/go/GoDiscoveryContext.java
+++ b/src/main/java/com/google/api/codegen/go/GoDiscoveryContext.java
@@ -16,6 +16,7 @@ package com.google.api.codegen.go;
 
 import com.google.api.codegen.ApiaryConfig;
 import com.google.api.codegen.DiscoveryContext;
+import com.google.api.codegen.DiscoveryImporter;
 import com.google.api.Service;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -107,6 +108,11 @@ public class GoDiscoveryContext extends DiscoveryContext implements GoContext {
     }
     throw new IllegalArgumentException(
         String.format("cannot find suitable type for %s %s", type.getName(), field.getName()));
+  }
+
+  @Override
+  public boolean isResponseEmpty(Method method) {
+    return method.getResponseTypeUrl().equals(DiscoveryImporter.EMPTY_TYPE_NAME);
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/go/GoDiscoveryContext.java
+++ b/src/main/java/com/google/api/codegen/go/GoDiscoveryContext.java
@@ -111,6 +111,12 @@ public class GoDiscoveryContext extends DiscoveryContext implements GoContext {
   }
 
   @Override
+  /**
+   * Most languages ignore return type "Empty". However, Go cannot since the client library will
+   * return an empty struct, and we have to assign it to something. Consequently, the only time the
+   * response is truly "empty" for Go is when DiscoveryImporter says EMPTY_TYPE_NAME, which
+   * signifies complete absence of return value.
+   */
   public boolean isResponseEmpty(Method method) {
     return method.getResponseTypeUrl().equals(DiscoveryImporter.EMPTY_TYPE_NAME);
   }

--- a/src/main/resources/com/google/api/codegen/go/discovery_fragment.snip
+++ b/src/main/resources/com/google/api/codegen/go/discovery_fragment.snip
@@ -67,13 +67,13 @@ func main() {
       _ = err
     }
   @else
-    callResult, err := {@methodPath(method)}({@callArg(method)}).Context(ctx).Do()
+    response, err := {@methodPath(method)}({@callArg(method)}).Context(ctx).Do()
     if err != nil {
       // TODO: Handle error.
       _ = err
     }
-    // doThingsWith(callResult)
-    _ = callResult
+    // doThingsWith(response)
+    _ = response
   @end
 @end
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_appengine.v1beta5.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_appengine.v1beta5.json.baseline
@@ -37,13 +37,13 @@ func main() {
     appsId = ""
   )
 
-  callResult, err := client.Apps.Get(appsId).Context(ctx).Do()
+  response, err := client.Apps.Get(appsId).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -86,13 +86,13 @@ func main() {
     operationsId = ""
   )
 
-  callResult, err := client.Apps.Operations.Get(appsId, operationsId).Context(ctx).Do()
+  response, err := client.Apps.Operations.Get(appsId, operationsId).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -186,13 +186,13 @@ func main() {
     servicesId = ""
   )
 
-  callResult, err := client.Apps.Services.Delete(appsId, servicesId).Context(ctx).Do()
+  response, err := client.Apps.Services.Delete(appsId, servicesId).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -235,13 +235,13 @@ func main() {
     servicesId = ""
   )
 
-  callResult, err := client.Apps.Services.Get(appsId, servicesId).Context(ctx).Do()
+  response, err := client.Apps.Services.Get(appsId, servicesId).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -337,13 +337,13 @@ func main() {
     requestBody = &appengine.Service{}
   )
 
-  callResult, err := client.Apps.Services.Patch(appsId, servicesId, requestBody).Context(ctx).Do()
+  response, err := client.Apps.Services.Patch(appsId, servicesId, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -388,13 +388,13 @@ func main() {
     requestBody = &appengine.Version{}
   )
 
-  callResult, err := client.Apps.Services.Versions.Create(appsId, servicesId, requestBody).Context(ctx).Do()
+  response, err := client.Apps.Services.Versions.Create(appsId, servicesId, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -440,13 +440,13 @@ func main() {
     versionsId = ""
   )
 
-  callResult, err := client.Apps.Services.Versions.Delete(appsId, servicesId, versionsId).Context(ctx).Do()
+  response, err := client.Apps.Services.Versions.Delete(appsId, servicesId, versionsId).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -492,13 +492,13 @@ func main() {
     versionsId = ""
   )
 
-  callResult, err := client.Apps.Services.Versions.Get(appsId, servicesId, versionsId).Context(ctx).Do()
+  response, err := client.Apps.Services.Versions.Get(appsId, servicesId, versionsId).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -657,11 +657,11 @@ func main() {
     requestBody = &appengine.Version{}
   )
 
-  callResult, err := client.Apps.Services.Versions.Patch(appsId, servicesId, versionsId, requestBody).Context(ctx).Do()
+  response, err := client.Apps.Services.Versions.Patch(appsId, servicesId, versionsId, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_autoscaler.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_autoscaler.v1beta2.json.baseline
@@ -43,13 +43,13 @@ func main() {
     autoscaler_ = ""
   )
 
-  callResult, err := client.Autoscalers.Delete(project, zone, autoscaler_).Context(ctx).Do()
+  response, err := client.Autoscalers.Delete(project, zone, autoscaler_).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -95,13 +95,13 @@ func main() {
     autoscaler_ = ""
   )
 
-  callResult, err := client.Autoscalers.Get(project, zone, autoscaler_).Context(ctx).Do()
+  response, err := client.Autoscalers.Get(project, zone, autoscaler_).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -146,13 +146,13 @@ func main() {
     requestBody = &autoscaler.Autoscaler{}
   )
 
-  callResult, err := client.Autoscalers.Insert(project, zone, requestBody).Context(ctx).Do()
+  response, err := client.Autoscalers.Insert(project, zone, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -254,13 +254,13 @@ func main() {
     requestBody = &autoscaler.Autoscaler{}
   )
 
-  callResult, err := client.Autoscalers.Patch(project, zone, autoscaler_, requestBody).Context(ctx).Do()
+  response, err := client.Autoscalers.Patch(project, zone, autoscaler_, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -308,13 +308,13 @@ func main() {
     requestBody = &autoscaler.Autoscaler{}
   )
 
-  callResult, err := client.Autoscalers.Update(project, zone, autoscaler_, requestBody).Context(ctx).Do()
+  response, err := client.Autoscalers.Update(project, zone, autoscaler_, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -409,13 +409,13 @@ func main() {
     operation = ""
   )
 
-  callResult, err := client.ZoneOperations.Get(project, zone, operation).Context(ctx).Do()
+  response, err := client.ZoneOperations.Get(project, zone, operation).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_bigquery.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_bigquery.v2.json.baseline
@@ -86,13 +86,13 @@ func main() {
     datasetId = ""
   )
 
-  callResult, err := client.Datasets.Get(projectId, datasetId).Context(ctx).Do()
+  response, err := client.Datasets.Get(projectId, datasetId).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -134,13 +134,13 @@ func main() {
     requestBody = &bigquery.Dataset{}
   )
 
-  callResult, err := client.Datasets.Insert(projectId, requestBody).Context(ctx).Do()
+  response, err := client.Datasets.Insert(projectId, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -236,13 +236,13 @@ func main() {
     requestBody = &bigquery.Dataset{}
   )
 
-  callResult, err := client.Datasets.Patch(projectId, datasetId, requestBody).Context(ctx).Do()
+  response, err := client.Datasets.Patch(projectId, datasetId, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -287,13 +287,13 @@ func main() {
     requestBody = &bigquery.Dataset{}
   )
 
-  callResult, err := client.Datasets.Update(projectId, datasetId, requestBody).Context(ctx).Do()
+  response, err := client.Datasets.Update(projectId, datasetId, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -336,13 +336,13 @@ func main() {
     jobId = ""
   )
 
-  callResult, err := client.Jobs.Cancel(projectId, jobId).Context(ctx).Do()
+  response, err := client.Jobs.Cancel(projectId, jobId).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -385,13 +385,13 @@ func main() {
     jobId = ""
   )
 
-  callResult, err := client.Jobs.Get(projectId, jobId).Context(ctx).Do()
+  response, err := client.Jobs.Get(projectId, jobId).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -434,13 +434,13 @@ func main() {
     jobId = ""
   )
 
-  callResult, err := client.Jobs.GetQueryResults(projectId, jobId).Context(ctx).Do()
+  response, err := client.Jobs.GetQueryResults(projectId, jobId).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -482,13 +482,13 @@ func main() {
     requestBody = &bigquery.Job{}
   )
 
-  callResult, err := client.Jobs.Insert(projectId, requestBody).Context(ctx).Do()
+  response, err := client.Jobs.Insert(projectId, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -581,13 +581,13 @@ func main() {
     requestBody = &bigquery.QueryRequest{}
   )
 
-  callResult, err := client.Jobs.Query(projectId, requestBody).Context(ctx).Do()
+  response, err := client.Jobs.Query(projectId, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -683,13 +683,13 @@ func main() {
     requestBody = &bigquery.TableDataInsertAllRequest{}
   )
 
-  callResult, err := client.Tabledata.InsertAll(projectId, datasetId, tableId, requestBody).Context(ctx).Do()
+  response, err := client.Tabledata.InsertAll(projectId, datasetId, tableId, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -735,13 +735,13 @@ func main() {
     tableId = ""
   )
 
-  callResult, err := client.Tabledata.List(projectId, datasetId, tableId).Context(ctx).Do()
+  response, err := client.Tabledata.List(projectId, datasetId, tableId).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -836,13 +836,13 @@ func main() {
     tableId = ""
   )
 
-  callResult, err := client.Tables.Get(projectId, datasetId, tableId).Context(ctx).Do()
+  response, err := client.Tables.Get(projectId, datasetId, tableId).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -887,13 +887,13 @@ func main() {
     requestBody = &bigquery.Table{}
   )
 
-  callResult, err := client.Tables.Insert(projectId, datasetId, requestBody).Context(ctx).Do()
+  response, err := client.Tables.Insert(projectId, datasetId, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -995,13 +995,13 @@ func main() {
     requestBody = &bigquery.Table{}
   )
 
-  callResult, err := client.Tables.Patch(projectId, datasetId, tableId, requestBody).Context(ctx).Do()
+  response, err := client.Tables.Patch(projectId, datasetId, tableId, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -1049,11 +1049,11 @@ func main() {
     requestBody = &bigquery.Table{}
   )
 
-  callResult, err := client.Tables.Update(projectId, datasetId, tableId, requestBody).Context(ctx).Do()
+  response, err := client.Tables.Update(projectId, datasetId, tableId, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudbilling.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudbilling.v1.json.baseline
@@ -37,13 +37,13 @@ func main() {
     name = ""
   )
 
-  callResult, err := client.BillingAccounts.Get(name).Context(ctx).Do()
+  response, err := client.BillingAccounts.Get(name).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -182,13 +182,13 @@ func main() {
     name = ""
   )
 
-  callResult, err := client.Projects.GetBillingInfo(name).Context(ctx).Do()
+  response, err := client.Projects.GetBillingInfo(name).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -230,11 +230,11 @@ func main() {
     requestBody = &cloudbilling.ProjectBillingInfo{}
   )
 
-  callResult, err := client.Projects.UpdateBillingInfo(name, requestBody).Context(ctx).Do()
+  response, err := client.Projects.UpdateBillingInfo(name, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_clouddebugger.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_clouddebugger.v2.json.baseline
@@ -183,10 +183,13 @@ func main() {
     breakpointId = ""
   )
 
-  if err = client.Debugger.Debuggees.Breakpoints.Delete(debuggeeId, breakpointId).Context(ctx).Do(); err != nil {
+  callResult, err := client.Debugger.Debuggees.Breakpoints.Delete(debuggeeId, breakpointId).Context(ctx).Do()
+  if err != nil {
     // TODO: Handle error.
     _ = err
   }
+  // doThingsWith(callResult)
+  _ = callResult
 }
 package main
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_clouddebugger.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_clouddebugger.v2.json.baseline
@@ -37,13 +37,13 @@ func main() {
     debuggeeId = ""
   )
 
-  callResult, err := client.Controller.Debuggees.Breakpoints.List(debuggeeId).Context(ctx).Do()
+  response, err := client.Controller.Debuggees.Breakpoints.List(debuggeeId).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -88,13 +88,13 @@ func main() {
     requestBody = &clouddebugger.UpdateActiveBreakpointRequest{}
   )
 
-  callResult, err := client.Controller.Debuggees.Breakpoints.Update(debuggeeId, id, requestBody).Context(ctx).Do()
+  response, err := client.Controller.Debuggees.Breakpoints.Update(debuggeeId, id, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -134,13 +134,13 @@ func main() {
     requestBody = &clouddebugger.RegisterDebuggeeRequest{}
   )
 
-  callResult, err := client.Controller.Debuggees.Register(requestBody).Context(ctx).Do()
+  response, err := client.Controller.Debuggees.Register(requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -183,13 +183,13 @@ func main() {
     breakpointId = ""
   )
 
-  callResult, err := client.Debugger.Debuggees.Breakpoints.Delete(debuggeeId, breakpointId).Context(ctx).Do()
+  response, err := client.Debugger.Debuggees.Breakpoints.Delete(debuggeeId, breakpointId).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -232,13 +232,13 @@ func main() {
     breakpointId = ""
   )
 
-  callResult, err := client.Debugger.Debuggees.Breakpoints.Get(debuggeeId, breakpointId).Context(ctx).Do()
+  response, err := client.Debugger.Debuggees.Breakpoints.Get(debuggeeId, breakpointId).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -278,13 +278,13 @@ func main() {
     debuggeeId = ""
   )
 
-  callResult, err := client.Debugger.Debuggees.Breakpoints.List(debuggeeId).Context(ctx).Do()
+  response, err := client.Debugger.Debuggees.Breakpoints.List(debuggeeId).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -326,13 +326,13 @@ func main() {
     requestBody = &clouddebugger.Breakpoint{}
   )
 
-  callResult, err := client.Debugger.Debuggees.Breakpoints.Set(debuggeeId, requestBody).Context(ctx).Do()
+  response, err := client.Debugger.Debuggees.Breakpoints.Set(debuggeeId, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -369,11 +369,11 @@ func main() {
   var (
   )
 
-  callResult, err := client.Debugger.Debuggees.List().Context(ctx).Do()
+  response, err := client.Debugger.Debuggees.List().Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudmonitoring.v2beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudmonitoring.v2beta2.json.baseline
@@ -39,13 +39,13 @@ func main() {
     requestBody = &cloudmonitoring.MetricDescriptor{}
   )
 
-  callResult, err := client.MetricDescriptors.Create(project, requestBody).Context(ctx).Do()
+  response, err := client.MetricDescriptors.Create(project, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -88,13 +88,13 @@ func main() {
     metric = ""
   )
 
-  callResult, err := client.MetricDescriptors.Delete(project, metric).Context(ctx).Do()
+  response, err := client.MetricDescriptors.Delete(project, metric).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -136,13 +136,13 @@ func main() {
     requestBody = &cloudmonitoring.ListMetricDescriptorsRequest{}
   )
 
-  callResult, err := client.MetricDescriptors.List(project, requestBody).Context(ctx).Do()
+  response, err := client.MetricDescriptors.List(project, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -190,13 +190,13 @@ func main() {
     requestBody = &cloudmonitoring.ListTimeseriesRequest{}
   )
 
-  callResult, err := client.Timeseries.List(project, metric, youngest, requestBody).Context(ctx).Do()
+  response, err := client.Timeseries.List(project, metric, youngest, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -238,13 +238,13 @@ func main() {
     requestBody = &cloudmonitoring.WriteTimeseriesRequest{}
   )
 
-  callResult, err := client.Timeseries.Write(project, requestBody).Context(ctx).Do()
+  response, err := client.Timeseries.Write(project, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -292,11 +292,11 @@ func main() {
     requestBody = &cloudmonitoring.ListTimeseriesDescriptorsRequest{}
   )
 
-  callResult, err := client.TimeseriesDescriptors.List(project, metric, youngest, requestBody).Context(ctx).Do()
+  response, err := client.TimeseriesDescriptors.List(project, metric, youngest, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudresourcemanager.v1beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudresourcemanager.v1beta1.json.baseline
@@ -37,13 +37,13 @@ func main() {
     organizationId = ""
   )
 
-  callResult, err := client.Organizations.Get(organizationId).Context(ctx).Do()
+  response, err := client.Organizations.Get(organizationId).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -85,13 +85,13 @@ func main() {
     requestBody = &cloudresourcemanager.GetIamPolicyRequest{}
   )
 
-  callResult, err := client.Organizations.GetIamPolicy(resource, requestBody).Context(ctx).Do()
+  response, err := client.Organizations.GetIamPolicy(resource, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -181,13 +181,13 @@ func main() {
     requestBody = &cloudresourcemanager.SetIamPolicyRequest{}
   )
 
-  callResult, err := client.Organizations.SetIamPolicy(resource, requestBody).Context(ctx).Do()
+  response, err := client.Organizations.SetIamPolicy(resource, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -229,13 +229,13 @@ func main() {
     requestBody = &cloudresourcemanager.TestIamPermissionsRequest{}
   )
 
-  callResult, err := client.Organizations.TestIamPermissions(resource, requestBody).Context(ctx).Do()
+  response, err := client.Organizations.TestIamPermissions(resource, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -277,13 +277,13 @@ func main() {
     requestBody = &cloudresourcemanager.Organization{}
   )
 
-  callResult, err := client.Organizations.Update(organizationId, requestBody).Context(ctx).Do()
+  response, err := client.Organizations.Update(organizationId, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -323,13 +323,13 @@ func main() {
     requestBody = &cloudresourcemanager.Project{}
   )
 
-  callResult, err := client.Projects.Create(requestBody).Context(ctx).Do()
+  response, err := client.Projects.Create(requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -369,13 +369,13 @@ func main() {
     projectId = ""
   )
 
-  callResult, err := client.Projects.Delete(projectId).Context(ctx).Do()
+  response, err := client.Projects.Delete(projectId).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -415,13 +415,13 @@ func main() {
     projectId = ""
   )
 
-  callResult, err := client.Projects.Get(projectId).Context(ctx).Do()
+  response, err := client.Projects.Get(projectId).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -463,13 +463,13 @@ func main() {
     requestBody = &cloudresourcemanager.GetIamPolicyRequest{}
   )
 
-  callResult, err := client.Projects.GetIamPolicy(resource, requestBody).Context(ctx).Do()
+  response, err := client.Projects.GetIamPolicy(resource, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -559,13 +559,13 @@ func main() {
     requestBody = &cloudresourcemanager.SetIamPolicyRequest{}
   )
 
-  callResult, err := client.Projects.SetIamPolicy(resource, requestBody).Context(ctx).Do()
+  response, err := client.Projects.SetIamPolicy(resource, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -607,13 +607,13 @@ func main() {
     requestBody = &cloudresourcemanager.TestIamPermissionsRequest{}
   )
 
-  callResult, err := client.Projects.TestIamPermissions(resource, requestBody).Context(ctx).Do()
+  response, err := client.Projects.TestIamPermissions(resource, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -655,13 +655,13 @@ func main() {
     requestBody = &cloudresourcemanager.UndeleteProjectRequest{}
   )
 
-  callResult, err := client.Projects.Undelete(projectId, requestBody).Context(ctx).Do()
+  response, err := client.Projects.Undelete(projectId, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -703,11 +703,11 @@ func main() {
     requestBody = &cloudresourcemanager.Project{}
   )
 
-  callResult, err := client.Projects.Update(projectId, requestBody).Context(ctx).Do()
+  response, err := client.Projects.Update(projectId, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudresourcemanager.v1beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudresourcemanager.v1beta1.json.baseline
@@ -369,10 +369,13 @@ func main() {
     projectId = ""
   )
 
-  if err = client.Projects.Delete(projectId).Context(ctx).Do(); err != nil {
+  callResult, err := client.Projects.Delete(projectId).Context(ctx).Do()
+  if err != nil {
     // TODO: Handle error.
     _ = err
   }
+  // doThingsWith(callResult)
+  _ = callResult
 }
 package main
 
@@ -652,10 +655,13 @@ func main() {
     requestBody = &cloudresourcemanager.UndeleteProjectRequest{}
   )
 
-  if err = client.Projects.Undelete(projectId, requestBody).Context(ctx).Do(); err != nil {
+  callResult, err := client.Projects.Undelete(projectId, requestBody).Context(ctx).Do()
+  if err != nil {
     // TODO: Handle error.
     _ = err
   }
+  // doThingsWith(callResult)
+  _ = callResult
 }
 package main
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudtrace.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudtrace.v1.json.baseline
@@ -39,10 +39,13 @@ func main() {
     requestBody = &cloudtrace.Traces{}
   )
 
-  if err = client.Projects.PatchTraces(projectId, requestBody).Context(ctx).Do(); err != nil {
+  callResult, err := client.Projects.PatchTraces(projectId, requestBody).Context(ctx).Do()
+  if err != nil {
     // TODO: Handle error.
     _ = err
   }
+  // doThingsWith(callResult)
+  _ = callResult
 }
 package main
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudtrace.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudtrace.v1.json.baseline
@@ -39,13 +39,13 @@ func main() {
     requestBody = &cloudtrace.Traces{}
   )
 
-  callResult, err := client.Projects.PatchTraces(projectId, requestBody).Context(ctx).Do()
+  response, err := client.Projects.PatchTraces(projectId, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -88,13 +88,13 @@ func main() {
     traceId = ""
   )
 
-  callResult, err := client.Projects.Traces.Get(projectId, traceId).Context(ctx).Do()
+  response, err := client.Projects.Traces.Get(projectId, traceId).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_clouduseraccounts.beta.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_clouduseraccounts.beta.json.baseline
@@ -86,13 +86,13 @@ func main() {
     operation = ""
   )
 
-  callResult, err := client.GlobalAccountsOperations.Get(project, operation).Context(ctx).Do()
+  response, err := client.GlobalAccountsOperations.Get(project, operation).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -188,13 +188,13 @@ func main() {
     requestBody = &clouduseraccounts.GroupsAddMemberRequest{}
   )
 
-  callResult, err := client.Groups.AddMember(project, groupName, requestBody).Context(ctx).Do()
+  response, err := client.Groups.AddMember(project, groupName, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -237,13 +237,13 @@ func main() {
     groupName = ""
   )
 
-  callResult, err := client.Groups.Delete(project, groupName).Context(ctx).Do()
+  response, err := client.Groups.Delete(project, groupName).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -286,13 +286,13 @@ func main() {
     groupName = ""
   )
 
-  callResult, err := client.Groups.Get(project, groupName).Context(ctx).Do()
+  response, err := client.Groups.Get(project, groupName).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -334,13 +334,13 @@ func main() {
     requestBody = &clouduseraccounts.Group{}
   )
 
-  callResult, err := client.Groups.Insert(project, requestBody).Context(ctx).Do()
+  response, err := client.Groups.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -436,13 +436,13 @@ func main() {
     requestBody = &clouduseraccounts.GroupsRemoveMemberRequest{}
   )
 
-  callResult, err := client.Groups.RemoveMember(project, groupName, requestBody).Context(ctx).Do()
+  response, err := client.Groups.RemoveMember(project, groupName, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -491,13 +491,13 @@ func main() {
     instance = ""
   )
 
-  callResult, err := client.Linux.GetAuthorizedKeysView(project, zone, user, instance).Context(ctx).Do()
+  response, err := client.Linux.GetAuthorizedKeysView(project, zone, user, instance).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -543,13 +543,13 @@ func main() {
     instance = ""
   )
 
-  callResult, err := client.Linux.GetLinuxAccountViews(project, zone, instance).Context(ctx).Do()
+  response, err := client.Linux.GetLinuxAccountViews(project, zone, instance).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -594,13 +594,13 @@ func main() {
     requestBody = &clouduseraccounts.PublicKey{}
   )
 
-  callResult, err := client.Users.AddPublicKey(project, user, requestBody).Context(ctx).Do()
+  response, err := client.Users.AddPublicKey(project, user, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -643,13 +643,13 @@ func main() {
     user = ""
   )
 
-  callResult, err := client.Users.Delete(project, user).Context(ctx).Do()
+  response, err := client.Users.Delete(project, user).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -692,13 +692,13 @@ func main() {
     user = ""
   )
 
-  callResult, err := client.Users.Get(project, user).Context(ctx).Do()
+  response, err := client.Users.Get(project, user).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -740,13 +740,13 @@ func main() {
     requestBody = &clouduseraccounts.User{}
   )
 
-  callResult, err := client.Users.Insert(project, requestBody).Context(ctx).Do()
+  response, err := client.Users.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -843,11 +843,11 @@ func main() {
     fingerprint = ""
   )
 
-  callResult, err := client.Users.RemovePublicKey(project, user, fingerprint).Context(ctx).Do()
+  response, err := client.Users.RemovePublicKey(project, user, fingerprint).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_compute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_compute.v1.json.baseline
@@ -94,13 +94,13 @@ func main() {
     address = ""
   )
 
-  callResult, err := client.Addresses.Delete(project, region, address).Context(ctx).Do()
+  response, err := client.Addresses.Delete(project, region, address).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -146,13 +146,13 @@ func main() {
     address = ""
   )
 
-  callResult, err := client.Addresses.Get(project, region, address).Context(ctx).Do()
+  response, err := client.Addresses.Get(project, region, address).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -197,13 +197,13 @@ func main() {
     requestBody = &compute.Address{}
   )
 
-  callResult, err := client.Addresses.Insert(project, region, requestBody).Context(ctx).Do()
+  response, err := client.Addresses.Insert(project, region, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -354,13 +354,13 @@ func main() {
     autoscaler = ""
   )
 
-  callResult, err := client.Autoscalers.Delete(project, zone, autoscaler).Context(ctx).Do()
+  response, err := client.Autoscalers.Delete(project, zone, autoscaler).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -406,13 +406,13 @@ func main() {
     autoscaler = ""
   )
 
-  callResult, err := client.Autoscalers.Get(project, zone, autoscaler).Context(ctx).Do()
+  response, err := client.Autoscalers.Get(project, zone, autoscaler).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -457,13 +457,13 @@ func main() {
     requestBody = &compute.Autoscaler{}
   )
 
-  callResult, err := client.Autoscalers.Insert(project, zone, requestBody).Context(ctx).Do()
+  response, err := client.Autoscalers.Insert(project, zone, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -565,13 +565,13 @@ func main() {
     requestBody = &compute.Autoscaler{}
   )
 
-  callResult, err := client.Autoscalers.Patch(project, zone, autoscaler, requestBody).Context(ctx).Do()
+  response, err := client.Autoscalers.Patch(project, zone, autoscaler, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -616,13 +616,13 @@ func main() {
     requestBody = &compute.Autoscaler{}
   )
 
-  callResult, err := client.Autoscalers.Update(project, zone, requestBody).Context(ctx).Do()
+  response, err := client.Autoscalers.Update(project, zone, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -665,13 +665,13 @@ func main() {
     backendService = ""
   )
 
-  callResult, err := client.BackendServices.Delete(project, backendService).Context(ctx).Do()
+  response, err := client.BackendServices.Delete(project, backendService).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -714,13 +714,13 @@ func main() {
     backendService = ""
   )
 
-  callResult, err := client.BackendServices.Get(project, backendService).Context(ctx).Do()
+  response, err := client.BackendServices.Get(project, backendService).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -765,13 +765,13 @@ func main() {
     requestBody = &compute.ResourceGroupReference{}
   )
 
-  callResult, err := client.BackendServices.GetHealth(project, backendService, requestBody).Context(ctx).Do()
+  response, err := client.BackendServices.GetHealth(project, backendService, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -813,13 +813,13 @@ func main() {
     requestBody = &compute.BackendService{}
   )
 
-  callResult, err := client.BackendServices.Insert(project, requestBody).Context(ctx).Do()
+  response, err := client.BackendServices.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -915,13 +915,13 @@ func main() {
     requestBody = &compute.BackendService{}
   )
 
-  callResult, err := client.BackendServices.Patch(project, backendService, requestBody).Context(ctx).Do()
+  response, err := client.BackendServices.Patch(project, backendService, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -966,13 +966,13 @@ func main() {
     requestBody = &compute.BackendService{}
   )
 
-  callResult, err := client.BackendServices.Update(project, backendService, requestBody).Context(ctx).Do()
+  response, err := client.BackendServices.Update(project, backendService, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -1069,13 +1069,13 @@ func main() {
     diskType = ""
   )
 
-  callResult, err := client.DiskTypes.Get(project, zone, diskType).Context(ctx).Do()
+  response, err := client.DiskTypes.Get(project, zone, diskType).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -1228,13 +1228,13 @@ func main() {
     requestBody = &compute.Snapshot{}
   )
 
-  callResult, err := client.Disks.CreateSnapshot(project, zone, disk, requestBody).Context(ctx).Do()
+  response, err := client.Disks.CreateSnapshot(project, zone, disk, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -1280,13 +1280,13 @@ func main() {
     disk = ""
   )
 
-  callResult, err := client.Disks.Delete(project, zone, disk).Context(ctx).Do()
+  response, err := client.Disks.Delete(project, zone, disk).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -1332,13 +1332,13 @@ func main() {
     disk = ""
   )
 
-  callResult, err := client.Disks.Get(project, zone, disk).Context(ctx).Do()
+  response, err := client.Disks.Get(project, zone, disk).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -1383,13 +1383,13 @@ func main() {
     requestBody = &compute.Disk{}
   )
 
-  callResult, err := client.Disks.Insert(project, zone, requestBody).Context(ctx).Do()
+  response, err := client.Disks.Insert(project, zone, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -1486,13 +1486,13 @@ func main() {
     firewall = ""
   )
 
-  callResult, err := client.Firewalls.Delete(project, firewall).Context(ctx).Do()
+  response, err := client.Firewalls.Delete(project, firewall).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -1535,13 +1535,13 @@ func main() {
     firewall = ""
   )
 
-  callResult, err := client.Firewalls.Get(project, firewall).Context(ctx).Do()
+  response, err := client.Firewalls.Get(project, firewall).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -1583,13 +1583,13 @@ func main() {
     requestBody = &compute.Firewall{}
   )
 
-  callResult, err := client.Firewalls.Insert(project, requestBody).Context(ctx).Do()
+  response, err := client.Firewalls.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -1685,13 +1685,13 @@ func main() {
     requestBody = &compute.Firewall{}
   )
 
-  callResult, err := client.Firewalls.Patch(project, firewall, requestBody).Context(ctx).Do()
+  response, err := client.Firewalls.Patch(project, firewall, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -1736,13 +1736,13 @@ func main() {
     requestBody = &compute.Firewall{}
   )
 
-  callResult, err := client.Firewalls.Update(project, firewall, requestBody).Context(ctx).Do()
+  response, err := client.Firewalls.Update(project, firewall, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -1839,13 +1839,13 @@ func main() {
     forwardingRule = ""
   )
 
-  callResult, err := client.ForwardingRules.Delete(project, region, forwardingRule).Context(ctx).Do()
+  response, err := client.ForwardingRules.Delete(project, region, forwardingRule).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -1891,13 +1891,13 @@ func main() {
     forwardingRule = ""
   )
 
-  callResult, err := client.ForwardingRules.Get(project, region, forwardingRule).Context(ctx).Do()
+  response, err := client.ForwardingRules.Get(project, region, forwardingRule).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -1942,13 +1942,13 @@ func main() {
     requestBody = &compute.ForwardingRule{}
   )
 
-  callResult, err := client.ForwardingRules.Insert(project, region, requestBody).Context(ctx).Do()
+  response, err := client.ForwardingRules.Insert(project, region, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -2050,13 +2050,13 @@ func main() {
     requestBody = &compute.TargetReference{}
   )
 
-  callResult, err := client.ForwardingRules.SetTarget(project, region, forwardingRule, requestBody).Context(ctx).Do()
+  response, err := client.ForwardingRules.SetTarget(project, region, forwardingRule, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -2099,13 +2099,13 @@ func main() {
     address = ""
   )
 
-  callResult, err := client.GlobalAddresses.Delete(project, address).Context(ctx).Do()
+  response, err := client.GlobalAddresses.Delete(project, address).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -2148,13 +2148,13 @@ func main() {
     address = ""
   )
 
-  callResult, err := client.GlobalAddresses.Get(project, address).Context(ctx).Do()
+  response, err := client.GlobalAddresses.Get(project, address).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -2196,13 +2196,13 @@ func main() {
     requestBody = &compute.Address{}
   )
 
-  callResult, err := client.GlobalAddresses.Insert(project, requestBody).Context(ctx).Do()
+  response, err := client.GlobalAddresses.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -2296,13 +2296,13 @@ func main() {
     forwardingRule = ""
   )
 
-  callResult, err := client.GlobalForwardingRules.Delete(project, forwardingRule).Context(ctx).Do()
+  response, err := client.GlobalForwardingRules.Delete(project, forwardingRule).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -2345,13 +2345,13 @@ func main() {
     forwardingRule = ""
   )
 
-  callResult, err := client.GlobalForwardingRules.Get(project, forwardingRule).Context(ctx).Do()
+  response, err := client.GlobalForwardingRules.Get(project, forwardingRule).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -2393,13 +2393,13 @@ func main() {
     requestBody = &compute.ForwardingRule{}
   )
 
-  callResult, err := client.GlobalForwardingRules.Insert(project, requestBody).Context(ctx).Do()
+  response, err := client.GlobalForwardingRules.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -2495,13 +2495,13 @@ func main() {
     requestBody = &compute.TargetReference{}
   )
 
-  callResult, err := client.GlobalForwardingRules.SetTarget(project, forwardingRule, requestBody).Context(ctx).Do()
+  response, err := client.GlobalForwardingRules.SetTarget(project, forwardingRule, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -2641,13 +2641,13 @@ func main() {
     operation = ""
   )
 
-  callResult, err := client.GlobalOperations.Get(project, operation).Context(ctx).Do()
+  response, err := client.GlobalOperations.Get(project, operation).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -2741,13 +2741,13 @@ func main() {
     httpHealthCheck = ""
   )
 
-  callResult, err := client.HttpHealthChecks.Delete(project, httpHealthCheck).Context(ctx).Do()
+  response, err := client.HttpHealthChecks.Delete(project, httpHealthCheck).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -2790,13 +2790,13 @@ func main() {
     httpHealthCheck = ""
   )
 
-  callResult, err := client.HttpHealthChecks.Get(project, httpHealthCheck).Context(ctx).Do()
+  response, err := client.HttpHealthChecks.Get(project, httpHealthCheck).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -2838,13 +2838,13 @@ func main() {
     requestBody = &compute.HttpHealthCheck{}
   )
 
-  callResult, err := client.HttpHealthChecks.Insert(project, requestBody).Context(ctx).Do()
+  response, err := client.HttpHealthChecks.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -2940,13 +2940,13 @@ func main() {
     requestBody = &compute.HttpHealthCheck{}
   )
 
-  callResult, err := client.HttpHealthChecks.Patch(project, httpHealthCheck, requestBody).Context(ctx).Do()
+  response, err := client.HttpHealthChecks.Patch(project, httpHealthCheck, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -2991,13 +2991,13 @@ func main() {
     requestBody = &compute.HttpHealthCheck{}
   )
 
-  callResult, err := client.HttpHealthChecks.Update(project, httpHealthCheck, requestBody).Context(ctx).Do()
+  response, err := client.HttpHealthChecks.Update(project, httpHealthCheck, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -3040,13 +3040,13 @@ func main() {
     httpsHealthCheck = ""
   )
 
-  callResult, err := client.HttpsHealthChecks.Delete(project, httpsHealthCheck).Context(ctx).Do()
+  response, err := client.HttpsHealthChecks.Delete(project, httpsHealthCheck).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -3089,13 +3089,13 @@ func main() {
     httpsHealthCheck = ""
   )
 
-  callResult, err := client.HttpsHealthChecks.Get(project, httpsHealthCheck).Context(ctx).Do()
+  response, err := client.HttpsHealthChecks.Get(project, httpsHealthCheck).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -3137,13 +3137,13 @@ func main() {
     requestBody = &compute.HttpsHealthCheck{}
   )
 
-  callResult, err := client.HttpsHealthChecks.Insert(project, requestBody).Context(ctx).Do()
+  response, err := client.HttpsHealthChecks.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -3239,13 +3239,13 @@ func main() {
     requestBody = &compute.HttpsHealthCheck{}
   )
 
-  callResult, err := client.HttpsHealthChecks.Patch(project, httpsHealthCheck, requestBody).Context(ctx).Do()
+  response, err := client.HttpsHealthChecks.Patch(project, httpsHealthCheck, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -3290,13 +3290,13 @@ func main() {
     requestBody = &compute.HttpsHealthCheck{}
   )
 
-  callResult, err := client.HttpsHealthChecks.Update(project, httpsHealthCheck, requestBody).Context(ctx).Do()
+  response, err := client.HttpsHealthChecks.Update(project, httpsHealthCheck, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -3339,13 +3339,13 @@ func main() {
     image = ""
   )
 
-  callResult, err := client.Images.Delete(project, image).Context(ctx).Do()
+  response, err := client.Images.Delete(project, image).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -3390,13 +3390,13 @@ func main() {
     requestBody = &compute.DeprecationStatus{}
   )
 
-  callResult, err := client.Images.Deprecate(project, image, requestBody).Context(ctx).Do()
+  response, err := client.Images.Deprecate(project, image, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -3439,13 +3439,13 @@ func main() {
     image = ""
   )
 
-  callResult, err := client.Images.Get(project, image).Context(ctx).Do()
+  response, err := client.Images.Get(project, image).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -3487,13 +3487,13 @@ func main() {
     requestBody = &compute.Image{}
   )
 
-  callResult, err := client.Images.Insert(project, requestBody).Context(ctx).Do()
+  response, err := client.Images.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -3592,13 +3592,13 @@ func main() {
     requestBody = &compute.InstanceGroupManagersAbandonInstancesRequest{}
   )
 
-  callResult, err := client.InstanceGroupManagers.AbandonInstances(project, zone, instanceGroupManager, requestBody).Context(ctx).Do()
+  response, err := client.InstanceGroupManagers.AbandonInstances(project, zone, instanceGroupManager, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -3695,13 +3695,13 @@ func main() {
     instanceGroupManager = ""
   )
 
-  callResult, err := client.InstanceGroupManagers.Delete(project, zone, instanceGroupManager).Context(ctx).Do()
+  response, err := client.InstanceGroupManagers.Delete(project, zone, instanceGroupManager).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -3749,13 +3749,13 @@ func main() {
     requestBody = &compute.InstanceGroupManagersDeleteInstancesRequest{}
   )
 
-  callResult, err := client.InstanceGroupManagers.DeleteInstances(project, zone, instanceGroupManager, requestBody).Context(ctx).Do()
+  response, err := client.InstanceGroupManagers.DeleteInstances(project, zone, instanceGroupManager, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -3801,13 +3801,13 @@ func main() {
     instanceGroupManager = ""
   )
 
-  callResult, err := client.InstanceGroupManagers.Get(project, zone, instanceGroupManager).Context(ctx).Do()
+  response, err := client.InstanceGroupManagers.Get(project, zone, instanceGroupManager).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -3852,13 +3852,13 @@ func main() {
     requestBody = &compute.InstanceGroupManager{}
   )
 
-  callResult, err := client.InstanceGroupManagers.Insert(project, zone, requestBody).Context(ctx).Do()
+  response, err := client.InstanceGroupManagers.Insert(project, zone, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -3958,13 +3958,13 @@ func main() {
     instanceGroupManager = ""
   )
 
-  callResult, err := client.InstanceGroupManagers.ListManagedInstances(project, zone, instanceGroupManager).Context(ctx).Do()
+  response, err := client.InstanceGroupManagers.ListManagedInstances(project, zone, instanceGroupManager).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -4012,13 +4012,13 @@ func main() {
     requestBody = &compute.InstanceGroupManagersRecreateInstancesRequest{}
   )
 
-  callResult, err := client.InstanceGroupManagers.RecreateInstances(project, zone, instanceGroupManager, requestBody).Context(ctx).Do()
+  response, err := client.InstanceGroupManagers.RecreateInstances(project, zone, instanceGroupManager, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -4067,13 +4067,13 @@ func main() {
     size = int64(0)
   )
 
-  callResult, err := client.InstanceGroupManagers.Resize(project, zone, instanceGroupManager, size).Context(ctx).Do()
+  response, err := client.InstanceGroupManagers.Resize(project, zone, instanceGroupManager, size).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -4121,13 +4121,13 @@ func main() {
     requestBody = &compute.InstanceGroupManagersSetInstanceTemplateRequest{}
   )
 
-  callResult, err := client.InstanceGroupManagers.SetInstanceTemplate(project, zone, instanceGroupManager, requestBody).Context(ctx).Do()
+  response, err := client.InstanceGroupManagers.SetInstanceTemplate(project, zone, instanceGroupManager, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -4175,13 +4175,13 @@ func main() {
     requestBody = &compute.InstanceGroupManagersSetTargetPoolsRequest{}
   )
 
-  callResult, err := client.InstanceGroupManagers.SetTargetPools(project, zone, instanceGroupManager, requestBody).Context(ctx).Do()
+  response, err := client.InstanceGroupManagers.SetTargetPools(project, zone, instanceGroupManager, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -4229,13 +4229,13 @@ func main() {
     requestBody = &compute.InstanceGroupsAddInstancesRequest{}
   )
 
-  callResult, err := client.InstanceGroups.AddInstances(project, zone, instanceGroup, requestBody).Context(ctx).Do()
+  response, err := client.InstanceGroups.AddInstances(project, zone, instanceGroup, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -4332,13 +4332,13 @@ func main() {
     instanceGroup = ""
   )
 
-  callResult, err := client.InstanceGroups.Delete(project, zone, instanceGroup).Context(ctx).Do()
+  response, err := client.InstanceGroups.Delete(project, zone, instanceGroup).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -4384,13 +4384,13 @@ func main() {
     instanceGroup = ""
   )
 
-  callResult, err := client.InstanceGroups.Get(project, zone, instanceGroup).Context(ctx).Do()
+  response, err := client.InstanceGroups.Get(project, zone, instanceGroup).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -4435,13 +4435,13 @@ func main() {
     requestBody = &compute.InstanceGroup{}
   )
 
-  callResult, err := client.InstanceGroups.Insert(project, zone, requestBody).Context(ctx).Do()
+  response, err := client.InstanceGroups.Insert(project, zone, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -4543,13 +4543,13 @@ func main() {
     requestBody = &compute.InstanceGroupsListInstancesRequest{}
   )
 
-  callResult, err := client.InstanceGroups.ListInstances(project, zone, instanceGroup, requestBody).Context(ctx).Do()
+  response, err := client.InstanceGroups.ListInstances(project, zone, instanceGroup, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -4597,13 +4597,13 @@ func main() {
     requestBody = &compute.InstanceGroupsRemoveInstancesRequest{}
   )
 
-  callResult, err := client.InstanceGroups.RemoveInstances(project, zone, instanceGroup, requestBody).Context(ctx).Do()
+  response, err := client.InstanceGroups.RemoveInstances(project, zone, instanceGroup, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -4651,13 +4651,13 @@ func main() {
     requestBody = &compute.InstanceGroupsSetNamedPortsRequest{}
   )
 
-  callResult, err := client.InstanceGroups.SetNamedPorts(project, zone, instanceGroup, requestBody).Context(ctx).Do()
+  response, err := client.InstanceGroups.SetNamedPorts(project, zone, instanceGroup, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -4700,13 +4700,13 @@ func main() {
     instanceTemplate = ""
   )
 
-  callResult, err := client.InstanceTemplates.Delete(project, instanceTemplate).Context(ctx).Do()
+  response, err := client.InstanceTemplates.Delete(project, instanceTemplate).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -4749,13 +4749,13 @@ func main() {
     instanceTemplate = ""
   )
 
-  callResult, err := client.InstanceTemplates.Get(project, instanceTemplate).Context(ctx).Do()
+  response, err := client.InstanceTemplates.Get(project, instanceTemplate).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -4797,13 +4797,13 @@ func main() {
     requestBody = &compute.InstanceTemplate{}
   )
 
-  callResult, err := client.InstanceTemplates.Insert(project, requestBody).Context(ctx).Do()
+  response, err := client.InstanceTemplates.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -4905,13 +4905,13 @@ func main() {
     requestBody = &compute.AccessConfig{}
   )
 
-  callResult, err := client.Instances.AddAccessConfig(project, zone, instance, networkInterface, requestBody).Context(ctx).Do()
+  response, err := client.Instances.AddAccessConfig(project, zone, instance, networkInterface, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -5010,13 +5010,13 @@ func main() {
     requestBody = &compute.AttachedDisk{}
   )
 
-  callResult, err := client.Instances.AttachDisk(project, zone, instance, requestBody).Context(ctx).Do()
+  response, err := client.Instances.AttachDisk(project, zone, instance, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -5062,13 +5062,13 @@ func main() {
     instance = ""
   )
 
-  callResult, err := client.Instances.Delete(project, zone, instance).Context(ctx).Do()
+  response, err := client.Instances.Delete(project, zone, instance).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -5120,13 +5120,13 @@ func main() {
     networkInterface = ""
   )
 
-  callResult, err := client.Instances.DeleteAccessConfig(project, zone, instance, accessConfig, networkInterface).Context(ctx).Do()
+  response, err := client.Instances.DeleteAccessConfig(project, zone, instance, accessConfig, networkInterface).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -5175,13 +5175,13 @@ func main() {
     deviceName = ""
   )
 
-  callResult, err := client.Instances.DetachDisk(project, zone, instance, deviceName).Context(ctx).Do()
+  response, err := client.Instances.DetachDisk(project, zone, instance, deviceName).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -5227,13 +5227,13 @@ func main() {
     instance = ""
   )
 
-  callResult, err := client.Instances.Get(project, zone, instance).Context(ctx).Do()
+  response, err := client.Instances.Get(project, zone, instance).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -5279,13 +5279,13 @@ func main() {
     instance = ""
   )
 
-  callResult, err := client.Instances.GetSerialPortOutput(project, zone, instance).Context(ctx).Do()
+  response, err := client.Instances.GetSerialPortOutput(project, zone, instance).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -5330,13 +5330,13 @@ func main() {
     requestBody = &compute.Instance{}
   )
 
-  callResult, err := client.Instances.Insert(project, zone, requestBody).Context(ctx).Do()
+  response, err := client.Instances.Insert(project, zone, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -5436,13 +5436,13 @@ func main() {
     instance = ""
   )
 
-  callResult, err := client.Instances.Reset(project, zone, instance).Context(ctx).Do()
+  response, err := client.Instances.Reset(project, zone, instance).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -5494,13 +5494,13 @@ func main() {
     deviceName = ""
   )
 
-  callResult, err := client.Instances.SetDiskAutoDelete(project, zone, instance, autoDelete, deviceName).Context(ctx).Do()
+  response, err := client.Instances.SetDiskAutoDelete(project, zone, instance, autoDelete, deviceName).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -5548,13 +5548,13 @@ func main() {
     requestBody = &compute.InstancesSetMachineTypeRequest{}
   )
 
-  callResult, err := client.Instances.SetMachineType(project, zone, instance, requestBody).Context(ctx).Do()
+  response, err := client.Instances.SetMachineType(project, zone, instance, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -5602,13 +5602,13 @@ func main() {
     requestBody = &compute.Metadata{}
   )
 
-  callResult, err := client.Instances.SetMetadata(project, zone, instance, requestBody).Context(ctx).Do()
+  response, err := client.Instances.SetMetadata(project, zone, instance, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -5656,13 +5656,13 @@ func main() {
     requestBody = &compute.Scheduling{}
   )
 
-  callResult, err := client.Instances.SetScheduling(project, zone, instance, requestBody).Context(ctx).Do()
+  response, err := client.Instances.SetScheduling(project, zone, instance, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -5710,13 +5710,13 @@ func main() {
     requestBody = &compute.Tags{}
   )
 
-  callResult, err := client.Instances.SetTags(project, zone, instance, requestBody).Context(ctx).Do()
+  response, err := client.Instances.SetTags(project, zone, instance, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -5762,13 +5762,13 @@ func main() {
     instance = ""
   )
 
-  callResult, err := client.Instances.Start(project, zone, instance).Context(ctx).Do()
+  response, err := client.Instances.Start(project, zone, instance).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -5814,13 +5814,13 @@ func main() {
     instance = ""
   )
 
-  callResult, err := client.Instances.Stop(project, zone, instance).Context(ctx).Do()
+  response, err := client.Instances.Stop(project, zone, instance).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -5863,13 +5863,13 @@ func main() {
     license = ""
   )
 
-  callResult, err := client.Licenses.Get(project, license).Context(ctx).Do()
+  response, err := client.Licenses.Get(project, license).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -5966,13 +5966,13 @@ func main() {
     machineType = ""
   )
 
-  callResult, err := client.MachineTypes.Get(project, zone, machineType).Context(ctx).Do()
+  response, err := client.MachineTypes.Get(project, zone, machineType).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -6069,13 +6069,13 @@ func main() {
     network = ""
   )
 
-  callResult, err := client.Networks.Delete(project, network).Context(ctx).Do()
+  response, err := client.Networks.Delete(project, network).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -6118,13 +6118,13 @@ func main() {
     network = ""
   )
 
-  callResult, err := client.Networks.Get(project, network).Context(ctx).Do()
+  response, err := client.Networks.Get(project, network).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -6166,13 +6166,13 @@ func main() {
     requestBody = &compute.Network{}
   )
 
-  callResult, err := client.Networks.Insert(project, requestBody).Context(ctx).Do()
+  response, err := client.Networks.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -6263,13 +6263,13 @@ func main() {
     project = ""
   )
 
-  callResult, err := client.Projects.Get(project).Context(ctx).Do()
+  response, err := client.Projects.Get(project).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -6311,13 +6311,13 @@ func main() {
     requestBody = &compute.DiskMoveRequest{}
   )
 
-  callResult, err := client.Projects.MoveDisk(project, requestBody).Context(ctx).Do()
+  response, err := client.Projects.MoveDisk(project, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -6359,13 +6359,13 @@ func main() {
     requestBody = &compute.InstanceMoveRequest{}
   )
 
-  callResult, err := client.Projects.MoveInstance(project, requestBody).Context(ctx).Do()
+  response, err := client.Projects.MoveInstance(project, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -6407,13 +6407,13 @@ func main() {
     requestBody = &compute.Metadata{}
   )
 
-  callResult, err := client.Projects.SetCommonInstanceMetadata(project, requestBody).Context(ctx).Do()
+  response, err := client.Projects.SetCommonInstanceMetadata(project, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -6455,13 +6455,13 @@ func main() {
     requestBody = &compute.UsageExportLocation{}
   )
 
-  callResult, err := client.Projects.SetUsageExportBucket(project, requestBody).Context(ctx).Do()
+  response, err := client.Projects.SetUsageExportBucket(project, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -6556,13 +6556,13 @@ func main() {
     operation = ""
   )
 
-  callResult, err := client.RegionOperations.Get(project, region, operation).Context(ctx).Do()
+  response, err := client.RegionOperations.Get(project, region, operation).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -6659,13 +6659,13 @@ func main() {
     region = ""
   )
 
-  callResult, err := client.Regions.Get(project, region).Context(ctx).Do()
+  response, err := client.Regions.Get(project, region).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -6759,13 +6759,13 @@ func main() {
     route = ""
   )
 
-  callResult, err := client.Routes.Delete(project, route).Context(ctx).Do()
+  response, err := client.Routes.Delete(project, route).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -6808,13 +6808,13 @@ func main() {
     route = ""
   )
 
-  callResult, err := client.Routes.Get(project, route).Context(ctx).Do()
+  response, err := client.Routes.Get(project, route).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -6856,13 +6856,13 @@ func main() {
     requestBody = &compute.Route{}
   )
 
-  callResult, err := client.Routes.Insert(project, requestBody).Context(ctx).Do()
+  response, err := client.Routes.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -6956,13 +6956,13 @@ func main() {
     snapshot = ""
   )
 
-  callResult, err := client.Snapshots.Delete(project, snapshot).Context(ctx).Do()
+  response, err := client.Snapshots.Delete(project, snapshot).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -7005,13 +7005,13 @@ func main() {
     snapshot = ""
   )
 
-  callResult, err := client.Snapshots.Get(project, snapshot).Context(ctx).Do()
+  response, err := client.Snapshots.Get(project, snapshot).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -7105,13 +7105,13 @@ func main() {
     sslCertificate = ""
   )
 
-  callResult, err := client.SslCertificates.Delete(project, sslCertificate).Context(ctx).Do()
+  response, err := client.SslCertificates.Delete(project, sslCertificate).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -7154,13 +7154,13 @@ func main() {
     sslCertificate = ""
   )
 
-  callResult, err := client.SslCertificates.Get(project, sslCertificate).Context(ctx).Do()
+  response, err := client.SslCertificates.Get(project, sslCertificate).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -7202,13 +7202,13 @@ func main() {
     requestBody = &compute.SslCertificate{}
   )
 
-  callResult, err := client.SslCertificates.Insert(project, requestBody).Context(ctx).Do()
+  response, err := client.SslCertificates.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -7356,13 +7356,13 @@ func main() {
     subnetwork = ""
   )
 
-  callResult, err := client.Subnetworks.Delete(project, region, subnetwork).Context(ctx).Do()
+  response, err := client.Subnetworks.Delete(project, region, subnetwork).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -7408,13 +7408,13 @@ func main() {
     subnetwork = ""
   )
 
-  callResult, err := client.Subnetworks.Get(project, region, subnetwork).Context(ctx).Do()
+  response, err := client.Subnetworks.Get(project, region, subnetwork).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -7459,13 +7459,13 @@ func main() {
     requestBody = &compute.Subnetwork{}
   )
 
-  callResult, err := client.Subnetworks.Insert(project, region, requestBody).Context(ctx).Do()
+  response, err := client.Subnetworks.Insert(project, region, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -7562,13 +7562,13 @@ func main() {
     targetHttpProxy = ""
   )
 
-  callResult, err := client.TargetHttpProxies.Delete(project, targetHttpProxy).Context(ctx).Do()
+  response, err := client.TargetHttpProxies.Delete(project, targetHttpProxy).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -7611,13 +7611,13 @@ func main() {
     targetHttpProxy = ""
   )
 
-  callResult, err := client.TargetHttpProxies.Get(project, targetHttpProxy).Context(ctx).Do()
+  response, err := client.TargetHttpProxies.Get(project, targetHttpProxy).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -7659,13 +7659,13 @@ func main() {
     requestBody = &compute.TargetHttpProxy{}
   )
 
-  callResult, err := client.TargetHttpProxies.Insert(project, requestBody).Context(ctx).Do()
+  response, err := client.TargetHttpProxies.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -7761,13 +7761,13 @@ func main() {
     requestBody = &compute.UrlMapReference{}
   )
 
-  callResult, err := client.TargetHttpProxies.SetUrlMap(project, targetHttpProxy, requestBody).Context(ctx).Do()
+  response, err := client.TargetHttpProxies.SetUrlMap(project, targetHttpProxy, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -7810,13 +7810,13 @@ func main() {
     targetHttpsProxy = ""
   )
 
-  callResult, err := client.TargetHttpsProxies.Delete(project, targetHttpsProxy).Context(ctx).Do()
+  response, err := client.TargetHttpsProxies.Delete(project, targetHttpsProxy).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -7859,13 +7859,13 @@ func main() {
     targetHttpsProxy = ""
   )
 
-  callResult, err := client.TargetHttpsProxies.Get(project, targetHttpsProxy).Context(ctx).Do()
+  response, err := client.TargetHttpsProxies.Get(project, targetHttpsProxy).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -7907,13 +7907,13 @@ func main() {
     requestBody = &compute.TargetHttpsProxy{}
   )
 
-  callResult, err := client.TargetHttpsProxies.Insert(project, requestBody).Context(ctx).Do()
+  response, err := client.TargetHttpsProxies.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -8009,13 +8009,13 @@ func main() {
     requestBody = &compute.TargetHttpsProxiesSetSslCertificatesRequest{}
   )
 
-  callResult, err := client.TargetHttpsProxies.SetSslCertificates(project, targetHttpsProxy, requestBody).Context(ctx).Do()
+  response, err := client.TargetHttpsProxies.SetSslCertificates(project, targetHttpsProxy, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -8060,13 +8060,13 @@ func main() {
     requestBody = &compute.UrlMapReference{}
   )
 
-  callResult, err := client.TargetHttpsProxies.SetUrlMap(project, targetHttpsProxy, requestBody).Context(ctx).Do()
+  response, err := client.TargetHttpsProxies.SetUrlMap(project, targetHttpsProxy, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -8163,13 +8163,13 @@ func main() {
     targetInstance = ""
   )
 
-  callResult, err := client.TargetInstances.Delete(project, zone, targetInstance).Context(ctx).Do()
+  response, err := client.TargetInstances.Delete(project, zone, targetInstance).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -8215,13 +8215,13 @@ func main() {
     targetInstance = ""
   )
 
-  callResult, err := client.TargetInstances.Get(project, zone, targetInstance).Context(ctx).Do()
+  response, err := client.TargetInstances.Get(project, zone, targetInstance).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -8266,13 +8266,13 @@ func main() {
     requestBody = &compute.TargetInstance{}
   )
 
-  callResult, err := client.TargetInstances.Insert(project, zone, requestBody).Context(ctx).Do()
+  response, err := client.TargetInstances.Insert(project, zone, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -8374,13 +8374,13 @@ func main() {
     requestBody = &compute.TargetPoolsAddHealthCheckRequest{}
   )
 
-  callResult, err := client.TargetPools.AddHealthCheck(project, region, targetPool, requestBody).Context(ctx).Do()
+  response, err := client.TargetPools.AddHealthCheck(project, region, targetPool, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -8428,13 +8428,13 @@ func main() {
     requestBody = &compute.TargetPoolsAddInstanceRequest{}
   )
 
-  callResult, err := client.TargetPools.AddInstance(project, region, targetPool, requestBody).Context(ctx).Do()
+  response, err := client.TargetPools.AddInstance(project, region, targetPool, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -8531,13 +8531,13 @@ func main() {
     targetPool = ""
   )
 
-  callResult, err := client.TargetPools.Delete(project, region, targetPool).Context(ctx).Do()
+  response, err := client.TargetPools.Delete(project, region, targetPool).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -8583,13 +8583,13 @@ func main() {
     targetPool = ""
   )
 
-  callResult, err := client.TargetPools.Get(project, region, targetPool).Context(ctx).Do()
+  response, err := client.TargetPools.Get(project, region, targetPool).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -8637,13 +8637,13 @@ func main() {
     requestBody = &compute.InstanceReference{}
   )
 
-  callResult, err := client.TargetPools.GetHealth(project, region, targetPool, requestBody).Context(ctx).Do()
+  response, err := client.TargetPools.GetHealth(project, region, targetPool, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -8688,13 +8688,13 @@ func main() {
     requestBody = &compute.TargetPool{}
   )
 
-  callResult, err := client.TargetPools.Insert(project, region, requestBody).Context(ctx).Do()
+  response, err := client.TargetPools.Insert(project, region, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -8796,13 +8796,13 @@ func main() {
     requestBody = &compute.TargetPoolsRemoveHealthCheckRequest{}
   )
 
-  callResult, err := client.TargetPools.RemoveHealthCheck(project, region, targetPool, requestBody).Context(ctx).Do()
+  response, err := client.TargetPools.RemoveHealthCheck(project, region, targetPool, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -8850,13 +8850,13 @@ func main() {
     requestBody = &compute.TargetPoolsRemoveInstanceRequest{}
   )
 
-  callResult, err := client.TargetPools.RemoveInstance(project, region, targetPool, requestBody).Context(ctx).Do()
+  response, err := client.TargetPools.RemoveInstance(project, region, targetPool, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -8904,13 +8904,13 @@ func main() {
     requestBody = &compute.TargetReference{}
   )
 
-  callResult, err := client.TargetPools.SetBackup(project, region, targetPool, requestBody).Context(ctx).Do()
+  response, err := client.TargetPools.SetBackup(project, region, targetPool, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -9007,13 +9007,13 @@ func main() {
     targetVpnGateway = ""
   )
 
-  callResult, err := client.TargetVpnGateways.Delete(project, region, targetVpnGateway).Context(ctx).Do()
+  response, err := client.TargetVpnGateways.Delete(project, region, targetVpnGateway).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -9059,13 +9059,13 @@ func main() {
     targetVpnGateway = ""
   )
 
-  callResult, err := client.TargetVpnGateways.Get(project, region, targetVpnGateway).Context(ctx).Do()
+  response, err := client.TargetVpnGateways.Get(project, region, targetVpnGateway).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -9110,13 +9110,13 @@ func main() {
     requestBody = &compute.TargetVpnGateway{}
   )
 
-  callResult, err := client.TargetVpnGateways.Insert(project, region, requestBody).Context(ctx).Do()
+  response, err := client.TargetVpnGateways.Insert(project, region, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -9213,13 +9213,13 @@ func main() {
     urlMap = ""
   )
 
-  callResult, err := client.UrlMaps.Delete(project, urlMap).Context(ctx).Do()
+  response, err := client.UrlMaps.Delete(project, urlMap).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -9262,13 +9262,13 @@ func main() {
     urlMap = ""
   )
 
-  callResult, err := client.UrlMaps.Get(project, urlMap).Context(ctx).Do()
+  response, err := client.UrlMaps.Get(project, urlMap).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -9310,13 +9310,13 @@ func main() {
     requestBody = &compute.UrlMap{}
   )
 
-  callResult, err := client.UrlMaps.Insert(project, requestBody).Context(ctx).Do()
+  response, err := client.UrlMaps.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -9412,13 +9412,13 @@ func main() {
     requestBody = &compute.UrlMap{}
   )
 
-  callResult, err := client.UrlMaps.Patch(project, urlMap, requestBody).Context(ctx).Do()
+  response, err := client.UrlMaps.Patch(project, urlMap, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -9463,13 +9463,13 @@ func main() {
     requestBody = &compute.UrlMap{}
   )
 
-  callResult, err := client.UrlMaps.Update(project, urlMap, requestBody).Context(ctx).Do()
+  response, err := client.UrlMaps.Update(project, urlMap, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -9514,13 +9514,13 @@ func main() {
     requestBody = &compute.UrlMapsValidateRequest{}
   )
 
-  callResult, err := client.UrlMaps.Validate(project, urlMap, requestBody).Context(ctx).Do()
+  response, err := client.UrlMaps.Validate(project, urlMap, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -9617,13 +9617,13 @@ func main() {
     vpnTunnel = ""
   )
 
-  callResult, err := client.VpnTunnels.Delete(project, region, vpnTunnel).Context(ctx).Do()
+  response, err := client.VpnTunnels.Delete(project, region, vpnTunnel).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -9669,13 +9669,13 @@ func main() {
     vpnTunnel = ""
   )
 
-  callResult, err := client.VpnTunnels.Get(project, region, vpnTunnel).Context(ctx).Do()
+  response, err := client.VpnTunnels.Get(project, region, vpnTunnel).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -9720,13 +9720,13 @@ func main() {
     requestBody = &compute.VpnTunnel{}
   )
 
-  callResult, err := client.VpnTunnels.Insert(project, region, requestBody).Context(ctx).Do()
+  response, err := client.VpnTunnels.Insert(project, region, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -9875,13 +9875,13 @@ func main() {
     operation = ""
   )
 
-  callResult, err := client.ZoneOperations.Get(project, zone, operation).Context(ctx).Do()
+  response, err := client.ZoneOperations.Get(project, zone, operation).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -9978,13 +9978,13 @@ func main() {
     zone = ""
   )
 
-  callResult, err := client.Zones.Get(project, zone).Context(ctx).Do()
+  response, err := client.Zones.Get(project, zone).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_container.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_container.v1.json.baseline
@@ -42,13 +42,13 @@ func main() {
     requestBody = &container.CreateClusterRequest{}
   )
 
-  callResult, err := client.Projects.Zones.Clusters.Create(projectId, zone, requestBody).Context(ctx).Do()
+  response, err := client.Projects.Zones.Clusters.Create(projectId, zone, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -94,13 +94,13 @@ func main() {
     clusterId = ""
   )
 
-  callResult, err := client.Projects.Zones.Clusters.Delete(projectId, zone, clusterId).Context(ctx).Do()
+  response, err := client.Projects.Zones.Clusters.Delete(projectId, zone, clusterId).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -146,13 +146,13 @@ func main() {
     clusterId = ""
   )
 
-  callResult, err := client.Projects.Zones.Clusters.Get(projectId, zone, clusterId).Context(ctx).Do()
+  response, err := client.Projects.Zones.Clusters.Get(projectId, zone, clusterId).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -195,13 +195,13 @@ func main() {
     zone = ""
   )
 
-  callResult, err := client.Projects.Zones.Clusters.List(projectId, zone).Context(ctx).Do()
+  response, err := client.Projects.Zones.Clusters.List(projectId, zone).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -249,13 +249,13 @@ func main() {
     requestBody = &container.UpdateClusterRequest{}
   )
 
-  callResult, err := client.Projects.Zones.Clusters.Update(projectId, zone, clusterId, requestBody).Context(ctx).Do()
+  response, err := client.Projects.Zones.Clusters.Update(projectId, zone, clusterId, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -298,13 +298,13 @@ func main() {
     zone = ""
   )
 
-  callResult, err := client.Projects.Zones.GetServerconfig(projectId, zone).Context(ctx).Do()
+  response, err := client.Projects.Zones.GetServerconfig(projectId, zone).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -350,13 +350,13 @@ func main() {
     operationId = ""
   )
 
-  callResult, err := client.Projects.Zones.Operations.Get(projectId, zone, operationId).Context(ctx).Do()
+  response, err := client.Projects.Zones.Operations.Get(projectId, zone, operationId).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -399,11 +399,11 @@ func main() {
     zone = ""
   )
 
-  callResult, err := client.Projects.Zones.Operations.List(projectId, zone).Context(ctx).Do()
+  response, err := client.Projects.Zones.Operations.List(projectId, zone).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_dataflow.v1b3.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_dataflow.v1b3.json.baseline
@@ -39,13 +39,13 @@ func main() {
     requestBody = &dataflow.Job{}
   )
 
-  callResult, err := client.Projects.Jobs.Create(projectId, requestBody).Context(ctx).Do()
+  response, err := client.Projects.Jobs.Create(projectId, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -88,13 +88,13 @@ func main() {
     jobId = ""
   )
 
-  callResult, err := client.Projects.Jobs.Get(projectId, jobId).Context(ctx).Do()
+  response, err := client.Projects.Jobs.Get(projectId, jobId).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -137,13 +137,13 @@ func main() {
     jobId = ""
   )
 
-  callResult, err := client.Projects.Jobs.GetMetrics(projectId, jobId).Context(ctx).Do()
+  response, err := client.Projects.Jobs.GetMetrics(projectId, jobId).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -293,13 +293,13 @@ func main() {
     requestBody = &dataflow.Job{}
   )
 
-  callResult, err := client.Projects.Jobs.Update(projectId, jobId, requestBody).Context(ctx).Do()
+  response, err := client.Projects.Jobs.Update(projectId, jobId, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -344,13 +344,13 @@ func main() {
     requestBody = &dataflow.LeaseWorkItemRequest{}
   )
 
-  callResult, err := client.Projects.Jobs.WorkItems.Lease(projectId, jobId, requestBody).Context(ctx).Do()
+  response, err := client.Projects.Jobs.WorkItems.Lease(projectId, jobId, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -395,13 +395,13 @@ func main() {
     requestBody = &dataflow.ReportWorkItemStatusRequest{}
   )
 
-  callResult, err := client.Projects.Jobs.WorkItems.ReportStatus(projectId, jobId, requestBody).Context(ctx).Do()
+  response, err := client.Projects.Jobs.WorkItems.ReportStatus(projectId, jobId, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -443,11 +443,11 @@ func main() {
     requestBody = &dataflow.SendWorkerMessagesRequest{}
   )
 
-  callResult, err := client.Projects.WorkerMessages(projectId, requestBody).Context(ctx).Do()
+  response, err := client.Projects.WorkerMessages(projectId, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_dataproc.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_dataproc.v1.json.baseline
@@ -37,13 +37,13 @@ func main() {
     resourceName = ""
   )
 
-  callResult, err := client.Media.Download(resourceName).Context(ctx).Do()
+  response, err := client.Media.Download(resourceName).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -85,13 +85,13 @@ func main() {
     requestBody = &dataproc.Media{}
   )
 
-  callResult, err := client.Media.Upload(resourceName, requestBody).Context(ctx).Do()
+  response, err := client.Media.Upload(resourceName, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -136,13 +136,13 @@ func main() {
     requestBody = &dataproc.Cluster{}
   )
 
-  callResult, err := client.Projects.Regions.Clusters.Create(projectId, region, requestBody).Context(ctx).Do()
+  response, err := client.Projects.Regions.Clusters.Create(projectId, region, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -188,13 +188,13 @@ func main() {
     clusterName = ""
   )
 
-  callResult, err := client.Projects.Regions.Clusters.Delete(projectId, region, clusterName).Context(ctx).Do()
+  response, err := client.Projects.Regions.Clusters.Delete(projectId, region, clusterName).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -242,13 +242,13 @@ func main() {
     requestBody = &dataproc.DiagnoseClusterRequest{}
   )
 
-  callResult, err := client.Projects.Regions.Clusters.Diagnose(projectId, region, clusterName, requestBody).Context(ctx).Do()
+  response, err := client.Projects.Regions.Clusters.Diagnose(projectId, region, clusterName, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -294,13 +294,13 @@ func main() {
     clusterName = ""
   )
 
-  callResult, err := client.Projects.Regions.Clusters.Get(projectId, region, clusterName).Context(ctx).Do()
+  response, err := client.Projects.Regions.Clusters.Get(projectId, region, clusterName).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -402,13 +402,13 @@ func main() {
     requestBody = &dataproc.Cluster{}
   )
 
-  callResult, err := client.Projects.Regions.Clusters.Patch(projectId, region, clusterName, requestBody).Context(ctx).Do()
+  response, err := client.Projects.Regions.Clusters.Patch(projectId, region, clusterName, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -456,13 +456,13 @@ func main() {
     requestBody = &dataproc.CancelJobRequest{}
   )
 
-  callResult, err := client.Projects.Regions.Jobs.Cancel(projectId, region, jobId, requestBody).Context(ctx).Do()
+  response, err := client.Projects.Regions.Jobs.Cancel(projectId, region, jobId, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -508,13 +508,13 @@ func main() {
     jobId = ""
   )
 
-  callResult, err := client.Projects.Regions.Jobs.Delete(projectId, region, jobId).Context(ctx).Do()
+  response, err := client.Projects.Regions.Jobs.Delete(projectId, region, jobId).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -560,13 +560,13 @@ func main() {
     jobId = ""
   )
 
-  callResult, err := client.Projects.Regions.Jobs.Get(projectId, region, jobId).Context(ctx).Do()
+  response, err := client.Projects.Regions.Jobs.Get(projectId, region, jobId).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -665,13 +665,13 @@ func main() {
     requestBody = &dataproc.SubmitJobRequest{}
   )
 
-  callResult, err := client.Projects.Regions.Jobs.Submit(projectId, region, requestBody).Context(ctx).Do()
+  response, err := client.Projects.Regions.Jobs.Submit(projectId, region, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -711,13 +711,13 @@ func main() {
     name = ""
   )
 
-  callResult, err := client.Projects.Regions.Operations.Cancel(name).Context(ctx).Do()
+  response, err := client.Projects.Regions.Operations.Cancel(name).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -757,13 +757,13 @@ func main() {
     name = ""
   )
 
-  callResult, err := client.Projects.Regions.Operations.Delete(name).Context(ctx).Do()
+  response, err := client.Projects.Regions.Operations.Delete(name).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -803,13 +803,13 @@ func main() {
     name = ""
   )
 
-  callResult, err := client.Projects.Regions.Operations.Get(name).Context(ctx).Do()
+  response, err := client.Projects.Regions.Operations.Get(name).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_dataproc.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_dataproc.v1.json.baseline
@@ -508,10 +508,13 @@ func main() {
     jobId = ""
   )
 
-  if err = client.Projects.Regions.Jobs.Delete(projectId, region, jobId).Context(ctx).Do(); err != nil {
+  callResult, err := client.Projects.Regions.Jobs.Delete(projectId, region, jobId).Context(ctx).Do()
+  if err != nil {
     // TODO: Handle error.
     _ = err
   }
+  // doThingsWith(callResult)
+  _ = callResult
 }
 package main
 
@@ -708,10 +711,13 @@ func main() {
     name = ""
   )
 
-  if err = client.Projects.Regions.Operations.Cancel(name).Context(ctx).Do(); err != nil {
+  callResult, err := client.Projects.Regions.Operations.Cancel(name).Context(ctx).Do()
+  if err != nil {
     // TODO: Handle error.
     _ = err
   }
+  // doThingsWith(callResult)
+  _ = callResult
 }
 package main
 
@@ -751,10 +757,13 @@ func main() {
     name = ""
   )
 
-  if err = client.Projects.Regions.Operations.Delete(name).Context(ctx).Do(); err != nil {
+  callResult, err := client.Projects.Regions.Operations.Delete(name).Context(ctx).Do()
+  if err != nil {
     // TODO: Handle error.
     _ = err
   }
+  // doThingsWith(callResult)
+  _ = callResult
 }
 package main
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_datastore.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_datastore.v1beta2.json.baseline
@@ -39,13 +39,13 @@ func main() {
     requestBody = &datastore.AllocateIdsRequest{}
   )
 
-  callResult, err := client.Datasets.AllocateIds(datasetId, requestBody).Context(ctx).Do()
+  response, err := client.Datasets.AllocateIds(datasetId, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -87,13 +87,13 @@ func main() {
     requestBody = &datastore.BeginTransactionRequest{}
   )
 
-  callResult, err := client.Datasets.BeginTransaction(datasetId, requestBody).Context(ctx).Do()
+  response, err := client.Datasets.BeginTransaction(datasetId, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -135,13 +135,13 @@ func main() {
     requestBody = &datastore.CommitRequest{}
   )
 
-  callResult, err := client.Datasets.Commit(datasetId, requestBody).Context(ctx).Do()
+  response, err := client.Datasets.Commit(datasetId, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -183,13 +183,13 @@ func main() {
     requestBody = &datastore.LookupRequest{}
   )
 
-  callResult, err := client.Datasets.Lookup(datasetId, requestBody).Context(ctx).Do()
+  response, err := client.Datasets.Lookup(datasetId, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -231,13 +231,13 @@ func main() {
     requestBody = &datastore.RollbackRequest{}
   )
 
-  callResult, err := client.Datasets.Rollback(datasetId, requestBody).Context(ctx).Do()
+  response, err := client.Datasets.Rollback(datasetId, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -279,11 +279,11 @@ func main() {
     requestBody = &datastore.RunQueryRequest{}
   )
 
-  callResult, err := client.Datasets.RunQuery(datasetId, requestBody).Context(ctx).Do()
+  response, err := client.Datasets.RunQuery(datasetId, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_deploymentmanager.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_deploymentmanager.v2.json.baseline
@@ -42,13 +42,13 @@ func main() {
     requestBody = &deploymentmanager.DeploymentsCancelPreviewRequest{}
   )
 
-  callResult, err := client.Deployments.CancelPreview(project, deployment, requestBody).Context(ctx).Do()
+  response, err := client.Deployments.CancelPreview(project, deployment, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -91,13 +91,13 @@ func main() {
     deployment = ""
   )
 
-  callResult, err := client.Deployments.Delete(project, deployment).Context(ctx).Do()
+  response, err := client.Deployments.Delete(project, deployment).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -140,13 +140,13 @@ func main() {
     deployment = ""
   )
 
-  callResult, err := client.Deployments.Get(project, deployment).Context(ctx).Do()
+  response, err := client.Deployments.Get(project, deployment).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -188,13 +188,13 @@ func main() {
     requestBody = &deploymentmanager.Deployment{}
   )
 
-  callResult, err := client.Deployments.Insert(project, requestBody).Context(ctx).Do()
+  response, err := client.Deployments.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -290,13 +290,13 @@ func main() {
     requestBody = &deploymentmanager.Deployment{}
   )
 
-  callResult, err := client.Deployments.Patch(project, deployment, requestBody).Context(ctx).Do()
+  response, err := client.Deployments.Patch(project, deployment, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -341,13 +341,13 @@ func main() {
     requestBody = &deploymentmanager.DeploymentsStopRequest{}
   )
 
-  callResult, err := client.Deployments.Stop(project, deployment, requestBody).Context(ctx).Do()
+  response, err := client.Deployments.Stop(project, deployment, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -392,13 +392,13 @@ func main() {
     requestBody = &deploymentmanager.Deployment{}
   )
 
-  callResult, err := client.Deployments.Update(project, deployment, requestBody).Context(ctx).Do()
+  response, err := client.Deployments.Update(project, deployment, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -444,13 +444,13 @@ func main() {
     manifest = ""
   )
 
-  callResult, err := client.Manifests.Get(project, deployment, manifest).Context(ctx).Do()
+  response, err := client.Manifests.Get(project, deployment, manifest).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -547,13 +547,13 @@ func main() {
     operation = ""
   )
 
-  callResult, err := client.Operations.Get(project, operation).Context(ctx).Do()
+  response, err := client.Operations.Get(project, operation).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -650,13 +650,13 @@ func main() {
     resource = ""
   )
 
-  callResult, err := client.Resources.Get(project, deployment, resource).Context(ctx).Do()
+  response, err := client.Resources.Get(project, deployment, resource).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_dns.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_dns.v1.json.baseline
@@ -42,13 +42,13 @@ func main() {
     requestBody = &dns.Change{}
   )
 
-  callResult, err := client.Changes.Create(project, managedZone, requestBody).Context(ctx).Do()
+  response, err := client.Changes.Create(project, managedZone, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -94,13 +94,13 @@ func main() {
     changeId = ""
   )
 
-  callResult, err := client.Changes.Get(project, managedZone, changeId).Context(ctx).Do()
+  response, err := client.Changes.Get(project, managedZone, changeId).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -196,13 +196,13 @@ func main() {
     requestBody = &dns.ManagedZone{}
   )
 
-  callResult, err := client.ManagedZones.Create(project, requestBody).Context(ctx).Do()
+  response, err := client.ManagedZones.Create(project, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -291,13 +291,13 @@ func main() {
     managedZone = ""
   )
 
-  callResult, err := client.ManagedZones.Get(project, managedZone).Context(ctx).Do()
+  response, err := client.ManagedZones.Get(project, managedZone).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -388,13 +388,13 @@ func main() {
     project = ""
   )
 
-  callResult, err := client.Projects.Get(project).Context(ctx).Do()
+  response, err := client.Projects.Get(project).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_logging.v2beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_logging.v2beta1.json.baseline
@@ -37,13 +37,13 @@ func main() {
     requestBody = &logging.ListLogEntriesRequest{}
   )
 
-  callResult, err := client.Entries.List(requestBody).Context(ctx).Do()
+  response, err := client.Entries.List(requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -83,13 +83,13 @@ func main() {
     requestBody = &logging.WriteLogEntriesRequest{}
   )
 
-  callResult, err := client.Entries.Write(requestBody).Context(ctx).Do()
+  response, err := client.Entries.Write(requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -177,13 +177,13 @@ func main() {
     logName = ""
   )
 
-  callResult, err := client.Projects.Logs.Delete(logName).Context(ctx).Do()
+  response, err := client.Projects.Logs.Delete(logName).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -225,13 +225,13 @@ func main() {
     requestBody = &logging.LogMetric{}
   )
 
-  callResult, err := client.Projects.Metrics.Create(projectName, requestBody).Context(ctx).Do()
+  response, err := client.Projects.Metrics.Create(projectName, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -271,13 +271,13 @@ func main() {
     metricName = ""
   )
 
-  callResult, err := client.Projects.Metrics.Delete(metricName).Context(ctx).Do()
+  response, err := client.Projects.Metrics.Delete(metricName).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -317,13 +317,13 @@ func main() {
     metricName = ""
   )
 
-  callResult, err := client.Projects.Metrics.Get(metricName).Context(ctx).Do()
+  response, err := client.Projects.Metrics.Get(metricName).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -416,13 +416,13 @@ func main() {
     requestBody = &logging.LogMetric{}
   )
 
-  callResult, err := client.Projects.Metrics.Update(metricName, requestBody).Context(ctx).Do()
+  response, err := client.Projects.Metrics.Update(metricName, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -464,13 +464,13 @@ func main() {
     requestBody = &logging.LogSink{}
   )
 
-  callResult, err := client.Projects.Sinks.Create(projectName, requestBody).Context(ctx).Do()
+  response, err := client.Projects.Sinks.Create(projectName, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -510,13 +510,13 @@ func main() {
     sinkName = ""
   )
 
-  callResult, err := client.Projects.Sinks.Delete(sinkName).Context(ctx).Do()
+  response, err := client.Projects.Sinks.Delete(sinkName).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -556,13 +556,13 @@ func main() {
     sinkName = ""
   )
 
-  callResult, err := client.Projects.Sinks.Get(sinkName).Context(ctx).Do()
+  response, err := client.Projects.Sinks.Get(sinkName).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -655,11 +655,11 @@ func main() {
     requestBody = &logging.LogSink{}
   )
 
-  callResult, err := client.Projects.Sinks.Update(sinkName, requestBody).Context(ctx).Do()
+  response, err := client.Projects.Sinks.Update(sinkName, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_logging.v2beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_logging.v2beta1.json.baseline
@@ -177,10 +177,13 @@ func main() {
     logName = ""
   )
 
-  if err = client.Projects.Logs.Delete(logName).Context(ctx).Do(); err != nil {
+  callResult, err := client.Projects.Logs.Delete(logName).Context(ctx).Do()
+  if err != nil {
     // TODO: Handle error.
     _ = err
   }
+  // doThingsWith(callResult)
+  _ = callResult
 }
 package main
 
@@ -268,10 +271,13 @@ func main() {
     metricName = ""
   )
 
-  if err = client.Projects.Metrics.Delete(metricName).Context(ctx).Do(); err != nil {
+  callResult, err := client.Projects.Metrics.Delete(metricName).Context(ctx).Do()
+  if err != nil {
     // TODO: Handle error.
     _ = err
   }
+  // doThingsWith(callResult)
+  _ = callResult
 }
 package main
 
@@ -504,10 +510,13 @@ func main() {
     sinkName = ""
   )
 
-  if err = client.Projects.Sinks.Delete(sinkName).Context(ctx).Do(); err != nil {
+  callResult, err := client.Projects.Sinks.Delete(sinkName).Context(ctx).Do()
+  if err != nil {
     // TODO: Handle error.
     _ = err
   }
+  // doThingsWith(callResult)
+  _ = callResult
 }
 package main
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_prediction.v1.6.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_prediction.v1.6.json.baseline
@@ -42,13 +42,13 @@ func main() {
     requestBody = &prediction.Input{}
   )
 
-  callResult, err := client.Hostedmodels.Predict(project, hostedModelName, requestBody).Context(ctx).Do()
+  response, err := client.Hostedmodels.Predict(project, hostedModelName, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -91,13 +91,13 @@ func main() {
     id = ""
   )
 
-  callResult, err := client.Trainedmodels.Analyze(project, id).Context(ctx).Do()
+  response, err := client.Trainedmodels.Analyze(project, id).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -186,13 +186,13 @@ func main() {
     id = ""
   )
 
-  callResult, err := client.Trainedmodels.Get(project, id).Context(ctx).Do()
+  response, err := client.Trainedmodels.Get(project, id).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -234,13 +234,13 @@ func main() {
     requestBody = &prediction.Insert{}
   )
 
-  callResult, err := client.Trainedmodels.Insert(project, requestBody).Context(ctx).Do()
+  response, err := client.Trainedmodels.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -336,13 +336,13 @@ func main() {
     requestBody = &prediction.Input{}
   )
 
-  callResult, err := client.Trainedmodels.Predict(project, id, requestBody).Context(ctx).Do()
+  response, err := client.Trainedmodels.Predict(project, id, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -387,11 +387,11 @@ func main() {
     requestBody = &prediction.Update{}
   )
 
-  callResult, err := client.Trainedmodels.Update(project, id, requestBody).Context(ctx).Do()
+  response, err := client.Trainedmodels.Update(project, id, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_pubsub.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_pubsub.v1.json.baseline
@@ -39,13 +39,13 @@ func main() {
     requestBody = &pubsub.AcknowledgeRequest{}
   )
 
-  callResult, err := client.Projects.Subscriptions.Acknowledge(subscription, requestBody).Context(ctx).Do()
+  response, err := client.Projects.Subscriptions.Acknowledge(subscription, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -87,13 +87,13 @@ func main() {
     requestBody = &pubsub.Subscription{}
   )
 
-  callResult, err := client.Projects.Subscriptions.Create(name, requestBody).Context(ctx).Do()
+  response, err := client.Projects.Subscriptions.Create(name, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -133,13 +133,13 @@ func main() {
     subscription = ""
   )
 
-  callResult, err := client.Projects.Subscriptions.Delete(subscription).Context(ctx).Do()
+  response, err := client.Projects.Subscriptions.Delete(subscription).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -179,13 +179,13 @@ func main() {
     subscription = ""
   )
 
-  callResult, err := client.Projects.Subscriptions.Get(subscription).Context(ctx).Do()
+  response, err := client.Projects.Subscriptions.Get(subscription).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -225,13 +225,13 @@ func main() {
     resource = ""
   )
 
-  callResult, err := client.Projects.Subscriptions.GetIamPolicy(resource).Context(ctx).Do()
+  response, err := client.Projects.Subscriptions.GetIamPolicy(resource).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -324,13 +324,13 @@ func main() {
     requestBody = &pubsub.ModifyAckDeadlineRequest{}
   )
 
-  callResult, err := client.Projects.Subscriptions.ModifyAckDeadline(subscription, requestBody).Context(ctx).Do()
+  response, err := client.Projects.Subscriptions.ModifyAckDeadline(subscription, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -372,13 +372,13 @@ func main() {
     requestBody = &pubsub.ModifyPushConfigRequest{}
   )
 
-  callResult, err := client.Projects.Subscriptions.ModifyPushConfig(subscription, requestBody).Context(ctx).Do()
+  response, err := client.Projects.Subscriptions.ModifyPushConfig(subscription, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -420,13 +420,13 @@ func main() {
     requestBody = &pubsub.PullRequest{}
   )
 
-  callResult, err := client.Projects.Subscriptions.Pull(subscription, requestBody).Context(ctx).Do()
+  response, err := client.Projects.Subscriptions.Pull(subscription, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -468,13 +468,13 @@ func main() {
     requestBody = &pubsub.SetIamPolicyRequest{}
   )
 
-  callResult, err := client.Projects.Subscriptions.SetIamPolicy(resource, requestBody).Context(ctx).Do()
+  response, err := client.Projects.Subscriptions.SetIamPolicy(resource, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -516,13 +516,13 @@ func main() {
     requestBody = &pubsub.TestIamPermissionsRequest{}
   )
 
-  callResult, err := client.Projects.Subscriptions.TestIamPermissions(resource, requestBody).Context(ctx).Do()
+  response, err := client.Projects.Subscriptions.TestIamPermissions(resource, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -564,13 +564,13 @@ func main() {
     requestBody = &pubsub.Topic{}
   )
 
-  callResult, err := client.Projects.Topics.Create(name, requestBody).Context(ctx).Do()
+  response, err := client.Projects.Topics.Create(name, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -610,13 +610,13 @@ func main() {
     topic = ""
   )
 
-  callResult, err := client.Projects.Topics.Delete(topic).Context(ctx).Do()
+  response, err := client.Projects.Topics.Delete(topic).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -656,13 +656,13 @@ func main() {
     topic = ""
   )
 
-  callResult, err := client.Projects.Topics.Get(topic).Context(ctx).Do()
+  response, err := client.Projects.Topics.Get(topic).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -702,13 +702,13 @@ func main() {
     resource = ""
   )
 
-  callResult, err := client.Projects.Topics.GetIamPolicy(resource).Context(ctx).Do()
+  response, err := client.Projects.Topics.GetIamPolicy(resource).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -801,13 +801,13 @@ func main() {
     requestBody = &pubsub.PublishRequest{}
   )
 
-  callResult, err := client.Projects.Topics.Publish(topic, requestBody).Context(ctx).Do()
+  response, err := client.Projects.Topics.Publish(topic, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -849,13 +849,13 @@ func main() {
     requestBody = &pubsub.SetIamPolicyRequest{}
   )
 
-  callResult, err := client.Projects.Topics.SetIamPolicy(resource, requestBody).Context(ctx).Do()
+  response, err := client.Projects.Topics.SetIamPolicy(resource, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -948,11 +948,11 @@ func main() {
     requestBody = &pubsub.TestIamPermissionsRequest{}
   )
 
-  callResult, err := client.Projects.Topics.TestIamPermissions(resource, requestBody).Context(ctx).Do()
+  response, err := client.Projects.Topics.TestIamPermissions(resource, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_pubsub.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_pubsub.v1.json.baseline
@@ -39,10 +39,13 @@ func main() {
     requestBody = &pubsub.AcknowledgeRequest{}
   )
 
-  if err = client.Projects.Subscriptions.Acknowledge(subscription, requestBody).Context(ctx).Do(); err != nil {
+  callResult, err := client.Projects.Subscriptions.Acknowledge(subscription, requestBody).Context(ctx).Do()
+  if err != nil {
     // TODO: Handle error.
     _ = err
   }
+  // doThingsWith(callResult)
+  _ = callResult
 }
 package main
 
@@ -130,10 +133,13 @@ func main() {
     subscription = ""
   )
 
-  if err = client.Projects.Subscriptions.Delete(subscription).Context(ctx).Do(); err != nil {
+  callResult, err := client.Projects.Subscriptions.Delete(subscription).Context(ctx).Do()
+  if err != nil {
     // TODO: Handle error.
     _ = err
   }
+  // doThingsWith(callResult)
+  _ = callResult
 }
 package main
 
@@ -318,10 +324,13 @@ func main() {
     requestBody = &pubsub.ModifyAckDeadlineRequest{}
   )
 
-  if err = client.Projects.Subscriptions.ModifyAckDeadline(subscription, requestBody).Context(ctx).Do(); err != nil {
+  callResult, err := client.Projects.Subscriptions.ModifyAckDeadline(subscription, requestBody).Context(ctx).Do()
+  if err != nil {
     // TODO: Handle error.
     _ = err
   }
+  // doThingsWith(callResult)
+  _ = callResult
 }
 package main
 
@@ -363,10 +372,13 @@ func main() {
     requestBody = &pubsub.ModifyPushConfigRequest{}
   )
 
-  if err = client.Projects.Subscriptions.ModifyPushConfig(subscription, requestBody).Context(ctx).Do(); err != nil {
+  callResult, err := client.Projects.Subscriptions.ModifyPushConfig(subscription, requestBody).Context(ctx).Do()
+  if err != nil {
     // TODO: Handle error.
     _ = err
   }
+  // doThingsWith(callResult)
+  _ = callResult
 }
 package main
 
@@ -598,10 +610,13 @@ func main() {
     topic = ""
   )
 
-  if err = client.Projects.Topics.Delete(topic).Context(ctx).Do(); err != nil {
+  callResult, err := client.Projects.Topics.Delete(topic).Context(ctx).Do()
+  if err != nil {
     // TODO: Handle error.
     _ = err
   }
+  // doThingsWith(callResult)
+  _ = callResult
 }
 package main
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_replicapoolupdater.v1beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_replicapoolupdater.v1beta1.json.baseline
@@ -43,13 +43,13 @@ func main() {
     rollingUpdate = ""
   )
 
-  callResult, err := client.RollingUpdates.Cancel(project, zone, rollingUpdate).Context(ctx).Do()
+  response, err := client.RollingUpdates.Cancel(project, zone, rollingUpdate).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -95,13 +95,13 @@ func main() {
     rollingUpdate = ""
   )
 
-  callResult, err := client.RollingUpdates.Get(project, zone, rollingUpdate).Context(ctx).Do()
+  response, err := client.RollingUpdates.Get(project, zone, rollingUpdate).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -146,13 +146,13 @@ func main() {
     requestBody = &replicapoolupdater.RollingUpdate{}
   )
 
-  callResult, err := client.RollingUpdates.Insert(project, zone, requestBody).Context(ctx).Do()
+  response, err := client.RollingUpdates.Insert(project, zone, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -309,13 +309,13 @@ func main() {
     rollingUpdate = ""
   )
 
-  callResult, err := client.RollingUpdates.Pause(project, zone, rollingUpdate).Context(ctx).Do()
+  response, err := client.RollingUpdates.Pause(project, zone, rollingUpdate).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -361,13 +361,13 @@ func main() {
     rollingUpdate = ""
   )
 
-  callResult, err := client.RollingUpdates.Resume(project, zone, rollingUpdate).Context(ctx).Do()
+  response, err := client.RollingUpdates.Resume(project, zone, rollingUpdate).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -413,13 +413,13 @@ func main() {
     rollingUpdate = ""
   )
 
-  callResult, err := client.RollingUpdates.Rollback(project, zone, rollingUpdate).Context(ctx).Do()
+  response, err := client.RollingUpdates.Rollback(project, zone, rollingUpdate).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -465,13 +465,13 @@ func main() {
     operation = ""
   )
 
-  callResult, err := client.ZoneOperations.Get(project, zone, operation).Context(ctx).Do()
+  response, err := client.ZoneOperations.Get(project, zone, operation).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_sqladmin.v1beta4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_sqladmin.v1beta4.json.baseline
@@ -43,13 +43,13 @@ func main() {
     id = int64(0)
   )
 
-  callResult, err := client.BackupRuns.Delete(project, instance, id).Context(ctx).Do()
+  response, err := client.BackupRuns.Delete(project, instance, id).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -95,13 +95,13 @@ func main() {
     id = int64(0)
   )
 
-  callResult, err := client.BackupRuns.Get(project, instance, id).Context(ctx).Do()
+  response, err := client.BackupRuns.Get(project, instance, id).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -201,13 +201,13 @@ func main() {
     database = ""
   )
 
-  callResult, err := client.Databases.Delete(project, instance, database).Context(ctx).Do()
+  response, err := client.Databases.Delete(project, instance, database).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -253,13 +253,13 @@ func main() {
     database = ""
   )
 
-  callResult, err := client.Databases.Get(project, instance, database).Context(ctx).Do()
+  response, err := client.Databases.Get(project, instance, database).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -304,13 +304,13 @@ func main() {
     requestBody = &sqladmin.Database{}
   )
 
-  callResult, err := client.Databases.Insert(project, instance, requestBody).Context(ctx).Do()
+  response, err := client.Databases.Insert(project, instance, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -353,13 +353,13 @@ func main() {
     instance = ""
   )
 
-  callResult, err := client.Databases.List(project, instance).Context(ctx).Do()
+  response, err := client.Databases.List(project, instance).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -407,13 +407,13 @@ func main() {
     requestBody = &sqladmin.Database{}
   )
 
-  callResult, err := client.Databases.Patch(project, instance, database, requestBody).Context(ctx).Do()
+  response, err := client.Databases.Patch(project, instance, database, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -461,13 +461,13 @@ func main() {
     requestBody = &sqladmin.Database{}
   )
 
-  callResult, err := client.Databases.Update(project, instance, database, requestBody).Context(ctx).Do()
+  response, err := client.Databases.Update(project, instance, database, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -504,13 +504,13 @@ func main() {
   var (
   )
 
-  callResult, err := client.Flags.List().Context(ctx).Do()
+  response, err := client.Flags.List().Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -555,13 +555,13 @@ func main() {
     requestBody = &sqladmin.InstancesCloneRequest{}
   )
 
-  callResult, err := client.Instances.Clone(project, instance, requestBody).Context(ctx).Do()
+  response, err := client.Instances.Clone(project, instance, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -604,13 +604,13 @@ func main() {
     instance = ""
   )
 
-  callResult, err := client.Instances.Delete(project, instance).Context(ctx).Do()
+  response, err := client.Instances.Delete(project, instance).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -655,13 +655,13 @@ func main() {
     requestBody = &sqladmin.InstancesExportRequest{}
   )
 
-  callResult, err := client.Instances.Export(project, instance, requestBody).Context(ctx).Do()
+  response, err := client.Instances.Export(project, instance, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -706,13 +706,13 @@ func main() {
     requestBody = &sqladmin.InstancesFailoverRequest{}
   )
 
-  callResult, err := client.Instances.Failover(project, instance, requestBody).Context(ctx).Do()
+  response, err := client.Instances.Failover(project, instance, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -755,13 +755,13 @@ func main() {
     instance = ""
   )
 
-  callResult, err := client.Instances.Get(project, instance).Context(ctx).Do()
+  response, err := client.Instances.Get(project, instance).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -806,13 +806,13 @@ func main() {
     requestBody = &sqladmin.InstancesImportRequest{}
   )
 
-  callResult, err := client.Instances.Import(project, instance, requestBody).Context(ctx).Do()
+  response, err := client.Instances.Import(project, instance, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -854,13 +854,13 @@ func main() {
     requestBody = &sqladmin.DatabaseInstance{}
   )
 
-  callResult, err := client.Instances.Insert(project, requestBody).Context(ctx).Do()
+  response, err := client.Instances.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -956,13 +956,13 @@ func main() {
     requestBody = &sqladmin.DatabaseInstance{}
   )
 
-  callResult, err := client.Instances.Patch(project, instance, requestBody).Context(ctx).Do()
+  response, err := client.Instances.Patch(project, instance, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -1005,13 +1005,13 @@ func main() {
     instance = ""
   )
 
-  callResult, err := client.Instances.PromoteReplica(project, instance).Context(ctx).Do()
+  response, err := client.Instances.PromoteReplica(project, instance).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -1054,13 +1054,13 @@ func main() {
     instance = ""
   )
 
-  callResult, err := client.Instances.ResetSslConfig(project, instance).Context(ctx).Do()
+  response, err := client.Instances.ResetSslConfig(project, instance).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -1103,13 +1103,13 @@ func main() {
     instance = ""
   )
 
-  callResult, err := client.Instances.Restart(project, instance).Context(ctx).Do()
+  response, err := client.Instances.Restart(project, instance).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -1154,13 +1154,13 @@ func main() {
     requestBody = &sqladmin.InstancesRestoreBackupRequest{}
   )
 
-  callResult, err := client.Instances.RestoreBackup(project, instance, requestBody).Context(ctx).Do()
+  response, err := client.Instances.RestoreBackup(project, instance, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -1203,13 +1203,13 @@ func main() {
     instance = ""
   )
 
-  callResult, err := client.Instances.StartReplica(project, instance).Context(ctx).Do()
+  response, err := client.Instances.StartReplica(project, instance).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -1252,13 +1252,13 @@ func main() {
     instance = ""
   )
 
-  callResult, err := client.Instances.StopReplica(project, instance).Context(ctx).Do()
+  response, err := client.Instances.StopReplica(project, instance).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -1303,13 +1303,13 @@ func main() {
     requestBody = &sqladmin.DatabaseInstance{}
   )
 
-  callResult, err := client.Instances.Update(project, instance, requestBody).Context(ctx).Do()
+  response, err := client.Instances.Update(project, instance, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -1352,13 +1352,13 @@ func main() {
     operation = ""
   )
 
-  callResult, err := client.Operations.Get(project, operation).Context(ctx).Do()
+  response, err := client.Operations.Get(project, operation).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -1457,13 +1457,13 @@ func main() {
     requestBody = &sqladmin.SslCertsCreateEphemeralRequest{}
   )
 
-  callResult, err := client.SslCerts.CreateEphemeral(project, instance, requestBody).Context(ctx).Do()
+  response, err := client.SslCerts.CreateEphemeral(project, instance, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -1509,13 +1509,13 @@ func main() {
     sha1Fingerprint = ""
   )
 
-  callResult, err := client.SslCerts.Delete(project, instance, sha1Fingerprint).Context(ctx).Do()
+  response, err := client.SslCerts.Delete(project, instance, sha1Fingerprint).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -1561,13 +1561,13 @@ func main() {
     sha1Fingerprint = ""
   )
 
-  callResult, err := client.SslCerts.Get(project, instance, sha1Fingerprint).Context(ctx).Do()
+  response, err := client.SslCerts.Get(project, instance, sha1Fingerprint).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -1612,13 +1612,13 @@ func main() {
     requestBody = &sqladmin.SslCertsInsertRequest{}
   )
 
-  callResult, err := client.SslCerts.Insert(project, instance, requestBody).Context(ctx).Do()
+  response, err := client.SslCerts.Insert(project, instance, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -1661,13 +1661,13 @@ func main() {
     instance = ""
   )
 
-  callResult, err := client.SslCerts.List(project, instance).Context(ctx).Do()
+  response, err := client.SslCerts.List(project, instance).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -1707,13 +1707,13 @@ func main() {
     project = ""
   )
 
-  callResult, err := client.Tiers.List(project).Context(ctx).Do()
+  response, err := client.Tiers.List(project).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -1762,13 +1762,13 @@ func main() {
     name = ""
   )
 
-  callResult, err := client.Users.Delete(project, instance, host, name).Context(ctx).Do()
+  response, err := client.Users.Delete(project, instance, host, name).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -1813,13 +1813,13 @@ func main() {
     requestBody = &sqladmin.User{}
   )
 
-  callResult, err := client.Users.Insert(project, instance, requestBody).Context(ctx).Do()
+  response, err := client.Users.Insert(project, instance, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -1862,13 +1862,13 @@ func main() {
     instance = ""
   )
 
-  callResult, err := client.Users.List(project, instance).Context(ctx).Do()
+  response, err := client.Users.List(project, instance).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -1919,11 +1919,11 @@ func main() {
     requestBody = &sqladmin.User{}
   )
 
-  callResult, err := client.Users.Update(project, instance, host, name, requestBody).Context(ctx).Do()
+  response, err := client.Users.Update(project, instance, host, name, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_storage.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_storage.v1.json.baseline
@@ -86,13 +86,13 @@ func main() {
     entity = ""
   )
 
-  callResult, err := client.BucketAccessControls.Get(bucket, entity).Context(ctx).Do()
+  response, err := client.BucketAccessControls.Get(bucket, entity).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -134,13 +134,13 @@ func main() {
     requestBody = &storage.BucketAccessControl{}
   )
 
-  callResult, err := client.BucketAccessControls.Insert(bucket, requestBody).Context(ctx).Do()
+  response, err := client.BucketAccessControls.Insert(bucket, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -180,13 +180,13 @@ func main() {
     bucket = ""
   )
 
-  callResult, err := client.BucketAccessControls.List(bucket).Context(ctx).Do()
+  response, err := client.BucketAccessControls.List(bucket).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -231,13 +231,13 @@ func main() {
     requestBody = &storage.BucketAccessControl{}
   )
 
-  callResult, err := client.BucketAccessControls.Patch(bucket, entity, requestBody).Context(ctx).Do()
+  response, err := client.BucketAccessControls.Patch(bucket, entity, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -282,13 +282,13 @@ func main() {
     requestBody = &storage.BucketAccessControl{}
   )
 
-  callResult, err := client.BucketAccessControls.Update(bucket, entity, requestBody).Context(ctx).Do()
+  response, err := client.BucketAccessControls.Update(bucket, entity, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -371,13 +371,13 @@ func main() {
     bucket = ""
   )
 
-  callResult, err := client.Buckets.Get(bucket).Context(ctx).Do()
+  response, err := client.Buckets.Get(bucket).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -419,13 +419,13 @@ func main() {
     requestBody = &storage.Bucket{}
   )
 
-  callResult, err := client.Buckets.Insert(project, requestBody).Context(ctx).Do()
+  response, err := client.Buckets.Insert(project, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -518,13 +518,13 @@ func main() {
     requestBody = &storage.Bucket{}
   )
 
-  callResult, err := client.Buckets.Patch(bucket, requestBody).Context(ctx).Do()
+  response, err := client.Buckets.Patch(bucket, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -566,13 +566,13 @@ func main() {
     requestBody = &storage.Bucket{}
   )
 
-  callResult, err := client.Buckets.Update(bucket, requestBody).Context(ctx).Do()
+  response, err := client.Buckets.Update(bucket, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -704,13 +704,13 @@ func main() {
     entity = ""
   )
 
-  callResult, err := client.DefaultObjectAccessControls.Get(bucket, entity).Context(ctx).Do()
+  response, err := client.DefaultObjectAccessControls.Get(bucket, entity).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -752,13 +752,13 @@ func main() {
     requestBody = &storage.ObjectAccessControl{}
   )
 
-  callResult, err := client.DefaultObjectAccessControls.Insert(bucket, requestBody).Context(ctx).Do()
+  response, err := client.DefaultObjectAccessControls.Insert(bucket, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -798,13 +798,13 @@ func main() {
     bucket = ""
   )
 
-  callResult, err := client.DefaultObjectAccessControls.List(bucket).Context(ctx).Do()
+  response, err := client.DefaultObjectAccessControls.List(bucket).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -849,13 +849,13 @@ func main() {
     requestBody = &storage.ObjectAccessControl{}
   )
 
-  callResult, err := client.DefaultObjectAccessControls.Patch(bucket, entity, requestBody).Context(ctx).Do()
+  response, err := client.DefaultObjectAccessControls.Patch(bucket, entity, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -900,13 +900,13 @@ func main() {
     requestBody = &storage.ObjectAccessControl{}
   )
 
-  callResult, err := client.DefaultObjectAccessControls.Update(bucket, entity, requestBody).Context(ctx).Do()
+  response, err := client.DefaultObjectAccessControls.Update(bucket, entity, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -1001,13 +1001,13 @@ func main() {
     entity = ""
   )
 
-  callResult, err := client.ObjectAccessControls.Get(bucket, object, entity).Context(ctx).Do()
+  response, err := client.ObjectAccessControls.Get(bucket, object, entity).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -1052,13 +1052,13 @@ func main() {
     requestBody = &storage.ObjectAccessControl{}
   )
 
-  callResult, err := client.ObjectAccessControls.Insert(bucket, object, requestBody).Context(ctx).Do()
+  response, err := client.ObjectAccessControls.Insert(bucket, object, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -1101,13 +1101,13 @@ func main() {
     object = ""
   )
 
-  callResult, err := client.ObjectAccessControls.List(bucket, object).Context(ctx).Do()
+  response, err := client.ObjectAccessControls.List(bucket, object).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -1155,13 +1155,13 @@ func main() {
     requestBody = &storage.ObjectAccessControl{}
   )
 
-  callResult, err := client.ObjectAccessControls.Patch(bucket, object, entity, requestBody).Context(ctx).Do()
+  response, err := client.ObjectAccessControls.Patch(bucket, object, entity, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -1209,13 +1209,13 @@ func main() {
     requestBody = &storage.ObjectAccessControl{}
   )
 
-  callResult, err := client.ObjectAccessControls.Update(bucket, object, entity, requestBody).Context(ctx).Do()
+  response, err := client.ObjectAccessControls.Update(bucket, object, entity, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -1260,13 +1260,13 @@ func main() {
     requestBody = &storage.ComposeRequest{}
   )
 
-  callResult, err := client.Objects.Compose(destinationBucket, destinationObject, requestBody).Context(ctx).Do()
+  response, err := client.Objects.Compose(destinationBucket, destinationObject, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -1317,13 +1317,13 @@ func main() {
     requestBody = &storage.Object{}
   )
 
-  callResult, err := client.Objects.Copy(sourceBucket, sourceObject, destinationBucket, destinationObject, requestBody).Context(ctx).Do()
+  response, err := client.Objects.Copy(sourceBucket, sourceObject, destinationBucket, destinationObject, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -1412,13 +1412,13 @@ func main() {
     object = ""
   )
 
-  callResult, err := client.Objects.Get(bucket, object).Context(ctx).Do()
+  response, err := client.Objects.Get(bucket, object).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -1460,13 +1460,13 @@ func main() {
     requestBody = &storage.Object{}
   )
 
-  callResult, err := client.Objects.Insert(bucket, requestBody).Context(ctx).Do()
+  response, err := client.Objects.Insert(bucket, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -1562,13 +1562,13 @@ func main() {
     requestBody = &storage.Object{}
   )
 
-  callResult, err := client.Objects.Patch(bucket, object, requestBody).Context(ctx).Do()
+  response, err := client.Objects.Patch(bucket, object, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -1619,13 +1619,13 @@ func main() {
     requestBody = &storage.Object{}
   )
 
-  callResult, err := client.Objects.Rewrite(sourceBucket, sourceObject, destinationBucket, destinationObject, requestBody).Context(ctx).Do()
+  response, err := client.Objects.Rewrite(sourceBucket, sourceObject, destinationBucket, destinationObject, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -1670,13 +1670,13 @@ func main() {
     requestBody = &storage.Object{}
   )
 
-  callResult, err := client.Objects.Update(bucket, object, requestBody).Context(ctx).Do()
+  response, err := client.Objects.Update(bucket, object, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -1718,11 +1718,11 @@ func main() {
     requestBody = &storage.Channel{}
   )
 
-  callResult, err := client.Objects.WatchAll(bucket, requestBody).Context(ctx).Do()
+  response, err := client.Objects.WatchAll(bucket, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_storagetransfer.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_storagetransfer.v1.json.baseline
@@ -314,10 +314,13 @@ func main() {
     name = ""
   )
 
-  if err = client.TransferOperations.Cancel(name).Context(ctx).Do(); err != nil {
+  callResult, err := client.TransferOperations.Cancel(name).Context(ctx).Do()
+  if err != nil {
     // TODO: Handle error.
     _ = err
   }
+  // doThingsWith(callResult)
+  _ = callResult
 }
 package main
 
@@ -357,10 +360,13 @@ func main() {
     name = ""
   )
 
-  if err = client.TransferOperations.Delete(name).Context(ctx).Do(); err != nil {
+  callResult, err := client.TransferOperations.Delete(name).Context(ctx).Do()
+  if err != nil {
     // TODO: Handle error.
     _ = err
   }
+  // doThingsWith(callResult)
+  _ = callResult
 }
 package main
 
@@ -499,10 +505,13 @@ func main() {
     requestBody = &storagetransfer.PauseTransferOperationRequest{}
   )
 
-  if err = client.TransferOperations.Pause(name, requestBody).Context(ctx).Do(); err != nil {
+  callResult, err := client.TransferOperations.Pause(name, requestBody).Context(ctx).Do()
+  if err != nil {
     // TODO: Handle error.
     _ = err
   }
+  // doThingsWith(callResult)
+  _ = callResult
 }
 package main
 
@@ -544,8 +553,11 @@ func main() {
     requestBody = &storagetransfer.ResumeTransferOperationRequest{}
   )
 
-  if err = client.TransferOperations.Resume(name, requestBody).Context(ctx).Do(); err != nil {
+  callResult, err := client.TransferOperations.Resume(name, requestBody).Context(ctx).Do()
+  if err != nil {
     // TODO: Handle error.
     _ = err
   }
+  // doThingsWith(callResult)
+  _ = callResult
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_storagetransfer.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_storagetransfer.v1.json.baseline
@@ -34,13 +34,13 @@ func main() {
   var (
   )
 
-  callResult, err := client.V1.GetGoogleServiceAccount().Context(ctx).Do()
+  response, err := client.V1.GetGoogleServiceAccount().Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -80,13 +80,13 @@ func main() {
     projectId = ""
   )
 
-  callResult, err := client.GoogleServiceAccounts.Get(projectId).Context(ctx).Do()
+  response, err := client.GoogleServiceAccounts.Get(projectId).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -126,13 +126,13 @@ func main() {
     requestBody = &storagetransfer.TransferJob{}
   )
 
-  callResult, err := client.TransferJobs.Create(requestBody).Context(ctx).Do()
+  response, err := client.TransferJobs.Create(requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -172,13 +172,13 @@ func main() {
     jobName = ""
   )
 
-  callResult, err := client.TransferJobs.Get(jobName).Context(ctx).Do()
+  response, err := client.TransferJobs.Get(jobName).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -268,13 +268,13 @@ func main() {
     requestBody = &storagetransfer.UpdateTransferJobRequest{}
   )
 
-  callResult, err := client.TransferJobs.Patch(jobName, requestBody).Context(ctx).Do()
+  response, err := client.TransferJobs.Patch(jobName, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -314,13 +314,13 @@ func main() {
     name = ""
   )
 
-  callResult, err := client.TransferOperations.Cancel(name).Context(ctx).Do()
+  response, err := client.TransferOperations.Cancel(name).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -360,13 +360,13 @@ func main() {
     name = ""
   )
 
-  callResult, err := client.TransferOperations.Delete(name).Context(ctx).Do()
+  response, err := client.TransferOperations.Delete(name).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -406,13 +406,13 @@ func main() {
     name = ""
   )
 
-  callResult, err := client.TransferOperations.Get(name).Context(ctx).Do()
+  response, err := client.TransferOperations.Get(name).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -505,13 +505,13 @@ func main() {
     requestBody = &storagetransfer.PauseTransferOperationRequest{}
   )
 
-  callResult, err := client.TransferOperations.Pause(name, requestBody).Context(ctx).Do()
+  response, err := client.TransferOperations.Pause(name, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -553,11 +553,11 @@ func main() {
     requestBody = &storagetransfer.ResumeTransferOperationRequest{}
   )
 
-  callResult, err := client.TransferOperations.Resume(name, requestBody).Context(ctx).Do()
+  response, err := client.TransferOperations.Resume(name, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_taskqueue.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_taskqueue.v1beta2.json.baseline
@@ -40,13 +40,13 @@ func main() {
     taskqueue_ = ""
   )
 
-  callResult, err := client.Taskqueues.Get(project, taskqueue_).Context(ctx).Do()
+  response, err := client.Taskqueues.Get(project, taskqueue_).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -141,13 +141,13 @@ func main() {
     task = ""
   )
 
-  callResult, err := client.Tasks.Get(project, taskqueue_, task).Context(ctx).Do()
+  response, err := client.Tasks.Get(project, taskqueue_, task).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -192,13 +192,13 @@ func main() {
     requestBody = &taskqueue.Task{}
   )
 
-  callResult, err := client.Tasks.Insert(project, taskqueue_, requestBody).Context(ctx).Do()
+  response, err := client.Tasks.Insert(project, taskqueue_, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -247,13 +247,13 @@ func main() {
     leaseSecs = int64(0)
   )
 
-  callResult, err := client.Tasks.Lease(project, taskqueue_, numTasks, leaseSecs).Context(ctx).Do()
+  response, err := client.Tasks.Lease(project, taskqueue_, numTasks, leaseSecs).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -296,13 +296,13 @@ func main() {
     taskqueue_ = ""
   )
 
-  callResult, err := client.Tasks.List(project, taskqueue_).Context(ctx).Do()
+  response, err := client.Tasks.List(project, taskqueue_).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -353,13 +353,13 @@ func main() {
     requestBody = &taskqueue.Task{}
   )
 
-  callResult, err := client.Tasks.Patch(project, taskqueue_, task, newLeaseSeconds, requestBody).Context(ctx).Do()
+  response, err := client.Tasks.Patch(project, taskqueue_, task, newLeaseSeconds, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -410,11 +410,11 @@ func main() {
     requestBody = &taskqueue.Task{}
   )
 
-  callResult, err := client.Tasks.Update(project, taskqueue_, task, newLeaseSeconds, requestBody).Context(ctx).Do()
+  response, err := client.Tasks.Update(project, taskqueue_, task, newLeaseSeconds, requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_translate.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_translate.v2.json.baseline
@@ -37,13 +37,13 @@ func main() {
     q = []string{}
   )
 
-  callResult, err := client.Detections.List(q).Context(ctx).Do()
+  response, err := client.Detections.List(q).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -80,13 +80,13 @@ func main() {
   var (
   )
 
-  callResult, err := client.Languages.List().Context(ctx).Do()
+  response, err := client.Languages.List().Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }
 package main
 
@@ -129,11 +129,11 @@ func main() {
     target = ""
   )
 
-  callResult, err := client.Translations.List(q, target).Context(ctx).Do()
+  response, err := client.Translations.List(q, target).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_vision.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_vision.v1.json.baseline
@@ -37,11 +37,11 @@ func main() {
     requestBody = &vision.BatchAnnotateImagesRequest{}
   )
 
-  callResult, err := client.Images.Annotate(requestBody).Context(ctx).Do()
+  response, err := client.Images.Annotate(requestBody).Context(ctx).Do()
   if err != nil {
     // TODO: Handle error.
     _ = err
   }
-  // doThingsWith(callResult)
-  _ = callResult
+  // doThingsWith(response)
+  _ = response
 }


### PR DESCRIPTION
The bug was introduced with Python Discovery generation, and I missed
it.

This commit reverts the change to DiscoveryImporter: Now it will only
report the return type of "empty$" if the return type is completely
missing from the Discovery doc.

Most languages can ignore return type "Empty", so the string "Empty" is
especially handled. Go cannot ignore "Empty" type and is special-cased.