### PR TITLE
Conditionally remove service name from constructor

### DIFF
--- a/src/main/java/com/google/api/codegen/go/GoGapicContext.java
+++ b/src/main/java/com/google/api/codegen/go/GoGapicContext.java
@@ -123,6 +123,11 @@ public class GoGapicContext extends GapicContext implements GoContext {
    */
   public String getClientName(Interface service) {
     String name = getReducedServiceName(service);
+    // If there's only one service, or the service name matches the package name, don't prefix with
+    // the service name.
+    if (getModel().getSymbolTable().getInterfaces().size() == 1 || name.equals(getPackageName())) {
+      return "Client";
+    }
     return LanguageUtil.lowerUnderscoreToUpperCamel(name) + "Client";
   }
 

--- a/src/test/java/com/google/api/codegen/testdata/go_example_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_example_library.baseline
@@ -24,16 +24,16 @@ import (
     "google.golang.org/cloud/library/apiv1"
 )
 
-func ExampleNewLibraryClient() {
+func ExampleNewClient() {
     ctx := context.Background()
     opts := []gax.ClientOption{ /* Optional client parameters. */ }
-    c, err := library.NewLibraryClient(ctx, opts...)
+    c, err := library.NewClient(ctx, opts...)
     _, _ = c, err // Handle error.
 }
 
-func ExampleLibraryClient_CreateShelf() {
+func ExampleClient_CreateShelf() {
     ctx := context.Background()
-    c, err := library.NewLibraryClient(ctx)
+    c, err := library.NewClient(ctx)
     _ = err // Handle error.
 
     req := &google_example_library_v1.CreateShelfRequest{ /* Data... */ }
@@ -42,9 +42,9 @@ func ExampleLibraryClient_CreateShelf() {
     _, _ = resp, err // Handle error.
 }
 
-func ExampleLibraryClient_GetShelf() {
+func ExampleClient_GetShelf() {
     ctx := context.Background()
-    c, err := library.NewLibraryClient(ctx)
+    c, err := library.NewClient(ctx)
     _ = err // Handle error.
 
     req := &google_example_library_v1.GetShelfRequest{ /* Data... */ }
@@ -53,9 +53,9 @@ func ExampleLibraryClient_GetShelf() {
     _, _ = resp, err // Handle error.
 }
 
-func ExampleLibraryClient_ListShelves() {
+func ExampleClient_ListShelves() {
     ctx := context.Background()
-    c, err := library.NewLibraryClient(ctx)
+    c, err := library.NewClient(ctx)
     _ = err // Handle error.
 
     req := &google_example_library_v1.ListShelvesRequest{ /* Data... */ }
@@ -70,9 +70,9 @@ func ExampleLibraryClient_ListShelves() {
     _ = resp
 }
 
-func ExampleLibraryClient_DeleteShelf() {
+func ExampleClient_DeleteShelf() {
     ctx := context.Background()
-    c, err := library.NewLibraryClient(ctx)
+    c, err := library.NewClient(ctx)
     _ = err // Handle error.
 
     req := &google_example_library_v1.DeleteShelfRequest{ /* Data... */ }
@@ -80,9 +80,9 @@ func ExampleLibraryClient_DeleteShelf() {
     _ = err // Handle error.
 }
 
-func ExampleLibraryClient_MergeShelves() {
+func ExampleClient_MergeShelves() {
     ctx := context.Background()
-    c, err := library.NewLibraryClient(ctx)
+    c, err := library.NewClient(ctx)
     _ = err // Handle error.
 
     req := &google_example_library_v1.MergeShelvesRequest{ /* Data... */ }
@@ -91,9 +91,9 @@ func ExampleLibraryClient_MergeShelves() {
     _, _ = resp, err // Handle error.
 }
 
-func ExampleLibraryClient_CreateBook() {
+func ExampleClient_CreateBook() {
     ctx := context.Background()
-    c, err := library.NewLibraryClient(ctx)
+    c, err := library.NewClient(ctx)
     _ = err // Handle error.
 
     req := &google_example_library_v1.CreateBookRequest{ /* Data... */ }
@@ -102,9 +102,9 @@ func ExampleLibraryClient_CreateBook() {
     _, _ = resp, err // Handle error.
 }
 
-func ExampleLibraryClient_PublishSeries() {
+func ExampleClient_PublishSeries() {
     ctx := context.Background()
-    c, err := library.NewLibraryClient(ctx)
+    c, err := library.NewClient(ctx)
     _ = err // Handle error.
 
     req := &google_example_library_v1.PublishSeriesRequest{ /* Data... */ }
@@ -113,9 +113,9 @@ func ExampleLibraryClient_PublishSeries() {
     _, _ = resp, err // Handle error.
 }
 
-func ExampleLibraryClient_GetBook() {
+func ExampleClient_GetBook() {
     ctx := context.Background()
-    c, err := library.NewLibraryClient(ctx)
+    c, err := library.NewClient(ctx)
     _ = err // Handle error.
 
     req := &google_example_library_v1.GetBookRequest{ /* Data... */ }
@@ -124,9 +124,9 @@ func ExampleLibraryClient_GetBook() {
     _, _ = resp, err // Handle error.
 }
 
-func ExampleLibraryClient_ListBooks() {
+func ExampleClient_ListBooks() {
     ctx := context.Background()
-    c, err := library.NewLibraryClient(ctx)
+    c, err := library.NewClient(ctx)
     _ = err // Handle error.
 
     req := &google_example_library_v1.ListBooksRequest{ /* Data... */ }
@@ -141,9 +141,9 @@ func ExampleLibraryClient_ListBooks() {
     _ = resp
 }
 
-func ExampleLibraryClient_DeleteBook() {
+func ExampleClient_DeleteBook() {
     ctx := context.Background()
-    c, err := library.NewLibraryClient(ctx)
+    c, err := library.NewClient(ctx)
     _ = err // Handle error.
 
     req := &google_example_library_v1.DeleteBookRequest{ /* Data... */ }
@@ -151,9 +151,9 @@ func ExampleLibraryClient_DeleteBook() {
     _ = err // Handle error.
 }
 
-func ExampleLibraryClient_UpdateBook() {
+func ExampleClient_UpdateBook() {
     ctx := context.Background()
-    c, err := library.NewLibraryClient(ctx)
+    c, err := library.NewClient(ctx)
     _ = err // Handle error.
 
     req := &google_example_library_v1.UpdateBookRequest{ /* Data... */ }
@@ -162,9 +162,9 @@ func ExampleLibraryClient_UpdateBook() {
     _, _ = resp, err // Handle error.
 }
 
-func ExampleLibraryClient_MoveBook() {
+func ExampleClient_MoveBook() {
     ctx := context.Background()
-    c, err := library.NewLibraryClient(ctx)
+    c, err := library.NewClient(ctx)
     _ = err // Handle error.
 
     req := &google_example_library_v1.MoveBookRequest{ /* Data... */ }
@@ -173,9 +173,9 @@ func ExampleLibraryClient_MoveBook() {
     _, _ = resp, err // Handle error.
 }
 
-func ExampleLibraryClient_ListStrings() {
+func ExampleClient_ListStrings() {
     ctx := context.Background()
-    c, err := library.NewLibraryClient(ctx)
+    c, err := library.NewClient(ctx)
     _ = err // Handle error.
 
     req := &google_example_library_v1.ListStringsRequest{ /* Data... */ }
@@ -190,9 +190,9 @@ func ExampleLibraryClient_ListStrings() {
     _ = resp
 }
 
-func ExampleLibraryClient_AddComments() {
+func ExampleClient_AddComments() {
     ctx := context.Background()
-    c, err := library.NewLibraryClient(ctx)
+    c, err := library.NewClient(ctx)
     _ = err // Handle error.
 
     req := &google_example_library_v1.AddCommentsRequest{ /* Data... */ }

--- a/src/test/java/com/google/api/codegen/testdata/go_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_main_library.baseline
@@ -35,7 +35,7 @@ var (
     libraryBookPathTemplate = gax.MustCompilePathTemplate("shelves/{shelf}/books/{book}")
 )
 
-func defaultLibraryClientSettings() gax.ClientSettings {
+func defaultClientSettings() gax.ClientSettings {
     withIdempotentRetryCodes := gax.WithRetryCodes(
         []codes.Code{
             codes.DeadlineExceeded,
@@ -74,8 +74,8 @@ func defaultLibraryClientSettings() gax.ClientSettings {
     }
 }
 
-// LibraryClient is a client for interacting with LibraryService.
-type LibraryClient struct {
+// Client is a client for interacting with LibraryService.
+type Client struct {
     // The connection to the service.
     conn *grpc.ClientConn
 
@@ -89,7 +89,7 @@ type LibraryClient struct {
     metadata map[string][]string
 }
 
-// NewLibraryClient creates a new library service client.
+// NewClient creates a new library service client.
 //
 // This API represents a simple digital library.  It lets you manage Shelf
 // resources and Book resources in the library. It defines the following
@@ -103,8 +103,8 @@ type LibraryClient struct {
 //
 // Check out [cloud docs!](/library/example/link).
 // This is [not a cloud link](http://www.google.com).
-func NewLibraryClient(ctx context.Context, opts ...gax.ClientOption) (*LibraryClient, error) {
-    s := defaultLibraryClientSettings()
+func NewClient(ctx context.Context, opts ...gax.ClientOption) (*Client, error) {
+    s := defaultClientSettings()
     for _, opt := range opts {
         opt.Resolve(&s)
     }
@@ -112,7 +112,7 @@ func NewLibraryClient(ctx context.Context, opts ...gax.ClientOption) (*LibraryCl
     if err != nil {
         return nil, err
     }
-    return &LibraryClient {
+    return &Client {
         conn: conn,
         client: google_example_library_v1.NewLibraryServiceClient(conn),
         callOptions: s.CallOptions,
@@ -124,7 +124,7 @@ func NewLibraryClient(ctx context.Context, opts ...gax.ClientOption) (*LibraryCl
 
 // Close closes the connection to the API service. The user should invoke this when
 // the client is no longer required.
-func (c *LibraryClient) Close() error {
+func (c *Client) Close() error {
     return c.conn.Close()
 }
 
@@ -156,7 +156,7 @@ func LibraryBookPath(shelf string, book string) string {
 // AUTO-GENERATED DOCUMENTATION AND METHOD -- see instructions at the top of the file for editing.
 
 // CreateShelf creates a shelf, and returns the new Shelf.
-func (c *LibraryClient) CreateShelf(ctx context.Context, req *google_example_library_v1.CreateShelfRequest) (*google_example_library_v1.Shelf, error) {
+func (c *Client) CreateShelf(ctx context.Context, req *google_example_library_v1.CreateShelfRequest) (*google_example_library_v1.Shelf, error) {
     ctx = metadata.NewContext(ctx, c.metadata)
     var resp *google_example_library_v1.Shelf
     err := gax.Invoke(ctx, func (ctx context.Context) error {
@@ -174,7 +174,7 @@ func (c *LibraryClient) CreateShelf(ctx context.Context, req *google_example_lib
 // AUTO-GENERATED DOCUMENTATION AND METHOD -- see instructions at the top of the file for editing.
 
 // GetShelf gets a shelf.
-func (c *LibraryClient) GetShelf(ctx context.Context, req *google_example_library_v1.GetShelfRequest) (*google_example_library_v1.Shelf, error) {
+func (c *Client) GetShelf(ctx context.Context, req *google_example_library_v1.GetShelfRequest) (*google_example_library_v1.Shelf, error) {
     ctx = metadata.NewContext(ctx, c.metadata)
     var resp *google_example_library_v1.Shelf
     err := gax.Invoke(ctx, func (ctx context.Context) error {
@@ -192,7 +192,7 @@ func (c *LibraryClient) GetShelf(ctx context.Context, req *google_example_librar
 // AUTO-GENERATED DOCUMENTATION AND METHOD -- see instructions at the top of the file for editing.
 
 // ListShelves lists shelves.
-func (c *LibraryClient) ListShelves(ctx context.Context, req *google_example_library_v1.ListShelvesRequest) *ShelfIterator {
+func (c *Client) ListShelves(ctx context.Context, req *google_example_library_v1.ListShelvesRequest) *ShelfIterator {
     ctx = metadata.NewContext(ctx, c.metadata)
     it := &ShelfIterator{}
     it.apiCall = func() error {
@@ -224,7 +224,7 @@ func (c *LibraryClient) ListShelves(ctx context.Context, req *google_example_lib
 // AUTO-GENERATED DOCUMENTATION AND METHOD -- see instructions at the top of the file for editing.
 
 // DeleteShelf deletes a shelf.
-func (c *LibraryClient) DeleteShelf(ctx context.Context, req *google_example_library_v1.DeleteShelfRequest) error {
+func (c *Client) DeleteShelf(ctx context.Context, req *google_example_library_v1.DeleteShelfRequest) error {
     ctx = metadata.NewContext(ctx, c.metadata)
     err := gax.Invoke(ctx, func (ctx context.Context) error {
         var err error
@@ -240,7 +240,7 @@ func (c *LibraryClient) DeleteShelf(ctx context.Context, req *google_example_lib
 // MergeShelves merges two shelves by adding all books from the shelf named
 // `other_shelf_name` to shelf `name`, and deletes
 // `other_shelf_name`. Returns the updated shelf.
-func (c *LibraryClient) MergeShelves(ctx context.Context, req *google_example_library_v1.MergeShelvesRequest) (*google_example_library_v1.Shelf, error) {
+func (c *Client) MergeShelves(ctx context.Context, req *google_example_library_v1.MergeShelvesRequest) (*google_example_library_v1.Shelf, error) {
     ctx = metadata.NewContext(ctx, c.metadata)
     var resp *google_example_library_v1.Shelf
     err := gax.Invoke(ctx, func (ctx context.Context) error {
@@ -258,7 +258,7 @@ func (c *LibraryClient) MergeShelves(ctx context.Context, req *google_example_li
 // AUTO-GENERATED DOCUMENTATION AND METHOD -- see instructions at the top of the file for editing.
 
 // CreateBook creates a book.
-func (c *LibraryClient) CreateBook(ctx context.Context, req *google_example_library_v1.CreateBookRequest) (*google_example_library_v1.Book, error) {
+func (c *Client) CreateBook(ctx context.Context, req *google_example_library_v1.CreateBookRequest) (*google_example_library_v1.Book, error) {
     ctx = metadata.NewContext(ctx, c.metadata)
     var resp *google_example_library_v1.Book
     err := gax.Invoke(ctx, func (ctx context.Context) error {
@@ -276,7 +276,7 @@ func (c *LibraryClient) CreateBook(ctx context.Context, req *google_example_libr
 // AUTO-GENERATED DOCUMENTATION AND METHOD -- see instructions at the top of the file for editing.
 
 // PublishSeries creates a series of books.
-func (c *LibraryClient) PublishSeries(ctx context.Context, req *google_example_library_v1.PublishSeriesRequest) (*google_example_library_v1.PublishSeriesResponse, error) {
+func (c *Client) PublishSeries(ctx context.Context, req *google_example_library_v1.PublishSeriesRequest) (*google_example_library_v1.PublishSeriesResponse, error) {
     ctx = metadata.NewContext(ctx, c.metadata)
     var resp *google_example_library_v1.PublishSeriesResponse
     err := gax.Invoke(ctx, func (ctx context.Context) error {
@@ -294,7 +294,7 @@ func (c *LibraryClient) PublishSeries(ctx context.Context, req *google_example_l
 // AUTO-GENERATED DOCUMENTATION AND METHOD -- see instructions at the top of the file for editing.
 
 // GetBook gets a book.
-func (c *LibraryClient) GetBook(ctx context.Context, req *google_example_library_v1.GetBookRequest) (*google_example_library_v1.Book, error) {
+func (c *Client) GetBook(ctx context.Context, req *google_example_library_v1.GetBookRequest) (*google_example_library_v1.Book, error) {
     ctx = metadata.NewContext(ctx, c.metadata)
     var resp *google_example_library_v1.Book
     err := gax.Invoke(ctx, func (ctx context.Context) error {
@@ -312,7 +312,7 @@ func (c *LibraryClient) GetBook(ctx context.Context, req *google_example_library
 // AUTO-GENERATED DOCUMENTATION AND METHOD -- see instructions at the top of the file for editing.
 
 // ListBooks lists books in a shelf.
-func (c *LibraryClient) ListBooks(ctx context.Context, req *google_example_library_v1.ListBooksRequest) *BookIterator {
+func (c *Client) ListBooks(ctx context.Context, req *google_example_library_v1.ListBooksRequest) *BookIterator {
     ctx = metadata.NewContext(ctx, c.metadata)
     it := &BookIterator{}
     it.apiCall = func() error {
@@ -345,7 +345,7 @@ func (c *LibraryClient) ListBooks(ctx context.Context, req *google_example_libra
 // AUTO-GENERATED DOCUMENTATION AND METHOD -- see instructions at the top of the file for editing.
 
 // DeleteBook deletes a book.
-func (c *LibraryClient) DeleteBook(ctx context.Context, req *google_example_library_v1.DeleteBookRequest) error {
+func (c *Client) DeleteBook(ctx context.Context, req *google_example_library_v1.DeleteBookRequest) error {
     ctx = metadata.NewContext(ctx, c.metadata)
     err := gax.Invoke(ctx, func (ctx context.Context) error {
         var err error
@@ -359,7 +359,7 @@ func (c *LibraryClient) DeleteBook(ctx context.Context, req *google_example_libr
 // AUTO-GENERATED DOCUMENTATION AND METHOD -- see instructions at the top of the file for editing.
 
 // UpdateBook updates a book.
-func (c *LibraryClient) UpdateBook(ctx context.Context, req *google_example_library_v1.UpdateBookRequest) (*google_example_library_v1.Book, error) {
+func (c *Client) UpdateBook(ctx context.Context, req *google_example_library_v1.UpdateBookRequest) (*google_example_library_v1.Book, error) {
     ctx = metadata.NewContext(ctx, c.metadata)
     var resp *google_example_library_v1.Book
     err := gax.Invoke(ctx, func (ctx context.Context) error {
@@ -377,7 +377,7 @@ func (c *LibraryClient) UpdateBook(ctx context.Context, req *google_example_libr
 // AUTO-GENERATED DOCUMENTATION AND METHOD -- see instructions at the top of the file for editing.
 
 // MoveBook moves a book to another shelf, and returns the new book.
-func (c *LibraryClient) MoveBook(ctx context.Context, req *google_example_library_v1.MoveBookRequest) (*google_example_library_v1.Book, error) {
+func (c *Client) MoveBook(ctx context.Context, req *google_example_library_v1.MoveBookRequest) (*google_example_library_v1.Book, error) {
     ctx = metadata.NewContext(ctx, c.metadata)
     var resp *google_example_library_v1.Book
     err := gax.Invoke(ctx, func (ctx context.Context) error {
@@ -395,7 +395,7 @@ func (c *LibraryClient) MoveBook(ctx context.Context, req *google_example_librar
 // AUTO-GENERATED DOCUMENTATION AND METHOD -- see instructions at the top of the file for editing.
 
 // ListStrings lists a primitive resource. To test go page streaming.
-func (c *LibraryClient) ListStrings(ctx context.Context, req *google_example_library_v1.ListStringsRequest) *StringIterator {
+func (c *Client) ListStrings(ctx context.Context, req *google_example_library_v1.ListStringsRequest) *StringIterator {
     ctx = metadata.NewContext(ctx, c.metadata)
     it := &StringIterator{}
     it.apiCall = func() error {
@@ -428,7 +428,7 @@ func (c *LibraryClient) ListStrings(ctx context.Context, req *google_example_lib
 // AUTO-GENERATED DOCUMENTATION AND METHOD -- see instructions at the top of the file for editing.
 
 // AddComments adds comments to a book
-func (c *LibraryClient) AddComments(ctx context.Context, req *google_example_library_v1.AddCommentsRequest) error {
+func (c *Client) AddComments(ctx context.Context, req *google_example_library_v1.AddCommentsRequest) error {
     ctx = metadata.NewContext(ctx, c.metadata)
     err := gax.Invoke(ctx, func (ctx context.Context) error {
         var err error


### PR DESCRIPTION
Changes client constructor to `NewClient` if the package name matches
the service name, or if there's only one service in the model.