### PR TITLE
Fix the basepath for generated .rb code.

### DIFF
--- a/src/main/java/com/google/api/codegen/ruby/RubyGapicContext.java
+++ b/src/main/java/com/google/api/codegen/ruby/RubyGapicContext.java
@@ -58,7 +58,7 @@ public class RubyGapicContext extends GapicContext implements RubyContext {
     for (String moduleName : getApiConfig().getPackageName().split("::")) {
       dirs.add(moduleName.toLowerCase());
     }
-    return Joiner.on("/").join(dirs);
+    return "lib/" + Joiner.on("/").join(dirs);
   }
 
   // Snippet Helpers

--- a/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
@@ -1,4 +1,4 @@
-============== file: google/example/library/v1/library_service_api.rb ==============
+============== file: lib/google/example/library/v1/library_service_api.rb ==============
 # Copyright 2016 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/com/google/api/codegen/testdata/ruby_message_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_message_library.baseline
@@ -1,4 +1,4 @@
-============== file: google/example/library/v1/doc/field_mask.rb ==============
+============== file: lib/google/example/library/v1/doc/field_mask.rb ==============
 # Copyright 2016 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,7 +36,7 @@ module Google
     end
   end
 end
-============== file: google/example/library/v1/doc/google/protobuf/any.rb ==============
+============== file: lib/google/example/library/v1/doc/google/protobuf/any.rb ==============
 # Copyright 2016 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -111,7 +111,7 @@ module Google
     class Any; end
   end
 end
-============== file: google/example/library/v1/doc/google/protobuf/duration.rb ==============
+============== file: lib/google/example/library/v1/doc/google/protobuf/duration.rb ==============
 # Copyright 2016 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -183,7 +183,7 @@ module Google
     class Duration; end
   end
 end
-============== file: google/example/library/v1/doc/google/protobuf/field_mask.rb ==============
+============== file: lib/google/example/library/v1/doc/google/protobuf/field_mask.rb ==============
 # Copyright 2016 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -328,7 +328,7 @@ module Google
     class FieldMask; end
   end
 end
-============== file: google/example/library/v1/doc/google/protobuf/timestamp.rb ==============
+============== file: lib/google/example/library/v1/doc/google/protobuf/timestamp.rb ==============
 # Copyright 2016 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -412,7 +412,7 @@ module Google
     class Timestamp; end
   end
 end
-============== file: google/example/library/v1/doc/google/protobuf/wrappers.rb ==============
+============== file: lib/google/example/library/v1/doc/google/protobuf/wrappers.rb ==============
 # Copyright 2016 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -502,7 +502,7 @@ module Google
     class BytesValue; end
   end
 end
-============== file: google/example/library/v1/doc/library.rb ==============
+============== file: lib/google/example/library/v1/doc/library.rb ==============
 # Copyright 2016 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
The ruby code is generated under 'lib' directory.
Fixes #193.