### PR TITLE
Add PathTemplate match helpers

### DIFF
--- a/src/main/resources/com/google/api/codegen/py/main.snip
+++ b/src/main/resources/com/google/api/codegen/py/main.snip
@@ -285,16 +285,43 @@
 
             {@createResourceFunction(collectionConfig)}
         @end
+        @join collectionConfig : context.getApiConfig.getInterfaceConfig(service).getCollectionConfigs()
+
+            {@createMatchFunctions(collectionConfig)}
+        @end
     @end
 @end
 
 @private createResourceFunction(collectionConfig)
-    {@"@classmethod"}
+    @@classmethod
     def {@collectionConfig.getEntityName}_path(cls, {@createResourceFunctionParams(collectionConfig)}):
         """Returns a fully-qualified {@collectionConfig.getEntityName} resource name string."""
         return cls.{@pathTemplateName(collectionConfig)}.render({
             {@createRenderDictionary(collectionConfig)}
         })
+@end
+
+@private createMatchFunctions(collectionConfig)
+  @join subField : collectionConfig.getNameTemplate.vars() on BREAK.add(BREAK)
+    @let fieldPath = resourceName(collectionConfig)
+      @@classmethod
+      def match_{@subField}_from_{@fieldPath}(cls, {@fieldPath}):
+          """Parses the {@subField} from a {@collectionConfig.getEntityName} resource.
+
+          Args:
+            {@fieldPath} (string): A fully-qualified path representing a {@collectionConfig.getEntityName}
+              resource.
+
+          Returns:
+            A string representing the {@subField}.
+          """
+          return cls.{@pathTemplateName(collectionConfig)}.match({@fieldPath}).get('{@subField}')
+    @end
+  @end
+@end
+
+@private resourceName(collectionConfig)
+  {@collectionConfig.getEntityName}_name
 @end
 
 @private createResourceFunctionParams(collectionConfig)

--- a/src/main/resources/com/google/api/codegen/ruby/main.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/main.snip
@@ -252,13 +252,17 @@
 
       {@createResourceFunction(collectionConfig)}
     @end
+    @join collectionConfig : context.getApiConfig.getInterfaceConfig(service).getCollectionConfigs()
+
+        {@createMatchFunctions(collectionConfig)}
+    @end
   @end
 @end
 
 @private createResourceFunction(collectionConfig)
   @# Returns a fully-qualified {@collectionConfig.getEntityName} resource name string.
   @join param : collectionConfig.getNameTemplate.vars()
-  @# @@param {@param} [String]
+    @# @@param {@param} [String]
   @end
   @# @@return [String]
   def self.{@collectionConfig.getEntityName}_path({@createResourceFunctionParams(collectionConfig)})
@@ -279,6 +283,22 @@
   @end
 @end
 
+@private createMatchFunctions(collectionConfig)
+  @join subField : collectionConfig.getNameTemplate.vars() on BREAK.add(BREAK)
+    @let fieldPath = resourceName(collectionConfig)
+      @# Parses the {@subField} from a {@collectionConfig.getEntityName} resource.
+      @# @@param {@fieldPath} [String]
+      @# @@return [String]
+      def self.match_{@subField}_from_{@fieldPath}({@fieldPath})
+        {@pathTemplateName(collectionConfig)}.match({@fieldPath})['{@subField}']
+      end
+    @end
+  @end
+@end
+
+@private resourceName(collectionConfig)
+  {@collectionConfig.getEntityName}_name
+@end
 @private comments(commentLines)
   @join comment : commentLines
     @# {@comment}

--- a/src/test/java/com/google/api/codegen/testdata/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_library.baseline
@@ -129,6 +129,45 @@ class LibraryServiceApi(object):
             'book': book,
         })
 
+    @classmethod
+    def match_shelf_from_shelf_name(cls, shelf_name):
+        """Parses the shelf from a shelf resource.
+
+        Args:
+          shelf_name (string): A fully-qualified path representing a shelf
+            resource.
+
+        Returns:
+          A string representing the shelf.
+        """
+        return cls._SHELF_PATH_TEMPLATE.match(shelf_name).get('shelf')
+
+    @classmethod
+    def match_shelf_from_book_name(cls, book_name):
+        """Parses the shelf from a book resource.
+
+        Args:
+          book_name (string): A fully-qualified path representing a book
+            resource.
+
+        Returns:
+          A string representing the shelf.
+        """
+        return cls._BOOK_PATH_TEMPLATE.match(book_name).get('shelf')
+
+    @classmethod
+    def match_book_from_book_name(cls, book_name):
+        """Parses the book from a book resource.
+
+        Args:
+          book_name (string): A fully-qualified path representing a book
+            resource.
+
+        Returns:
+          A string representing the book.
+        """
+        return cls._BOOK_PATH_TEMPLATE.match(book_name).get('book')
+
     def __init__(
             self,
             service_path=SERVICE_ADDRESS,

--- a/src/test/java/com/google/api/codegen/testdata/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_library.baseline
@@ -120,6 +120,27 @@ module Google
               :'book' => book)
           end
 
+          # Parses the shelf from a shelf resource.
+          # @param shelf_name [String]
+          # @return [String]
+          def self.match_shelf_from_shelf_name(shelf_name)
+            SHELF_PATH_TEMPLATE.match(shelf_name)['shelf']
+          end
+
+          # Parses the shelf from a book resource.
+          # @param book_name [String]
+          # @return [String]
+          def self.match_shelf_from_book_name(book_name)
+            BOOK_PATH_TEMPLATE.match(book_name)['shelf']
+          end
+
+          # Parses the book from a book resource.
+          # @param book_name [String]
+          # @return [String]
+          def self.match_book_from_book_name(book_name)
+            BOOK_PATH_TEMPLATE.match(book_name)['book']
+          end
+
           # @param service_path [String]
           #   The domain name of the API remote host.
           # @param port [Integer]


### PR DESCRIPTION
Previously Python/Ruby codegen lacked helpers for the "match" method
in PathTemplate. This change conforms to the Java surface.