### PR TITLE
User-friendly strings for Java Discovery snippets

### DIFF
--- a/src/main/java/com/google/api/codegen/ApiaryConfig.java
+++ b/src/main/java/com/google/api/codegen/ApiaryConfig.java
@@ -74,6 +74,13 @@ public class ApiaryConfig {
       HashBasedTable.<String, String, String>create();
 
   /**
+   * Specifies the pattern of the field. The pattern is expressed as a regular expression, like
+   * "^projects/[^/]*$". The table is indexed by (type name, field name).
+   */
+  private final Table<String, String, String> pattern =
+      HashBasedTable.<String, String, String>create();
+
+  /**
    * Records whether or not the method allows media upload.
    */
   private final Set<String> mediaUpload = new HashSet<>();
@@ -115,6 +122,10 @@ public class ApiaryConfig {
 
   public Table<String, String, String> getStringFormat() {
     return stringFormat;
+  }
+
+  public Table<String, String, String> getFieldPattern() {
+    return pattern;
   }
 
   public Map<String, Type> getTypes() {

--- a/src/main/java/com/google/api/codegen/ApiaryConfig.java
+++ b/src/main/java/com/google/api/codegen/ApiaryConfig.java
@@ -65,7 +65,7 @@ public class ApiaryConfig {
       HashBasedTable.<String, String, Boolean>create();
 
   /**
-   * Specifies the format of the field. A pair (type name, field name) is in this table if the type
+   * Specifies the format of each field. A pair (type name, field name) is in this table if the type
    * of the field is "string" and specific format is given in the discovery doc. The format is one
    * of {"int64", "uint64", "byte", "date", "date-time"}. Note: other string formats from the
    * discovery doc are encoded as types in the Service.
@@ -74,7 +74,7 @@ public class ApiaryConfig {
       HashBasedTable.<String, String, String>create();
 
   /**
-   * Specifies the pattern of the field. The pattern is expressed as a regular expression, like
+   * Specifies the pattern of each field. The pattern is expressed as a regular expression, like
    * "^projects/[^/]*$". The table is indexed by (type name, field name).
    */
   private final Table<String, String, String> pattern =
@@ -93,7 +93,8 @@ public class ApiaryConfig {
   /*
    * Maps method name to set of auth scope URLs, eg https://www.googleapis.com/auth/cloud-platform.
    */
-  private final ListMultimap<String, String> authScopes = ArrayListMultimap.<String, String>create();
+  private final ListMultimap<String, String> authScopes =
+      ArrayListMultimap.<String, String>create();
 
   /*
    * Maps (type, field name) to field.

--- a/src/main/java/com/google/api/codegen/DiscoveryImporter.java
+++ b/src/main/java/com/google/api/codegen/DiscoveryImporter.java
@@ -213,7 +213,8 @@ public class DiscoveryImporter {
     if (TYPE_TABLE.containsRow(typeText)) {
       return builder
           .setCardinality(Field.Cardinality.CARDINALITY_OPTIONAL)
-          .setKind(getFieldKind(typeName, fieldName, typeText, root.get("format")))
+          .setKind(
+              getFieldKind(typeName, fieldName, typeText, root.get("format"), root.get("pattern")))
           .build();
     }
 
@@ -251,7 +252,9 @@ public class DiscoveryImporter {
       String typeText = items.get("type").asText();
       if (TYPE_TABLE.containsRow(typeText)) {
         return builder
-            .setKind(getFieldKind(typeName, fieldName, typeText, items.get("format")))
+            .setKind(
+                getFieldKind(
+                    typeName, fieldName, typeText, items.get("format"), items.get("pattern")))
             .build();
       } else if (typeText.equals("object")) {
         String elementTypeName = typeName + "." + lowerCamelToUpperCamel(fieldName);
@@ -295,7 +298,9 @@ public class DiscoveryImporter {
     if (root.get("type") != null) {
       String valueTypeText = root.get("type").asText();
       if (TYPE_TABLE.containsRow(valueTypeText)) {
-        valueKind = getFieldKind(typeName, fieldName, valueTypeText, root.get("format"));
+        valueKind =
+            getFieldKind(
+                typeName, fieldName, valueTypeText, root.get("format"), root.get("pattern"));
         valueType = null;
       } else if (valueTypeText.equals("object") || valueTypeText.equals("array")) {
         valueKind = Field.Kind.TYPE_MESSAGE;
@@ -424,7 +429,8 @@ public class DiscoveryImporter {
    * Otherwise, the returned {@link Field.Kind} is simply {@link Field.Kind.TYPE_STRING}, and its
    * format, if exists, is recorded in {@link ApiaryConfig#stringFormat}.
    */
-  private Field.Kind getFieldKind(String type, String field, String kindName, JsonNode formatNode) {
+  private Field.Kind getFieldKind(
+      String type, String field, String kindName, JsonNode formatNode, JsonNode patternNode) {
     String format = "";
     if (formatNode != null) {
       format = formatNode.asText();
@@ -440,6 +446,9 @@ public class DiscoveryImporter {
             config.getStringFormat().put(type, field, format);
             // fall through
         }
+      }
+      if (patternNode != null) {
+        config.getFieldPattern().put(type, field, patternNode.asText());
       }
       return Field.Kind.TYPE_STRING;
     }

--- a/src/main/java/com/google/api/codegen/csharp/CSharpGapicContext.java
+++ b/src/main/java/com/google/api/codegen/csharp/CSharpGapicContext.java
@@ -47,13 +47,11 @@ import com.google.common.collect.Maps;
 import com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Type;
 
 import autovalue.shaded.com.google.common.common.collect.ImmutableList;
-import autovalue.shaded.com.google.common.common.collect.Iterables;
 
 import io.grpc.Status;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;

--- a/src/main/java/com/google/api/codegen/discovery/DefaultString.java
+++ b/src/main/java/com/google/api/codegen/discovery/DefaultString.java
@@ -33,11 +33,12 @@ public class DefaultString {
   /**
    * Returns a default string from `pattern`, or null if the pattern is not supported.
    */
-  public static String of(String pattern) {
-    // We only care about patterns that look like
-    //  ^projects/[^/]*/subscriptions/[^/]*$
+  public static String forPattern(String pattern) {
+    // We only care about patterns that has alternating literal and wildcard like
+    //  ^foo/[^/]*/bar/[^/]*$
     // Ignore if what we get looks nothing like this.
-    if (!pattern.startsWith("^")
+    if (pattern == null
+        || !pattern.startsWith("^")
         || !pattern.endsWith("$")
         || substrCount(pattern, "/") != substrCount(pattern, WILDCARD_PATTERN) * 3 - 1) {
       return null;
@@ -106,7 +107,7 @@ public class DefaultString {
    * Returns whether the pattern represented by the list is in a form we expect.
    *
    * A valid pattern must have the same number of literals and wildcards, alternating, and starts
-   * with a literal. Literals must be consisted only of letters.
+   * with a literal. Literals must consists of only letters.
    */
   private static boolean validElems(ImmutableList<Elem> elems) {
     if (elems.size() % 2 != 0) {

--- a/src/main/java/com/google/api/codegen/discovery/DefaultString.java
+++ b/src/main/java/com/google/api/codegen/discovery/DefaultString.java
@@ -53,8 +53,9 @@ public class DefaultString {
       String literal = elems.get(i).getLiteral();
       ret.append('/')
           .append(literal)
-          .append("/MY-")
-          .append(Inflector.singularize(literal).toUpperCase());
+          .append("/{MY-")
+          .append(Inflector.singularize(literal).toUpperCase())
+          .append('}');
     }
     return ret.substring(1);
   }

--- a/src/main/java/com/google/api/codegen/discovery/DefaultString.java
+++ b/src/main/java/com/google/api/codegen/discovery/DefaultString.java
@@ -1,0 +1,149 @@
+/* Copyright 2016 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.discovery;
+
+import com.google.api.codegen.Inflector;
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+/**
+ * Creates default string from path patterns.
+ */
+public class DefaultString {
+
+  private static final String WILDCARD_PATTERN = "[^/]*";
+
+  /**
+   * Returns a default string from `pattern`, or null if the pattern is not supported.
+   */
+  public static String of(String pattern) {
+    // We only care about patterns that look like
+    //  ^projects/[^/]*/subscriptions/[^/]*$
+    // Ignore if what we get looks nothing like this.
+    if (!pattern.startsWith("^")
+        || !pattern.endsWith("$")
+        || substrCount(pattern, "/") != substrCount(pattern, WILDCARD_PATTERN) * 3 - 1) {
+      return null;
+    }
+    pattern = pattern.substring(1, pattern.length() - 1);
+    ImmutableList<Elem> elems = parse(pattern);
+    if (!validElems(elems)) {
+      return null;
+    }
+
+    StringBuilder ret = new StringBuilder();
+    for (int i = 0; i < elems.size(); i += 2) {
+      String literal = elems.get(i).getLiteral();
+      ret.append('/')
+          .append(literal)
+          .append("/MY-")
+          .append(Inflector.singularize(literal).toUpperCase());
+    }
+    return ret.substring(1);
+  }
+
+  /**
+   * Counts the number of non-overlapping instances of `needle` in `haystack`.
+   */
+  private static int substrCount(String haystack, String needle) {
+    int count = 0;
+    int fromIndex = 0;
+    for (; ; ) {
+      int index = haystack.indexOf(needle, fromIndex);
+      if (index < 0) {
+        return count;
+      }
+      fromIndex = index + needle.length();
+      count++;
+    }
+  }
+
+  /**
+   * Parses pattern, with the leading '^' and trailing '$' removed, into a list representing the
+   * pattern.
+   */
+  private static ImmutableList<Elem> parse(String pattern) {
+    List<Elem> elems = new ArrayList<>();
+    while (pattern.length() > 0) {
+      int slash;
+      if (pattern.startsWith(WILDCARD_PATTERN)) {
+        elems.add(Elem.WILDCARD);
+        pattern = pattern.substring(WILDCARD_PATTERN.length());
+      } else if ((slash = pattern.indexOf("/")) >= 0) {
+        elems.add(Elem.createLiteral(pattern.substring(0, slash)));
+        pattern = pattern.substring(slash);
+      } else {
+        elems.add(Elem.createLiteral(pattern));
+        pattern = "";
+      }
+
+      if (pattern.startsWith("/")) {
+        pattern = pattern.substring(1);
+      }
+    }
+    return ImmutableList.<Elem>copyOf(elems);
+  }
+
+  /**
+   * Returns whether the pattern represented by the list is in a form we expect.
+   *
+   * A valid pattern must have the same number of literals and wildcards, alternating, and starts
+   * with a literal. Literals must be consisted only of letters.
+   */
+  private static boolean validElems(ImmutableList<Elem> elems) {
+    if (elems.size() % 2 != 0) {
+      return false;
+    }
+    ImmutableList<ElemType> expect =
+        ImmutableList.<ElemType>of(ElemType.LITERAL, ElemType.WILDCARD);
+    for (int i = 0; i < elems.size(); i++) {
+      if (elems.get(i).getType() != expect.get(i % expect.size())) {
+        return false;
+      }
+    }
+    for (int i = 0; i < elems.size(); i += 2) {
+      for (char c : elems.get(i).getLiteral().toCharArray()) {
+        if (!Character.isLetter(c)) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  enum ElemType {
+    LITERAL,
+    WILDCARD
+  }
+
+  @AutoValue
+  abstract static class Elem {
+    abstract ElemType getType();
+
+    @Nullable
+    abstract String getLiteral();
+
+    private static final Elem WILDCARD = new AutoValue_DefaultString_Elem(ElemType.WILDCARD, null);
+
+    private static Elem createLiteral(String lit) {
+      return new AutoValue_DefaultString_Elem(ElemType.LITERAL, lit);
+    }
+  }
+}

--- a/src/main/java/com/google/api/codegen/java/JavaDiscoveryContext.java
+++ b/src/main/java/com/google/api/codegen/java/JavaDiscoveryContext.java
@@ -367,7 +367,7 @@ public class JavaDiscoveryContext extends DiscoveryContext implements JavaContex
       }
       String stringPattern =
           getApiaryConfig().getFieldPattern().get(type.getName(), field.getName());
-      String patternSample = stringPattern == null ? null : DefaultString.of(stringPattern);
+      String patternSample = stringPattern == null ? null : DefaultString.forPattern(stringPattern);
       if (patternSample != null) {
         return String.format("\"%s\";", patternSample);
       }

--- a/src/main/java/com/google/api/codegen/java/JavaDiscoveryContext.java
+++ b/src/main/java/com/google/api/codegen/java/JavaDiscoveryContext.java
@@ -14,11 +14,12 @@
  */
 package com.google.api.codegen.java;
 
-import com.google.api.Service;
 import com.google.api.client.util.DateTime;
 import com.google.api.codegen.ApiaryConfig;
+import com.google.api.codegen.discovery.DefaultString;
 import com.google.api.codegen.DiscoveryContext;
 import com.google.api.codegen.DiscoveryImporter;
+import com.google.api.Service;
 import com.google.common.base.Defaults;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -82,13 +83,15 @@ public class JavaDiscoveryContext extends DiscoveryContext implements JavaContex
    */
   private static final ImmutableMap<String, String> STRING_DEFAULT_MAP =
       ImmutableMap.<String, String>builder()
-          .put("byte", "\"\";"
-              + "  // base64-encoded string of bytes: see http://tools.ietf.org/html/rfc4648")
-          .put("date", "\"1969-12-31\";"
-              + "  // \"YYYY-MM-DD\": see java.text.SimpleDateFormat")
-          .put("date-time", "\"" + new DateTime(0L).toStringRfc3339() + "\";"
-              + "  // \"YYYY-MM-DDThh:mm:ss.fffZ\" (UTC): "
-              + "see com.google.api.client.util.DateTime.toStringRfc3339()")
+          .put(
+              "byte",
+              "\"\";  // base64-encoded string of bytes: see http://tools.ietf.org/html/rfc4648")
+          .put("date", "\"1969-12-31\";  // \"YYYY-MM-DD\": see java.text.SimpleDateFormat")
+          .put(
+              "date-time",
+              String.format("\"%s\";", new DateTime(0L).toStringRfc3339())
+                  + "  // \"YYYY-MM-DDThh:mm:ss.fffZ\" (UTC): "
+                  + "see com.google.api.client.util.DateTime.toStringRfc3339()")
           .build();
 
   private static final ImmutableMap<String, String> RENAMED_METHOD_MAP =
@@ -342,30 +345,35 @@ public class JavaDiscoveryContext extends DiscoveryContext implements JavaContex
             getTypeName("java.util.HashMap"),
             typeName(items, this.getField(items, "key")),
             typeName(items, this.getField(items, "value")));
-      } else {
-        return String.format(
-            "new %s<%s>();", getTypeName("java.util.ArrayList"), elementTypeName(field));
       }
-    } else {
-      String typeName = FIELD_TYPE_MAP.get(field.getKind());
-      if (typeName != null) {
-        Class<?> primitiveClass = PRIMITIVE_CLASS_MAP.get(typeName);
-        if (primitiveClass != null) {
-          return String.valueOf(Defaults.defaultValue(primitiveClass)) + ";";
-        }
-        if (typeName.equals("java.lang.String")) {
-          String stringFormat = getApiaryConfig().getStringFormat(type.getName(), field.getName());
-          if (stringFormat != null) {
-            String value = STRING_DEFAULT_MAP.get(stringFormat);
-            if (value != null) {
-              return value;
-            }
-          }
-          return "\"\";";
-        }
-      }
+      return String.format(
+          "new %s<%s>();", getTypeName("java.util.ArrayList"), elementTypeName(field));
+    }
+    String typeName = FIELD_TYPE_MAP.get(field.getKind());
+    if (typeName == null) {
       return "null;";
     }
+    Class<?> primitiveClass = PRIMITIVE_CLASS_MAP.get(typeName);
+    if (primitiveClass != null) {
+      return String.valueOf(Defaults.defaultValue(primitiveClass)) + ";";
+    }
+    if (typeName.equals("java.lang.String")) {
+      String stringFormat = getApiaryConfig().getStringFormat(type.getName(), field.getName());
+      if (stringFormat != null) {
+        String value = STRING_DEFAULT_MAP.get(stringFormat);
+        if (value != null) {
+          return value;
+        }
+      }
+      String stringPattern =
+          getApiaryConfig().getFieldPattern().get(type.getName(), field.getName());
+      String patternSample = stringPattern == null ? null : DefaultString.of(stringPattern);
+      if (patternSample != null) {
+        return String.format("\"%s\";", patternSample);
+      }
+      return "\"\";";
+    }
+    return "null;";
   }
 
   // Handlers for Exceptional Inconsistencies

--- a/src/main/java/com/google/api/codegen/ruby/RubyDiscoveryContext.java
+++ b/src/main/java/com/google/api/codegen/ruby/RubyDiscoveryContext.java
@@ -24,8 +24,6 @@ import com.google.protobuf.Type;
 import com.google.api.codegen.ApiaryConfig;
 import com.google.api.codegen.DiscoveryContext;
 
-import java.net.URL;
-
 /**
  * A DiscoveryContext specialized for Ruby.
  */

--- a/src/test/java/com/google/api/codegen/discovery/DefaultStringTest.java
+++ b/src/test/java/com/google/api/codegen/discovery/DefaultStringTest.java
@@ -1,0 +1,55 @@
+/* Copyright 2016 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.discovery;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.truth.Truth;
+
+import org.junit.Test;
+
+import java.util.Map;
+
+public class DefaultStringTest {
+  @Test
+  public void testInvalidString() {
+    String[] invalid =
+        new String[] {
+          "abc",
+          "(?:(?:[-a-z0-9]{1,63}\\.)*(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?):)?(?:[0-9]{1,19}|(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?))",
+          "[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?",
+          "^projects/[^/]*/topics$"
+        };
+
+    for (String s : invalid) {
+      Truth.assertThat(DefaultString.of(s)).isNull();
+    }
+  }
+
+  @Test
+  public void testDefault() {
+    ImmutableMap<String, String> tests =
+        ImmutableMap.<String, String>builder()
+            .put("^projects/[^/]*$", "projects/MY-PROJECT")
+            .put("^projects/[^/]*/topics/[^/]*$", "projects/MY-PROJECT/topics/MY-TOPIC")
+            .put(
+                "^projects/[^/]*/regions/[^/]*/operations/[^/]*$",
+                "projects/MY-PROJECT/regions/MY-REGION/operations/MY-OPERATION")
+            .build();
+
+    for (Map.Entry<String, String> entry : tests.entrySet()) {
+      Truth.assertThat(DefaultString.of(entry.getKey())).isEqualTo(entry.getValue());
+    }
+  }
+}

--- a/src/test/java/com/google/api/codegen/discovery/DefaultStringTest.java
+++ b/src/test/java/com/google/api/codegen/discovery/DefaultStringTest.java
@@ -41,11 +41,11 @@ public class DefaultStringTest {
   public void testDefault() {
     ImmutableMap<String, String> tests =
         ImmutableMap.<String, String>builder()
-            .put("^projects/[^/]*$", "projects/MY-PROJECT")
-            .put("^projects/[^/]*/topics/[^/]*$", "projects/MY-PROJECT/topics/MY-TOPIC")
+            .put("^projects/[^/]*$", "projects/{MY-PROJECT}")
+            .put("^projects/[^/]*/topics/[^/]*$", "projects/{MY-PROJECT}/topics/{MY-TOPIC}")
             .put(
                 "^projects/[^/]*/regions/[^/]*/operations/[^/]*$",
-                "projects/MY-PROJECT/regions/MY-REGION/operations/MY-OPERATION")
+                "projects/{MY-PROJECT}/regions/{MY-REGION}/operations/{MY-OPERATION}")
             .build();
 
     for (Map.Entry<String, String> entry : tests.entrySet()) {

--- a/src/test/java/com/google/api/codegen/discovery/DefaultStringTest.java
+++ b/src/test/java/com/google/api/codegen/discovery/DefaultStringTest.java
@@ -23,9 +23,10 @@ import java.util.Map;
 
 public class DefaultStringTest {
   @Test
-  public void testInvalidString() {
+  public void testInvalidPattern() {
     String[] invalid =
         new String[] {
+          null,
           "abc",
           "(?:(?:[-a-z0-9]{1,63}\\.)*(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?):)?(?:[0-9]{1,19}|(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?))",
           "[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?",
@@ -33,7 +34,7 @@ public class DefaultStringTest {
         };
 
     for (String s : invalid) {
-      Truth.assertThat(DefaultString.of(s)).isNull();
+      Truth.assertThat(DefaultString.forPattern(s)).isNull();
     }
   }
 
@@ -49,7 +50,7 @@ public class DefaultStringTest {
             .build();
 
     for (Map.Entry<String, String> entry : tests.entrySet()) {
-      Truth.assertThat(DefaultString.of(entry.getKey())).isEqualTo(entry.getValue());
+      Truth.assertThat(DefaultString.forPattern(entry.getKey())).isEqualTo(entry.getValue());
     }
   }
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_cloudbilling.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_cloudbilling.v1.json.baseline
@@ -47,7 +47,7 @@ public class CloudbillingExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
     // * The resource name of the billing account to retrieve. For example, `billingAccounts/012345-567890-ABCDEF`.
-    String name = "billingAccounts/MY-BILLINGACCOUNT";
+    String name = "billingAccounts/{MY-BILLINGACCOUNT}";
 
     Cloudbilling.BillingAccounts.Get request = cloudbillingService.billingAccounts().get(name);
     BillingAccount response = request.execute();
@@ -167,7 +167,7 @@ public class CloudbillingExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
     // * The resource name of the billing account associated with the projects that you want to list. For example, `billingAccounts/012345-567890-ABCDEF`.
-    String name = "billingAccounts/MY-BILLINGACCOUNT";
+    String name = "billingAccounts/{MY-BILLINGACCOUNT}";
 
     Cloudbilling.BillingAccounts.Projects.List request = cloudbillingService.billingAccounts().projects().list(name);
     ListProjectBillingInfoResponse response;
@@ -232,7 +232,7 @@ public class CloudbillingExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'getBillingInfo' method:
     // * The resource name of the project for which billing information is retrieved. For example, `projects/tokyo-rain-123`.
-    String name = "projects/MY-PROJECT";
+    String name = "projects/{MY-PROJECT}";
 
     Cloudbilling.Projects.GetBillingInfo request = cloudbillingService.projects().getBillingInfo(name);
     ProjectBillingInfo response = request.execute();
@@ -288,7 +288,7 @@ public class CloudbillingExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'updateBillingInfo' method:
     // * The resource name of the project associated with the billing information that you want to update. For example, `projects/tokyo-rain-123`.
-    String name = "projects/MY-PROJECT";
+    String name = "projects/{MY-PROJECT}";
 
     ProjectBillingInfo content = new ProjectBillingInfo();
     // TODO: Add code here to assign values to desired fields of the 'content' object

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_cloudbilling.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_cloudbilling.v1.json.baseline
@@ -47,7 +47,7 @@ public class CloudbillingExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
     // * The resource name of the billing account to retrieve. For example, `billingAccounts/012345-567890-ABCDEF`.
-    String name = "";
+    String name = "billingAccounts/MY-BILLINGACCOUNT";
 
     Cloudbilling.BillingAccounts.Get request = cloudbillingService.billingAccounts().get(name);
     BillingAccount response = request.execute();
@@ -167,7 +167,7 @@ public class CloudbillingExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
     // * The resource name of the billing account associated with the projects that you want to list. For example, `billingAccounts/012345-567890-ABCDEF`.
-    String name = "";
+    String name = "billingAccounts/MY-BILLINGACCOUNT";
 
     Cloudbilling.BillingAccounts.Projects.List request = cloudbillingService.billingAccounts().projects().list(name);
     ListProjectBillingInfoResponse response;
@@ -232,7 +232,7 @@ public class CloudbillingExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'getBillingInfo' method:
     // * The resource name of the project for which billing information is retrieved. For example, `projects/tokyo-rain-123`.
-    String name = "";
+    String name = "projects/MY-PROJECT";
 
     Cloudbilling.Projects.GetBillingInfo request = cloudbillingService.projects().getBillingInfo(name);
     ProjectBillingInfo response = request.execute();
@@ -288,7 +288,7 @@ public class CloudbillingExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'updateBillingInfo' method:
     // * The resource name of the project associated with the billing information that you want to update. For example, `projects/tokyo-rain-123`.
-    String name = "";
+    String name = "projects/MY-PROJECT";
 
     ProjectBillingInfo content = new ProjectBillingInfo();
     // TODO: Add code here to assign values to desired fields of the 'content' object

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_dataproc.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_dataproc.v1.json.baseline
@@ -850,7 +850,7 @@ public class DataprocExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'cancel' method:
     // * The name of the operation resource to be cancelled.
-    String name = "projects/MY-PROJECT/regions/MY-REGION/operations/MY-OPERATION";
+    String name = "projects/{MY-PROJECT}/regions/{MY-REGION}/operations/{MY-OPERATION}";
 
     Dataproc.Projects.Regions.Operations.Cancel request = dataprocService.projects().regions().operations().cancel(name);
     request.execute();
@@ -903,7 +903,7 @@ public class DataprocExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
     // * The name of the operation resource to be deleted.
-    String name = "projects/MY-PROJECT/regions/MY-REGION/operations/MY-OPERATION";
+    String name = "projects/{MY-PROJECT}/regions/{MY-REGION}/operations/{MY-OPERATION}";
 
     Dataproc.Projects.Regions.Operations.Delete request = dataprocService.projects().regions().operations().delete(name);
     request.execute();
@@ -957,7 +957,7 @@ public class DataprocExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
     // * The name of the operation resource.
-    String name = "projects/MY-PROJECT/regions/MY-REGION/operations/MY-OPERATION";
+    String name = "projects/{MY-PROJECT}/regions/{MY-REGION}/operations/{MY-OPERATION}";
 
     Dataproc.Projects.Regions.Operations.Get request = dataprocService.projects().regions().operations().get(name);
     Operation response = request.execute();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_dataproc.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_dataproc.v1.json.baseline
@@ -850,7 +850,7 @@ public class DataprocExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'cancel' method:
     // * The name of the operation resource to be cancelled.
-    String name = "";
+    String name = "projects/MY-PROJECT/regions/MY-REGION/operations/MY-OPERATION";
 
     Dataproc.Projects.Regions.Operations.Cancel request = dataprocService.projects().regions().operations().cancel(name);
     request.execute();
@@ -903,7 +903,7 @@ public class DataprocExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
     // * The name of the operation resource to be deleted.
-    String name = "";
+    String name = "projects/MY-PROJECT/regions/MY-REGION/operations/MY-OPERATION";
 
     Dataproc.Projects.Regions.Operations.Delete request = dataprocService.projects().regions().operations().delete(name);
     request.execute();
@@ -957,7 +957,7 @@ public class DataprocExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
     // * The name of the operation resource.
-    String name = "";
+    String name = "projects/MY-PROJECT/regions/MY-REGION/operations/MY-OPERATION";
 
     Dataproc.Projects.Regions.Operations.Get request = dataprocService.projects().regions().operations().get(name);
     Operation response = request.execute();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_logging.v2beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_logging.v2beta1.json.baseline
@@ -233,7 +233,7 @@ public class LoggingExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
     // * Required. The resource name of the log to delete. Example: `"projects/my-project/logs/syslog"`.
-    String logName = "";
+    String logName = "projects/MY-PROJECT/logs/MY-LOG";
 
     Logging.Projects.Logs.Delete request = loggingService.projects().logs().delete(logName);
     request.execute();
@@ -287,7 +287,7 @@ public class LoggingExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'create' method:
     // * The resource name of the project in which to create the metric. Example: `"projects/my-project-id"`. The new metric must be provided in the request.
-    String projectName = "";
+    String projectName = "projects/MY-PROJECT";
 
     LogMetric content = new LogMetric();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -345,7 +345,7 @@ public class LoggingExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
     // * The resource name of the metric to delete. Example: `"projects/my-project-id/metrics/my-metric-id"`.
-    String metricName = "";
+    String metricName = "projects/MY-PROJECT/metrics/MY-METRIC";
 
     Logging.Projects.Metrics.Delete request = loggingService.projects().metrics().delete(metricName);
     request.execute();
@@ -399,7 +399,7 @@ public class LoggingExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
     // * The resource name of the desired metric. Example: `"projects/my-project-id/metrics/my-metric-id"`.
-    String metricName = "";
+    String metricName = "projects/MY-PROJECT/metrics/MY-METRIC";
 
     Logging.Projects.Metrics.Get request = loggingService.projects().metrics().get(metricName);
     LogMetric response = request.execute();
@@ -456,7 +456,7 @@ public class LoggingExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
     // * Required. The resource name of the project containing the metrics. Example: `"projects/my-project-id"`.
-    String projectName = "";
+    String projectName = "projects/MY-PROJECT";
 
     Logging.Projects.Metrics.List request = loggingService.projects().metrics().list(projectName);
     ListLogMetricsResponse response;
@@ -521,7 +521,7 @@ public class LoggingExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
     // * The resource name of the metric to update. Example: `"projects/my-project-id/metrics/my-metric-id"`. The updated metric must be provided in the request and have the same identifier that is specified in `metricName`. If the metric does not exist, it is created.
-    String metricName = "";
+    String metricName = "projects/MY-PROJECT/metrics/MY-METRIC";
 
     LogMetric content = new LogMetric();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -580,7 +580,7 @@ public class LoggingExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'create' method:
     // * The resource name of the project in which to create the sink. Example: `"projects/my-project-id"`. The new sink must be provided in the request.
-    String projectName = "";
+    String projectName = "projects/MY-PROJECT";
 
     LogSink content = new LogSink();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -638,7 +638,7 @@ public class LoggingExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
     // * The resource name of the sink to delete. Example: `"projects/my-project-id/sinks/my-sink-id"`.
-    String sinkName = "";
+    String sinkName = "projects/MY-PROJECT/sinks/MY-SINK";
 
     Logging.Projects.Sinks.Delete request = loggingService.projects().sinks().delete(sinkName);
     request.execute();
@@ -692,7 +692,7 @@ public class LoggingExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
     // * The resource name of the sink to return. Example: `"projects/my-project-id/sinks/my-sink-id"`.
-    String sinkName = "";
+    String sinkName = "projects/MY-PROJECT/sinks/MY-SINK";
 
     Logging.Projects.Sinks.Get request = loggingService.projects().sinks().get(sinkName);
     LogSink response = request.execute();
@@ -749,7 +749,7 @@ public class LoggingExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
     // * Required. The resource name of the project containing the sinks. Example: `"projects/my-logging-project"`, `"projects/01234567890"`.
-    String projectName = "";
+    String projectName = "projects/MY-PROJECT";
 
     Logging.Projects.Sinks.List request = loggingService.projects().sinks().list(projectName);
     ListSinksResponse response;
@@ -814,7 +814,7 @@ public class LoggingExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
     // * The resource name of the sink to update. Example: `"projects/my-project-id/sinks/my-sink-id"`. The updated sink must be provided in the request and have the same name that is specified in `sinkName`. If the sink does not exist, it is created.
-    String sinkName = "";
+    String sinkName = "projects/MY-PROJECT/sinks/MY-SINK";
 
     LogSink content = new LogSink();
     // TODO: Add code here to assign values to desired fields of the 'content' object

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_logging.v2beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_logging.v2beta1.json.baseline
@@ -233,7 +233,7 @@ public class LoggingExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
     // * Required. The resource name of the log to delete. Example: `"projects/my-project/logs/syslog"`.
-    String logName = "projects/MY-PROJECT/logs/MY-LOG";
+    String logName = "projects/{MY-PROJECT}/logs/{MY-LOG}";
 
     Logging.Projects.Logs.Delete request = loggingService.projects().logs().delete(logName);
     request.execute();
@@ -287,7 +287,7 @@ public class LoggingExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'create' method:
     // * The resource name of the project in which to create the metric. Example: `"projects/my-project-id"`. The new metric must be provided in the request.
-    String projectName = "projects/MY-PROJECT";
+    String projectName = "projects/{MY-PROJECT}";
 
     LogMetric content = new LogMetric();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -345,7 +345,7 @@ public class LoggingExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
     // * The resource name of the metric to delete. Example: `"projects/my-project-id/metrics/my-metric-id"`.
-    String metricName = "projects/MY-PROJECT/metrics/MY-METRIC";
+    String metricName = "projects/{MY-PROJECT}/metrics/{MY-METRIC}";
 
     Logging.Projects.Metrics.Delete request = loggingService.projects().metrics().delete(metricName);
     request.execute();
@@ -399,7 +399,7 @@ public class LoggingExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
     // * The resource name of the desired metric. Example: `"projects/my-project-id/metrics/my-metric-id"`.
-    String metricName = "projects/MY-PROJECT/metrics/MY-METRIC";
+    String metricName = "projects/{MY-PROJECT}/metrics/{MY-METRIC}";
 
     Logging.Projects.Metrics.Get request = loggingService.projects().metrics().get(metricName);
     LogMetric response = request.execute();
@@ -456,7 +456,7 @@ public class LoggingExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
     // * Required. The resource name of the project containing the metrics. Example: `"projects/my-project-id"`.
-    String projectName = "projects/MY-PROJECT";
+    String projectName = "projects/{MY-PROJECT}";
 
     Logging.Projects.Metrics.List request = loggingService.projects().metrics().list(projectName);
     ListLogMetricsResponse response;
@@ -521,7 +521,7 @@ public class LoggingExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
     // * The resource name of the metric to update. Example: `"projects/my-project-id/metrics/my-metric-id"`. The updated metric must be provided in the request and have the same identifier that is specified in `metricName`. If the metric does not exist, it is created.
-    String metricName = "projects/MY-PROJECT/metrics/MY-METRIC";
+    String metricName = "projects/{MY-PROJECT}/metrics/{MY-METRIC}";
 
     LogMetric content = new LogMetric();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -580,7 +580,7 @@ public class LoggingExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'create' method:
     // * The resource name of the project in which to create the sink. Example: `"projects/my-project-id"`. The new sink must be provided in the request.
-    String projectName = "projects/MY-PROJECT";
+    String projectName = "projects/{MY-PROJECT}";
 
     LogSink content = new LogSink();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -638,7 +638,7 @@ public class LoggingExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
     // * The resource name of the sink to delete. Example: `"projects/my-project-id/sinks/my-sink-id"`.
-    String sinkName = "projects/MY-PROJECT/sinks/MY-SINK";
+    String sinkName = "projects/{MY-PROJECT}/sinks/{MY-SINK}";
 
     Logging.Projects.Sinks.Delete request = loggingService.projects().sinks().delete(sinkName);
     request.execute();
@@ -692,7 +692,7 @@ public class LoggingExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
     // * The resource name of the sink to return. Example: `"projects/my-project-id/sinks/my-sink-id"`.
-    String sinkName = "projects/MY-PROJECT/sinks/MY-SINK";
+    String sinkName = "projects/{MY-PROJECT}/sinks/{MY-SINK}";
 
     Logging.Projects.Sinks.Get request = loggingService.projects().sinks().get(sinkName);
     LogSink response = request.execute();
@@ -749,7 +749,7 @@ public class LoggingExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
     // * Required. The resource name of the project containing the sinks. Example: `"projects/my-logging-project"`, `"projects/01234567890"`.
-    String projectName = "projects/MY-PROJECT";
+    String projectName = "projects/{MY-PROJECT}";
 
     Logging.Projects.Sinks.List request = loggingService.projects().sinks().list(projectName);
     ListSinksResponse response;
@@ -814,7 +814,7 @@ public class LoggingExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
     // * The resource name of the sink to update. Example: `"projects/my-project-id/sinks/my-sink-id"`. The updated sink must be provided in the request and have the same name that is specified in `sinkName`. If the sink does not exist, it is created.
-    String sinkName = "projects/MY-PROJECT/sinks/MY-SINK";
+    String sinkName = "projects/{MY-PROJECT}/sinks/{MY-SINK}";
 
     LogSink content = new LogSink();
     // TODO: Add code here to assign values to desired fields of the 'content' object

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_pubsub.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_pubsub.v1.json.baseline
@@ -47,7 +47,7 @@ public class PubsubExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'acknowledge' method:
     // * The subscription whose message is being acknowledged.
-    String subscription = "projects/MY-PROJECT/subscriptions/MY-SUBSCRIPTION";
+    String subscription = "projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}";
 
     AcknowledgeRequest content = new AcknowledgeRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -104,7 +104,7 @@ public class PubsubExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'create' method:
     // * The name of the subscription. It must have the format `"projects/{project}/subscriptions/{subscription}"`. `{subscription}` must start with a letter, and contain only letters (`[A-Za-z]`), numbers (`[0-9]`), dashes (`-`), underscores (`_`), periods (`.`), tildes (`~`), plus (`+`) or percent signs (`%`). It must be between 3 and 255 characters in length, and it must not start with `"goog"`.
-    String name = "projects/MY-PROJECT/subscriptions/MY-SUBSCRIPTION";
+    String name = "projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}";
 
     Subscription content = new Subscription();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -162,7 +162,7 @@ public class PubsubExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
     // * The subscription to delete.
-    String subscription = "projects/MY-PROJECT/subscriptions/MY-SUBSCRIPTION";
+    String subscription = "projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}";
 
     Pubsub.Projects.Subscriptions.Delete request = pubsubService.projects().subscriptions().delete(subscription);
     request.execute();
@@ -216,7 +216,7 @@ public class PubsubExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
     // * The name of the subscription to get.
-    String subscription = "projects/MY-PROJECT/subscriptions/MY-SUBSCRIPTION";
+    String subscription = "projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}";
 
     Pubsub.Projects.Subscriptions.Get request = pubsubService.projects().subscriptions().get(subscription);
     Subscription response = request.execute();
@@ -272,7 +272,7 @@ public class PubsubExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'getIamPolicy' method:
     // * REQUIRED: The resource for which policy is being requested. `resource` is usually specified as a path, such as, `projects/{project}/zones/{zone}/disks/{disk}`. The format for the path specified in this value is resource specific and is specified in the documentation for the respective GetIamPolicy rpc.
-    String resource = "projects/MY-PROJECT/subscriptions/MY-SUBSCRIPTION";
+    String resource = "projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}";
 
     Pubsub.Projects.Subscriptions.GetIamPolicy request = pubsubService.projects().subscriptions().getIamPolicy(resource);
     Policy response = request.execute();
@@ -329,7 +329,7 @@ public class PubsubExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
     // * The name of the cloud project that subscriptions belong to.
-    String project = "projects/MY-PROJECT";
+    String project = "projects/{MY-PROJECT}";
 
     Pubsub.Projects.Subscriptions.List request = pubsubService.projects().subscriptions().list(project);
     ListSubscriptionsResponse response;
@@ -394,7 +394,7 @@ public class PubsubExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'modifyAckDeadline' method:
     // * The name of the subscription.
-    String subscription = "projects/MY-PROJECT/subscriptions/MY-SUBSCRIPTION";
+    String subscription = "projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}";
 
     ModifyAckDeadlineRequest content = new ModifyAckDeadlineRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -451,7 +451,7 @@ public class PubsubExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'modifyPushConfig' method:
     // * The name of the subscription.
-    String subscription = "projects/MY-PROJECT/subscriptions/MY-SUBSCRIPTION";
+    String subscription = "projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}";
 
     ModifyPushConfigRequest content = new ModifyPushConfigRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -509,7 +509,7 @@ public class PubsubExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'pull' method:
     // * The subscription from which messages should be pulled.
-    String subscription = "projects/MY-PROJECT/subscriptions/MY-SUBSCRIPTION";
+    String subscription = "projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}";
 
     PullRequest content = new PullRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -569,7 +569,7 @@ public class PubsubExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'setIamPolicy' method:
     // * REQUIRED: The resource for which policy is being specified. `resource` is usually specified as a path, such as, `projects/{project}/zones/{zone}/disks/{disk}`. The format for the path specified in this value is resource specific and is specified in the documentation for the respective SetIamPolicy rpc.
-    String resource = "projects/MY-PROJECT/subscriptions/MY-SUBSCRIPTION";
+    String resource = "projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}";
 
     SetIamPolicyRequest content = new SetIamPolicyRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -629,7 +629,7 @@ public class PubsubExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'testIamPermissions' method:
     // * REQUIRED: The resource for which policy detail is being requested. `resource` is usually specified as a path, such as, `projects/{project}/zones/{zone}/disks/{disk}`. The format for the path specified in this value is resource specific and is specified in the documentation for the respective TestIamPermissions rpc.
-    String resource = "projects/MY-PROJECT/subscriptions/MY-SUBSCRIPTION";
+    String resource = "projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}";
 
     TestIamPermissionsRequest content = new TestIamPermissionsRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -688,7 +688,7 @@ public class PubsubExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'create' method:
     // * The name of the topic. It must have the format `"projects/{project}/topics/{topic}"`. `{topic}` must start with a letter, and contain only letters (`[A-Za-z]`), numbers (`[0-9]`), dashes (`-`), underscores (`_`), periods (`.`), tildes (`~`), plus (`+`) or percent signs (`%`). It must be between 3 and 255 characters in length, and it must not start with `"goog"`.
-    String name = "projects/MY-PROJECT/topics/MY-TOPIC";
+    String name = "projects/{MY-PROJECT}/topics/{MY-TOPIC}";
 
     Topic content = new Topic();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -746,7 +746,7 @@ public class PubsubExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
     // * Name of the topic to delete.
-    String topic = "projects/MY-PROJECT/topics/MY-TOPIC";
+    String topic = "projects/{MY-PROJECT}/topics/{MY-TOPIC}";
 
     Pubsub.Projects.Topics.Delete request = pubsubService.projects().topics().delete(topic);
     request.execute();
@@ -800,7 +800,7 @@ public class PubsubExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
     // * The name of the topic to get.
-    String topic = "projects/MY-PROJECT/topics/MY-TOPIC";
+    String topic = "projects/{MY-PROJECT}/topics/{MY-TOPIC}";
 
     Pubsub.Projects.Topics.Get request = pubsubService.projects().topics().get(topic);
     Topic response = request.execute();
@@ -856,7 +856,7 @@ public class PubsubExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'getIamPolicy' method:
     // * REQUIRED: The resource for which policy is being requested. `resource` is usually specified as a path, such as, `projects/{project}/zones/{zone}/disks/{disk}`. The format for the path specified in this value is resource specific and is specified in the documentation for the respective GetIamPolicy rpc.
-    String resource = "projects/MY-PROJECT/topics/MY-TOPIC";
+    String resource = "projects/{MY-PROJECT}/topics/{MY-TOPIC}";
 
     Pubsub.Projects.Topics.GetIamPolicy request = pubsubService.projects().topics().getIamPolicy(resource);
     Policy response = request.execute();
@@ -913,7 +913,7 @@ public class PubsubExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
     // * The name of the cloud project that topics belong to.
-    String project = "projects/MY-PROJECT";
+    String project = "projects/{MY-PROJECT}";
 
     Pubsub.Projects.Topics.List request = pubsubService.projects().topics().list(project);
     ListTopicsResponse response;
@@ -979,7 +979,7 @@ public class PubsubExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'publish' method:
     // * The messages in the request will be published on this topic.
-    String topic = "projects/MY-PROJECT/topics/MY-TOPIC";
+    String topic = "projects/{MY-PROJECT}/topics/{MY-TOPIC}";
 
     PublishRequest content = new PublishRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -1039,7 +1039,7 @@ public class PubsubExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'setIamPolicy' method:
     // * REQUIRED: The resource for which policy is being specified. `resource` is usually specified as a path, such as, `projects/{project}/zones/{zone}/disks/{disk}`. The format for the path specified in this value is resource specific and is specified in the documentation for the respective SetIamPolicy rpc.
-    String resource = "projects/MY-PROJECT/topics/MY-TOPIC";
+    String resource = "projects/{MY-PROJECT}/topics/{MY-TOPIC}";
 
     SetIamPolicyRequest content = new SetIamPolicyRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -1098,7 +1098,7 @@ public class PubsubExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
     // * The name of the topic that subscriptions are attached to.
-    String topic = "projects/MY-PROJECT/topics/MY-TOPIC";
+    String topic = "projects/{MY-PROJECT}/topics/{MY-TOPIC}";
 
     Pubsub.Projects.Topics.Subscriptions.List request = pubsubService.projects().topics().subscriptions().list(topic);
     ListTopicSubscriptionsResponse response;
@@ -1164,7 +1164,7 @@ public class PubsubExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'testIamPermissions' method:
     // * REQUIRED: The resource for which policy detail is being requested. `resource` is usually specified as a path, such as, `projects/{project}/zones/{zone}/disks/{disk}`. The format for the path specified in this value is resource specific and is specified in the documentation for the respective TestIamPermissions rpc.
-    String resource = "projects/MY-PROJECT/topics/MY-TOPIC";
+    String resource = "projects/{MY-PROJECT}/topics/{MY-TOPIC}";
 
     TestIamPermissionsRequest content = new TestIamPermissionsRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_pubsub.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_pubsub.v1.json.baseline
@@ -47,7 +47,7 @@ public class PubsubExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'acknowledge' method:
     // * The subscription whose message is being acknowledged.
-    String subscription = "";
+    String subscription = "projects/MY-PROJECT/subscriptions/MY-SUBSCRIPTION";
 
     AcknowledgeRequest content = new AcknowledgeRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -104,7 +104,7 @@ public class PubsubExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'create' method:
     // * The name of the subscription. It must have the format `"projects/{project}/subscriptions/{subscription}"`. `{subscription}` must start with a letter, and contain only letters (`[A-Za-z]`), numbers (`[0-9]`), dashes (`-`), underscores (`_`), periods (`.`), tildes (`~`), plus (`+`) or percent signs (`%`). It must be between 3 and 255 characters in length, and it must not start with `"goog"`.
-    String name = "";
+    String name = "projects/MY-PROJECT/subscriptions/MY-SUBSCRIPTION";
 
     Subscription content = new Subscription();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -162,7 +162,7 @@ public class PubsubExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
     // * The subscription to delete.
-    String subscription = "";
+    String subscription = "projects/MY-PROJECT/subscriptions/MY-SUBSCRIPTION";
 
     Pubsub.Projects.Subscriptions.Delete request = pubsubService.projects().subscriptions().delete(subscription);
     request.execute();
@@ -216,7 +216,7 @@ public class PubsubExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
     // * The name of the subscription to get.
-    String subscription = "";
+    String subscription = "projects/MY-PROJECT/subscriptions/MY-SUBSCRIPTION";
 
     Pubsub.Projects.Subscriptions.Get request = pubsubService.projects().subscriptions().get(subscription);
     Subscription response = request.execute();
@@ -272,7 +272,7 @@ public class PubsubExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'getIamPolicy' method:
     // * REQUIRED: The resource for which policy is being requested. `resource` is usually specified as a path, such as, `projects/{project}/zones/{zone}/disks/{disk}`. The format for the path specified in this value is resource specific and is specified in the documentation for the respective GetIamPolicy rpc.
-    String resource = "";
+    String resource = "projects/MY-PROJECT/subscriptions/MY-SUBSCRIPTION";
 
     Pubsub.Projects.Subscriptions.GetIamPolicy request = pubsubService.projects().subscriptions().getIamPolicy(resource);
     Policy response = request.execute();
@@ -329,7 +329,7 @@ public class PubsubExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
     // * The name of the cloud project that subscriptions belong to.
-    String project = "";
+    String project = "projects/MY-PROJECT";
 
     Pubsub.Projects.Subscriptions.List request = pubsubService.projects().subscriptions().list(project);
     ListSubscriptionsResponse response;
@@ -394,7 +394,7 @@ public class PubsubExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'modifyAckDeadline' method:
     // * The name of the subscription.
-    String subscription = "";
+    String subscription = "projects/MY-PROJECT/subscriptions/MY-SUBSCRIPTION";
 
     ModifyAckDeadlineRequest content = new ModifyAckDeadlineRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -451,7 +451,7 @@ public class PubsubExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'modifyPushConfig' method:
     // * The name of the subscription.
-    String subscription = "";
+    String subscription = "projects/MY-PROJECT/subscriptions/MY-SUBSCRIPTION";
 
     ModifyPushConfigRequest content = new ModifyPushConfigRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -509,7 +509,7 @@ public class PubsubExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'pull' method:
     // * The subscription from which messages should be pulled.
-    String subscription = "";
+    String subscription = "projects/MY-PROJECT/subscriptions/MY-SUBSCRIPTION";
 
     PullRequest content = new PullRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -569,7 +569,7 @@ public class PubsubExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'setIamPolicy' method:
     // * REQUIRED: The resource for which policy is being specified. `resource` is usually specified as a path, such as, `projects/{project}/zones/{zone}/disks/{disk}`. The format for the path specified in this value is resource specific and is specified in the documentation for the respective SetIamPolicy rpc.
-    String resource = "";
+    String resource = "projects/MY-PROJECT/subscriptions/MY-SUBSCRIPTION";
 
     SetIamPolicyRequest content = new SetIamPolicyRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -629,7 +629,7 @@ public class PubsubExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'testIamPermissions' method:
     // * REQUIRED: The resource for which policy detail is being requested. `resource` is usually specified as a path, such as, `projects/{project}/zones/{zone}/disks/{disk}`. The format for the path specified in this value is resource specific and is specified in the documentation for the respective TestIamPermissions rpc.
-    String resource = "";
+    String resource = "projects/MY-PROJECT/subscriptions/MY-SUBSCRIPTION";
 
     TestIamPermissionsRequest content = new TestIamPermissionsRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -688,7 +688,7 @@ public class PubsubExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'create' method:
     // * The name of the topic. It must have the format `"projects/{project}/topics/{topic}"`. `{topic}` must start with a letter, and contain only letters (`[A-Za-z]`), numbers (`[0-9]`), dashes (`-`), underscores (`_`), periods (`.`), tildes (`~`), plus (`+`) or percent signs (`%`). It must be between 3 and 255 characters in length, and it must not start with `"goog"`.
-    String name = "";
+    String name = "projects/MY-PROJECT/topics/MY-TOPIC";
 
     Topic content = new Topic();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -746,7 +746,7 @@ public class PubsubExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
     // * Name of the topic to delete.
-    String topic = "";
+    String topic = "projects/MY-PROJECT/topics/MY-TOPIC";
 
     Pubsub.Projects.Topics.Delete request = pubsubService.projects().topics().delete(topic);
     request.execute();
@@ -800,7 +800,7 @@ public class PubsubExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
     // * The name of the topic to get.
-    String topic = "";
+    String topic = "projects/MY-PROJECT/topics/MY-TOPIC";
 
     Pubsub.Projects.Topics.Get request = pubsubService.projects().topics().get(topic);
     Topic response = request.execute();
@@ -856,7 +856,7 @@ public class PubsubExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'getIamPolicy' method:
     // * REQUIRED: The resource for which policy is being requested. `resource` is usually specified as a path, such as, `projects/{project}/zones/{zone}/disks/{disk}`. The format for the path specified in this value is resource specific and is specified in the documentation for the respective GetIamPolicy rpc.
-    String resource = "";
+    String resource = "projects/MY-PROJECT/topics/MY-TOPIC";
 
     Pubsub.Projects.Topics.GetIamPolicy request = pubsubService.projects().topics().getIamPolicy(resource);
     Policy response = request.execute();
@@ -913,7 +913,7 @@ public class PubsubExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
     // * The name of the cloud project that topics belong to.
-    String project = "";
+    String project = "projects/MY-PROJECT";
 
     Pubsub.Projects.Topics.List request = pubsubService.projects().topics().list(project);
     ListTopicsResponse response;
@@ -979,7 +979,7 @@ public class PubsubExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'publish' method:
     // * The messages in the request will be published on this topic.
-    String topic = "";
+    String topic = "projects/MY-PROJECT/topics/MY-TOPIC";
 
     PublishRequest content = new PublishRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -1039,7 +1039,7 @@ public class PubsubExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'setIamPolicy' method:
     // * REQUIRED: The resource for which policy is being specified. `resource` is usually specified as a path, such as, `projects/{project}/zones/{zone}/disks/{disk}`. The format for the path specified in this value is resource specific and is specified in the documentation for the respective SetIamPolicy rpc.
-    String resource = "";
+    String resource = "projects/MY-PROJECT/topics/MY-TOPIC";
 
     SetIamPolicyRequest content = new SetIamPolicyRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -1098,7 +1098,7 @@ public class PubsubExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
     // * The name of the topic that subscriptions are attached to.
-    String topic = "";
+    String topic = "projects/MY-PROJECT/topics/MY-TOPIC";
 
     Pubsub.Projects.Topics.Subscriptions.List request = pubsubService.projects().topics().subscriptions().list(topic);
     ListTopicSubscriptionsResponse response;
@@ -1164,7 +1164,7 @@ public class PubsubExample {
 
     // TODO: Change placeholders below to appropriate parameter values for the 'testIamPermissions' method:
     // * REQUIRED: The resource for which policy detail is being requested. `resource` is usually specified as a path, such as, `projects/{project}/zones/{zone}/disks/{disk}`. The format for the path specified in this value is resource specific and is specified in the documentation for the respective TestIamPermissions rpc.
-    String resource = "";
+    String resource = "projects/MY-PROJECT/topics/MY-TOPIC";
 
     TestIamPermissionsRequest content = new TestIamPermissionsRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object


### PR DESCRIPTION
Equivalents for other languages can easily be implemented
once this lands.

This change only concerns itself with patterns of the form
  ^A/[^/]*/B/[^/]*$
There are only a handful other common patterns.
However, they are large and difficult to automate.
They can be special-cased instead.