### PR TITLE
Removing the hiding of page_token as a parameter

### DIFF
--- a/src/main/java/com/google/api/codegen/MethodConfig.java
+++ b/src/main/java/com/google/api/codegen/MethodConfig.java
@@ -142,7 +142,7 @@ public class MethodConfig {
 
     Iterable<Field> optionalFields =
         Iterables.filter(
-            new ServiceMessages().flattenedFields(method.getInputType()),
+            method.getInputType().getMessageType().getFields(),
             new Predicate<Field>() {
               @Override
               public boolean apply(Field input) {

--- a/src/main/java/com/google/api/codegen/ServiceMessages.java
+++ b/src/main/java/com/google/api/codegen/ServiceMessages.java
@@ -14,14 +14,12 @@
  */
 package com.google.api.codegen;
 
-import com.google.api.tools.framework.model.Field;
 import com.google.api.tools.framework.model.Method;
 import com.google.api.tools.framework.model.TypeRef;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import com.google.protobuf.Empty;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -67,22 +65,5 @@ public class ServiceMessages {
         };
 
     return Iterables.filter(methods, isBundling);
-  }
-
-  /**
-   * Returns the list of flattened fields from the given request type, excluding fields related to
-   * page streaming.
-   */
-  public Iterable<Field> flattenedFields(TypeRef requestType) {
-    List<Field> fields = new ArrayList<>();
-    for (Field field : requestType.getMessageType().getFields()) {
-      String simpleName = field.getSimpleName();
-      // TODO: Look this up from the config rather than hard coding it.
-      if (simpleName.equals("page_token")) {
-        continue;
-      }
-      fields.add(field);
-    }
-    return fields;
   }
 }

--- a/src/main/java/com/google/api/codegen/php/PhpGapicContext.java
+++ b/src/main/java/com/google/api/codegen/php/PhpGapicContext.java
@@ -132,8 +132,10 @@ public class PhpGapicContext extends GapicContext implements PhpContext {
    * Returns the PHP representation of a reference to a type.
    */
   public String typeName(TypeRef type) {
-    if (type.isMap() || type.isRepeated()) {
+    if (type.isMap()) {
       return "array";
+    } else if (type.isRepeated()) {
+      return basicTypeName(type) + "[]";
     } else {
       return basicTypeName(type);
     }

--- a/src/main/java/com/google/api/codegen/py/PythonGapicContext.java
+++ b/src/main/java/com/google/api/codegen/py/PythonGapicContext.java
@@ -266,7 +266,7 @@ public class PythonGapicContext extends GapicContext {
 
     // parameter types
     contentBuilder.append("Args:\n");
-    for (Field field : this.messages().flattenedFields(method.getInputType())) {
+    for (Field field : method.getInputType().getMessageType().getFields()) {
       if (config.isPageStreaming()
           && field.equals((config.getPageStreaming().getPageSizeField()))) {
         contentBuilder.append(

--- a/src/main/java/com/google/api/codegen/ruby/RubyGapicContext.java
+++ b/src/main/java/com/google/api/codegen/ruby/RubyGapicContext.java
@@ -176,7 +176,7 @@ public class RubyGapicContext extends GapicContext implements RubyContext {
 
     // Generate parameter types
     StringBuilder paramTypesBuilder = new StringBuilder();
-    for (Field field : this.messages().flattenedFields(method.getInputType())) {
+    for (Field field : method.getInputType().getMessageType().getFields()) {
       if (config.isPageStreaming()
           && field.equals((config.getPageStreaming().getPageSizeField()))) {
         paramTypesBuilder.append(

--- a/src/main/resources/com/google/api/codegen/php/main.snip
+++ b/src/main/resources/com/google/api/codegen/php/main.snip
@@ -48,11 +48,9 @@
      * This class provides the ability to make remote calls to the backing service through method
      * calls that map to API methods. Sample code to get started:
      *
-     * <pre>
-     * <code>
+     * ```
     {@createMethodSampleDoc(service, context.getFirstMethod(service))}
-     * </code>
-     * </pre>
+     * ```
      *
      * Many parameters require resource names to be formatted in a particular way. To assist
      * with these names, this class includes a format method for each type of name, and additionally
@@ -449,9 +447,9 @@
     {@docLinesFromStr(context.getDescription(method))}
      *
      * Sample code:
-     * <pre><code>
+     * ```
     {@createMethodSampleDoc(service, method)}
-     * </code></pre>
+     * ```
     {@requiredArgsDoc(service, method)}
     {@optionalArgsDoc(service, method)}
      * @@param array $callSettings {

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_main_library.baseline
@@ -344,6 +344,12 @@ LibraryServiceApi.prototype.getShelf = function getShelf() {
 /**
  * Lists shelves.
  *
+ * @param {?Object} otherArgs
+ * @param {String} otherArgs.pageToken
+ *   A token identifying a page of results the server should return.
+ *   Typically, this is the value of
+ *   {@link ListShelvesResponse.next_page_token}
+ *   returned from the previous call to `ListShelves` method.
  * @param {?gax.CallOptions} options
  *   Overrides the default settings for this call, e.g, timeout,
  *   retries, etc.
@@ -355,9 +361,11 @@ LibraryServiceApi.prototype.getShelf = function getShelf() {
  */
 LibraryServiceApi.prototype.listShelves = function listShelves() {
   var args = arguejs({
+    'otherArgs': [Object],
     'options': [gax.CallOptions]
   });
   var req = {
+    'page_token': args.otherArgs.pageToken || ''
   };
   var stream = through2.obj();
   Promise.all([this.defaults, this.stub]).then(function(vars) {
@@ -575,6 +583,11 @@ LibraryServiceApi.prototype.getBook = function getBook() {
  *   parameter does not affect the return value. If page streaming is
  *   performed per-page, this determines the maximum number of
  *   resources in a page.
+ * @param {String} otherArgs.pageToken
+ *   A token identifying a page of results the server should return.
+ *   Typically, this is the value of
+ *   {@link ListBooksResponse.next_page_token}.
+ *   returned from the previous call to `ListBooks` method.
  * @param {String} otherArgs.filter
  *   To test python built-in wrapping.
  * @param {?gax.CallOptions} options
@@ -595,6 +608,7 @@ LibraryServiceApi.prototype.listBooks = function listBooks() {
   var req = {
     'name': args.name,
     'page_size': args.otherArgs.pageSize || 0,
+    'page_token': args.otherArgs.pageToken || '',
     'filter': args.otherArgs.filter || ''
   };
   var stream = through2.obj();
@@ -741,6 +755,7 @@ LibraryServiceApi.prototype.moveBook = function moveBook() {
  *   parameter does not affect the return value. If page streaming is
  *   performed per-page, this determines the maximum number of
  *   resources in a page.
+ * @param {String} otherArgs.pageToken
  * @param {?gax.CallOptions} options
  *   Overrides the default settings for this call, e.g, timeout,
  *   retries, etc.
@@ -757,7 +772,8 @@ LibraryServiceApi.prototype.listStrings = function listStrings() {
   });
   var req = {
     'name': args.otherArgs.name || '',
-    'page_size': args.otherArgs.pageSize || 0
+    'page_size': args.otherArgs.pageSize || 0,
+    'page_token': args.otherArgs.pageToken || ''
   };
   var stream = through2.obj();
   Promise.all([this.defaults, this.stub]).then(function(vars) {

--- a/src/test/java/com/google/api/codegen/testdata/php_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php_main_library.baseline
@@ -74,8 +74,7 @@ use google\protobuf\FieldMask;
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods. Sample code to get started:
  *
- * <pre>
- * <code>
+ * ```
  * try {
  *     $libraryServiceApi = new LibraryServiceApi();
  *     $shelf = new Shelf();
@@ -85,8 +84,7 @@ use google\protobuf\FieldMask;
  *         $libraryServiceApi->close();
  *     }
  * }
- * </code>
- * </pre>
+ * ```
  *
  * Many parameters require resource names to be formatted in a particular way. To assist
  * with these names, this class includes a format method for each type of name, and additionally
@@ -370,7 +368,7 @@ class LibraryServiceApi
      * Creates a shelf, and returns the new Shelf.
      *
      * Sample code:
-     * <pre><code>
+     * ```
      * try {
      *     $libraryServiceApi = new LibraryServiceApi();
      *     $shelf = new Shelf();
@@ -380,7 +378,7 @@ class LibraryServiceApi
      *         $libraryServiceApi->close();
      *     }
      * }
-     * </code></pre>
+     * ```
      *
      * @param Shelf $shelf The shelf to create.
      * @param array $optionalArgs {
@@ -421,7 +419,7 @@ class LibraryServiceApi
      * Gets a shelf.
      *
      * Sample code:
-     * <pre><code>
+     * ```
      * try {
      *     $libraryServiceApi = new LibraryServiceApi();
      *     $formattedName = LibraryServiceApi::formatShelfName("[SHELF]");
@@ -431,7 +429,7 @@ class LibraryServiceApi
      *         $libraryServiceApi->close();
      *     }
      * }
-     * </code></pre>
+     * ```
      *
      * @param string $name The name of the shelf to retrieve.
      * @param array $optionalArgs {
@@ -479,7 +477,7 @@ class LibraryServiceApi
      * Lists shelves.
      *
      * Sample code:
-     * <pre><code>
+     * ```
      * try {
      *     $libraryServiceApi = new LibraryServiceApi();
      *
@@ -491,11 +489,14 @@ class LibraryServiceApi
      *         $libraryServiceApi->close();
      *     }
      * }
-     * </code></pre>
+     * ```
      *
      * @param array $optionalArgs {
-     *     Optional. There are no optional parameters for this method yet;
-     *               this $optionalArgs parameter reserves a spot for future ones.
+     *     Optional.
+     *     @var string $pageToken A token identifying a page of results the server should return.
+     *           Typically, this is the value of
+     *           [ListShelvesResponse.next_page_token][google.example.library.v1.ListShelvesResponse.next_page_token]
+     *           returned from the previous call to `ListShelves` method.
      * }
      * @param array $callSettings {
      *    Optional.
@@ -514,6 +515,9 @@ class LibraryServiceApi
     public function listShelves($optionalArgs = [], $callSettings = [])
     {
         $request = new ListShelvesRequest();
+        if (isset($optionalArgs['pageToken'])) {
+            $request->setPageToken($optionalArgs['pageToken']);
+        }
 
         $mergedSettings = $this->defaultCallSettings['listShelves']->merge(
             new CallSettings($callSettings));
@@ -530,7 +534,7 @@ class LibraryServiceApi
      * Deletes a shelf.
      *
      * Sample code:
-     * <pre><code>
+     * ```
      * try {
      *     $libraryServiceApi = new LibraryServiceApi();
      *     $formattedName = LibraryServiceApi::formatShelfName("[SHELF]");
@@ -540,7 +544,7 @@ class LibraryServiceApi
      *         $libraryServiceApi->close();
      *     }
      * }
-     * </code></pre>
+     * ```
      *
      * @param string $name The name of the shelf to delete.
      * @param array $optionalArgs {
@@ -581,7 +585,7 @@ class LibraryServiceApi
      * `other_shelf_name`. Returns the updated shelf.
      *
      * Sample code:
-     * <pre><code>
+     * ```
      * try {
      *     $libraryServiceApi = new LibraryServiceApi();
      *     $formattedName = LibraryServiceApi::formatShelfName("[SHELF]");
@@ -592,7 +596,7 @@ class LibraryServiceApi
      *         $libraryServiceApi->close();
      *     }
      * }
-     * </code></pre>
+     * ```
      *
      * @param string $name The name of the shelf we're adding books to.
      * @param string $otherShelfName The name of the shelf we're removing books from and deleting.
@@ -635,7 +639,7 @@ class LibraryServiceApi
      * Creates a book.
      *
      * Sample code:
-     * <pre><code>
+     * ```
      * try {
      *     $libraryServiceApi = new LibraryServiceApi();
      *     $formattedName = LibraryServiceApi::formatShelfName("[SHELF]");
@@ -646,7 +650,7 @@ class LibraryServiceApi
      *         $libraryServiceApi->close();
      *     }
      * }
-     * </code></pre>
+     * ```
      *
      * @param string $name The name of the shelf in which the book is created.
      * @param Book $book The book to create.
@@ -689,7 +693,7 @@ class LibraryServiceApi
      * Creates a series of books.
      *
      * Sample code:
-     * <pre><code>
+     * ```
      * try {
      *     $libraryServiceApi = new LibraryServiceApi();
      *     $shelf = new Shelf();
@@ -700,10 +704,10 @@ class LibraryServiceApi
      *         $libraryServiceApi->close();
      *     }
      * }
-     * </code></pre>
+     * ```
      *
      * @param Shelf $shelf The shelf in which the series is created.
-     * @param array $books The books to publish in the series.
+     * @param Book[] $books The books to publish in the series.
      * @param array $optionalArgs {
      *     Optional.
      *     @var int $edition The edition of the series
@@ -748,7 +752,7 @@ class LibraryServiceApi
      * Gets a book.
      *
      * Sample code:
-     * <pre><code>
+     * ```
      * try {
      *     $libraryServiceApi = new LibraryServiceApi();
      *     $formattedName = LibraryServiceApi::formatBookName("[SHELF]", "[BOOK]");
@@ -758,7 +762,7 @@ class LibraryServiceApi
      *         $libraryServiceApi->close();
      *     }
      * }
-     * </code></pre>
+     * ```
      *
      * @param string $name The name of the book to retrieve.
      * @param array $optionalArgs {
@@ -799,7 +803,7 @@ class LibraryServiceApi
      * Lists books in a shelf.
      *
      * Sample code:
-     * <pre><code>
+     * ```
      * try {
      *     $libraryServiceApi = new LibraryServiceApi();
      *     $formattedName = LibraryServiceApi::formatShelfName("[SHELF]");
@@ -811,7 +815,7 @@ class LibraryServiceApi
      *         $libraryServiceApi->close();
      *     }
      * }
-     * </code></pre>
+     * ```
      *
      * @param string $name The name of the shelf whose books we'd like to list.
      * @param array $optionalArgs {
@@ -822,6 +826,10 @@ class LibraryServiceApi
      *           parameter does not affect the return value. If page streaming is
      *           performed per-page, this determines the maximum number of
      *           resources in a page.
+     *     @var string $pageToken A token identifying a page of results the server should return.
+     *           Typically, this is the value of
+     *           [ListBooksResponse.next_page_token][google.example.library.v1.ListBooksResponse.next_page_token].
+     *           returned from the previous call to `ListBooks` method.
      *     @var string $filter To test python built-in wrapping.
      * }
      * @param array $callSettings {
@@ -845,6 +853,9 @@ class LibraryServiceApi
         if (isset($optionalArgs['pageSize'])) {
             $request->setPageSize($optionalArgs['pageSize']);
         }
+        if (isset($optionalArgs['pageToken'])) {
+            $request->setPageToken($optionalArgs['pageToken']);
+        }
         if (isset($optionalArgs['filter'])) {
             $request->setFilter($optionalArgs['filter']);
         }
@@ -864,7 +875,7 @@ class LibraryServiceApi
      * Deletes a book.
      *
      * Sample code:
-     * <pre><code>
+     * ```
      * try {
      *     $libraryServiceApi = new LibraryServiceApi();
      *     $formattedName = LibraryServiceApi::formatBookName("[SHELF]", "[BOOK]");
@@ -874,7 +885,7 @@ class LibraryServiceApi
      *         $libraryServiceApi->close();
      *     }
      * }
-     * </code></pre>
+     * ```
      *
      * @param string $name The name of the book to delete.
      * @param array $optionalArgs {
@@ -913,7 +924,7 @@ class LibraryServiceApi
      * Updates a book.
      *
      * Sample code:
-     * <pre><code>
+     * ```
      * try {
      *     $libraryServiceApi = new LibraryServiceApi();
      *     $formattedName = LibraryServiceApi::formatBookName("[SHELF]", "[BOOK]");
@@ -924,7 +935,7 @@ class LibraryServiceApi
      *         $libraryServiceApi->close();
      *     }
      * }
-     * </code></pre>
+     * ```
      *
      * @param string $name The name of the book to update.
      * @param Book $book The book to update with.
@@ -974,7 +985,7 @@ class LibraryServiceApi
      * Moves a book to another shelf, and returns the new book.
      *
      * Sample code:
-     * <pre><code>
+     * ```
      * try {
      *     $libraryServiceApi = new LibraryServiceApi();
      *     $formattedName = LibraryServiceApi::formatBookName("[SHELF]", "[BOOK]");
@@ -985,7 +996,7 @@ class LibraryServiceApi
      *         $libraryServiceApi->close();
      *     }
      * }
-     * </code></pre>
+     * ```
      *
      * @param string $name The name of the book to move.
      * @param string $otherShelfName The name of the destination shelf.
@@ -1028,7 +1039,7 @@ class LibraryServiceApi
      * Lists a primitive resource. To test go page streaming.
      *
      * Sample code:
-     * <pre><code>
+     * ```
      * try {
      *     $libraryServiceApi = new LibraryServiceApi();
      *
@@ -1040,7 +1051,7 @@ class LibraryServiceApi
      *         $libraryServiceApi->close();
      *     }
      * }
-     * </code></pre>
+     * ```
      *
      * @param array $optionalArgs {
      *     Optional.
@@ -1051,6 +1062,7 @@ class LibraryServiceApi
      *           parameter does not affect the return value. If page streaming is
      *           performed per-page, this determines the maximum number of
      *           resources in a page.
+     *     @var string $pageToken
      * }
      * @param array $callSettings {
      *    Optional.
@@ -1075,6 +1087,9 @@ class LibraryServiceApi
         if (isset($optionalArgs['pageSize'])) {
             $request->setPageSize($optionalArgs['pageSize']);
         }
+        if (isset($optionalArgs['pageToken'])) {
+            $request->setPageToken($optionalArgs['pageToken']);
+        }
 
         $mergedSettings = $this->defaultCallSettings['listStrings']->merge(
             new CallSettings($callSettings));
@@ -1091,7 +1106,7 @@ class LibraryServiceApi
      * Adds comments to a book
      *
      * Sample code:
-     * <pre><code>
+     * ```
      * try {
      *     $libraryServiceApi = new LibraryServiceApi();
      *     $formattedName = LibraryServiceApi::formatBookName("[SHELF]", "[BOOK]");
@@ -1105,10 +1120,10 @@ class LibraryServiceApi
      *         $libraryServiceApi->close();
      *     }
      * }
-     * </code></pre>
+     * ```
      *
      * @param string $name
-     * @param array $comments
+     * @param Comment[] $comments
      * @param array $optionalArgs {
      *     Optional. There are no optional parameters for this method yet;
      *               this $optionalArgs parameter reserves a spot for future ones.
@@ -1148,7 +1163,7 @@ class LibraryServiceApi
      * Gets a book from an archive.
      *
      * Sample code:
-     * <pre><code>
+     * ```
      * try {
      *     $libraryServiceApi = new LibraryServiceApi();
      *     $formattedName = LibraryServiceApi::formatArchivedBookName("[ARCHIVE_PATH]", "[BOOK]");
@@ -1158,7 +1173,7 @@ class LibraryServiceApi
      *         $libraryServiceApi->close();
      *     }
      * }
-     * </code></pre>
+     * ```
      *
      * @param string $name The name of the book to retrieve.
      * @param array $optionalArgs {

--- a/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
@@ -387,6 +387,7 @@ class LibraryServiceApi(object):
 
     def list_shelves(
             self,
+            page_token='',
             options=None):
         """
         Lists shelves.
@@ -408,6 +409,10 @@ class LibraryServiceApi(object):
           >>>     pass
 
         Args:
+          page_token (string): A token identifying a page of results the server should return.
+            Typically, this is the value of
+            ``ListShelvesResponse.next_page_token``
+            returned from the previous call to ``ListShelves`` method.
           options (:class:`google.gax.CallOptions`): Overrides the default
             settings for this call, e.g, timeout, retries etc.
 
@@ -420,7 +425,8 @@ class LibraryServiceApi(object):
         Raises:
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
         """
-        request = library_pb2.ListShelvesRequest()
+        request = library_pb2.ListShelvesRequest(
+            page_token=page_token)
         return self._list_shelves(request, options)
 
     def delete_shelf(
@@ -583,6 +589,7 @@ class LibraryServiceApi(object):
             self,
             name,
             page_size=0,
+            page_token='',
             filter_='',
             options=None):
         """
@@ -612,6 +619,10 @@ class LibraryServiceApi(object):
             resource, this parameter does not affect the return value. If page
             streaming is performed per-page, this determines the maximum number
             of resources in a page.
+          page_token (string): A token identifying a page of results the server should return.
+            Typically, this is the value of
+            ``ListBooksResponse.next_page_token``.
+            returned from the previous call to ``ListBooks`` method.
           filter (string): To test python built-in wrapping.
           options (:class:`google.gax.CallOptions`): Overrides the default
             settings for this call, e.g, timeout, retries etc.
@@ -628,6 +639,7 @@ class LibraryServiceApi(object):
         request = library_pb2.ListBooksRequest(
             name=name,
             page_size=page_size,
+            page_token=page_token,
             filter=filter_)
         return self._list_books(request, options)
 
@@ -735,6 +747,7 @@ class LibraryServiceApi(object):
             self,
             name='',
             page_size=0,
+            page_token='',
             options=None):
         """
         Lists a primitive resource. To test go page streaming.
@@ -762,6 +775,7 @@ class LibraryServiceApi(object):
             resource, this parameter does not affect the return value. If page
             streaming is performed per-page, this determines the maximum number
             of resources in a page.
+          page_token (string)
           options (:class:`google.gax.CallOptions`): Overrides the default
             settings for this call, e.g, timeout, retries etc.
 
@@ -776,7 +790,8 @@ class LibraryServiceApi(object):
         """
         request = library_pb2.ListStringsRequest(
             name=name,
-            page_size=page_size)
+            page_size=page_size,
+            page_token=page_token)
         return self._list_strings(request, options)
 
     def add_comments(

--- a/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
@@ -275,6 +275,11 @@ module Google
 
           # Lists shelves.
           #
+          # @param page_token [String]
+          #   A token identifying a page of results the server should return.
+          #   Typically, this is the value of
+          #   ListShelvesResponse#next_page_token
+          #   returned from the previous call to +ListShelves+ method.
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -285,8 +290,10 @@ module Google
           #   object.
           # @raise [Google::Gax::GaxError] if the RPC is aborted.
           def list_shelves(
+            page_token: '',
             options: nil)
-            req = Google::Example::Library::V1::ListShelvesRequest.new
+            req = Google::Example::Library::V1::ListShelvesRequest.new(
+              page_token: page_token)
             settings = @defaults['list_shelves'].merge(options)
             api_call = Google::Gax.create_api_call(
               @stub.method(:list_shelves), settings)
@@ -420,6 +427,11 @@ module Google
           #   parameter does not affect the return value. If page streaming is
           #   performed per-page, this determines the maximum number of
           #   resources in a page.
+          # @param page_token [String]
+          #   A token identifying a page of results the server should return.
+          #   Typically, this is the value of
+          #   ListBooksResponse#next_page_token.
+          #   returned from the previous call to +ListBooks+ method.
           # @param filter [String]
           #   To test python built-in wrapping.
           # @param options [Google::Gax::CallOptions]
@@ -434,11 +446,13 @@ module Google
           def list_books(
             name,
             page_size: 0,
+            page_token: '',
             filter: '',
             options: nil)
             req = Google::Example::Library::V1::ListBooksRequest.new(
               name: name,
               page_size: page_size,
+              page_token: page_token,
               filter: filter)
             settings = @defaults['list_books'].merge(options)
             api_call = Google::Gax.create_api_call(
@@ -530,6 +544,7 @@ module Google
           #   parameter does not affect the return value. If page streaming is
           #   performed per-page, this determines the maximum number of
           #   resources in a page.
+          # @param page_token [String]
           # @param options [Google::Gax::CallOptions]
           #   Overrides the default settings for this call, e.g, timeout,
           #   retries, etc.
@@ -542,10 +557,12 @@ module Google
           def list_strings(
             name: '',
             page_size: 0,
+            page_token: '',
             options: nil)
             req = Google::Example::Library::V1::ListStringsRequest.new(
               name: name,
-              page_size: page_size)
+              page_size: page_size,
+              page_token: page_token)
             settings = @defaults['list_strings'].merge(options)
             api_call = Google::Gax.create_api_call(
               @stub.method(:list_strings), settings)


### PR DESCRIPTION
Also:
* PHP: switching from html tags to three ticks for code blocks
* PHP: Switching repeated types to the type plus brackets

@jmuk @geigerj Please check Python/Ruby/Node and make sure the changes are acceptable. 
