### PR TITLE
Replace :method: with :func: in Python __init__ docstring.

### DIFF
--- a/src/main/resources/com/google/api/codegen/py/main.snip
+++ b/src/main/resources/com/google/api/codegen/py/main.snip
@@ -215,7 +215,7 @@
                 A `ClientCredentials` for use with an SSL-enabled channel.
               client_config (dict):
                 A dictionary for call options for each method. See
-                :method:`google.gax.construct_settings` for the structure of
+                :func:`google.gax.construct_settings` for the structure of
                 this data. Falls back to the default config if not specified
                 or the specified config is missing data points.
               metadata_transformer (Callable[[], list]): A function that creates

--- a/src/test/java/com/google/api/codegen/testdata/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_library.baseline
@@ -191,7 +191,7 @@ class LibraryServiceApi(object):
             A `ClientCredentials` for use with an SSL-enabled channel.
           client_config (dict):
             A dictionary for call options for each method. See
-            :method:`google.gax.construct_settings` for the structure of
+            :func:`google.gax.construct_settings` for the structure of
             this data. Falls back to the default config if not specified
             or the specified config is missing data points.
           metadata_transformer (Callable[[], list]): A function that creates

--- a/src/test/java/com/google/api/codegen/testdata/python_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_no_path_templates.baseline
@@ -78,7 +78,7 @@ class NoTemplatesServiceApi(object):
             A `ClientCredentials` for use with an SSL-enabled channel.
           client_config (dict):
             A dictionary for call options for each method. See
-            :method:`google.gax.construct_settings` for the structure of
+            :func:`google.gax.construct_settings` for the structure of
             this data. Falls back to the default config if not specified
             or the specified config is missing data points.
           metadata_transformer (Callable[[], list]): A function that creates


### PR DESCRIPTION
Otherwise the following failure occurs in `tox -e docs`:

```
Warning, treated as error:
/usr/local/google/home/brianwatson/src/gapi-dev/gapi-pubsub-python/.tox/docs/lib/python2.7/site-packages/google/pubsub/v1/publisher_api.py:docstring
of google.pubsub.v1.publisher_api.PublisherApi:15: ERROR: Unknown
interpreted text role "method".

ERROR: InvocationError:
'/usr/local/google/home/brianwatson/src/gapi-dev/gapi-pubsub-python/.tox/docs/bin/sphinx-build
-W -b html -d docs/_build/doctrees docs docs/_build/html'
_________________________________________________ summary
_________________________________________________
ERROR:   docs: commands failed
```

Pre-push hook installed.

Change-Id: Ieced602e803e05a6acfa056f8e43700b9831e91e