### PR TITLE
Remove error return from path template methods

### DIFF
--- a/src/main/resources/com/google/api/codegen/go/main.snip
+++ b/src/main/resources/com/google/api/codegen/go/main.snip
@@ -184,12 +184,16 @@
              methodReceiver = context.lowerUnderscoreToLowerCamel(collectionConfig.getEntityName)
 
             // {@pathTypeName}Path returns the path for the {@humanReadableName} resource.
-            func {@pathTypeName}Path({@pathParams(collectionConfig.getNameTemplate.vars())}) (string, error) {
-                return {@pathTemplateVarName(collectionConfig)}.Instantiate(map[string]string{
+            func {@pathTypeName}Path({@pathParams(collectionConfig.getNameTemplate.vars())}) string {
+                path, err := {@pathTemplateVarName(collectionConfig)}.Instantiate(map[string]string{
                     @join param : collectionConfig.getNameTemplate.vars()
                     "{@param}": {@context.lowerUnderscoreToLowerCamel(param)},
                     @end
                 })
+                if err != nil {
+                    panic(err)
+                }
+                return path
             }
         @end
     @end

--- a/src/test/java/com/google/api/codegen/testdata/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_library.baseline
@@ -162,18 +162,26 @@ func (client *Client) Close() error {
 // Path templates.
 
 // ShelfPath returns the path for the shelf resource.
-func ShelfPath(shelf string) (string, error) {
-    return shelfPathTemplate.Instantiate(map[string]string{
+func ShelfPath(shelf string) string {
+    path, err := shelfPathTemplate.Instantiate(map[string]string{
         "shelf": shelf,
     })
+    if err != nil {
+        panic(err)
+    }
+    return path
 }
 
 // BookPath returns the path for the book resource.
-func BookPath(shelf string, book string) (string, error) {
-    return bookPathTemplate.Instantiate(map[string]string{
+func BookPath(shelf string, book string) string {
+    path, err := bookPathTemplate.Instantiate(map[string]string{
         "shelf": shelf,
         "book": book,
     })
+    if err != nil {
+        panic(err)
+    }
+    return path
 }
 
 // AUTO-GENERATED DOCUMENTATION AND METHOD -- see instructions at the top of the file for editing.


### PR DESCRIPTION
Since the code generator ensures that the correct variable mapping is
passed to the `Instantiate` function, it's impossible for an error to be
returned.

Resolves #132 