### PR TITLE
Update nodejs codegen.

### DIFF
--- a/src/main/java/com/google/api/codegen/nodejs/NodeJSGapicContext.java
+++ b/src/main/java/com/google/api/codegen/nodejs/NodeJSGapicContext.java
@@ -68,6 +68,13 @@ public class NodeJSGapicContext extends GapicContext implements NodeJSContext {
   }
 
   /**
+   * The package name of the grpc module for the API.
+   */
+  public String grpcClientName(Interface service) {
+    return "grpc-" + service.getParent().getFullName().replace('.', '-');
+  }
+
+  /**
    * Returns type information for a field in JSDoc style.
    */
   private String fieldTypeCardinalityComment(Field field) {

--- a/src/main/java/com/google/api/codegen/nodejs/NodeJSGapicContext.java
+++ b/src/main/java/com/google/api/codegen/nodejs/NodeJSGapicContext.java
@@ -71,7 +71,7 @@ public class NodeJSGapicContext extends GapicContext implements NodeJSContext {
    * The package name of the grpc module for the API.
    */
   public String grpcClientName(Interface service) {
-    return "grpc-" + service.getParent().getFullName().replace('.', '-');
+    return "grpc-" + service.getFile().getFullName().replace('.', '-');
   }
 
   /**

--- a/src/main/resources/com/google/api/codegen/nodejs/main.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/main.snip
@@ -44,10 +44,9 @@
   var fsp = require('fs-promise');
   var gax = require('google-gax');
   var grpc = require('grpc');
+  var grpcClient = require('{@context.grpcClientName(service)}').client;
   var path = require('path');
   var through2 = require('through2');
-
-  var google = grpc.loadObject(require('./service')).google;
 @end
 
 @private serviceClass(service)
@@ -101,9 +100,8 @@
           @let pageStreaming = ifaceConfig.getMethodConfig(method).getPageStreaming(), \
                requestToken = pageStreaming.getRequestTokenField().getSimpleName(), \
                responseToken = pageStreaming.getResponseTokenField().getSimpleName(), \
-               resources = pageStreaming.getResourcesField().getSimpleName(), \
-               methodName = context.upperCamelToLowerCamel(method.getSimpleName)
-              '{@methodName}': new gax.PageDescriptor(
+               resources = pageStreaming.getResourcesField().getSimpleName()
+              '{@methodName(method)}': new gax.PageDescriptor(
                   '{@requestToken}',
                   '{@responseToken}',
                   '{@resources}')
@@ -121,7 +119,6 @@
         '{@auth_scope}'
       @end
     ];
-    exports.ALL_SCOPES = ALL_SCOPES;
   @end
 @end
 
@@ -130,7 +127,7 @@
        jsonBaseName = {@context.upperCamelToLowerUnderscore(service.getSimpleName)}
     var clientConfigFile = path.join(
         __dirname, '{@jsonBaseName}_client_config.json');
-    this.defaults = fsp.readJson(clientConfigFile).then(function(data) {
+    var defaults = fsp.readJson(clientConfigFile).then(function(data) {
       @if context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods)
         return gax.constructSettings(
             '{@service.getFullName}',
@@ -138,14 +135,17 @@
             clientConfig,
             grpc.status,
             timeout,
-            PAGE_DESCRIPTORS);
+            PAGE_DESCRIPTORS,
+            {'metadata': metadata});
       @else
         return gax.constructSettings(
             '{@service.getFullName}',
             data,
             clientConfig,
             grpc.status,
-            timeout);
+            timeout,
+            null,
+            {'metadata': metadata});
       @end
     });
   @end
@@ -191,21 +191,34 @@
       var appName = opts.appName || 'gax';
       var appVersion = opts.appVersion || gax.Version;
 
-      {@constructDefaults(service)}
-
       var googleApiClient = [
         appName + '/' + appVersion,
         CODE_GEN_NAME_VERSION,
         'nodejs/' + process.version].join(' ');
-      this.headers = new grpc.Metadata();
-      this.headers.set('x-goog-api-client', googleApiClient);
+      var metadata = new grpc.Metadata();
+      metadata.set('x-goog-api-client', googleApiClient);
+
+      {@constructDefaults(service)}
+
       this.stub = gax.createStub(
           servicePath,
           port,
-          google.example.library.v1.LibraryService,
+          grpcClient.{@service.getFullName},
           {'getCredentials': getCredentials,
            'sslCreds': sslCreds,
            'scopes': scopes});
+      var methods = [
+        @join method : service.getMethods on {@","}.add(BREAK)
+          '{@methodName(method)}'
+        @end
+      ];
+      methods.forEach(function(methodName) {
+        this['_' + methodName] = Promise.all([defaults, this.stub]).then(function(vars) {
+          var options = vars[0];
+          var stub = vars[1];
+          return gax.createApiCall(stub[methodName].bind(stub), options);
+        }.bind(this));
+      }.bind(this));
     };
     exports.{@serviceName} = {@serviceName};
   @end
@@ -302,9 +315,12 @@
   api_call.call(req, **@@headers)
 @end
 
+@private methodName(method)
+  {@context.upperCamelToLowerCamel(method.getSimpleName())}
+@end
+
 @private flattenedMethod(service, method)
   @let serviceName = context.getApiWrapperName(service), \
-       methodName = context.upperCamelToLowerCamel(method.getSimpleName()), \
        documentation = comments(context.methodComments(method)), \
        methodConfig = context.getApiConfig.getInterfaceConfig(service).getMethodConfig(method), \
        requiredParams = methodConfig.getRequiredFields(), \
@@ -315,13 +331,13 @@
        */
     @end
 
-    {@serviceName}.prototype.{@methodName} = function {@methodName}() {
+    {@serviceName}.prototype.{@methodName(method)} = function {@methodName(method)}() {
       var args = arguejs({
         @if requiredParams
           {@requiredParameterDefs(requiredParams)},
         @end
         @if optionalParams
-          'otherArgs': [Object],
+          'otherArgs': [Object, {}],
         @end
         @if methodConfig.isPageStreaming
           'options': [gax.CallOptions]
@@ -329,7 +345,7 @@
           'options': [gax.CallOptions],
           'callback': [Function]
         @end
-      });
+      }, arguments);
       var req = {
         @if requiredParams
           @if optionalParams
@@ -344,26 +360,18 @@
       };
       @if methodConfig.isPageStreaming
         var stream = through2.obj();
-        Promise.all([this.defaults, this.stub]).then(function(vars) {
-          var defaults = vars[0];
-          var stub = vars[1];
-          var options = defaults.{@methodName}.merge(args.options);
-          var apiCall = gax.createApiCall(stub.{@methodName}.bind(stub), options);
-          var result = apiCall(req, args.callback, this.headers, {});
+        this._{@methodName(method)}.then(function(apiCall) {
+          var result = apiCall(req, args.options);
           result.pipe(stream);
           stream.on('end', function() { result.end(); });
-        }.bind(this))['catch'](function(err) {
+        })['catch'](function(err) {
           stream.emit('error', err);
         });
         return stream;
       @else
-        Promise.all([this.defaults, this.stub]).then(function(vars) {
-          var defaults = vars[0];
-          var stub = vars[1];
-          var options = defaults.{@methodName}.merge(args.options);
-          var apiCall = gax.createApiCall(stub.{@methodName}.bind(stub), options);
-          apiCall(req, args.callback, this.headers, {});
-        }.bind(this))['catch'](function(err) {
+        this._{@methodName(method)}.then(function(apiCall) {
+          apiCall(req, args.options, args.callback);
+        })['catch'](function(err) {
           if (args.callback) {
             args.callback(err);
           }

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_main_library.baseline
@@ -30,10 +30,9 @@ var arguejs = require('arguejs');
 var fsp = require('fs-promise');
 var gax = require('google-gax');
 var grpc = require('grpc');
+var grpcClient = require('grpc-google-example-library-v1').client;
 var path = require('path');
 var through2 = require('through2');
-
-var google = grpc.loadObject(require('./service')).google;
 
 /** The default address of the service. */
 var SERVICE_ADDRESS = 'library-example.googleapis.com';
@@ -68,7 +67,6 @@ var ALL_SCOPES = [
   'https://www.googleapis.com/auth/library',
   'https://www.googleapis.com/auth/cloud-platform'
 ];
-exports.ALL_SCOPES = ALL_SCOPES;
 
 /**
  * This API represents a simple digital library.  It lets you manage Shelf
@@ -116,31 +114,57 @@ function LibraryServiceApi(opts) {
   var appName = opts.appName || 'gax';
   var appVersion = opts.appVersion || gax.Version;
 
+  var googleApiClient = [
+    appName + '/' + appVersion,
+    CODE_GEN_NAME_VERSION,
+    'nodejs/' + process.version].join(' ');
+  var metadata = new grpc.Metadata();
+  metadata.set('x-goog-api-client', googleApiClient);
+
   var clientConfigFile = path.join(
       __dirname, 'library_service_client_config.json');
-  this.defaults = fsp.readJson(clientConfigFile).then(function(data) {
+  var defaults = fsp.readJson(clientConfigFile).then(function(data) {
     return gax.constructSettings(
         'google.example.library.v1.LibraryService',
         data,
         clientConfig,
         grpc.status,
         timeout,
-        PAGE_DESCRIPTORS);
+        PAGE_DESCRIPTORS,
+        {'metadata': metadata});
   });
 
-  var googleApiClient = [
-    appName + '/' + appVersion,
-    CODE_GEN_NAME_VERSION,
-    'nodejs/' + process.version].join(' ');
-  this.headers = new grpc.Metadata();
-  this.headers.set('x-goog-api-client', googleApiClient);
   this.stub = gax.createStub(
       servicePath,
       port,
-      google.example.library.v1.LibraryService,
+      grpcClient.google.example.library.v1.LibraryService,
       {'getCredentials': getCredentials,
        'sslCreds': sslCreds,
        'scopes': scopes});
+  var methods = [
+    'createShelf',
+    'getShelf',
+    'listShelves',
+    'deleteShelf',
+    'mergeShelves',
+    'createBook',
+    'publishSeries',
+    'getBook',
+    'listBooks',
+    'deleteBook',
+    'updateBook',
+    'moveBook',
+    'listStrings',
+    'addComments',
+    'getBookFromArchive'
+  ];
+  methods.forEach(function(methodName) {
+    this['_' + methodName] = Promise.all([defaults, this.stub]).then(function(vars) {
+      var options = vars[0];
+      var stub = vars[1];
+      return gax.createApiCall(stub[methodName].bind(stub), options);
+    }.bind(this));
+  }.bind(this));
 };
 exports.LibraryServiceApi = LibraryServiceApi;
 
@@ -283,17 +307,13 @@ LibraryServiceApi.prototype.createShelf = function createShelf() {
     'shelf': Object,
     'options': [gax.CallOptions],
     'callback': [Function]
-  });
+  }, arguments);
   var req = {
     'shelf': args.shelf
   };
-  Promise.all([this.defaults, this.stub]).then(function(vars) {
-    var defaults = vars[0];
-    var stub = vars[1];
-    var options = defaults.createShelf.merge(args.options);
-    var apiCall = gax.createApiCall(stub.createShelf.bind(stub), options);
-    apiCall(req, args.callback, this.headers, {});
-  }.bind(this))['catch'](function(err) {
+  this._createShelf.then(function(apiCall) {
+    apiCall(req, args.options, args.callback);
+  })['catch'](function(err) {
     if (args.callback) {
       args.callback(err);
     }
@@ -319,22 +339,18 @@ LibraryServiceApi.prototype.createShelf = function createShelf() {
 LibraryServiceApi.prototype.getShelf = function getShelf() {
   var args = arguejs({
     'name': String,
-    'otherArgs': [Object],
+    'otherArgs': [Object, {}],
     'options': [gax.CallOptions],
     'callback': [Function]
-  });
+  }, arguments);
   var req = {
     'name': args.name,
     'message': args.otherArgs.message || {},
     'string_builder': args.otherArgs.stringBuilder || {}
   };
-  Promise.all([this.defaults, this.stub]).then(function(vars) {
-    var defaults = vars[0];
-    var stub = vars[1];
-    var options = defaults.getShelf.merge(args.options);
-    var apiCall = gax.createApiCall(stub.getShelf.bind(stub), options);
-    apiCall(req, args.callback, this.headers, {});
-  }.bind(this))['catch'](function(err) {
+  this._getShelf.then(function(apiCall) {
+    apiCall(req, args.options, args.callback);
+  })['catch'](function(err) {
     if (args.callback) {
       args.callback(err);
     }
@@ -356,19 +372,15 @@ LibraryServiceApi.prototype.getShelf = function getShelf() {
 LibraryServiceApi.prototype.listShelves = function listShelves() {
   var args = arguejs({
     'options': [gax.CallOptions]
-  });
+  }, arguments);
   var req = {
   };
   var stream = through2.obj();
-  Promise.all([this.defaults, this.stub]).then(function(vars) {
-    var defaults = vars[0];
-    var stub = vars[1];
-    var options = defaults.listShelves.merge(args.options);
-    var apiCall = gax.createApiCall(stub.listShelves.bind(stub), options);
-    var result = apiCall(req, args.callback, this.headers, {});
+  this._listShelves.then(function(apiCall) {
+    var result = apiCall(req, args.options);
     result.pipe(stream);
     stream.on('end', function() { result.end(); });
-  }.bind(this))['catch'](function(err) {
+  })['catch'](function(err) {
     stream.emit('error', err);
   });
   return stream;
@@ -391,17 +403,13 @@ LibraryServiceApi.prototype.deleteShelf = function deleteShelf() {
     'name': String,
     'options': [gax.CallOptions],
     'callback': [Function]
-  });
+  }, arguments);
   var req = {
     'name': args.name
   };
-  Promise.all([this.defaults, this.stub]).then(function(vars) {
-    var defaults = vars[0];
-    var stub = vars[1];
-    var options = defaults.deleteShelf.merge(args.options);
-    var apiCall = gax.createApiCall(stub.deleteShelf.bind(stub), options);
-    apiCall(req, args.callback, this.headers, {});
-  }.bind(this))['catch'](function(err) {
+  this._deleteShelf.then(function(apiCall) {
+    apiCall(req, args.options, args.callback);
+  })['catch'](function(err) {
     if (args.callback) {
       args.callback(err);
     }
@@ -430,18 +438,14 @@ LibraryServiceApi.prototype.mergeShelves = function mergeShelves() {
     'otherShelfName': String,
     'options': [gax.CallOptions],
     'callback': [Function]
-  });
+  }, arguments);
   var req = {
     'name': args.name,
     'other_shelf_name': args.otherShelfName
   };
-  Promise.all([this.defaults, this.stub]).then(function(vars) {
-    var defaults = vars[0];
-    var stub = vars[1];
-    var options = defaults.mergeShelves.merge(args.options);
-    var apiCall = gax.createApiCall(stub.mergeShelves.bind(stub), options);
-    apiCall(req, args.callback, this.headers, {});
-  }.bind(this))['catch'](function(err) {
+  this._mergeShelves.then(function(apiCall) {
+    apiCall(req, args.options, args.callback);
+  })['catch'](function(err) {
     if (args.callback) {
       args.callback(err);
     }
@@ -468,18 +472,14 @@ LibraryServiceApi.prototype.createBook = function createBook() {
     'book': Object,
     'options': [gax.CallOptions],
     'callback': [Function]
-  });
+  }, arguments);
   var req = {
     'name': args.name,
     'book': args.book
   };
-  Promise.all([this.defaults, this.stub]).then(function(vars) {
-    var defaults = vars[0];
-    var stub = vars[1];
-    var options = defaults.createBook.merge(args.options);
-    var apiCall = gax.createApiCall(stub.createBook.bind(stub), options);
-    apiCall(req, args.callback, this.headers, {});
-  }.bind(this))['catch'](function(err) {
+  this._createBook.then(function(apiCall) {
+    apiCall(req, args.options, args.callback);
+  })['catch'](function(err) {
     if (args.callback) {
       args.callback(err);
     }
@@ -507,22 +507,18 @@ LibraryServiceApi.prototype.publishSeries = function publishSeries() {
   var args = arguejs({
     'shelf': Object,
     'books': Array,
-    'otherArgs': [Object],
+    'otherArgs': [Object, {}],
     'options': [gax.CallOptions],
     'callback': [Function]
-  });
+  }, arguments);
   var req = {
     'shelf': args.shelf,
     'books': args.books,
     'edition': args.otherArgs.edition || 0
   };
-  Promise.all([this.defaults, this.stub]).then(function(vars) {
-    var defaults = vars[0];
-    var stub = vars[1];
-    var options = defaults.publishSeries.merge(args.options);
-    var apiCall = gax.createApiCall(stub.publishSeries.bind(stub), options);
-    apiCall(req, args.callback, this.headers, {});
-  }.bind(this))['catch'](function(err) {
+  this._publishSeries.then(function(apiCall) {
+    apiCall(req, args.options, args.callback);
+  })['catch'](function(err) {
     if (args.callback) {
       args.callback(err);
     }
@@ -546,17 +542,13 @@ LibraryServiceApi.prototype.getBook = function getBook() {
     'name': String,
     'options': [gax.CallOptions],
     'callback': [Function]
-  });
+  }, arguments);
   var req = {
     'name': args.name
   };
-  Promise.all([this.defaults, this.stub]).then(function(vars) {
-    var defaults = vars[0];
-    var stub = vars[1];
-    var options = defaults.getBook.merge(args.options);
-    var apiCall = gax.createApiCall(stub.getBook.bind(stub), options);
-    apiCall(req, args.callback, this.headers, {});
-  }.bind(this))['catch'](function(err) {
+  this._getBook.then(function(apiCall) {
+    apiCall(req, args.options, args.callback);
+  })['catch'](function(err) {
     if (args.callback) {
       args.callback(err);
     }
@@ -589,24 +581,20 @@ LibraryServiceApi.prototype.getBook = function getBook() {
 LibraryServiceApi.prototype.listBooks = function listBooks() {
   var args = arguejs({
     'name': String,
-    'otherArgs': [Object],
+    'otherArgs': [Object, {}],
     'options': [gax.CallOptions]
-  });
+  }, arguments);
   var req = {
     'name': args.name,
     'page_size': args.otherArgs.pageSize || 0,
     'filter': args.otherArgs.filter || ''
   };
   var stream = through2.obj();
-  Promise.all([this.defaults, this.stub]).then(function(vars) {
-    var defaults = vars[0];
-    var stub = vars[1];
-    var options = defaults.listBooks.merge(args.options);
-    var apiCall = gax.createApiCall(stub.listBooks.bind(stub), options);
-    var result = apiCall(req, args.callback, this.headers, {});
+  this._listBooks.then(function(apiCall) {
+    var result = apiCall(req, args.options);
     result.pipe(stream);
     stream.on('end', function() { result.end(); });
-  }.bind(this))['catch'](function(err) {
+  })['catch'](function(err) {
     stream.emit('error', err);
   });
   return stream;
@@ -629,17 +617,13 @@ LibraryServiceApi.prototype.deleteBook = function deleteBook() {
     'name': String,
     'options': [gax.CallOptions],
     'callback': [Function]
-  });
+  }, arguments);
   var req = {
     'name': args.name
   };
-  Promise.all([this.defaults, this.stub]).then(function(vars) {
-    var defaults = vars[0];
-    var stub = vars[1];
-    var options = defaults.deleteBook.merge(args.options);
-    var apiCall = gax.createApiCall(stub.deleteBook.bind(stub), options);
-    apiCall(req, args.callback, this.headers, {});
-  }.bind(this))['catch'](function(err) {
+  this._deleteBook.then(function(apiCall) {
+    apiCall(req, args.options, args.callback);
+  })['catch'](function(err) {
     if (args.callback) {
       args.callback(err);
     }
@@ -669,23 +653,19 @@ LibraryServiceApi.prototype.updateBook = function updateBook() {
   var args = arguejs({
     'name': String,
     'book': Object,
-    'otherArgs': [Object],
+    'otherArgs': [Object, {}],
     'options': [gax.CallOptions],
     'callback': [Function]
-  });
+  }, arguments);
   var req = {
     'name': args.name,
     'book': args.book,
     'update_mask': args.otherArgs.updateMask || {},
     'physical_mask': args.otherArgs.physicalMask || {}
   };
-  Promise.all([this.defaults, this.stub]).then(function(vars) {
-    var defaults = vars[0];
-    var stub = vars[1];
-    var options = defaults.updateBook.merge(args.options);
-    var apiCall = gax.createApiCall(stub.updateBook.bind(stub), options);
-    apiCall(req, args.callback, this.headers, {});
-  }.bind(this))['catch'](function(err) {
+  this._updateBook.then(function(apiCall) {
+    apiCall(req, args.options, args.callback);
+  })['catch'](function(err) {
     if (args.callback) {
       args.callback(err);
     }
@@ -712,18 +692,14 @@ LibraryServiceApi.prototype.moveBook = function moveBook() {
     'otherShelfName': String,
     'options': [gax.CallOptions],
     'callback': [Function]
-  });
+  }, arguments);
   var req = {
     'name': args.name,
     'other_shelf_name': args.otherShelfName
   };
-  Promise.all([this.defaults, this.stub]).then(function(vars) {
-    var defaults = vars[0];
-    var stub = vars[1];
-    var options = defaults.moveBook.merge(args.options);
-    var apiCall = gax.createApiCall(stub.moveBook.bind(stub), options);
-    apiCall(req, args.callback, this.headers, {});
-  }.bind(this))['catch'](function(err) {
+  this._moveBook.then(function(apiCall) {
+    apiCall(req, args.options, args.callback);
+  })['catch'](function(err) {
     if (args.callback) {
       args.callback(err);
     }
@@ -752,23 +728,19 @@ LibraryServiceApi.prototype.moveBook = function moveBook() {
  */
 LibraryServiceApi.prototype.listStrings = function listStrings() {
   var args = arguejs({
-    'otherArgs': [Object],
+    'otherArgs': [Object, {}],
     'options': [gax.CallOptions]
-  });
+  }, arguments);
   var req = {
     'name': args.otherArgs.name || '',
     'page_size': args.otherArgs.pageSize || 0
   };
   var stream = through2.obj();
-  Promise.all([this.defaults, this.stub]).then(function(vars) {
-    var defaults = vars[0];
-    var stub = vars[1];
-    var options = defaults.listStrings.merge(args.options);
-    var apiCall = gax.createApiCall(stub.listStrings.bind(stub), options);
-    var result = apiCall(req, args.callback, this.headers, {});
+  this._listStrings.then(function(apiCall) {
+    var result = apiCall(req, args.options);
     result.pipe(stream);
     stream.on('end', function() { result.end(); });
-  }.bind(this))['catch'](function(err) {
+  })['catch'](function(err) {
     stream.emit('error', err);
   });
   return stream;
@@ -792,18 +764,14 @@ LibraryServiceApi.prototype.addComments = function addComments() {
     'comments': Array,
     'options': [gax.CallOptions],
     'callback': [Function]
-  });
+  }, arguments);
   var req = {
     'name': args.name,
     'comments': args.comments
   };
-  Promise.all([this.defaults, this.stub]).then(function(vars) {
-    var defaults = vars[0];
-    var stub = vars[1];
-    var options = defaults.addComments.merge(args.options);
-    var apiCall = gax.createApiCall(stub.addComments.bind(stub), options);
-    apiCall(req, args.callback, this.headers, {});
-  }.bind(this))['catch'](function(err) {
+  this._addComments.then(function(apiCall) {
+    apiCall(req, args.options, args.callback);
+  })['catch'](function(err) {
     if (args.callback) {
       args.callback(err);
     }
@@ -827,17 +795,13 @@ LibraryServiceApi.prototype.getBookFromArchive = function getBookFromArchive() {
     'name': String,
     'options': [gax.CallOptions],
     'callback': [Function]
-  });
+  }, arguments);
   var req = {
     'name': args.name
   };
-  Promise.all([this.defaults, this.stub]).then(function(vars) {
-    var defaults = vars[0];
-    var stub = vars[1];
-    var options = defaults.getBookFromArchive.merge(args.options);
-    var apiCall = gax.createApiCall(stub.getBookFromArchive.bind(stub), options);
-    apiCall(req, args.callback, this.headers, {});
-  }.bind(this))['catch'](function(err) {
+  this._getBookFromArchive.then(function(apiCall) {
+    apiCall(req, args.options, args.callback);
+  })['catch'](function(err) {
     if (args.callback) {
       args.callback(err);
     }


### PR DESCRIPTION
- supports the new ApiCallable structure
- adds 'arguments' at the end of arguejs -- that's necessary
  in the strict mode.
- adds default value for otherArgs, otherwise it fails when missing values.
- modifies the module structure bit -- this will depend on the
  grpc client package. The same package structure as python/ruby has.