### PR TITLE
Fix NodeJS page-streaming method

### DIFF
--- a/src/main/java/com/google/api/codegen/nodejs/NodeJSGapicContext.java
+++ b/src/main/java/com/google/api/codegen/nodejs/NodeJSGapicContext.java
@@ -123,35 +123,27 @@ public class NodeJSGapicContext extends GapicContext implements NodeJSContext {
    */
   @Nullable
   private String returnTypeComment(Method method, MethodConfig config) {
+    if (config.isPageStreaming()) {
+      String resourceType = jsTypeName(config.getPageStreaming().getResourcesField().getType());
+      return "@returns {Stream<"
+          + resourceType
+          + ">}\n"
+          + "  An object stream. By default, this emits "
+          + resourceType
+          + "\n  instances on 'data' event. This object can also be configured to emit\n"
+          + "  pages of the responses through the options parameter.";
+    }
+
     MessageType returnMessageType = method.getOutputMessage();
     boolean isEmpty = returnMessageType.getFullName().equals("google.protobuf.Empty");
 
     String classInfo = jsTypeName(method.getOutputType());
 
     String callbackType = isEmpty ? "EmptyCallback" : String.format("APICallback<%s>", classInfo);
-    String callbackComment =
-        "@param {?"
+    return "@param {?"
             + callbackType
             + "} callback\n"
             + "  The function which will be called with the result of the API call.";
-    if (config.isPageStreaming()) {
-      String resourceType = jsTypeName(config.getPageStreaming().getResourcesField().getType());
-      return callbackComment
-          + "\n@returns {?Stream<"
-          + resourceType
-          + ">}\n"
-          + "  An object stream of "
-          + resourceType
-          + " instances, unless\n"
-          + "  page streaming is disabled through the call options or a callback\n"
-          + "  is specified. If page streaming is disabled or a callback is specified,\n"
-          + "  this returns null, and the callback will be called with a single instance\n"
-          + "  of "
-          + classInfo
-          + ".";
-    } else {
-      return callbackComment;
-    }
   }
 
   /**

--- a/src/main/java/com/google/api/codegen/nodejs/NodeJSGapicProvider.java
+++ b/src/main/java/com/google/api/codegen/nodejs/NodeJSGapicProvider.java
@@ -52,7 +52,7 @@ public class NodeJSGapicProvider<InputElementT extends ProtoElement>
   public <Element> void output(
       String outputPath, Multimap<Element, GeneratedResult> elements)
       throws IOException {
-    CodeGeneratorUtil.writeGeneratedOutput("lib/" + outputPath, elements);
+    CodeGeneratorUtil.writeGeneratedOutput(outputPath + "/lib/", elements);
   }
 
   @Override

--- a/src/main/resources/com/google/api/codegen/nodejs/main.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/main.snip
@@ -323,8 +323,12 @@
         @if optionalParams
           'otherArgs': [Object],
         @end
-        'options': [gax.CallOptions],
-        'callback': [Function]
+        @if methodConfig.isPageStreaming
+          'options': [gax.CallOptions]
+        @else
+          'options': [gax.CallOptions],
+          'callback': [Function]
+        @end
       });
       var req = {
         @if requiredParams
@@ -339,22 +343,17 @@
         @end
       };
       @if methodConfig.isPageStreaming
-        var stream = (args.callback) ? null : through2.obj();
+        var stream = through2.obj();
         Promise.all([this.defaults, this.stub]).then(function(vars) {
           var defaults = vars[0];
           var stub = vars[1];
           var options = defaults.{@methodName}.merge(args.options);
           var apiCall = gax.createApiCall(stub.{@methodName}.bind(stub), options);
           var result = apiCall(req, args.callback, this.headers, {});
-          if (stream) {
-            result.pipe(stream);
-          }
+          result.pipe(stream);
+          stream.on('end', function() { result.end(); });
         }.bind(this))['catch'](function(err) {
-          if (args.callback) {
-            args.callback(err);
-          } else {
-            stream.emit('error', err);
-          }
+          stream.emit('error', err);
         });
         return stream;
       @else

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_library.baseline
@@ -309,39 +309,29 @@ LibraryServiceApi.prototype.getShelf = function getShelf() {
  * @param {?gax.CallOptions} options
  *   Overrides the default settings for this call, e.g, timeout,
  *   retries, etc.
- * @param {?APICallback<google.example.library.v1.ListShelvesResponse>} callback
- *   The function which will be called with the result of the API call.
- * @returns {?Stream<google.example.library.v1.Shelf>}
- *   An object stream of google.example.library.v1.Shelf instances, unless
- *   page streaming is disabled through the call options or a callback
- *   is specified. If page streaming is disabled or a callback is specified,
- *   this returns null, and the callback will be called with a single instance
- *   of google.example.library.v1.ListShelvesResponse.
+ * @returns {Stream<google.example.library.v1.Shelf>}
+ *   An object stream. By default, this emits google.example.library.v1.Shelf
+ *   instances on 'data' event. This object can also be configured to emit
+ *   pages of the responses through the options parameter.
  * @throws an error if the RPC is aborted.
  */
 LibraryServiceApi.prototype.listShelves = function listShelves() {
   var args = arguejs({
-    'options': [gax.CallOptions],
-    'callback': [Function]
+    'options': [gax.CallOptions]
   });
   var req = {
   };
-  var stream = (args.callback) ? null : through2.obj();
+  var stream = through2.obj();
   Promise.all([this.defaults, this.stub]).then(function(vars) {
     var defaults = vars[0];
     var stub = vars[1];
     var options = defaults.listShelves.merge(args.options);
     var apiCall = gax.createApiCall(stub.listShelves.bind(stub), options);
     var result = apiCall(req, args.callback, this.headers, {});
-    if (stream) {
-      result.pipe(stream);
-    }
+    result.pipe(stream);
+    stream.on('end', function() { result.end(); });
   }.bind(this))['catch'](function(err) {
-    if (args.callback) {
-      args.callback(err);
-    } else {
-      stream.emit('error', err);
-    }
+    stream.emit('error', err);
   });
   return stream;
 };
@@ -552,44 +542,34 @@ LibraryServiceApi.prototype.getBook = function getBook() {
  * @param {?gax.CallOptions} options
  *   Overrides the default settings for this call, e.g, timeout,
  *   retries, etc.
- * @param {?APICallback<google.example.library.v1.ListBooksResponse>} callback
- *   The function which will be called with the result of the API call.
- * @returns {?Stream<google.example.library.v1.Book>}
- *   An object stream of google.example.library.v1.Book instances, unless
- *   page streaming is disabled through the call options or a callback
- *   is specified. If page streaming is disabled or a callback is specified,
- *   this returns null, and the callback will be called with a single instance
- *   of google.example.library.v1.ListBooksResponse.
+ * @returns {Stream<google.example.library.v1.Book>}
+ *   An object stream. By default, this emits google.example.library.v1.Book
+ *   instances on 'data' event. This object can also be configured to emit
+ *   pages of the responses through the options parameter.
  * @throws an error if the RPC is aborted.
  */
 LibraryServiceApi.prototype.listBooks = function listBooks() {
   var args = arguejs({
     'name': String,
     'otherArgs': [Object],
-    'options': [gax.CallOptions],
-    'callback': [Function]
+    'options': [gax.CallOptions]
   });
   var req = {
     'name': args.name,
     'page_size': args.otherArgs.pageSize || 0,
     'filter': args.otherArgs.filter || ''
   };
-  var stream = (args.callback) ? null : through2.obj();
+  var stream = through2.obj();
   Promise.all([this.defaults, this.stub]).then(function(vars) {
     var defaults = vars[0];
     var stub = vars[1];
     var options = defaults.listBooks.merge(args.options);
     var apiCall = gax.createApiCall(stub.listBooks.bind(stub), options);
     var result = apiCall(req, args.callback, this.headers, {});
-    if (stream) {
-      result.pipe(stream);
-    }
+    result.pipe(stream);
+    stream.on('end', function() { result.end(); });
   }.bind(this))['catch'](function(err) {
-    if (args.callback) {
-      args.callback(err);
-    } else {
-      stream.emit('error', err);
-    }
+    stream.emit('error', err);
   });
   return stream;
 };
@@ -726,42 +706,32 @@ LibraryServiceApi.prototype.moveBook = function moveBook() {
  * @param {?gax.CallOptions} options
  *   Overrides the default settings for this call, e.g, timeout,
  *   retries, etc.
- * @param {?APICallback<google.example.library.v1.ListStringsResponse>} callback
- *   The function which will be called with the result of the API call.
- * @returns {?Stream<String>}
- *   An object stream of String instances, unless
- *   page streaming is disabled through the call options or a callback
- *   is specified. If page streaming is disabled or a callback is specified,
- *   this returns null, and the callback will be called with a single instance
- *   of google.example.library.v1.ListStringsResponse.
+ * @returns {Stream<String>}
+ *   An object stream. By default, this emits String
+ *   instances on 'data' event. This object can also be configured to emit
+ *   pages of the responses through the options parameter.
  * @throws an error if the RPC is aborted.
  */
 LibraryServiceApi.prototype.listStrings = function listStrings() {
   var args = arguejs({
     'otherArgs': [Object],
-    'options': [gax.CallOptions],
-    'callback': [Function]
+    'options': [gax.CallOptions]
   });
   var req = {
     'name': args.otherArgs.name || '',
     'page_size': args.otherArgs.pageSize || 0
   };
-  var stream = (args.callback) ? null : through2.obj();
+  var stream = through2.obj();
   Promise.all([this.defaults, this.stub]).then(function(vars) {
     var defaults = vars[0];
     var stub = vars[1];
     var options = defaults.listStrings.merge(args.options);
     var apiCall = gax.createApiCall(stub.listStrings.bind(stub), options);
     var result = apiCall(req, args.callback, this.headers, {});
-    if (stream) {
-      result.pipe(stream);
-    }
+    result.pipe(stream);
+    stream.on('end', function() { result.end(); });
   }.bind(this))['catch'](function(err) {
-    if (args.callback) {
-      args.callback(err);
-    } else {
-      stream.emit('error', err);
-    }
+    stream.emit('error', err);
   });
   return stream;
 };


### PR DESCRIPTION
- As with https://github.com/googleapis/gax-nodejs/pull/14, callback
  for page-streaming methods are ignored. So callback parameters
  should be removed, and it should always return stream.
- Update the comment of stream to mention per-page streaming feature.
- Transfer the 'end' event. So it can finish repeating API calls
  when the user wants to end the stream.