### PR TITLE
Remove auto-generated warning above method docs

### DIFF
--- a/src/main/resources/com/google/api/codegen/go/common.snip
+++ b/src/main/resources/com/google/api/codegen/go/common.snip
@@ -7,7 +7,7 @@
 @snippet generateClass(service, body)
     {@headerComment()}
 
-    // AUTO-GENERATED
+    // AUTO-GENERATED CODE. DO NOT EDIT.
 
     package {@context.getPackageName}
 

--- a/src/main/resources/com/google/api/codegen/go/doc.snip
+++ b/src/main/resources/com/google/api/codegen/go/doc.snip
@@ -7,6 +7,8 @@
 @snippet generateClass(service, body)
     {@headerComment()}
 
+    // AUTO-GENERATED CODE. DO NOT EDIT.
+
     // Package {@context.getPackageName} is an experimental, auto-generated package for the
     // {@context.getPackageName} API.
     //

--- a/src/main/resources/com/google/api/codegen/go/example.snip
+++ b/src/main/resources/com/google/api/codegen/go/example.snip
@@ -7,7 +7,7 @@
 @snippet generateClass(service, body)
     {@headerComment()}
 
-    // AUTO-GENERATED EXAMPLES
+    // AUTO-GENERATED CODE. DO NOT EDIT.
 
     package {@context.getPackageName}_test
 

--- a/src/main/resources/com/google/api/codegen/go/main.snip
+++ b/src/main/resources/com/google/api/codegen/go/main.snip
@@ -7,7 +7,7 @@
 @snippet generateClass(service, body)
     {@headerComment()}
 
-    // AUTO-GENERATED DOCUMENTATION AND SERVICE
+    // AUTO-GENERATED CODE. DO NOT EDIT.
 
     package {@context.getPackageName}
 
@@ -269,8 +269,6 @@
 @end
 
 @private methodComment(method, methodName)
-    // AUTO-GENERATED DOCUMENTATION AND METHOD -- see instructions at the top of the file for editing.
-
     @join commentLine : context.getMethodComments(method, methodName)
         {@commentLine}
     @end

--- a/src/test/java/com/google/api/codegen/testdata/go_common_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_common_library.baseline
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// AUTO-GENERATED
+// AUTO-GENERATED CODE. DO NOT EDIT.
 
 package library
 

--- a/src/test/java/com/google/api/codegen/testdata/go_doc_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_doc_library.baseline
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// AUTO-GENERATED CODE. DO NOT EDIT.
+
 // Package library is an experimental, auto-generated package for the
 // library API.
 //

--- a/src/test/java/com/google/api/codegen/testdata/go_example_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_example_library.baseline
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// AUTO-GENERATED EXAMPLES
+// AUTO-GENERATED CODE. DO NOT EDIT.
 
 package library_test
 

--- a/src/test/java/com/google/api/codegen/testdata/go_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_main_library.baseline
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// AUTO-GENERATED DOCUMENTATION AND SERVICE
+// AUTO-GENERATED CODE. DO NOT EDIT.
 
 package library
 
@@ -158,8 +158,6 @@ func LibraryBookPath(shelf string, book string) string {
     return path
 }
 
-// AUTO-GENERATED DOCUMENTATION AND METHOD -- see instructions at the top of the file for editing.
-
 // CreateShelf creates a shelf, and returns the new Shelf.
 func (c *Client) CreateShelf(ctx context.Context, req *google_example_library_v1.CreateShelfRequest) (*google_example_library_v1.Shelf, error) {
     ctx = metadata.NewContext(ctx, c.metadata)
@@ -176,8 +174,6 @@ func (c *Client) CreateShelf(ctx context.Context, req *google_example_library_v1
 }
 
 
-// AUTO-GENERATED DOCUMENTATION AND METHOD -- see instructions at the top of the file for editing.
-
 // GetShelf gets a shelf.
 func (c *Client) GetShelf(ctx context.Context, req *google_example_library_v1.GetShelfRequest) (*google_example_library_v1.Shelf, error) {
     ctx = metadata.NewContext(ctx, c.metadata)
@@ -193,8 +189,6 @@ func (c *Client) GetShelf(ctx context.Context, req *google_example_library_v1.Ge
     return resp, nil
 }
 
-
-// AUTO-GENERATED DOCUMENTATION AND METHOD -- see instructions at the top of the file for editing.
 
 // ListShelves lists shelves.
 func (c *Client) ListShelves(ctx context.Context, req *google_example_library_v1.ListShelvesRequest) *ShelfIterator {
@@ -222,8 +216,6 @@ func (c *Client) ListShelves(ctx context.Context, req *google_example_library_v1
 }
 
 
-// AUTO-GENERATED DOCUMENTATION AND METHOD -- see instructions at the top of the file for editing.
-
 // DeleteShelf deletes a shelf.
 func (c *Client) DeleteShelf(ctx context.Context, req *google_example_library_v1.DeleteShelfRequest) error {
     ctx = metadata.NewContext(ctx, c.metadata)
@@ -235,8 +227,6 @@ func (c *Client) DeleteShelf(ctx context.Context, req *google_example_library_v1
     return err
 }
 
-
-// AUTO-GENERATED DOCUMENTATION AND METHOD -- see instructions at the top of the file for editing.
 
 // MergeShelves merges two shelves by adding all books from the shelf named
 // `other_shelf_name` to shelf `name`, and deletes
@@ -256,8 +246,6 @@ func (c *Client) MergeShelves(ctx context.Context, req *google_example_library_v
 }
 
 
-// AUTO-GENERATED DOCUMENTATION AND METHOD -- see instructions at the top of the file for editing.
-
 // CreateBook creates a book.
 func (c *Client) CreateBook(ctx context.Context, req *google_example_library_v1.CreateBookRequest) (*google_example_library_v1.Book, error) {
     ctx = metadata.NewContext(ctx, c.metadata)
@@ -273,8 +261,6 @@ func (c *Client) CreateBook(ctx context.Context, req *google_example_library_v1.
     return resp, nil
 }
 
-
-// AUTO-GENERATED DOCUMENTATION AND METHOD -- see instructions at the top of the file for editing.
 
 // PublishSeries creates a series of books.
 func (c *Client) PublishSeries(ctx context.Context, req *google_example_library_v1.PublishSeriesRequest) (*google_example_library_v1.PublishSeriesResponse, error) {
@@ -292,8 +278,6 @@ func (c *Client) PublishSeries(ctx context.Context, req *google_example_library_
 }
 
 
-// AUTO-GENERATED DOCUMENTATION AND METHOD -- see instructions at the top of the file for editing.
-
 // GetBook gets a book.
 func (c *Client) GetBook(ctx context.Context, req *google_example_library_v1.GetBookRequest) (*google_example_library_v1.Book, error) {
     ctx = metadata.NewContext(ctx, c.metadata)
@@ -309,8 +293,6 @@ func (c *Client) GetBook(ctx context.Context, req *google_example_library_v1.Get
     return resp, nil
 }
 
-
-// AUTO-GENERATED DOCUMENTATION AND METHOD -- see instructions at the top of the file for editing.
 
 // ListBooks lists books in a shelf.
 func (c *Client) ListBooks(ctx context.Context, req *google_example_library_v1.ListBooksRequest) *BookIterator {
@@ -339,8 +321,6 @@ func (c *Client) ListBooks(ctx context.Context, req *google_example_library_v1.L
 }
 
 
-// AUTO-GENERATED DOCUMENTATION AND METHOD -- see instructions at the top of the file for editing.
-
 // DeleteBook deletes a book.
 func (c *Client) DeleteBook(ctx context.Context, req *google_example_library_v1.DeleteBookRequest) error {
     ctx = metadata.NewContext(ctx, c.metadata)
@@ -352,8 +332,6 @@ func (c *Client) DeleteBook(ctx context.Context, req *google_example_library_v1.
     return err
 }
 
-
-// AUTO-GENERATED DOCUMENTATION AND METHOD -- see instructions at the top of the file for editing.
 
 // UpdateBook updates a book.
 func (c *Client) UpdateBook(ctx context.Context, req *google_example_library_v1.UpdateBookRequest) (*google_example_library_v1.Book, error) {
@@ -371,8 +349,6 @@ func (c *Client) UpdateBook(ctx context.Context, req *google_example_library_v1.
 }
 
 
-// AUTO-GENERATED DOCUMENTATION AND METHOD -- see instructions at the top of the file for editing.
-
 // MoveBook moves a book to another shelf, and returns the new book.
 func (c *Client) MoveBook(ctx context.Context, req *google_example_library_v1.MoveBookRequest) (*google_example_library_v1.Book, error) {
     ctx = metadata.NewContext(ctx, c.metadata)
@@ -388,8 +364,6 @@ func (c *Client) MoveBook(ctx context.Context, req *google_example_library_v1.Mo
     return resp, nil
 }
 
-
-// AUTO-GENERATED DOCUMENTATION AND METHOD -- see instructions at the top of the file for editing.
 
 // ListStrings lists a primitive resource. To test go page streaming.
 func (c *Client) ListStrings(ctx context.Context, req *google_example_library_v1.ListStringsRequest) *StringIterator {
@@ -417,8 +391,6 @@ func (c *Client) ListStrings(ctx context.Context, req *google_example_library_v1
     return it
 }
 
-
-// AUTO-GENERATED DOCUMENTATION AND METHOD -- see instructions at the top of the file for editing.
 
 // AddComments adds comments to a book
 func (c *Client) AddComments(ctx context.Context, req *google_example_library_v1.AddCommentsRequest) error {


### PR DESCRIPTION
They became redundant after the header doc changed.