### PR TITLE
Reduce package name via regex

### DIFF
--- a/src/main/java/com/google/api/codegen/go/GoGapicContext.java
+++ b/src/main/java/com/google/api/codegen/go/GoGapicContext.java
@@ -118,6 +118,12 @@ public class GoGapicContext extends GapicContext implements GoContext {
     return fullPackageName.substring(lastSlash + 1);
   }
 
+  public String getReducedServiceName(Interface service) {
+    String name = service.getSimpleName().replaceAll("V[0-9]+$", "");
+    name = name.replaceAll("Service$", "");
+    return name;
+  }
+
   /**
    * Returns the type name of the gRPC-generated service client.
    */

--- a/src/main/resources/com/google/api/codegen/go/main.snip
+++ b/src/main/resources/com/google/api/codegen/go/main.snip
@@ -1,7 +1,7 @@
 @extends "common.snip"
 
 @snippet generateFilename(service)
-    {@context.upperCamelToLowerUnderscore(service.getSimpleName)}/client.go
+    {@context.upperCamelToLowerUnderscore(context.getReducedServiceName(service))}/client.go
 @end
 
 @snippet generateClass(service, body)

--- a/src/test/java/com/google/api/codegen/testdata/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_library.baseline
@@ -1,4 +1,4 @@
-============== file: library_service/client.go ==============
+============== file: library/client.go ==============
 // Copyright 2016 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Removes `V[0-9]+` and `Service` from the end of the go package.