### PR TITLE
Documentation changes

### DIFF
--- a/src/main/java/com/google/api/codegen/py/PythonGapicContext.java
+++ b/src/main/java/com/google/api/codegen/py/PythonGapicContext.java
@@ -138,7 +138,8 @@ public class PythonGapicContext extends GapicContext {
     String prefix;
     if (type.getCardinality() == Cardinality.REPEATED) {
       if (type.isMap()) {
-        prefix = String.format("dict[%s, ", fieldTypeComment(type.getMapKeyField(), importHandler));
+        prefix =
+            String.format("dict[%s -> ", fieldTypeComment(type.getMapKeyField(), importHandler));
       } else {
         prefix = "list[";
       }
@@ -227,12 +228,13 @@ public class PythonGapicContext extends GapicContext {
         getApiConfig().getInterfaceConfig((Interface) method.getParent()).getMethodConfig(method);
 
     if (config.isPageStreaming()) {
-      return "Yields:\n  Instances of "
+      return "Returns:"
+          + "\n  A :class:`google.gax.PageIterator` instance. By default, this"
+          + "\n  is an iterable of "
           + fieldTypeComment(config.getPageStreaming().getResourcesField(), importHandler)
-          + "\n  unless page streaming is disabled through the call options. If"
-          + "\n  page streaming is disabled, a single \n  "
-          + classInfo
-          + "\n  is returned.";
+          + " instances."
+          + "\n  This object can also be configured to iterate over the pages"
+          + "\n  of the response through the `CallOptions` parameter.";
 
     } else {
       return "Returns:\n  A " + classInfo + ".";

--- a/src/test/java/com/google/api/codegen/testdata/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_library.baseline
@@ -306,12 +306,11 @@ class LibraryServiceApi(object):
           options (:class:`google.gax.CallOptions`): Overrides the default
             settings for this call, e.g, timeout, retries etc.
 
-        Yields:
-          Instances of :class:`google.example.library.v1.library_pb2.Shelf`
-          unless page streaming is disabled through the call options. If
-          page streaming is disabled, a single
-          :class:`google.example.library.v1.library_pb2.ListShelvesResponse` instance
-          is returned.
+        Returns:
+          A :class:`google.gax.PageIterator` instance. By default, this
+          is an iterable of :class:`google.example.library.v1.library_pb2.Shelf` instances.
+          This object can also be configured to iterate over the pages
+          of the response through the `CallOptions` parameter.
 
         Raises:
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
@@ -472,12 +471,11 @@ class LibraryServiceApi(object):
           options (:class:`google.gax.CallOptions`): Overrides the default
             settings for this call, e.g, timeout, retries etc.
 
-        Yields:
-          Instances of :class:`google.example.library.v1.library_pb2.Book`
-          unless page streaming is disabled through the call options. If
-          page streaming is disabled, a single
-          :class:`google.example.library.v1.library_pb2.ListBooksResponse` instance
-          is returned.
+        Returns:
+          A :class:`google.gax.PageIterator` instance. By default, this
+          is an iterable of :class:`google.example.library.v1.library_pb2.Book` instances.
+          This object can also be configured to iterate over the pages
+          of the response through the `CallOptions` parameter.
 
         Raises:
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
@@ -590,12 +588,11 @@ class LibraryServiceApi(object):
           options (:class:`google.gax.CallOptions`): Overrides the default
             settings for this call, e.g, timeout, retries etc.
 
-        Yields:
-          Instances of string
-          unless page streaming is disabled through the call options. If
-          page streaming is disabled, a single
-          :class:`google.example.library.v1.library_pb2.ListStringsResponse` instance
-          is returned.
+        Returns:
+          A :class:`google.gax.PageIterator` instance. By default, this
+          is an iterable of string instances.
+          This object can also be configured to iterate over the pages
+          of the response through the `CallOptions` parameter.
 
         Raises:
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
@@ -1180,7 +1177,7 @@ class Book(object):
       struct_value (:class:`google.protobuf.struct_pb2.Struct`)
       value_value (:class:`google.protobuf.struct_pb2.Value`)
       list_value_value (:class:`google.protobuf.struct_pb2.ListValue`)
-      map_list_value_value (dict[string, :class:`google.example.library.v1.library_pb2.Book.MapListValueValueEntry`])
+      map_list_value_value (dict[string -> :class:`google.example.library.v1.library_pb2.Book.MapListValueValueEntry`])
       time_value (:class:`google.protobuf.timestamp_pb2.Timestamp`)
       duration_value (:class:`google.protobuf.duration_pb2.Duration`)
       field_mask_value (:class:`google.protobuf.field_mask_pb2.FieldMask`)
@@ -1193,8 +1190,8 @@ class Book(object):
       string_value (:class:`google.protobuf.wrappers_pb2.StringValue`)
       bool_value (:class:`google.protobuf.wrappers_pb2.BoolValue`)
       bytes_value (:class:`google.protobuf.wrappers_pb2.BytesValue`)
-      map_string_value (dict[int, :class:`google.example.library.v1.library_pb2.Book.MapStringValueEntry`])
-      map_message_value (dict[string, :class:`google.example.library.v1.library_pb2.Book.MapMessageValueEntry`])
+      map_string_value (dict[int -> :class:`google.example.library.v1.library_pb2.Book.MapStringValueEntry`])
+      map_message_value (dict[string -> :class:`google.example.library.v1.library_pb2.Book.MapMessageValueEntry`])
 
     """
     pass


### PR DESCRIPTION
- Dictionary type hints are now in [key -> value] style. Previously
  they were in [key, value] style.
- Update page streaming return type to reflect changes to the page
  streaming implementation in GAX.

Fixes #41 
Fixes #43 

cc: @tbetbetbe 