### PR TITLE
Make default string more informative

### DIFF
--- a/src/main/java/com/google/api/codegen/DiscoveryContext.java
+++ b/src/main/java/com/google/api/codegen/DiscoveryContext.java
@@ -210,10 +210,13 @@ public abstract class DiscoveryContext extends CodegenContext {
       }
     }
     String stringPattern = getApiaryConfig().getFieldPattern().get(type.getName(), field.getName());
-    return lineEnding(
-        stringLiteral(
-            Strings.nullToEmpty(
-                DefaultString.of(getApi().getName(), field.getName(), stringPattern))));
+    DefaultString defString = DefaultString.of(getApi().getName(), field.getName(), stringPattern);
+
+    String line = stringLiteral(defString.getDeclare());
+    if (defString.getComment() != null) {
+      line = lineComment(line, "eg. " + stringLiteral(defString.getComment()));
+    }
+    return lineEnding(line);
   }
 
   // Line wrap `str`, returning a list of lines. Each line in the returned list is guaranteed to not

--- a/src/main/java/com/google/api/codegen/DiscoveryContext.java
+++ b/src/main/java/com/google/api/codegen/DiscoveryContext.java
@@ -210,7 +210,10 @@ public abstract class DiscoveryContext extends CodegenContext {
       }
     }
     String stringPattern = getApiaryConfig().getFieldPattern().get(type.getName(), field.getName());
-    return lineEnding(stringLiteral(Strings.nullToEmpty(DefaultString.forPattern(stringPattern))));
+    return lineEnding(
+        stringLiteral(
+            Strings.nullToEmpty(
+                DefaultString.of(getApi().getName(), field.getName(), stringPattern))));
   }
 
   // Line wrap `str`, returning a list of lines. Each line in the returned list is guaranteed to not

--- a/src/main/java/com/google/api/codegen/LanguageUtil.java
+++ b/src/main/java/com/google/api/codegen/LanguageUtil.java
@@ -70,4 +70,8 @@ public class LanguageUtil {
   public static String lowerCamelToLowerUnderscore(String name) {
     return CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, name);
   }
+
+  public static String lowerCamelToUpperUnderscore(String name) {
+    return CaseFormat.LOWER_CAMEL.to(CaseFormat.UPPER_UNDERSCORE, name);
+  }
 }

--- a/src/main/java/com/google/api/codegen/discovery/DefaultString.java
+++ b/src/main/java/com/google/api/codegen/discovery/DefaultString.java
@@ -103,13 +103,10 @@ public class DefaultString {
    */
   @VisibleForTesting
   static String forPattern(String pattern) {
-    // We only care about patterns that has alternating literal and wildcard like
+    // We only care about patterns that have alternating literal and wildcard like
     //  ^foo/[^/]*/bar/[^/]*$
     // Ignore if what we get looks nothing like this.
-    if (pattern == null
-        || !pattern.startsWith("^")
-        || !pattern.endsWith("$")
-        || substrCount(pattern, "/") != substrCount(pattern, WILDCARD_PATTERN) * 3 - 1) {
+    if (pattern == null || !pattern.startsWith("^") || !pattern.endsWith("$")) {
       return null;
     }
     pattern = pattern.substring(1, pattern.length() - 1);
@@ -128,22 +125,6 @@ public class DefaultString {
           .append('}');
     }
     return ret.substring(1);
-  }
-
-  /**
-   * Counts the number of non-overlapping instances of `needle` in `haystack`.
-   */
-  private static int substrCount(String haystack, String needle) {
-    int count = 0;
-    int fromIndex = 0;
-    for (; ; ) {
-      int index = haystack.indexOf(needle, fromIndex);
-      if (index < 0) {
-        return count;
-      }
-      fromIndex = index + needle.length();
-      count++;
-    }
   }
 
   /**

--- a/src/main/resources/com/google/api/codegen/go/discovery_fragment.snip
+++ b/src/main/resources/com/google/api/codegen/go/discovery_fragment.snip
@@ -32,7 +32,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  # TODO(pongad): Every API except autoscaler has the string as API.CloudPlatformScope, find out why
   hc, err := google.DefaultClient(ctx{@scopeArg(method)})
   if err != nil {
     // {@TODO()} Handle error.
@@ -73,7 +72,6 @@ func main() {
       }
     @end
   @else
-    # TODO(pongad): generate a better name for "resp"
     resp, err := {@methodPath(method)}({@callArg(method)}).Context(ctx).Do()
     if err != nil {
       // {@TODO()} Handle error.
@@ -119,7 +117,8 @@ func main() {
         paramValue = context.typeDefaultValue(signatureType, paramField), \
         paramDescription = context.getApiaryConfig.getDescription(signatureType.getName, param)
       {@description(paramDescription)}
-      {@unclashVar(param)} := {@paramValue} // {@TODO()} Update placeholder value.
+      // {@TODO()} Update placeholder value.
+      {@unclashVar(param)} := {@paramValue}
     @end
   @end
 @end

--- a/src/test/java/com/google/api/codegen/discovery/DefaultStringTest.java
+++ b/src/test/java/com/google/api/codegen/discovery/DefaultStringTest.java
@@ -23,6 +23,21 @@ import java.util.Map;
 
 public class DefaultStringTest {
   @Test
+  public void testOf() {
+    DefaultString def = DefaultString.of("compute", "zone", "[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?");
+    Truth.assertThat(def.getDeclare()).isEqualTo("{MY-ZONE}");
+    Truth.assertThat(def.getComment()).isEqualTo("us-central1-f");
+
+    def = DefaultString.of("pubsub", "project", "^projects/[^/]*$");
+    Truth.assertThat(def.getDeclare()).isEqualTo("projects/{MY-PROJECT}");
+    Truth.assertThat(def.getComment()).isNull();
+
+    def = DefaultString.of("foo", "bar", null);
+    Truth.assertThat(def.getDeclare()).isEqualTo("{MY-BAR}");
+    Truth.assertThat(def.getComment()).isNull();
+  }
+
+  @Test
   public void testInvalidPattern() {
     String[] invalid =
         new String[] {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_adexchangebuyer.v1.4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_adexchangebuyer.v1.4.json.baseline
@@ -571,7 +571,7 @@ namespace AdExchangeBuyerSample
             int accountId = 0;
 
             // The buyer-specific id for this creative.
-            string buyerCreativeId = "";
+            string buyerCreativeId = "{MY-BUYER-CREATIVE-ID}";
 
             // The id of the deal id to associate with this creative.
             long dealId = 0L;
@@ -812,7 +812,7 @@ namespace AdExchangeBuyerSample
             int accountId = 0;
 
             // The buyer-specific id for this creative.
-            string buyerCreativeId = "";
+            string buyerCreativeId = "{MY-BUYER-CREATIVE-ID}";
 
             // The id of the deal id to disassociate with this creative.
             long dealId = 0L;
@@ -1290,7 +1290,7 @@ namespace AdExchangeBuyerSample
             long accountId = 0L;
 
             // The end time of the report in ISO 8601 timestamp format using UTC.
-            string endDateTime = "";
+            string endDateTime = "{MY-END-DATE-TIME}";
 
             // The start time of the report in ISO 8601 timestamp format using UTC.
             string startDateTime = "{MY-START-DATE-TIME}";
@@ -1932,7 +1932,7 @@ namespace AdExchangeBuyerSample
             // TODO: Change placeholders below to values for parameters to the Patch() method:
 
             // The proposal id to update.
-            string proposalId = "";
+            string proposalId = "{MY-PROPOSAL-ID}";
 
             // The last known revision number to update. If the head revision in the marketplace database has since
             // changed, an error will be thrown. The caller should then fetch the latest proposal at head revision
@@ -2107,7 +2107,7 @@ namespace AdExchangeBuyerSample
             // TODO: Change placeholders below to values for parameters to the Update() method:
 
             // The proposal id to update.
-            string proposalId = "";
+            string proposalId = "{MY-PROPOSAL-ID}";
 
             // The last known revision number to update. If the head revision in the marketplace database has since
             // changed, an error will be thrown. The caller should then fetch the latest proposal at head revision

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_adexchangebuyer.v1.4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_adexchangebuyer.v1.4.json.baseline
@@ -634,7 +634,7 @@ namespace AdExchangeBuyerSample
             int accountId = 0;
 
             // The buyer-specific id for this creative.
-            string buyerCreativeId = "";
+            string buyerCreativeId = "{MY-BUYER-CREATIVE-ID}";
 
             CreativesResource.GetRequest request = adExchangeBuyerService.Creatives.Get(accountId, buyerCreativeId);
             Data.Creative response = request.Execute();
@@ -872,7 +872,7 @@ namespace AdExchangeBuyerSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // The proposalId to delete deals from.
-            string proposalId = "";
+            string proposalId = "{MY-PROPOSAL-ID}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.DeleteOrderDealsRequest content = new Data.DeleteOrderDealsRequest();
@@ -932,7 +932,7 @@ namespace AdExchangeBuyerSample
             // TODO: Change placeholders below to values for parameters to the Insert() method:
 
             // proposalId for which deals need to be added.
-            string proposalId = "";
+            string proposalId = "{MY-PROPOSAL-ID}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.AddOrderDealsRequest content = new Data.AddOrderDealsRequest();
@@ -993,7 +993,7 @@ namespace AdExchangeBuyerSample
 
             // The proposalId to get deals for. To search across proposals specify order_id = '-' as part of the
             // URL.
-            string proposalId = "";
+            string proposalId = "{MY-PROPOSAL-ID}";
 
             MarketplacedealsResource.ListRequest request = adExchangeBuyerService.Marketplacedeals.List(proposalId);
             Data.GetOrderDealsResponse response = request.Execute();
@@ -1050,7 +1050,7 @@ namespace AdExchangeBuyerSample
             // TODO: Change placeholders below to values for parameters to the Update() method:
 
             // The proposalId to edit deals on.
-            string proposalId = "";
+            string proposalId = "{MY-PROPOSAL-ID}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.EditAllOrderDealsRequest content = new Data.EditAllOrderDealsRequest();
@@ -1110,7 +1110,7 @@ namespace AdExchangeBuyerSample
             // TODO: Change placeholders below to values for parameters to the Insert() method:
 
             // The proposalId to add notes for.
-            string proposalId = "";
+            string proposalId = "{MY-PROPOSAL-ID}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.AddOrderNotesRequest content = new Data.AddOrderNotesRequest();
@@ -1170,7 +1170,7 @@ namespace AdExchangeBuyerSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // The proposalId to get notes for.
-            string proposalId = "";
+            string proposalId = "{MY-PROPOSAL-ID}";
 
             MarketplacenotesResource.ListRequest request = adExchangeBuyerService.Marketplacenotes.List(proposalId);
             Data.GetOrderNotesResponse response = request.Execute();
@@ -1227,7 +1227,7 @@ namespace AdExchangeBuyerSample
             // TODO: Change placeholders below to values for parameters to the Updateproposal() method:
 
             // The private auction id to be updated.
-            string privateAuctionId = "";
+            string privateAuctionId = "{MY-PRIVATE-AUCTION-ID}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.UpdatePrivateAuctionProposalRequest content = new Data.UpdatePrivateAuctionProposalRequest();
@@ -1293,7 +1293,7 @@ namespace AdExchangeBuyerSample
             string endDateTime = "";
 
             // The start time of the report in ISO 8601 timestamp format using UTC.
-            string startDateTime = "";
+            string startDateTime = "{MY-START-DATE-TIME}";
 
             PerformanceReportResource.ListRequest request = adExchangeBuyerService.PerformanceReport.List(accountId, endDateTime, startDateTime);
             Data.PerformanceReportList response = request.Execute();
@@ -1711,7 +1711,7 @@ namespace AdExchangeBuyerSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // The id for the product to get the head revision for.
-            string productId = "";
+            string productId = "{MY-PRODUCT-ID}";
 
             ProductsResource.GetRequest request = adExchangeBuyerService.Products.Get(productId);
             Data.Product response = request.Execute();
@@ -1820,7 +1820,7 @@ namespace AdExchangeBuyerSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Id of the proposal to retrieve.
-            string proposalId = "";
+            string proposalId = "{MY-PROPOSAL-ID}";
 
             ProposalsResource.GetRequest request = adExchangeBuyerService.Proposals.Get(proposalId);
             Data.Proposal response = request.Execute();
@@ -2050,7 +2050,7 @@ namespace AdExchangeBuyerSample
             // TODO: Change placeholders below to values for parameters to the Setupcomplete() method:
 
             // The proposal id for which the setup is complete
-            string proposalId = "";
+            string proposalId = "{MY-PROPOSAL-ID}";
 
             ProposalsResource.SetupcompleteRequest request = adExchangeBuyerService.Proposals.Setupcomplete(proposalId);
             request.Execute();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_appengine.v1beta5.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_appengine.v1beta5.json.baseline
@@ -46,7 +46,7 @@ namespace AppengineSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Part of `name`. Name of the application to get. For example: "apps/myapp".
-            string appsId = "";
+            string appsId = "{MY-APPS-ID}";
 
             AppsResource.GetRequest request = appengineService.Apps.Get(appsId);
             Data.Application response = request.Execute();
@@ -106,7 +106,7 @@ namespace AppengineSample
             string appsId = "";
 
             // Part of `name`. See documentation of `appsId`.
-            string operationsId = "";
+            string operationsId = "{MY-OPERATIONS-ID}";
 
             AppsResource.OperationsResource.GetRequest request = appengineService.Apps.Operations.Get(appsId, operationsId);
             Data.Operation response = request.Execute();
@@ -163,7 +163,7 @@ namespace AppengineSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Part of `name`. The name of the operation collection.
-            string appsId = "";
+            string appsId = "{MY-APPS-ID}";
 
             AppsResource.OperationsResource.ListRequest request = appengineService.Apps.Operations.List(appsId);
             Data.ListOperationsResponse response;
@@ -236,7 +236,7 @@ namespace AppengineSample
             string appsId = "";
 
             // Part of `name`. See documentation of `appsId`.
-            string servicesId = "";
+            string servicesId = "{MY-SERVICES-ID}";
 
             AppsResource.ServicesResource.DeleteRequest request = appengineService.Apps.Services.Delete(appsId, servicesId);
             Data.Operation response = request.Execute();
@@ -296,7 +296,7 @@ namespace AppengineSample
             string appsId = "";
 
             // Part of `name`. See documentation of `appsId`.
-            string servicesId = "";
+            string servicesId = "{MY-SERVICES-ID}";
 
             AppsResource.ServicesResource.GetRequest request = appengineService.Apps.Services.Get(appsId, servicesId);
             Data.Service response = request.Execute();
@@ -353,7 +353,7 @@ namespace AppengineSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Part of `name`. Name of the resource requested. For example: "apps/myapp".
-            string appsId = "";
+            string appsId = "{MY-APPS-ID}";
 
             AppsResource.ServicesResource.ListRequest request = appengineService.Apps.Services.List(appsId);
             Data.ListServicesResponse response;
@@ -426,7 +426,7 @@ namespace AppengineSample
             string appsId = "";
 
             // Part of `name`. See documentation of `appsId`.
-            string servicesId = "";
+            string servicesId = "{MY-SERVICES-ID}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Service content = new Data.Service();
@@ -489,7 +489,7 @@ namespace AppengineSample
             string appsId = "";
 
             // Part of `name`. See documentation of `appsId`.
-            string servicesId = "";
+            string servicesId = "{MY-SERVICES-ID}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Version content = new Data.Version();
@@ -556,7 +556,7 @@ namespace AppengineSample
             string servicesId = "";
 
             // Part of `name`. See documentation of `appsId`.
-            string versionsId = "";
+            string versionsId = "{MY-VERSIONS-ID}";
 
             AppsResource.ServicesResource.VersionsResource.DeleteRequest request = appengineService.Apps.Services.Versions.Delete(appsId, servicesId, versionsId);
             Data.Operation response = request.Execute();
@@ -620,7 +620,7 @@ namespace AppengineSample
             string servicesId = "";
 
             // Part of `name`. See documentation of `appsId`.
-            string versionsId = "";
+            string versionsId = "{MY-VERSIONS-ID}";
 
             AppsResource.ServicesResource.VersionsResource.GetRequest request = appengineService.Apps.Services.Versions.Get(appsId, servicesId, versionsId);
             Data.Version response = request.Execute();
@@ -684,7 +684,7 @@ namespace AppengineSample
             string servicesId = "";
 
             // Part of `name`. See documentation of `appsId`.
-            string versionsId = "";
+            string versionsId = "{MY-VERSIONS-ID}";
 
             AppsResource.ServicesResource.VersionsResource.InstancesResource.ListRequest request = appengineService.Apps.Services.Versions.Instances.List(appsId, servicesId, versionsId);
             Data.ListInstancesResponse response;
@@ -757,7 +757,7 @@ namespace AppengineSample
             string appsId = "";
 
             // Part of `name`. See documentation of `appsId`.
-            string servicesId = "";
+            string servicesId = "{MY-SERVICES-ID}";
 
             AppsResource.ServicesResource.VersionsResource.ListRequest request = appengineService.Apps.Services.Versions.List(appsId, servicesId);
             Data.ListVersionsResponse response;
@@ -834,7 +834,7 @@ namespace AppengineSample
             string servicesId = "";
 
             // Part of `name`. See documentation of `appsId`.
-            string versionsId = "";
+            string versionsId = "{MY-VERSIONS-ID}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Version content = new Data.Version();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_appengine.v1beta5.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_appengine.v1beta5.json.baseline
@@ -103,7 +103,7 @@ namespace AppengineSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Part of `name`. The name of the operation resource.
-            string appsId = "";
+            string appsId = "{MY-APPS-ID}";
 
             // Part of `name`. See documentation of `appsId`.
             string operationsId = "{MY-OPERATIONS-ID}";
@@ -233,7 +233,7 @@ namespace AppengineSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Part of `name`. Name of the resource requested. For example: "apps/myapp/services/default".
-            string appsId = "";
+            string appsId = "{MY-APPS-ID}";
 
             // Part of `name`. See documentation of `appsId`.
             string servicesId = "{MY-SERVICES-ID}";
@@ -293,7 +293,7 @@ namespace AppengineSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Part of `name`. Name of the resource requested. For example: "apps/myapp/services/default".
-            string appsId = "";
+            string appsId = "{MY-APPS-ID}";
 
             // Part of `name`. See documentation of `appsId`.
             string servicesId = "{MY-SERVICES-ID}";
@@ -423,7 +423,7 @@ namespace AppengineSample
             // TODO: Change placeholders below to values for parameters to the Patch() method:
 
             // Part of `name`. Name of the resource to update. For example: "apps/myapp/services/default".
-            string appsId = "";
+            string appsId = "{MY-APPS-ID}";
 
             // Part of `name`. See documentation of `appsId`.
             string servicesId = "{MY-SERVICES-ID}";
@@ -486,7 +486,7 @@ namespace AppengineSample
             // TODO: Change placeholders below to values for parameters to the Create() method:
 
             // Part of `name`. Name of the resource to update. For example: "apps/myapp/services/default".
-            string appsId = "";
+            string appsId = "{MY-APPS-ID}";
 
             // Part of `name`. See documentation of `appsId`.
             string servicesId = "{MY-SERVICES-ID}";
@@ -550,10 +550,10 @@ namespace AppengineSample
 
             // Part of `name`. Name of the resource requested. For example:
             // "apps/myapp/services/default/versions/v1".
-            string appsId = "";
+            string appsId = "{MY-APPS-ID}";
 
             // Part of `name`. See documentation of `appsId`.
-            string servicesId = "";
+            string servicesId = "{MY-SERVICES-ID}";
 
             // Part of `name`. See documentation of `appsId`.
             string versionsId = "{MY-VERSIONS-ID}";
@@ -614,10 +614,10 @@ namespace AppengineSample
 
             // Part of `name`. Name of the resource requested. For example:
             // "apps/myapp/services/default/versions/v1".
-            string appsId = "";
+            string appsId = "{MY-APPS-ID}";
 
             // Part of `name`. See documentation of `appsId`.
-            string servicesId = "";
+            string servicesId = "{MY-SERVICES-ID}";
 
             // Part of `name`. See documentation of `appsId`.
             string versionsId = "{MY-VERSIONS-ID}";
@@ -678,10 +678,10 @@ namespace AppengineSample
 
             // Part of `name`. Name of the resource requested. For example:
             // "apps/myapp/services/default/versions/v1".
-            string appsId = "";
+            string appsId = "{MY-APPS-ID}";
 
             // Part of `name`. See documentation of `appsId`.
-            string servicesId = "";
+            string servicesId = "{MY-SERVICES-ID}";
 
             // Part of `name`. See documentation of `appsId`.
             string versionsId = "{MY-VERSIONS-ID}";
@@ -754,7 +754,7 @@ namespace AppengineSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Part of `name`. Name of the resource requested. For example: "apps/myapp/services/default".
-            string appsId = "";
+            string appsId = "{MY-APPS-ID}";
 
             // Part of `name`. See documentation of `appsId`.
             string servicesId = "{MY-SERVICES-ID}";
@@ -828,10 +828,10 @@ namespace AppengineSample
 
             // Part of `name`. Name of the resource to update. For example:
             // "apps/myapp/services/default/versions/1".
-            string appsId = "";
+            string appsId = "{MY-APPS-ID}";
 
             // Part of `name`. See documentation of `appsId`.
-            string servicesId = "";
+            string servicesId = "{MY-SERVICES-ID}";
 
             // Part of `name`. See documentation of `appsId`.
             string versionsId = "{MY-VERSIONS-ID}";

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_autoscaler.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_autoscaler.v1beta2.json.baseline
@@ -46,10 +46,10 @@ namespace AutoscalerSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Project ID of Autoscaler resource.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Zone name of Autoscaler resource.
-            string zone = "";
+            string zone = "{MY-ZONE}";
 
             // Name of the Autoscaler resource.
             string autoscaler = "{MY-AUTOSCALER}";
@@ -109,10 +109,10 @@ namespace AutoscalerSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID of Autoscaler resource.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Zone name of Autoscaler resource.
-            string zone = "";
+            string zone = "{MY-ZONE}";
 
             // Name of the Autoscaler resource.
             string autoscaler = "{MY-AUTOSCALER}";
@@ -172,7 +172,7 @@ namespace AutoscalerSample
             // TODO: Change placeholders below to values for parameters to the Insert() method:
 
             // Project ID of Autoscaler resource.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Zone name of Autoscaler resource.
             string zone = "{MY-ZONE}";
@@ -235,7 +235,7 @@ namespace AutoscalerSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID of Autoscaler resource.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Zone name of Autoscaler resource.
             string zone = "{MY-ZONE}";
@@ -308,10 +308,10 @@ namespace AutoscalerSample
             // TODO: Change placeholders below to values for parameters to the Patch() method:
 
             // Project ID of Autoscaler resource.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Zone name of Autoscaler resource.
-            string zone = "";
+            string zone = "{MY-ZONE}";
 
             // Name of the Autoscaler resource.
             string autoscaler = "{MY-AUTOSCALER}";
@@ -374,10 +374,10 @@ namespace AutoscalerSample
             // TODO: Change placeholders below to values for parameters to the Update() method:
 
             // Project ID of Autoscaler resource.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Zone name of Autoscaler resource.
-            string zone = "";
+            string zone = "{MY-ZONE}";
 
             // Name of the Autoscaler resource.
             string autoscaler = "{MY-AUTOSCALER}";

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_autoscaler.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_autoscaler.v1beta2.json.baseline
@@ -439,7 +439,7 @@ namespace AutoscalerSample
 
             string project = "{MY-PROJECT}";
 
-            string zone = "us-central1-f";
+            string zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
             string operation = "{MY-OPERATION}";
 
@@ -499,7 +499,7 @@ namespace AutoscalerSample
 
             string project = "{MY-PROJECT}";
 
-            string zone = "us-central1-f";
+            string zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
             string operation = "{MY-OPERATION}";
 
@@ -559,7 +559,7 @@ namespace AutoscalerSample
 
             string project = "{MY-PROJECT}";
 
-            string zone = "us-central1-f";
+            string zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
             ZoneOperationsResource.ListRequest request = autoscalerService.ZoneOperations.List(project, zone);
             Data.OperationList response;

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_autoscaler.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_autoscaler.v1beta2.json.baseline
@@ -52,7 +52,7 @@ namespace AutoscalerSample
             string zone = "";
 
             // Name of the Autoscaler resource.
-            string autoscaler = "";
+            string autoscaler = "{MY-AUTOSCALER}";
 
             AutoscalersResource.DeleteRequest request = autoscalerService.Autoscalers.Delete(project, zone, autoscaler);
             Data.Operation response = request.Execute();
@@ -115,7 +115,7 @@ namespace AutoscalerSample
             string zone = "";
 
             // Name of the Autoscaler resource.
-            string autoscaler = "";
+            string autoscaler = "{MY-AUTOSCALER}";
 
             AutoscalersResource.GetRequest request = autoscalerService.Autoscalers.Get(project, zone, autoscaler);
             Data.Autoscaler response = request.Execute();
@@ -175,7 +175,7 @@ namespace AutoscalerSample
             string project = "";
 
             // Zone name of Autoscaler resource.
-            string zone = "";
+            string zone = "{MY-ZONE}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Autoscaler content = new Data.Autoscaler();
@@ -238,7 +238,7 @@ namespace AutoscalerSample
             string project = "";
 
             // Zone name of Autoscaler resource.
-            string zone = "";
+            string zone = "{MY-ZONE}";
 
             AutoscalersResource.ListRequest request = autoscalerService.Autoscalers.List(project, zone);
             Data.AutoscalerListResponse response;
@@ -314,7 +314,7 @@ namespace AutoscalerSample
             string zone = "";
 
             // Name of the Autoscaler resource.
-            string autoscaler = "";
+            string autoscaler = "{MY-AUTOSCALER}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Autoscaler content = new Data.Autoscaler();
@@ -380,7 +380,7 @@ namespace AutoscalerSample
             string zone = "";
 
             // Name of the Autoscaler resource.
-            string autoscaler = "";
+            string autoscaler = "{MY-AUTOSCALER}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Autoscaler content = new Data.Autoscaler();
@@ -437,11 +437,11 @@ namespace AutoscalerSample
 
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
-            string project = "";
+            string project = "{MY-PROJECT}";
 
-            string zone = "";
+            string zone = "us-central1-f";
 
-            string operation = "";
+            string operation = "{MY-OPERATION}";
 
             ZoneOperationsResource.DeleteRequest request = autoscalerService.ZoneOperations.Delete(project, zone, operation);
             request.Execute();
@@ -497,11 +497,11 @@ namespace AutoscalerSample
 
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
-            string project = "";
+            string project = "{MY-PROJECT}";
 
-            string zone = "";
+            string zone = "us-central1-f";
 
-            string operation = "";
+            string operation = "{MY-OPERATION}";
 
             ZoneOperationsResource.GetRequest request = autoscalerService.ZoneOperations.Get(project, zone, operation);
             Data.Operation response = request.Execute();
@@ -557,9 +557,9 @@ namespace AutoscalerSample
 
             // TODO: Change placeholders below to values for parameters to the List() method:
 
-            string project = "";
+            string project = "{MY-PROJECT}";
 
-            string zone = "";
+            string zone = "us-central1-f";
 
             ZoneOperationsResource.ListRequest request = autoscalerService.ZoneOperations.List(project, zone);
             Data.OperationList response;
@@ -628,7 +628,7 @@ namespace AutoscalerSample
 
             // TODO: Change placeholders below to values for parameters to the List() method:
 
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             ZonesResource.ListRequest request = autoscalerService.Zones.List(project);
             Data.ZoneList response;

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_bigquery.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_bigquery.v2.json.baseline
@@ -44,7 +44,7 @@ namespace BigquerySample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Project ID of the dataset being deleted
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // Dataset ID of dataset being deleted
             string datasetId = "{MY-DATASET-ID}";
@@ -104,7 +104,7 @@ namespace BigquerySample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID of the requested dataset
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // Dataset ID of the requested dataset
             string datasetId = "{MY-DATASET-ID}";
@@ -294,7 +294,7 @@ namespace BigquerySample
             // TODO: Change placeholders below to values for parameters to the Patch() method:
 
             // Project ID of the dataset being updated
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // Dataset ID of the dataset being updated
             string datasetId = "{MY-DATASET-ID}";
@@ -357,7 +357,7 @@ namespace BigquerySample
             // TODO: Change placeholders below to values for parameters to the Update() method:
 
             // Project ID of the dataset being updated
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // Dataset ID of the dataset being updated
             string datasetId = "{MY-DATASET-ID}";
@@ -420,7 +420,7 @@ namespace BigquerySample
             // TODO: Change placeholders below to values for parameters to the Cancel() method:
 
             // [Required] Project ID of the job to cancel
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // [Required] Job ID of the job to cancel
             string jobId = "{MY-JOB-ID}";
@@ -480,7 +480,7 @@ namespace BigquerySample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // [Required] Project ID of the requested job
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // [Required] Job ID of the requested job
             string jobId = "{MY-JOB-ID}";
@@ -540,7 +540,7 @@ namespace BigquerySample
             // TODO: Change placeholders below to values for parameters to the GetQueryResults() method:
 
             // [Required] Project ID of the query job
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // [Required] Job ID of the query job
             string jobId = "{MY-JOB-ID}";
@@ -855,10 +855,10 @@ namespace BigquerySample
             // TODO: Change placeholders below to values for parameters to the InsertAll() method:
 
             // Project ID of the destination table.
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // Dataset ID of the destination table.
-            string datasetId = "";
+            string datasetId = "{MY-DATASET-ID}";
 
             // Table ID of the destination table.
             string tableId = "{MY-TABLE-ID}";
@@ -921,10 +921,10 @@ namespace BigquerySample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID of the table to read
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // Dataset ID of the table to read
-            string datasetId = "";
+            string datasetId = "{MY-DATASET-ID}";
 
             // Table ID of the table to read
             string tableId = "{MY-TABLE-ID}";
@@ -982,10 +982,10 @@ namespace BigquerySample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Project ID of the table to delete
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // Dataset ID of the table to delete
-            string datasetId = "";
+            string datasetId = "{MY-DATASET-ID}";
 
             // Table ID of the table to delete
             string tableId = "{MY-TABLE-ID}";
@@ -1045,10 +1045,10 @@ namespace BigquerySample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID of the requested table
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // Dataset ID of the requested table
-            string datasetId = "";
+            string datasetId = "{MY-DATASET-ID}";
 
             // Table ID of the requested table
             string tableId = "{MY-TABLE-ID}";
@@ -1108,7 +1108,7 @@ namespace BigquerySample
             // TODO: Change placeholders below to values for parameters to the Insert() method:
 
             // Project ID of the new table
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // Dataset ID of the new table
             string datasetId = "{MY-DATASET-ID}";
@@ -1171,7 +1171,7 @@ namespace BigquerySample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID of the tables to list
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // Dataset ID of the tables to list
             string datasetId = "{MY-DATASET-ID}";
@@ -1244,10 +1244,10 @@ namespace BigquerySample
             // TODO: Change placeholders below to values for parameters to the Patch() method:
 
             // Project ID of the table to update
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // Dataset ID of the table to update
-            string datasetId = "";
+            string datasetId = "{MY-DATASET-ID}";
 
             // Table ID of the table to update
             string tableId = "{MY-TABLE-ID}";
@@ -1310,10 +1310,10 @@ namespace BigquerySample
             // TODO: Change placeholders below to values for parameters to the Update() method:
 
             // Project ID of the table to update
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // Dataset ID of the table to update
-            string datasetId = "";
+            string datasetId = "{MY-DATASET-ID}";
 
             // Table ID of the table to update
             string tableId = "{MY-TABLE-ID}";

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_bigquery.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_bigquery.v2.json.baseline
@@ -47,7 +47,7 @@ namespace BigquerySample
             string projectId = "";
 
             // Dataset ID of dataset being deleted
-            string datasetId = "";
+            string datasetId = "{MY-DATASET-ID}";
 
             DatasetsResource.DeleteRequest request = bigqueryService.Datasets.Delete(projectId, datasetId);
             request.Execute();
@@ -107,7 +107,7 @@ namespace BigquerySample
             string projectId = "";
 
             // Dataset ID of the requested dataset
-            string datasetId = "";
+            string datasetId = "{MY-DATASET-ID}";
 
             DatasetsResource.GetRequest request = bigqueryService.Datasets.Get(projectId, datasetId);
             Data.Dataset response = request.Execute();
@@ -164,7 +164,7 @@ namespace BigquerySample
             // TODO: Change placeholders below to values for parameters to the Insert() method:
 
             // Project ID of the new dataset
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Dataset content = new Data.Dataset();
@@ -224,7 +224,7 @@ namespace BigquerySample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID of the datasets to be listed
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             DatasetsResource.ListRequest request = bigqueryService.Datasets.List(projectId);
             Data.DatasetList response;
@@ -297,7 +297,7 @@ namespace BigquerySample
             string projectId = "";
 
             // Dataset ID of the dataset being updated
-            string datasetId = "";
+            string datasetId = "{MY-DATASET-ID}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Dataset content = new Data.Dataset();
@@ -360,7 +360,7 @@ namespace BigquerySample
             string projectId = "";
 
             // Dataset ID of the dataset being updated
-            string datasetId = "";
+            string datasetId = "{MY-DATASET-ID}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Dataset content = new Data.Dataset();
@@ -423,7 +423,7 @@ namespace BigquerySample
             string projectId = "";
 
             // [Required] Job ID of the job to cancel
-            string jobId = "";
+            string jobId = "{MY-JOB-ID}";
 
             JobsResource.CancelRequest request = bigqueryService.Jobs.Cancel(projectId, jobId);
             Data.JobCancelResponse response = request.Execute();
@@ -483,7 +483,7 @@ namespace BigquerySample
             string projectId = "";
 
             // [Required] Job ID of the requested job
-            string jobId = "";
+            string jobId = "{MY-JOB-ID}";
 
             JobsResource.GetRequest request = bigqueryService.Jobs.Get(projectId, jobId);
             Data.Job response = request.Execute();
@@ -543,7 +543,7 @@ namespace BigquerySample
             string projectId = "";
 
             // [Required] Job ID of the query job
-            string jobId = "";
+            string jobId = "{MY-JOB-ID}";
 
             JobsResource.GetQueryResultsRequest request = bigqueryService.Jobs.GetQueryResults(projectId, jobId);
             Data.GetQueryResultsResponse response = request.Execute();
@@ -600,7 +600,7 @@ namespace BigquerySample
             // TODO: Change placeholders below to values for parameters to the Insert() method:
 
             // Project ID of the project that will be billed for the job
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Job content = new Data.Job();
@@ -660,7 +660,7 @@ namespace BigquerySample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID of the jobs to list
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             JobsResource.ListRequest request = bigqueryService.Jobs.List(projectId);
             Data.JobList response;
@@ -730,7 +730,7 @@ namespace BigquerySample
             // TODO: Change placeholders below to values for parameters to the Query() method:
 
             // Project ID of the project billed for the query
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.QueryRequest content = new Data.QueryRequest();
@@ -861,7 +861,7 @@ namespace BigquerySample
             string datasetId = "";
 
             // Table ID of the destination table.
-            string tableId = "";
+            string tableId = "{MY-TABLE-ID}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.TableDataInsertAllRequest content = new Data.TableDataInsertAllRequest();
@@ -927,7 +927,7 @@ namespace BigquerySample
             string datasetId = "";
 
             // Table ID of the table to read
-            string tableId = "";
+            string tableId = "{MY-TABLE-ID}";
 
             TabledataResource.ListRequest request = bigqueryService.Tabledata.List(projectId, datasetId, tableId);
             Data.TableDataList response = request.Execute();
@@ -988,7 +988,7 @@ namespace BigquerySample
             string datasetId = "";
 
             // Table ID of the table to delete
-            string tableId = "";
+            string tableId = "{MY-TABLE-ID}";
 
             TablesResource.DeleteRequest request = bigqueryService.Tables.Delete(projectId, datasetId, tableId);
             request.Execute();
@@ -1051,7 +1051,7 @@ namespace BigquerySample
             string datasetId = "";
 
             // Table ID of the requested table
-            string tableId = "";
+            string tableId = "{MY-TABLE-ID}";
 
             TablesResource.GetRequest request = bigqueryService.Tables.Get(projectId, datasetId, tableId);
             Data.Table response = request.Execute();
@@ -1111,7 +1111,7 @@ namespace BigquerySample
             string projectId = "";
 
             // Dataset ID of the new table
-            string datasetId = "";
+            string datasetId = "{MY-DATASET-ID}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Table content = new Data.Table();
@@ -1174,7 +1174,7 @@ namespace BigquerySample
             string projectId = "";
 
             // Dataset ID of the tables to list
-            string datasetId = "";
+            string datasetId = "{MY-DATASET-ID}";
 
             TablesResource.ListRequest request = bigqueryService.Tables.List(projectId, datasetId);
             Data.TableList response;
@@ -1250,7 +1250,7 @@ namespace BigquerySample
             string datasetId = "";
 
             // Table ID of the table to update
-            string tableId = "";
+            string tableId = "{MY-TABLE-ID}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Table content = new Data.Table();
@@ -1316,7 +1316,7 @@ namespace BigquerySample
             string datasetId = "";
 
             // Table ID of the table to update
-            string tableId = "";
+            string tableId = "{MY-TABLE-ID}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Table content = new Data.Table();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_clouddebugger.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_clouddebugger.v2.json.baseline
@@ -103,7 +103,7 @@ namespace ClouddebuggerSample
             // TODO: Change placeholders below to values for parameters to the Update() method:
 
             // Identifies the debuggee being debugged.
-            string debuggeeId = "";
+            string debuggeeId = "{MY-DEBUGGEE-ID}";
 
             // Breakpoint identifier, unique in the scope of the debuggee.
             string id = "{MY-ID}";
@@ -221,7 +221,7 @@ namespace ClouddebuggerSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // ID of the debuggee whose breakpoint to delete.
-            string debuggeeId = "";
+            string debuggeeId = "{MY-DEBUGGEE-ID}";
 
             // ID of the breakpoint to delete.
             string breakpointId = "{MY-BREAKPOINT-ID}";
@@ -281,7 +281,7 @@ namespace ClouddebuggerSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // ID of the debuggee whose breakpoint to get.
-            string debuggeeId = "";
+            string debuggeeId = "{MY-DEBUGGEE-ID}";
 
             // ID of the breakpoint to get.
             string breakpointId = "{MY-BREAKPOINT-ID}";

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_clouddebugger.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_clouddebugger.v2.json.baseline
@@ -46,7 +46,7 @@ namespace ClouddebuggerSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Identifies the debuggee.
-            string debuggeeId = "";
+            string debuggeeId = "{MY-DEBUGGEE-ID}";
 
             ControllerResource.DebuggeesResource.BreakpointsResource.ListRequest request = clouddebuggerService.Controller.Debuggees.Breakpoints.List(debuggeeId);
             Data.ListActiveBreakpointsResponse response = request.Execute();
@@ -106,7 +106,7 @@ namespace ClouddebuggerSample
             string debuggeeId = "";
 
             // Breakpoint identifier, unique in the scope of the debuggee.
-            string id = "";
+            string id = "{MY-ID}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.UpdateActiveBreakpointRequest content = new Data.UpdateActiveBreakpointRequest();
@@ -224,7 +224,7 @@ namespace ClouddebuggerSample
             string debuggeeId = "";
 
             // ID of the breakpoint to delete.
-            string breakpointId = "";
+            string breakpointId = "{MY-BREAKPOINT-ID}";
 
             DebuggerResource.DebuggeesResource.BreakpointsResource.DeleteRequest request = clouddebuggerService.Debugger.Debuggees.Breakpoints.Delete(debuggeeId, breakpointId);
             Data.Empty response = request.Execute();
@@ -284,7 +284,7 @@ namespace ClouddebuggerSample
             string debuggeeId = "";
 
             // ID of the breakpoint to get.
-            string breakpointId = "";
+            string breakpointId = "{MY-BREAKPOINT-ID}";
 
             DebuggerResource.DebuggeesResource.BreakpointsResource.GetRequest request = clouddebuggerService.Debugger.Debuggees.Breakpoints.Get(debuggeeId, breakpointId);
             Data.GetBreakpointResponse response = request.Execute();
@@ -341,7 +341,7 @@ namespace ClouddebuggerSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // ID of the debuggee whose breakpoints to list.
-            string debuggeeId = "";
+            string debuggeeId = "{MY-DEBUGGEE-ID}";
 
             DebuggerResource.DebuggeesResource.BreakpointsResource.ListRequest request = clouddebuggerService.Debugger.Debuggees.Breakpoints.List(debuggeeId);
             Data.ListBreakpointsResponse response = request.Execute();
@@ -398,7 +398,7 @@ namespace ClouddebuggerSample
             // TODO: Change placeholders below to values for parameters to the Set() method:
 
             // ID of the debuggee where the breakpoint is to be set.
-            string debuggeeId = "";
+            string debuggeeId = "{MY-DEBUGGEE-ID}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Breakpoint content = new Data.Breakpoint();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_cloudmonitoring.v2beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_cloudmonitoring.v2beta2.json.baseline
@@ -106,7 +106,7 @@ namespace CloudMonitoringSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // The project ID to which the metric belongs.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the metric.
             string metric = "{MY-METRIC}";
@@ -240,11 +240,11 @@ namespace CloudMonitoringSample
 
             // The project ID to which this time series belongs. The value can be the numeric project ID or
             // string-based project name.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Metric names are protocol-free URLs as listed in the Supported Metrics page. For example,
             // compute.googleapis.com/instance/disk/read_ops_count.
-            string metric = "";
+            string metric = "{MY-METRIC}";
 
             // End of the time interval (inclusive), which is expressed as an RFC 3339 timestamp.
             string youngest = "{MY-YOUNGEST}";
@@ -381,11 +381,11 @@ namespace CloudMonitoringSample
 
             // The project ID to which this time series belongs. The value can be the numeric project ID or
             // string-based project name.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Metric names are protocol-free URLs as listed in the Supported Metrics page. For example,
             // compute.googleapis.com/instance/disk/read_ops_count.
-            string metric = "";
+            string metric = "{MY-METRIC}";
 
             // End of the time interval (inclusive), which is expressed as an RFC 3339 timestamp.
             string youngest = "{MY-YOUNGEST}";

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_cloudmonitoring.v2beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_cloudmonitoring.v2beta2.json.baseline
@@ -46,7 +46,7 @@ namespace CloudMonitoringSample
             // TODO: Change placeholders below to values for parameters to the Create() method:
 
             // The project id. The value can be the numeric project ID or string-based project name.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.MetricDescriptor content = new Data.MetricDescriptor();
@@ -109,7 +109,7 @@ namespace CloudMonitoringSample
             string project = "";
 
             // Name of the metric.
-            string metric = "";
+            string metric = "{MY-METRIC}";
 
             MetricDescriptorsResource.DeleteRequest request = cloudMonitoringService.MetricDescriptors.Delete(project, metric);
             Data.DeleteMetricDescriptorResponse response = request.Execute();
@@ -166,7 +166,7 @@ namespace CloudMonitoringSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // The project id. The value can be the numeric project ID or string-based project name.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.ListMetricDescriptorsRequest content = new Data.ListMetricDescriptorsRequest();
@@ -247,7 +247,7 @@ namespace CloudMonitoringSample
             string metric = "";
 
             // End of the time interval (inclusive), which is expressed as an RFC 3339 timestamp.
-            string youngest = "";
+            string youngest = "{MY-YOUNGEST}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.ListTimeseriesRequest content = new Data.ListTimeseriesRequest();
@@ -320,7 +320,7 @@ namespace CloudMonitoringSample
             // TODO: Change placeholders below to values for parameters to the Write() method:
 
             // The project ID. The value can be the numeric project ID or string-based project name.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.WriteTimeseriesRequest content = new Data.WriteTimeseriesRequest();
@@ -388,7 +388,7 @@ namespace CloudMonitoringSample
             string metric = "";
 
             // End of the time interval (inclusive), which is expressed as an RFC 3339 timestamp.
-            string youngest = "";
+            string youngest = "{MY-YOUNGEST}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.ListTimeseriesDescriptorsRequest content = new Data.ListTimeseriesDescriptorsRequest();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_cloudresourcemanager.v1beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_cloudresourcemanager.v1beta1.json.baseline
@@ -46,7 +46,7 @@ namespace CloudresourcemanagerSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // The id of the Organization resource to fetch.
-            string organizationId = "";
+            string organizationId = "{MY-ORGANIZATION-ID}";
 
             OrganizationsResource.GetRequest request = cloudresourcemanagerService.Organizations.Get(organizationId);
             Data.Organization response = request.Execute();
@@ -105,7 +105,7 @@ namespace CloudresourcemanagerSample
             // REQUIRED: The resource for which the policy is being requested. `resource` is usually specified as a
             // path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
             // this value is resource specific and is specified in the `getIamPolicy` documentation.
-            string resource = "";
+            string resource = "{MY-RESOURCE}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.GetIamPolicyRequest content = new Data.GetIamPolicyRequest();
@@ -232,7 +232,7 @@ namespace CloudresourcemanagerSample
             // REQUIRED: The resource for which the policy is being specified. `resource` is usually specified as a
             // path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
             // this value is resource specific and is specified in the `setIamPolicy` documentation.
-            string resource = "";
+            string resource = "{MY-RESOURCE}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.SetIamPolicyRequest content = new Data.SetIamPolicyRequest();
@@ -295,7 +295,7 @@ namespace CloudresourcemanagerSample
             // specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path
             // specified in this value is resource specific and is specified in the `testIamPermissions`
             // documentation.
-            string resource = "";
+            string resource = "{MY-RESOURCE}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.TestIamPermissionsRequest content = new Data.TestIamPermissionsRequest();
@@ -356,7 +356,7 @@ namespace CloudresourcemanagerSample
 
             // An immutable id for the Organization that is assigned on creation. This should be omitted when
             // creating a new Organization. This field is read-only.
-            string organizationId = "";
+            string organizationId = "{MY-ORGANIZATION-ID}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Organization content = new Data.Organization();
@@ -471,7 +471,7 @@ namespace CloudresourcemanagerSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // The Project ID (for example, `foo-bar-123`). Required.
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             ProjectsResource.DeleteRequest request = cloudresourcemanagerService.Projects.Delete(projectId);
             Data.Empty response = request.Execute();
@@ -528,7 +528,7 @@ namespace CloudresourcemanagerSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // The Project ID (for example, `my-project-123`). Required.
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             ProjectsResource.GetRequest request = cloudresourcemanagerService.Projects.Get(projectId);
             Data.Project response = request.Execute();
@@ -587,7 +587,7 @@ namespace CloudresourcemanagerSample
             // REQUIRED: The resource for which the policy is being requested. `resource` is usually specified as a
             // path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
             // this value is resource specific and is specified in the `getIamPolicy` documentation.
-            string resource = "";
+            string resource = "{MY-RESOURCE}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.GetIamPolicyRequest content = new Data.GetIamPolicyRequest();
@@ -714,7 +714,7 @@ namespace CloudresourcemanagerSample
             // REQUIRED: The resource for which the policy is being specified. `resource` is usually specified as a
             // path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
             // this value is resource specific and is specified in the `setIamPolicy` documentation.
-            string resource = "";
+            string resource = "{MY-RESOURCE}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.SetIamPolicyRequest content = new Data.SetIamPolicyRequest();
@@ -777,7 +777,7 @@ namespace CloudresourcemanagerSample
             // specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path
             // specified in this value is resource specific and is specified in the `testIamPermissions`
             // documentation.
-            string resource = "";
+            string resource = "{MY-RESOURCE}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.TestIamPermissionsRequest content = new Data.TestIamPermissionsRequest();
@@ -837,7 +837,7 @@ namespace CloudresourcemanagerSample
             // TODO: Change placeholders below to values for parameters to the Undelete() method:
 
             // The project ID (for example, `foo-bar-123`). Required.
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.UndeleteProjectRequest content = new Data.UndeleteProjectRequest();
@@ -897,7 +897,7 @@ namespace CloudresourcemanagerSample
             // TODO: Change placeholders below to values for parameters to the Update() method:
 
             // The project ID (for example, `my-project-123`). Required.
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Project content = new Data.Project();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_cloudtrace.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_cloudtrace.v1.json.baseline
@@ -46,7 +46,7 @@ namespace CloudtraceSample
             // TODO: Change placeholders below to values for parameters to the PatchTraces() method:
 
             // ID of the Cloud project where the trace data is stored.
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Traces content = new Data.Traces();
@@ -109,7 +109,7 @@ namespace CloudtraceSample
             string projectId = "";
 
             // ID of the trace to return.
-            string traceId = "";
+            string traceId = "{MY-TRACE-ID}";
 
             ProjectsResource.TracesResource.GetRequest request = cloudtraceService.Projects.Traces.Get(projectId, traceId);
             Data.Trace response = request.Execute();
@@ -166,7 +166,7 @@ namespace CloudtraceSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // ID of the Cloud project where the trace data is stored.
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             ProjectsResource.TracesResource.ListRequest request = cloudtraceService.Projects.Traces.List(projectId);
             Data.ListTracesResponse response;

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_cloudtrace.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_cloudtrace.v1.json.baseline
@@ -106,7 +106,7 @@ namespace CloudtraceSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // ID of the Cloud project where the trace data is stored.
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // ID of the trace to return.
             string traceId = "{MY-TRACE-ID}";

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_clouduseraccounts.beta.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_clouduseraccounts.beta.json.baseline
@@ -47,7 +47,7 @@ namespace CloudUserAccountsSample
             string project = "";
 
             // Name of the Operations resource to delete.
-            string operation = "";
+            string operation = "{MY-OPERATION}";
 
             GlobalAccountsOperationsResource.DeleteRequest request = cloudUserAccountsService.GlobalAccountsOperations.Delete(project, operation);
             request.Execute();
@@ -107,7 +107,7 @@ namespace CloudUserAccountsSample
             string project = "";
 
             // Name of the Operations resource to return.
-            string operation = "";
+            string operation = "{MY-OPERATION}";
 
             GlobalAccountsOperationsResource.GetRequest request = cloudUserAccountsService.GlobalAccountsOperations.Get(project, operation);
             Data.Operation response = request.Execute();
@@ -164,7 +164,7 @@ namespace CloudUserAccountsSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             GlobalAccountsOperationsResource.ListRequest request = cloudUserAccountsService.GlobalAccountsOperations.List(project);
             Data.OperationList response;
@@ -237,7 +237,7 @@ namespace CloudUserAccountsSample
             string project = "";
 
             // Name of the group for this request.
-            string groupName = "";
+            string groupName = "{MY-GROUP-NAME}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.GroupsAddMemberRequest content = new Data.GroupsAddMemberRequest();
@@ -300,7 +300,7 @@ namespace CloudUserAccountsSample
             string project = "";
 
             // Name of the Group resource to delete.
-            string groupName = "";
+            string groupName = "{MY-GROUP-NAME}";
 
             GroupsResource.DeleteRequest request = cloudUserAccountsService.Groups.Delete(project, groupName);
             Data.Operation response = request.Execute();
@@ -360,7 +360,7 @@ namespace CloudUserAccountsSample
             string project = "";
 
             // Name of the Group resource to return.
-            string groupName = "";
+            string groupName = "{MY-GROUP-NAME}";
 
             GroupsResource.GetRequest request = cloudUserAccountsService.Groups.Get(project, groupName);
             Data.Group response = request.Execute();
@@ -417,7 +417,7 @@ namespace CloudUserAccountsSample
             // TODO: Change placeholders below to values for parameters to the Insert() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Group content = new Data.Group();
@@ -477,7 +477,7 @@ namespace CloudUserAccountsSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             GroupsResource.ListRequest request = cloudUserAccountsService.Groups.List(project);
             Data.GroupList response;
@@ -550,7 +550,7 @@ namespace CloudUserAccountsSample
             string project = "";
 
             // Name of the group for this request.
-            string groupName = "";
+            string groupName = "{MY-GROUP-NAME}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.GroupsRemoveMemberRequest content = new Data.GroupsRemoveMemberRequest();
@@ -619,7 +619,7 @@ namespace CloudUserAccountsSample
             string user = "";
 
             // The fully-qualified URL of the virtual machine requesting the view.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             LinuxResource.GetAuthorizedKeysViewRequest request = cloudUserAccountsService.Linux.GetAuthorizedKeysView(project, zone, user, instance);
             Data.LinuxGetAuthorizedKeysViewResponse response = request.Execute();
@@ -682,7 +682,7 @@ namespace CloudUserAccountsSample
             string zone = "";
 
             // The fully-qualified URL of the virtual machine requesting the views.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             LinuxResource.GetLinuxAccountViewsRequest request = cloudUserAccountsService.Linux.GetLinuxAccountViews(project, zone, instance);
             Data.LinuxGetLinuxAccountViewsResponse response = request.Execute();
@@ -742,7 +742,7 @@ namespace CloudUserAccountsSample
             string project = "";
 
             // Name of the user for this request.
-            string user = "";
+            string user = "{MY-USER}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.PublicKey content = new Data.PublicKey();
@@ -805,7 +805,7 @@ namespace CloudUserAccountsSample
             string project = "";
 
             // Name of the user resource to delete.
-            string user = "";
+            string user = "{MY-USER}";
 
             UsersResource.DeleteRequest request = cloudUserAccountsService.Users.Delete(project, user);
             Data.Operation response = request.Execute();
@@ -865,7 +865,7 @@ namespace CloudUserAccountsSample
             string project = "";
 
             // Name of the user resource to return.
-            string user = "";
+            string user = "{MY-USER}";
 
             UsersResource.GetRequest request = cloudUserAccountsService.Users.Get(project, user);
             Data.User response = request.Execute();
@@ -922,7 +922,7 @@ namespace CloudUserAccountsSample
             // TODO: Change placeholders below to values for parameters to the Insert() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.User content = new Data.User();
@@ -982,7 +982,7 @@ namespace CloudUserAccountsSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             UsersResource.ListRequest request = cloudUserAccountsService.Users.List(project);
             Data.UserList response;
@@ -1059,7 +1059,7 @@ namespace CloudUserAccountsSample
 
             // The fingerprint of the public key to delete. Public keys are identified by their fingerprint, which
             // is defined by RFC4716 to be the MD5 digest of the public key.
-            string fingerprint = "";
+            string fingerprint = "{MY-FINGERPRINT}";
 
             UsersResource.RemovePublicKeyRequest request = cloudUserAccountsService.Users.RemovePublicKey(project, user, fingerprint);
             Data.Operation response = request.Execute();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_clouduseraccounts.beta.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_clouduseraccounts.beta.json.baseline
@@ -44,7 +44,7 @@ namespace CloudUserAccountsSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the Operations resource to delete.
             string operation = "{MY-OPERATION}";
@@ -104,7 +104,7 @@ namespace CloudUserAccountsSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the Operations resource to return.
             string operation = "{MY-OPERATION}";
@@ -234,7 +234,7 @@ namespace CloudUserAccountsSample
             // TODO: Change placeholders below to values for parameters to the AddMember() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the group for this request.
             string groupName = "{MY-GROUP-NAME}";
@@ -297,7 +297,7 @@ namespace CloudUserAccountsSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the Group resource to delete.
             string groupName = "{MY-GROUP-NAME}";
@@ -357,7 +357,7 @@ namespace CloudUserAccountsSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the Group resource to return.
             string groupName = "{MY-GROUP-NAME}";
@@ -547,7 +547,7 @@ namespace CloudUserAccountsSample
             // TODO: Change placeholders below to values for parameters to the RemoveMember() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the group for this request.
             string groupName = "{MY-GROUP-NAME}";
@@ -610,13 +610,13 @@ namespace CloudUserAccountsSample
             // TODO: Change placeholders below to values for parameters to the GetAuthorizedKeysView() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the zone for this request.
-            string zone = "";
+            string zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
             // The user account for which you want to get a list of authorized public keys.
-            string user = "";
+            string user = "{MY-USER}";
 
             // The fully-qualified URL of the virtual machine requesting the view.
             string instance = "{MY-INSTANCE}";
@@ -676,10 +676,10 @@ namespace CloudUserAccountsSample
             // TODO: Change placeholders below to values for parameters to the GetLinuxAccountViews() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the zone for this request.
-            string zone = "";
+            string zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
             // The fully-qualified URL of the virtual machine requesting the views.
             string instance = "{MY-INSTANCE}";
@@ -739,7 +739,7 @@ namespace CloudUserAccountsSample
             // TODO: Change placeholders below to values for parameters to the AddPublicKey() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the user for this request.
             string user = "{MY-USER}";
@@ -802,7 +802,7 @@ namespace CloudUserAccountsSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the user resource to delete.
             string user = "{MY-USER}";
@@ -862,7 +862,7 @@ namespace CloudUserAccountsSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the user resource to return.
             string user = "{MY-USER}";
@@ -1052,10 +1052,10 @@ namespace CloudUserAccountsSample
             // TODO: Change placeholders below to values for parameters to the RemovePublicKey() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the user for this request.
-            string user = "";
+            string user = "{MY-USER}";
 
             // The fingerprint of the public key to delete. Public keys are identified by their fingerprint, which
             // is defined by RFC4716 to be the MD5 digest of the public key.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_compute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_compute.v1.json.baseline
@@ -117,10 +117,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the region for this request.
-            string region = "";
+            string region = "{MY-REGION}";
 
             // Name of the address resource to delete.
             string address = "{MY-ADDRESS}";
@@ -180,10 +180,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the region for this request.
-            string region = "";
+            string region = "{MY-REGION}";
 
             // Name of the address resource to return.
             string address = "{MY-ADDRESS}";
@@ -243,7 +243,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Insert() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the region for this request.
             string region = "{MY-REGION}";
@@ -306,7 +306,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the region for this request.
             string region = "{MY-REGION}";
@@ -450,10 +450,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the zone for this request.
-            string zone = "";
+            string zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
             // Name of the autoscaler to delete.
             string autoscaler = "{MY-AUTOSCALER}";
@@ -513,10 +513,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the zone for this request.
-            string zone = "";
+            string zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
             // Name of the autoscaler to return.
             string autoscaler = "{MY-AUTOSCALER}";
@@ -576,7 +576,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Insert() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the zone for this request.
             string zone = "{MY-ZONE}"  // eg. "us-central1-f";
@@ -639,7 +639,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the zone for this request.
             string zone = "{MY-ZONE}"  // eg. "us-central1-f";
@@ -712,10 +712,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Patch() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the zone for this request.
-            string zone = "";
+            string zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
             // Name of the autoscaler to update.
             string autoscaler = "{MY-AUTOSCALER}";
@@ -778,7 +778,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Update() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the zone for this request.
             string zone = "{MY-ZONE}"  // eg. "us-central1-f";
@@ -841,7 +841,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the BackendService resource to delete.
             string backendService = "{MY-BACKEND-SERVICE}";
@@ -901,7 +901,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the BackendService resource to return.
             string backendService = "{MY-BACKEND-SERVICE}";
@@ -960,7 +960,7 @@ namespace ComputeSample
 
             // TODO: Change placeholders below to values for parameters to the GetHealth() method:
 
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the BackendService resource to which the queried instance belongs.
             string backendService = "{MY-BACKEND-SERVICE}";
@@ -1153,7 +1153,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Patch() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the BackendService resource to update.
             string backendService = "{MY-BACKEND-SERVICE}";
@@ -1216,7 +1216,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Update() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the BackendService resource to update.
             string backendService = "{MY-BACKEND-SERVICE}";
@@ -1350,10 +1350,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone for this request.
-            string zone = "";
+            string zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
             // Name of the disk type to return.
             string diskType = "{MY-DISK-TYPE}";
@@ -1413,7 +1413,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone for this request.
             string zone = "{MY-ZONE}"  // eg. "us-central1-f";
@@ -1557,10 +1557,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the CreateSnapshot() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone for this request.
-            string zone = "";
+            string zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
             // Name of the persistent disk to snapshot.
             string disk = "{MY-DISK}";
@@ -1623,10 +1623,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone for this request.
-            string zone = "";
+            string zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
             // Name of the persistent disk to delete.
             string disk = "{MY-DISK}";
@@ -1686,10 +1686,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone for this request.
-            string zone = "";
+            string zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
             // Name of the persistent disk to return.
             string disk = "{MY-DISK}";
@@ -1749,7 +1749,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Insert() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone for this request.
             string zone = "{MY-ZONE}"  // eg. "us-central1-f";
@@ -1812,7 +1812,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone for this request.
             string zone = "{MY-ZONE}"  // eg. "us-central1-f";
@@ -1885,7 +1885,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the firewall rule to delete.
             string firewall = "{MY-FIREWALL}";
@@ -1945,7 +1945,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the firewall rule to return.
             string firewall = "{MY-FIREWALL}";
@@ -2135,7 +2135,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Patch() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the firewall rule to update.
             string firewall = "{MY-FIREWALL}";
@@ -2198,7 +2198,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Update() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the firewall rule to update.
             string firewall = "{MY-FIREWALL}";
@@ -2332,10 +2332,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the region scoping this request.
-            string region = "";
+            string region = "{MY-REGION}";
 
             // Name of the ForwardingRule resource to delete.
             string forwardingRule = "{MY-FORWARDING-RULE}";
@@ -2395,10 +2395,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the region scoping this request.
-            string region = "";
+            string region = "{MY-REGION}";
 
             // Name of the ForwardingRule resource to return.
             string forwardingRule = "{MY-FORWARDING-RULE}";
@@ -2458,7 +2458,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Insert() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the region scoping this request.
             string region = "{MY-REGION}";
@@ -2521,7 +2521,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the region scoping this request.
             string region = "{MY-REGION}";
@@ -2594,10 +2594,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the SetTarget() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the region scoping this request.
-            string region = "";
+            string region = "{MY-REGION}";
 
             // Name of the ForwardingRule resource in which target is to be set.
             string forwardingRule = "{MY-FORWARDING-RULE}";
@@ -2660,7 +2660,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the address resource to delete.
             string address = "{MY-ADDRESS}";
@@ -2720,7 +2720,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the address resource to return.
             string address = "{MY-ADDRESS}";
@@ -2910,7 +2910,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the ForwardingRule resource to delete.
             string forwardingRule = "{MY-FORWARDING-RULE}";
@@ -2970,7 +2970,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the ForwardingRule resource to return.
             string forwardingRule = "{MY-FORWARDING-RULE}";
@@ -3160,7 +3160,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the SetTarget() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the ForwardingRule resource in which target is to be set.
             string forwardingRule = "{MY-FORWARDING-RULE}";
@@ -3292,7 +3292,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the Operations resource to delete.
             string operation = "{MY-OPERATION}";
@@ -3352,7 +3352,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the Operations resource to return.
             string operation = "{MY-OPERATION}";
@@ -3482,7 +3482,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the HttpHealthCheck resource to delete.
             string httpHealthCheck = "{MY-HTTP-HEALTH-CHECK}";
@@ -3542,7 +3542,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the HttpHealthCheck resource to return.
             string httpHealthCheck = "{MY-HTTP-HEALTH-CHECK}";
@@ -3732,7 +3732,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Patch() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the HttpHealthCheck resource to update.
             string httpHealthCheck = "{MY-HTTP-HEALTH-CHECK}";
@@ -3795,7 +3795,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Update() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the HttpHealthCheck resource to update.
             string httpHealthCheck = "{MY-HTTP-HEALTH-CHECK}";
@@ -3858,7 +3858,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the HttpsHealthCheck resource to delete.
             string httpsHealthCheck = "{MY-HTTPS-HEALTH-CHECK}";
@@ -3918,7 +3918,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the HttpsHealthCheck resource to return.
             string httpsHealthCheck = "{MY-HTTPS-HEALTH-CHECK}";
@@ -4108,7 +4108,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Patch() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the HttpsHealthCheck resource to update.
             string httpsHealthCheck = "{MY-HTTPS-HEALTH-CHECK}";
@@ -4171,7 +4171,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Update() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the HttpsHealthCheck resource to update.
             string httpsHealthCheck = "{MY-HTTPS-HEALTH-CHECK}";
@@ -4234,7 +4234,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the image resource to delete.
             string image = "{MY-IMAGE}";
@@ -4294,7 +4294,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Deprecate() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Image name.
             string image = "{MY-IMAGE}";
@@ -4357,7 +4357,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the image resource to return.
             string image = "{MY-IMAGE}";
@@ -4547,10 +4547,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the AbandonInstances() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone where the managed instance group is located.
-            string zone = "";
+            string zone = "{MY-ZONE}";
 
             // The name of the managed instance group.
             string instanceGroupManager = "{MY-INSTANCE-GROUP-MANAGER}";
@@ -4684,10 +4684,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone where the managed instance group is located.
-            string zone = "";
+            string zone = "{MY-ZONE}";
 
             // The name of the managed instance group to delete.
             string instanceGroupManager = "{MY-INSTANCE-GROUP-MANAGER}";
@@ -4747,10 +4747,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the DeleteInstances() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone where the managed instance group is located.
-            string zone = "";
+            string zone = "{MY-ZONE}";
 
             // The name of the managed instance group.
             string instanceGroupManager = "{MY-INSTANCE-GROUP-MANAGER}";
@@ -4813,10 +4813,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone where the managed instance group is located.
-            string zone = "";
+            string zone = "{MY-ZONE}";
 
             // The name of the managed instance group.
             string instanceGroupManager = "{MY-INSTANCE-GROUP-MANAGER}";
@@ -4876,7 +4876,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Insert() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone where you want to create the managed instance group.
             string zone = "{MY-ZONE}";
@@ -4939,7 +4939,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone where the managed instance group is located.
             string zone = "{MY-ZONE}";
@@ -5012,10 +5012,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the ListManagedInstances() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone where the managed instance group is located.
-            string zone = "";
+            string zone = "{MY-ZONE}";
 
             // The name of the managed instance group.
             string instanceGroupManager = "{MY-INSTANCE-GROUP-MANAGER}";
@@ -5075,10 +5075,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the RecreateInstances() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone where the managed instance group is located.
-            string zone = "";
+            string zone = "{MY-ZONE}";
 
             // The name of the managed instance group.
             string instanceGroupManager = "{MY-INSTANCE-GROUP-MANAGER}";
@@ -5141,13 +5141,13 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Resize() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone where the managed instance group is located.
-            string zone = "";
+            string zone = "{MY-ZONE}";
 
             // The name of the managed instance group.
-            string instanceGroupManager = "";
+            string instanceGroupManager = "{MY-INSTANCE-GROUP-MANAGER}";
 
             // The number of running instances that the managed instance group should maintain at any given time.
             // The group automatically adds or removes instances to maintain the number of instances specified by
@@ -5209,10 +5209,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the SetInstanceTemplate() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone where the managed instance group is located.
-            string zone = "";
+            string zone = "{MY-ZONE}";
 
             // The name of the managed instance group.
             string instanceGroupManager = "{MY-INSTANCE-GROUP-MANAGER}";
@@ -5275,10 +5275,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the SetTargetPools() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone where the managed instance group is located.
-            string zone = "";
+            string zone = "{MY-ZONE}";
 
             // The name of the managed instance group.
             string instanceGroupManager = "{MY-INSTANCE-GROUP-MANAGER}";
@@ -5341,10 +5341,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the AddInstances() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone where the instance group is located.
-            string zone = "";
+            string zone = "{MY-ZONE}";
 
             // The name of the instance group where you are adding instances.
             string instanceGroup = "{MY-INSTANCE-GROUP}";
@@ -5478,10 +5478,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone where the instance group is located.
-            string zone = "";
+            string zone = "{MY-ZONE}";
 
             // The name of the instance group to delete.
             string instanceGroup = "{MY-INSTANCE-GROUP}";
@@ -5541,10 +5541,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone where the instance group is located.
-            string zone = "";
+            string zone = "{MY-ZONE}";
 
             // The name of the instance group.
             string instanceGroup = "{MY-INSTANCE-GROUP}";
@@ -5604,7 +5604,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Insert() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone where you want to create the instance group.
             string zone = "{MY-ZONE}";
@@ -5667,7 +5667,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone where the instance group is located.
             string zone = "{MY-ZONE}";
@@ -5740,10 +5740,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the ListInstances() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone where the instance group is located.
-            string zone = "";
+            string zone = "{MY-ZONE}";
 
             // The name of the instance group from which you want to generate a list of included instances.
             string instanceGroup = "{MY-INSTANCE-GROUP}";
@@ -5819,10 +5819,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the RemoveInstances() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone where the instance group is located.
-            string zone = "";
+            string zone = "{MY-ZONE}";
 
             // The name of the instance group where the specified instances will be removed.
             string instanceGroup = "{MY-INSTANCE-GROUP}";
@@ -5885,10 +5885,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the SetNamedPorts() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone where the instance group is located.
-            string zone = "";
+            string zone = "{MY-ZONE}";
 
             // The name of the instance group where the named ports are updated.
             string instanceGroup = "{MY-INSTANCE-GROUP}";
@@ -5951,7 +5951,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the instance template to delete.
             string instanceTemplate = "{MY-INSTANCE-TEMPLATE}";
@@ -6011,7 +6011,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the instance template.
             string instanceTemplate = "{MY-INSTANCE-TEMPLATE}";
@@ -6201,13 +6201,13 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the AddAccessConfig() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone for this request.
-            string zone = "";
+            string zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
             // The instance name for this request.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             // The name of the network interface to add to this instance.
             string networkInterface = "{MY-NETWORK-INTERFACE}";
@@ -6341,10 +6341,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the AttachDisk() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone for this request.
-            string zone = "";
+            string zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
             // The instance name for this request.
             string instance = "{MY-INSTANCE}";
@@ -6407,10 +6407,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone for this request.
-            string zone = "";
+            string zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
             // Name of the instance resource to delete.
             string instance = "{MY-INSTANCE}";
@@ -6470,16 +6470,16 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the DeleteAccessConfig() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone for this request.
-            string zone = "";
+            string zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
             // The instance name for this request.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             // The name of the access config to delete.
-            string accessConfig = "";
+            string accessConfig = "{MY-ACCESS-CONFIG}";
 
             // The name of the network interface.
             string networkInterface = "{MY-NETWORK-INTERFACE}";
@@ -6539,13 +6539,13 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the DetachDisk() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone for this request.
-            string zone = "";
+            string zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
             // Instance name.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             // Disk device name to detach.
             string deviceName = "{MY-DEVICE-NAME}";
@@ -6605,10 +6605,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone for this request.
-            string zone = "";
+            string zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
             // Name of the instance resource to return.
             string instance = "{MY-INSTANCE}";
@@ -6668,10 +6668,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the GetSerialPortOutput() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone for this request.
-            string zone = "";
+            string zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
             // Name of the instance scoping this request.
             string instance = "{MY-INSTANCE}";
@@ -6731,7 +6731,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Insert() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone for this request.
             string zone = "{MY-ZONE}"  // eg. "us-central1-f";
@@ -6794,7 +6794,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone for this request.
             string zone = "{MY-ZONE}"  // eg. "us-central1-f";
@@ -6867,10 +6867,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Reset() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone for this request.
-            string zone = "";
+            string zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
             // Name of the instance scoping this request.
             string instance = "{MY-INSTANCE}";
@@ -6930,13 +6930,13 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the SetDiskAutoDelete() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone for this request.
-            string zone = "";
+            string zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
             // The instance name.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             // Whether to auto-delete the disk when the instance is deleted.
             bool autoDelete = false;
@@ -6999,10 +6999,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the SetMachineType() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone for this request.
-            string zone = "";
+            string zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
             // Name of the instance scoping this request.
             string instance = "{MY-INSTANCE}";
@@ -7065,10 +7065,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the SetMetadata() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone for this request.
-            string zone = "";
+            string zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
             // Name of the instance scoping this request.
             string instance = "{MY-INSTANCE}";
@@ -7131,10 +7131,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the SetScheduling() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone for this request.
-            string zone = "";
+            string zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
             // Instance name.
             string instance = "{MY-INSTANCE}";
@@ -7197,10 +7197,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the SetTags() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone for this request.
-            string zone = "";
+            string zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
             // Name of the instance scoping this request.
             string instance = "{MY-INSTANCE}";
@@ -7263,10 +7263,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Start() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone for this request.
-            string zone = "";
+            string zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
             // Name of the instance resource to start.
             string instance = "{MY-INSTANCE}";
@@ -7326,10 +7326,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Stop() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone for this request.
-            string zone = "";
+            string zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
             // Name of the instance resource to stop.
             string instance = "{MY-INSTANCE}";
@@ -7389,7 +7389,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the License resource to return.
             string license = "{MY-LICENSE}";
@@ -7520,10 +7520,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone for this request.
-            string zone = "";
+            string zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
             // Name of the machine type to return.
             string machineType = "{MY-MACHINE-TYPE}";
@@ -7583,7 +7583,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone for this request.
             string zone = "{MY-ZONE}"  // eg. "us-central1-f";
@@ -7656,7 +7656,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the network to delete.
             string network = "{MY-NETWORK}";
@@ -7716,7 +7716,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the network to return.
             string network = "{MY-NETWORK}";
@@ -8201,10 +8201,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the region for this request.
-            string region = "";
+            string region = "{MY-REGION}";
 
             // Name of the Operations resource to delete.
             string operation = "{MY-OPERATION}";
@@ -8264,10 +8264,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the region for this request.
-            string region = "";
+            string region = "{MY-REGION}";
 
             // Name of the Operations resource to return.
             string operation = "{MY-OPERATION}";
@@ -8327,7 +8327,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the region for this request.
             string region = "{MY-REGION}";
@@ -8400,7 +8400,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the region resource to return.
             string region = "{MY-REGION}";
@@ -8530,7 +8530,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the Route resource to delete.
             string route = "{MY-ROUTE}";
@@ -8590,7 +8590,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the Route resource to return.
             string route = "{MY-ROUTE}";
@@ -8780,7 +8780,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the Snapshot resource to delete.
             string snapshot = "{MY-SNAPSHOT}";
@@ -8840,7 +8840,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the Snapshot resource to return.
             string snapshot = "{MY-SNAPSHOT}";
@@ -8970,7 +8970,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the SslCertificate resource to delete.
             string sslCertificate = "{MY-SSL-CERTIFICATE}";
@@ -9030,7 +9030,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the SslCertificate resource to return.
             string sslCertificate = "{MY-SSL-CERTIFICATE}";
@@ -9291,10 +9291,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the region scoping this request.
-            string region = "";
+            string region = "{MY-REGION}";
 
             // Name of the Subnetwork resource to delete.
             string subnetwork = "{MY-SUBNETWORK}";
@@ -9354,10 +9354,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the region scoping this request.
-            string region = "";
+            string region = "{MY-REGION}";
 
             // Name of the Subnetwork resource to return.
             string subnetwork = "{MY-SUBNETWORK}";
@@ -9417,7 +9417,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Insert() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the region scoping this request.
             string region = "{MY-REGION}";
@@ -9480,7 +9480,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the region scoping this request.
             string region = "{MY-REGION}";
@@ -9553,7 +9553,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the TargetHttpProxy resource to delete.
             string targetHttpProxy = "{MY-TARGET-HTTP-PROXY}";
@@ -9613,7 +9613,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the TargetHttpProxy resource to return.
             string targetHttpProxy = "{MY-TARGET-HTTP-PROXY}";
@@ -9803,7 +9803,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the SetUrlMap() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the TargetHttpProxy to set a URL map for.
             string targetHttpProxy = "{MY-TARGET-HTTP-PROXY}";
@@ -9866,7 +9866,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the TargetHttpsProxy resource to delete.
             string targetHttpsProxy = "{MY-TARGET-HTTPS-PROXY}";
@@ -9926,7 +9926,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the TargetHttpsProxy resource to return.
             string targetHttpsProxy = "{MY-TARGET-HTTPS-PROXY}";
@@ -10116,7 +10116,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the SetSslCertificates() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the TargetHttpsProxy resource to set an SslCertificates resource for.
             string targetHttpsProxy = "{MY-TARGET-HTTPS-PROXY}";
@@ -10179,7 +10179,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the SetUrlMap() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the TargetHttpsProxy resource whose URL map is to be set.
             string targetHttpsProxy = "{MY-TARGET-HTTPS-PROXY}";
@@ -10313,10 +10313,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the zone scoping this request.
-            string zone = "";
+            string zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
             // Name of the TargetInstance resource to delete.
             string targetInstance = "{MY-TARGET-INSTANCE}";
@@ -10376,10 +10376,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the zone scoping this request.
-            string zone = "";
+            string zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
             // Name of the TargetInstance resource to return.
             string targetInstance = "{MY-TARGET-INSTANCE}";
@@ -10439,7 +10439,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Insert() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the zone scoping this request.
             string zone = "{MY-ZONE}"  // eg. "us-central1-f";
@@ -10502,7 +10502,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the zone scoping this request.
             string zone = "{MY-ZONE}"  // eg. "us-central1-f";
@@ -10575,10 +10575,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the AddHealthCheck() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the region scoping this request.
-            string region = "";
+            string region = "{MY-REGION}";
 
             // Name of the target pool to add a health check to.
             string targetPool = "{MY-TARGET-POOL}";
@@ -10641,10 +10641,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the AddInstance() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the region scoping this request.
-            string region = "";
+            string region = "{MY-REGION}";
 
             // Name of the TargetPool resource to add instances to.
             string targetPool = "{MY-TARGET-POOL}";
@@ -10778,10 +10778,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the region scoping this request.
-            string region = "";
+            string region = "{MY-REGION}";
 
             // Name of the TargetPool resource to delete.
             string targetPool = "{MY-TARGET-POOL}";
@@ -10841,10 +10841,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the region scoping this request.
-            string region = "";
+            string region = "{MY-REGION}";
 
             // Name of the TargetPool resource to return.
             string targetPool = "{MY-TARGET-POOL}";
@@ -10904,10 +10904,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the GetHealth() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the region scoping this request.
-            string region = "";
+            string region = "{MY-REGION}";
 
             // Name of the TargetPool resource to which the queried instance belongs.
             string targetPool = "{MY-TARGET-POOL}";
@@ -10970,7 +10970,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Insert() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the region scoping this request.
             string region = "{MY-REGION}";
@@ -11033,7 +11033,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the region scoping this request.
             string region = "{MY-REGION}";
@@ -11106,10 +11106,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the RemoveHealthCheck() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the region for this request.
-            string region = "";
+            string region = "{MY-REGION}";
 
             // Name of the target pool to remove health checks from.
             string targetPool = "{MY-TARGET-POOL}";
@@ -11172,10 +11172,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the RemoveInstance() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the region scoping this request.
-            string region = "";
+            string region = "{MY-REGION}";
 
             // Name of the TargetPool resource to remove instances from.
             string targetPool = "{MY-TARGET-POOL}";
@@ -11238,10 +11238,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the SetBackup() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the region scoping this request.
-            string region = "";
+            string region = "{MY-REGION}";
 
             // Name of the TargetPool resource to set a backup pool for.
             string targetPool = "{MY-TARGET-POOL}";
@@ -11375,10 +11375,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the region for this request.
-            string region = "";
+            string region = "{MY-REGION}";
 
             // Name of the target VPN gateway to delete.
             string targetVpnGateway = "{MY-TARGET-VPN-GATEWAY}";
@@ -11438,10 +11438,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the region for this request.
-            string region = "";
+            string region = "{MY-REGION}";
 
             // Name of the target VPN gateway to return.
             string targetVpnGateway = "{MY-TARGET-VPN-GATEWAY}";
@@ -11501,7 +11501,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Insert() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the region for this request.
             string region = "{MY-REGION}";
@@ -11564,7 +11564,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the region for this request.
             string region = "{MY-REGION}";
@@ -11637,7 +11637,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the UrlMap resource to delete.
             string urlMap = "{MY-URL-MAP}";
@@ -11697,7 +11697,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the UrlMap resource to return.
             string urlMap = "{MY-URL-MAP}";
@@ -11887,7 +11887,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Patch() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the UrlMap resource to update.
             string urlMap = "{MY-URL-MAP}";
@@ -11950,7 +11950,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Update() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the UrlMap resource to update.
             string urlMap = "{MY-URL-MAP}";
@@ -12013,7 +12013,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Validate() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the UrlMap resource to be validated as.
             string urlMap = "{MY-URL-MAP}";
@@ -12147,10 +12147,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the region for this request.
-            string region = "";
+            string region = "{MY-REGION}";
 
             // Name of the VpnTunnel resource to delete.
             string vpnTunnel = "{MY-VPN-TUNNEL}";
@@ -12210,10 +12210,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the region for this request.
-            string region = "";
+            string region = "{MY-REGION}";
 
             // Name of the VpnTunnel resource to return.
             string vpnTunnel = "{MY-VPN-TUNNEL}";
@@ -12273,7 +12273,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Insert() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the region for this request.
             string region = "{MY-REGION}";
@@ -12336,7 +12336,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the region for this request.
             string region = "{MY-REGION}";
@@ -12407,10 +12407,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the zone for this request.
-            string zone = "";
+            string zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
             // Name of the Operations resource to delete.
             string operation = "{MY-OPERATION}";
@@ -12470,10 +12470,10 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the zone for this request.
-            string zone = "";
+            string zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
             // Name of the Operations resource to return.
             string operation = "{MY-OPERATION}";
@@ -12533,7 +12533,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the zone for request.
             string zone = "{MY-ZONE}"  // eg. "us-central1-f";
@@ -12606,7 +12606,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the zone resource to return.
             string zone = "{MY-ZONE}"  // eg. "us-central1-f";

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_compute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_compute.v1.json.baseline
@@ -47,7 +47,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the AggregatedList() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             AddressesResource.AggregatedListRequest request = computeService.Addresses.AggregatedList(project);
             Data.AddressAggregatedList response;
@@ -123,7 +123,7 @@ namespace ComputeSample
             string region = "";
 
             // Name of the address resource to delete.
-            string address = "";
+            string address = "{MY-ADDRESS}";
 
             AddressesResource.DeleteRequest request = computeService.Addresses.Delete(project, region, address);
             Data.Operation response = request.Execute();
@@ -186,7 +186,7 @@ namespace ComputeSample
             string region = "";
 
             // Name of the address resource to return.
-            string address = "";
+            string address = "{MY-ADDRESS}";
 
             AddressesResource.GetRequest request = computeService.Addresses.Get(project, region, address);
             Data.Address response = request.Execute();
@@ -246,7 +246,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the region for this request.
-            string region = "";
+            string region = "{MY-REGION}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Address content = new Data.Address();
@@ -309,7 +309,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the region for this request.
-            string region = "";
+            string region = "{MY-REGION}";
 
             AddressesResource.ListRequest request = computeService.Addresses.List(project, region);
             Data.AddressList response;
@@ -380,7 +380,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the AggregatedList() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             AutoscalersResource.AggregatedListRequest request = computeService.Autoscalers.AggregatedList(project);
             Data.AutoscalerAggregatedList response;
@@ -456,7 +456,7 @@ namespace ComputeSample
             string zone = "";
 
             // Name of the autoscaler to delete.
-            string autoscaler = "";
+            string autoscaler = "{MY-AUTOSCALER}";
 
             AutoscalersResource.DeleteRequest request = computeService.Autoscalers.Delete(project, zone, autoscaler);
             Data.Operation response = request.Execute();
@@ -519,7 +519,7 @@ namespace ComputeSample
             string zone = "";
 
             // Name of the autoscaler to return.
-            string autoscaler = "";
+            string autoscaler = "{MY-AUTOSCALER}";
 
             AutoscalersResource.GetRequest request = computeService.Autoscalers.Get(project, zone, autoscaler);
             Data.Autoscaler response = request.Execute();
@@ -579,7 +579,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the zone for this request.
-            string zone = "";
+            string zone = "us-central1-f";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Autoscaler content = new Data.Autoscaler();
@@ -642,7 +642,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the zone for this request.
-            string zone = "";
+            string zone = "us-central1-f";
 
             AutoscalersResource.ListRequest request = computeService.Autoscalers.List(project, zone);
             Data.AutoscalerList response;
@@ -718,7 +718,7 @@ namespace ComputeSample
             string zone = "";
 
             // Name of the autoscaler to update.
-            string autoscaler = "";
+            string autoscaler = "{MY-AUTOSCALER}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Autoscaler content = new Data.Autoscaler();
@@ -781,7 +781,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the zone for this request.
-            string zone = "";
+            string zone = "us-central1-f";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Autoscaler content = new Data.Autoscaler();
@@ -844,7 +844,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the BackendService resource to delete.
-            string backendService = "";
+            string backendService = "{MY-BACKEND-SERVICE}";
 
             BackendServicesResource.DeleteRequest request = computeService.BackendServices.Delete(project, backendService);
             Data.Operation response = request.Execute();
@@ -904,7 +904,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the BackendService resource to return.
-            string backendService = "";
+            string backendService = "{MY-BACKEND-SERVICE}";
 
             BackendServicesResource.GetRequest request = computeService.BackendServices.Get(project, backendService);
             Data.BackendService response = request.Execute();
@@ -963,7 +963,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the BackendService resource to which the queried instance belongs.
-            string backendService = "";
+            string backendService = "{MY-BACKEND-SERVICE}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.ResourceGroupReference content = new Data.ResourceGroupReference();
@@ -1023,7 +1023,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Insert() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.BackendService content = new Data.BackendService();
@@ -1083,7 +1083,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             BackendServicesResource.ListRequest request = computeService.BackendServices.List(project);
             Data.BackendServiceList response;
@@ -1156,7 +1156,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the BackendService resource to update.
-            string backendService = "";
+            string backendService = "{MY-BACKEND-SERVICE}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.BackendService content = new Data.BackendService();
@@ -1219,7 +1219,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the BackendService resource to update.
-            string backendService = "";
+            string backendService = "{MY-BACKEND-SERVICE}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.BackendService content = new Data.BackendService();
@@ -1280,7 +1280,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the AggregatedList() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             DiskTypesResource.AggregatedListRequest request = computeService.DiskTypes.AggregatedList(project);
             Data.DiskTypeAggregatedList response;
@@ -1356,7 +1356,7 @@ namespace ComputeSample
             string zone = "";
 
             // Name of the disk type to return.
-            string diskType = "";
+            string diskType = "{MY-DISK-TYPE}";
 
             DiskTypesResource.GetRequest request = computeService.DiskTypes.Get(project, zone, diskType);
             Data.DiskType response = request.Execute();
@@ -1416,7 +1416,7 @@ namespace ComputeSample
             string project = "";
 
             // The name of the zone for this request.
-            string zone = "";
+            string zone = "us-central1-f";
 
             DiskTypesResource.ListRequest request = computeService.DiskTypes.List(project, zone);
             Data.DiskTypeList response;
@@ -1487,7 +1487,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the AggregatedList() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             DisksResource.AggregatedListRequest request = computeService.Disks.AggregatedList(project);
             Data.DiskAggregatedList response;
@@ -1563,7 +1563,7 @@ namespace ComputeSample
             string zone = "";
 
             // Name of the persistent disk to snapshot.
-            string disk = "";
+            string disk = "{MY-DISK}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Snapshot content = new Data.Snapshot();
@@ -1629,7 +1629,7 @@ namespace ComputeSample
             string zone = "";
 
             // Name of the persistent disk to delete.
-            string disk = "";
+            string disk = "{MY-DISK}";
 
             DisksResource.DeleteRequest request = computeService.Disks.Delete(project, zone, disk);
             Data.Operation response = request.Execute();
@@ -1692,7 +1692,7 @@ namespace ComputeSample
             string zone = "";
 
             // Name of the persistent disk to return.
-            string disk = "";
+            string disk = "{MY-DISK}";
 
             DisksResource.GetRequest request = computeService.Disks.Get(project, zone, disk);
             Data.Disk response = request.Execute();
@@ -1752,7 +1752,7 @@ namespace ComputeSample
             string project = "";
 
             // The name of the zone for this request.
-            string zone = "";
+            string zone = "us-central1-f";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Disk content = new Data.Disk();
@@ -1815,7 +1815,7 @@ namespace ComputeSample
             string project = "";
 
             // The name of the zone for this request.
-            string zone = "";
+            string zone = "us-central1-f";
 
             DisksResource.ListRequest request = computeService.Disks.List(project, zone);
             Data.DiskList response;
@@ -1888,7 +1888,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the firewall rule to delete.
-            string firewall = "";
+            string firewall = "{MY-FIREWALL}";
 
             FirewallsResource.DeleteRequest request = computeService.Firewalls.Delete(project, firewall);
             Data.Operation response = request.Execute();
@@ -1948,7 +1948,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the firewall rule to return.
-            string firewall = "";
+            string firewall = "{MY-FIREWALL}";
 
             FirewallsResource.GetRequest request = computeService.Firewalls.Get(project, firewall);
             Data.Firewall response = request.Execute();
@@ -2005,7 +2005,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Insert() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Firewall content = new Data.Firewall();
@@ -2065,7 +2065,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             FirewallsResource.ListRequest request = computeService.Firewalls.List(project);
             Data.FirewallList response;
@@ -2138,7 +2138,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the firewall rule to update.
-            string firewall = "";
+            string firewall = "{MY-FIREWALL}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Firewall content = new Data.Firewall();
@@ -2201,7 +2201,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the firewall rule to update.
-            string firewall = "";
+            string firewall = "{MY-FIREWALL}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Firewall content = new Data.Firewall();
@@ -2262,7 +2262,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the AggregatedList() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             ForwardingRulesResource.AggregatedListRequest request = computeService.ForwardingRules.AggregatedList(project);
             Data.ForwardingRuleAggregatedList response;
@@ -2338,7 +2338,7 @@ namespace ComputeSample
             string region = "";
 
             // Name of the ForwardingRule resource to delete.
-            string forwardingRule = "";
+            string forwardingRule = "{MY-FORWARDING-RULE}";
 
             ForwardingRulesResource.DeleteRequest request = computeService.ForwardingRules.Delete(project, region, forwardingRule);
             Data.Operation response = request.Execute();
@@ -2401,7 +2401,7 @@ namespace ComputeSample
             string region = "";
 
             // Name of the ForwardingRule resource to return.
-            string forwardingRule = "";
+            string forwardingRule = "{MY-FORWARDING-RULE}";
 
             ForwardingRulesResource.GetRequest request = computeService.ForwardingRules.Get(project, region, forwardingRule);
             Data.ForwardingRule response = request.Execute();
@@ -2461,7 +2461,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the region scoping this request.
-            string region = "";
+            string region = "{MY-REGION}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.ForwardingRule content = new Data.ForwardingRule();
@@ -2524,7 +2524,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the region scoping this request.
-            string region = "";
+            string region = "{MY-REGION}";
 
             ForwardingRulesResource.ListRequest request = computeService.ForwardingRules.List(project, region);
             Data.ForwardingRuleList response;
@@ -2600,7 +2600,7 @@ namespace ComputeSample
             string region = "";
 
             // Name of the ForwardingRule resource in which target is to be set.
-            string forwardingRule = "";
+            string forwardingRule = "{MY-FORWARDING-RULE}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.TargetReference content = new Data.TargetReference();
@@ -2663,7 +2663,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the address resource to delete.
-            string address = "";
+            string address = "{MY-ADDRESS}";
 
             GlobalAddressesResource.DeleteRequest request = computeService.GlobalAddresses.Delete(project, address);
             Data.Operation response = request.Execute();
@@ -2723,7 +2723,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the address resource to return.
-            string address = "";
+            string address = "{MY-ADDRESS}";
 
             GlobalAddressesResource.GetRequest request = computeService.GlobalAddresses.Get(project, address);
             Data.Address response = request.Execute();
@@ -2780,7 +2780,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Insert() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Address content = new Data.Address();
@@ -2840,7 +2840,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             GlobalAddressesResource.ListRequest request = computeService.GlobalAddresses.List(project);
             Data.AddressList response;
@@ -2913,7 +2913,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the ForwardingRule resource to delete.
-            string forwardingRule = "";
+            string forwardingRule = "{MY-FORWARDING-RULE}";
 
             GlobalForwardingRulesResource.DeleteRequest request = computeService.GlobalForwardingRules.Delete(project, forwardingRule);
             Data.Operation response = request.Execute();
@@ -2973,7 +2973,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the ForwardingRule resource to return.
-            string forwardingRule = "";
+            string forwardingRule = "{MY-FORWARDING-RULE}";
 
             GlobalForwardingRulesResource.GetRequest request = computeService.GlobalForwardingRules.Get(project, forwardingRule);
             Data.ForwardingRule response = request.Execute();
@@ -3030,7 +3030,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Insert() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.ForwardingRule content = new Data.ForwardingRule();
@@ -3090,7 +3090,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             GlobalForwardingRulesResource.ListRequest request = computeService.GlobalForwardingRules.List(project);
             Data.ForwardingRuleList response;
@@ -3163,7 +3163,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the ForwardingRule resource in which target is to be set.
-            string forwardingRule = "";
+            string forwardingRule = "{MY-FORWARDING-RULE}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.TargetReference content = new Data.TargetReference();
@@ -3224,7 +3224,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the AggregatedList() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             GlobalOperationsResource.AggregatedListRequest request = computeService.GlobalOperations.AggregatedList(project);
             Data.OperationAggregatedList response;
@@ -3295,7 +3295,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the Operations resource to delete.
-            string operation = "";
+            string operation = "{MY-OPERATION}";
 
             GlobalOperationsResource.DeleteRequest request = computeService.GlobalOperations.Delete(project, operation);
             request.Execute();
@@ -3355,7 +3355,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the Operations resource to return.
-            string operation = "";
+            string operation = "{MY-OPERATION}";
 
             GlobalOperationsResource.GetRequest request = computeService.GlobalOperations.Get(project, operation);
             Data.Operation response = request.Execute();
@@ -3412,7 +3412,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             GlobalOperationsResource.ListRequest request = computeService.GlobalOperations.List(project);
             Data.OperationList response;
@@ -3485,7 +3485,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the HttpHealthCheck resource to delete.
-            string httpHealthCheck = "";
+            string httpHealthCheck = "{MY-HTTP-HEALTH-CHECK}";
 
             HttpHealthChecksResource.DeleteRequest request = computeService.HttpHealthChecks.Delete(project, httpHealthCheck);
             Data.Operation response = request.Execute();
@@ -3545,7 +3545,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the HttpHealthCheck resource to return.
-            string httpHealthCheck = "";
+            string httpHealthCheck = "{MY-HTTP-HEALTH-CHECK}";
 
             HttpHealthChecksResource.GetRequest request = computeService.HttpHealthChecks.Get(project, httpHealthCheck);
             Data.HttpHealthCheck response = request.Execute();
@@ -3602,7 +3602,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Insert() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.HttpHealthCheck content = new Data.HttpHealthCheck();
@@ -3662,7 +3662,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             HttpHealthChecksResource.ListRequest request = computeService.HttpHealthChecks.List(project);
             Data.HttpHealthCheckList response;
@@ -3735,7 +3735,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the HttpHealthCheck resource to update.
-            string httpHealthCheck = "";
+            string httpHealthCheck = "{MY-HTTP-HEALTH-CHECK}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.HttpHealthCheck content = new Data.HttpHealthCheck();
@@ -3798,7 +3798,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the HttpHealthCheck resource to update.
-            string httpHealthCheck = "";
+            string httpHealthCheck = "{MY-HTTP-HEALTH-CHECK}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.HttpHealthCheck content = new Data.HttpHealthCheck();
@@ -3861,7 +3861,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the HttpsHealthCheck resource to delete.
-            string httpsHealthCheck = "";
+            string httpsHealthCheck = "{MY-HTTPS-HEALTH-CHECK}";
 
             HttpsHealthChecksResource.DeleteRequest request = computeService.HttpsHealthChecks.Delete(project, httpsHealthCheck);
             Data.Operation response = request.Execute();
@@ -3921,7 +3921,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the HttpsHealthCheck resource to return.
-            string httpsHealthCheck = "";
+            string httpsHealthCheck = "{MY-HTTPS-HEALTH-CHECK}";
 
             HttpsHealthChecksResource.GetRequest request = computeService.HttpsHealthChecks.Get(project, httpsHealthCheck);
             Data.HttpsHealthCheck response = request.Execute();
@@ -3978,7 +3978,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Insert() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.HttpsHealthCheck content = new Data.HttpsHealthCheck();
@@ -4038,7 +4038,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             HttpsHealthChecksResource.ListRequest request = computeService.HttpsHealthChecks.List(project);
             Data.HttpsHealthCheckList response;
@@ -4111,7 +4111,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the HttpsHealthCheck resource to update.
-            string httpsHealthCheck = "";
+            string httpsHealthCheck = "{MY-HTTPS-HEALTH-CHECK}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.HttpsHealthCheck content = new Data.HttpsHealthCheck();
@@ -4174,7 +4174,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the HttpsHealthCheck resource to update.
-            string httpsHealthCheck = "";
+            string httpsHealthCheck = "{MY-HTTPS-HEALTH-CHECK}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.HttpsHealthCheck content = new Data.HttpsHealthCheck();
@@ -4237,7 +4237,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the image resource to delete.
-            string image = "";
+            string image = "{MY-IMAGE}";
 
             ImagesResource.DeleteRequest request = computeService.Images.Delete(project, image);
             Data.Operation response = request.Execute();
@@ -4297,7 +4297,7 @@ namespace ComputeSample
             string project = "";
 
             // Image name.
-            string image = "";
+            string image = "{MY-IMAGE}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.DeprecationStatus content = new Data.DeprecationStatus();
@@ -4360,7 +4360,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the image resource to return.
-            string image = "";
+            string image = "{MY-IMAGE}";
 
             ImagesResource.GetRequest request = computeService.Images.Get(project, image);
             Data.Image response = request.Execute();
@@ -4417,7 +4417,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Insert() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Image content = new Data.Image();
@@ -4477,7 +4477,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             ImagesResource.ListRequest request = computeService.Images.List(project);
             Data.ImageList response;
@@ -4553,7 +4553,7 @@ namespace ComputeSample
             string zone = "";
 
             // The name of the managed instance group.
-            string instanceGroupManager = "";
+            string instanceGroupManager = "{MY-INSTANCE-GROUP-MANAGER}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.InstanceGroupManagersAbandonInstancesRequest content = new Data.InstanceGroupManagersAbandonInstancesRequest();
@@ -4614,7 +4614,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the AggregatedList() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             InstanceGroupManagersResource.AggregatedListRequest request = computeService.InstanceGroupManagers.AggregatedList(project);
             Data.InstanceGroupManagerAggregatedList response;
@@ -4690,7 +4690,7 @@ namespace ComputeSample
             string zone = "";
 
             // The name of the managed instance group to delete.
-            string instanceGroupManager = "";
+            string instanceGroupManager = "{MY-INSTANCE-GROUP-MANAGER}";
 
             InstanceGroupManagersResource.DeleteRequest request = computeService.InstanceGroupManagers.Delete(project, zone, instanceGroupManager);
             Data.Operation response = request.Execute();
@@ -4753,7 +4753,7 @@ namespace ComputeSample
             string zone = "";
 
             // The name of the managed instance group.
-            string instanceGroupManager = "";
+            string instanceGroupManager = "{MY-INSTANCE-GROUP-MANAGER}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.InstanceGroupManagersDeleteInstancesRequest content = new Data.InstanceGroupManagersDeleteInstancesRequest();
@@ -4819,7 +4819,7 @@ namespace ComputeSample
             string zone = "";
 
             // The name of the managed instance group.
-            string instanceGroupManager = "";
+            string instanceGroupManager = "{MY-INSTANCE-GROUP-MANAGER}";
 
             InstanceGroupManagersResource.GetRequest request = computeService.InstanceGroupManagers.Get(project, zone, instanceGroupManager);
             Data.InstanceGroupManager response = request.Execute();
@@ -4879,7 +4879,7 @@ namespace ComputeSample
             string project = "";
 
             // The name of the zone where you want to create the managed instance group.
-            string zone = "";
+            string zone = "{MY-ZONE}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.InstanceGroupManager content = new Data.InstanceGroupManager();
@@ -4942,7 +4942,7 @@ namespace ComputeSample
             string project = "";
 
             // The name of the zone where the managed instance group is located.
-            string zone = "";
+            string zone = "{MY-ZONE}";
 
             InstanceGroupManagersResource.ListRequest request = computeService.InstanceGroupManagers.List(project, zone);
             Data.InstanceGroupManagerList response;
@@ -5018,7 +5018,7 @@ namespace ComputeSample
             string zone = "";
 
             // The name of the managed instance group.
-            string instanceGroupManager = "";
+            string instanceGroupManager = "{MY-INSTANCE-GROUP-MANAGER}";
 
             InstanceGroupManagersResource.ListManagedInstancesRequest request = computeService.InstanceGroupManagers.ListManagedInstances(project, zone, instanceGroupManager);
             Data.InstanceGroupManagersListManagedInstancesResponse response = request.Execute();
@@ -5081,7 +5081,7 @@ namespace ComputeSample
             string zone = "";
 
             // The name of the managed instance group.
-            string instanceGroupManager = "";
+            string instanceGroupManager = "{MY-INSTANCE-GROUP-MANAGER}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.InstanceGroupManagersRecreateInstancesRequest content = new Data.InstanceGroupManagersRecreateInstancesRequest();
@@ -5215,7 +5215,7 @@ namespace ComputeSample
             string zone = "";
 
             // The name of the managed instance group.
-            string instanceGroupManager = "";
+            string instanceGroupManager = "{MY-INSTANCE-GROUP-MANAGER}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.InstanceGroupManagersSetInstanceTemplateRequest content = new Data.InstanceGroupManagersSetInstanceTemplateRequest();
@@ -5281,7 +5281,7 @@ namespace ComputeSample
             string zone = "";
 
             // The name of the managed instance group.
-            string instanceGroupManager = "";
+            string instanceGroupManager = "{MY-INSTANCE-GROUP-MANAGER}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.InstanceGroupManagersSetTargetPoolsRequest content = new Data.InstanceGroupManagersSetTargetPoolsRequest();
@@ -5347,7 +5347,7 @@ namespace ComputeSample
             string zone = "";
 
             // The name of the instance group where you are adding instances.
-            string instanceGroup = "";
+            string instanceGroup = "{MY-INSTANCE-GROUP}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.InstanceGroupsAddInstancesRequest content = new Data.InstanceGroupsAddInstancesRequest();
@@ -5408,7 +5408,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the AggregatedList() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             InstanceGroupsResource.AggregatedListRequest request = computeService.InstanceGroups.AggregatedList(project);
             Data.InstanceGroupAggregatedList response;
@@ -5484,7 +5484,7 @@ namespace ComputeSample
             string zone = "";
 
             // The name of the instance group to delete.
-            string instanceGroup = "";
+            string instanceGroup = "{MY-INSTANCE-GROUP}";
 
             InstanceGroupsResource.DeleteRequest request = computeService.InstanceGroups.Delete(project, zone, instanceGroup);
             Data.Operation response = request.Execute();
@@ -5547,7 +5547,7 @@ namespace ComputeSample
             string zone = "";
 
             // The name of the instance group.
-            string instanceGroup = "";
+            string instanceGroup = "{MY-INSTANCE-GROUP}";
 
             InstanceGroupsResource.GetRequest request = computeService.InstanceGroups.Get(project, zone, instanceGroup);
             Data.InstanceGroup response = request.Execute();
@@ -5607,7 +5607,7 @@ namespace ComputeSample
             string project = "";
 
             // The name of the zone where you want to create the instance group.
-            string zone = "";
+            string zone = "{MY-ZONE}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.InstanceGroup content = new Data.InstanceGroup();
@@ -5670,7 +5670,7 @@ namespace ComputeSample
             string project = "";
 
             // The name of the zone where the instance group is located.
-            string zone = "";
+            string zone = "{MY-ZONE}";
 
             InstanceGroupsResource.ListRequest request = computeService.InstanceGroups.List(project, zone);
             Data.InstanceGroupList response;
@@ -5746,7 +5746,7 @@ namespace ComputeSample
             string zone = "";
 
             // The name of the instance group from which you want to generate a list of included instances.
-            string instanceGroup = "";
+            string instanceGroup = "{MY-INSTANCE-GROUP}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.InstanceGroupsListInstancesRequest content = new Data.InstanceGroupsListInstancesRequest();
@@ -5825,7 +5825,7 @@ namespace ComputeSample
             string zone = "";
 
             // The name of the instance group where the specified instances will be removed.
-            string instanceGroup = "";
+            string instanceGroup = "{MY-INSTANCE-GROUP}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.InstanceGroupsRemoveInstancesRequest content = new Data.InstanceGroupsRemoveInstancesRequest();
@@ -5891,7 +5891,7 @@ namespace ComputeSample
             string zone = "";
 
             // The name of the instance group where the named ports are updated.
-            string instanceGroup = "";
+            string instanceGroup = "{MY-INSTANCE-GROUP}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.InstanceGroupsSetNamedPortsRequest content = new Data.InstanceGroupsSetNamedPortsRequest();
@@ -5954,7 +5954,7 @@ namespace ComputeSample
             string project = "";
 
             // The name of the instance template to delete.
-            string instanceTemplate = "";
+            string instanceTemplate = "{MY-INSTANCE-TEMPLATE}";
 
             InstanceTemplatesResource.DeleteRequest request = computeService.InstanceTemplates.Delete(project, instanceTemplate);
             Data.Operation response = request.Execute();
@@ -6014,7 +6014,7 @@ namespace ComputeSample
             string project = "";
 
             // The name of the instance template.
-            string instanceTemplate = "";
+            string instanceTemplate = "{MY-INSTANCE-TEMPLATE}";
 
             InstanceTemplatesResource.GetRequest request = computeService.InstanceTemplates.Get(project, instanceTemplate);
             Data.InstanceTemplate response = request.Execute();
@@ -6071,7 +6071,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Insert() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.InstanceTemplate content = new Data.InstanceTemplate();
@@ -6131,7 +6131,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             InstanceTemplatesResource.ListRequest request = computeService.InstanceTemplates.List(project);
             Data.InstanceTemplateList response;
@@ -6210,7 +6210,7 @@ namespace ComputeSample
             string instance = "";
 
             // The name of the network interface to add to this instance.
-            string networkInterface = "";
+            string networkInterface = "{MY-NETWORK-INTERFACE}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.AccessConfig content = new Data.AccessConfig();
@@ -6271,7 +6271,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the AggregatedList() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             InstancesResource.AggregatedListRequest request = computeService.Instances.AggregatedList(project);
             Data.InstanceAggregatedList response;
@@ -6347,7 +6347,7 @@ namespace ComputeSample
             string zone = "";
 
             // The instance name for this request.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.AttachedDisk content = new Data.AttachedDisk();
@@ -6413,7 +6413,7 @@ namespace ComputeSample
             string zone = "";
 
             // Name of the instance resource to delete.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             InstancesResource.DeleteRequest request = computeService.Instances.Delete(project, zone, instance);
             Data.Operation response = request.Execute();
@@ -6482,7 +6482,7 @@ namespace ComputeSample
             string accessConfig = "";
 
             // The name of the network interface.
-            string networkInterface = "";
+            string networkInterface = "{MY-NETWORK-INTERFACE}";
 
             InstancesResource.DeleteAccessConfigRequest request = computeService.Instances.DeleteAccessConfig(project, zone, instance, accessConfig, networkInterface);
             Data.Operation response = request.Execute();
@@ -6548,7 +6548,7 @@ namespace ComputeSample
             string instance = "";
 
             // Disk device name to detach.
-            string deviceName = "";
+            string deviceName = "{MY-DEVICE-NAME}";
 
             InstancesResource.DetachDiskRequest request = computeService.Instances.DetachDisk(project, zone, instance, deviceName);
             Data.Operation response = request.Execute();
@@ -6611,7 +6611,7 @@ namespace ComputeSample
             string zone = "";
 
             // Name of the instance resource to return.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             InstancesResource.GetRequest request = computeService.Instances.Get(project, zone, instance);
             Data.Instance response = request.Execute();
@@ -6674,7 +6674,7 @@ namespace ComputeSample
             string zone = "";
 
             // Name of the instance scoping this request.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             InstancesResource.GetSerialPortOutputRequest request = computeService.Instances.GetSerialPortOutput(project, zone, instance);
             Data.SerialPortOutput response = request.Execute();
@@ -6734,7 +6734,7 @@ namespace ComputeSample
             string project = "";
 
             // The name of the zone for this request.
-            string zone = "";
+            string zone = "us-central1-f";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Instance content = new Data.Instance();
@@ -6797,7 +6797,7 @@ namespace ComputeSample
             string project = "";
 
             // The name of the zone for this request.
-            string zone = "";
+            string zone = "us-central1-f";
 
             InstancesResource.ListRequest request = computeService.Instances.List(project, zone);
             Data.InstanceList response;
@@ -6873,7 +6873,7 @@ namespace ComputeSample
             string zone = "";
 
             // Name of the instance scoping this request.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             InstancesResource.ResetRequest request = computeService.Instances.Reset(project, zone, instance);
             Data.Operation response = request.Execute();
@@ -6942,7 +6942,7 @@ namespace ComputeSample
             bool autoDelete = false;
 
             // The device name of the disk to modify.
-            string deviceName = "";
+            string deviceName = "{MY-DEVICE-NAME}";
 
             InstancesResource.SetDiskAutoDeleteRequest request = computeService.Instances.SetDiskAutoDelete(project, zone, instance, autoDelete, deviceName);
             Data.Operation response = request.Execute();
@@ -7005,7 +7005,7 @@ namespace ComputeSample
             string zone = "";
 
             // Name of the instance scoping this request.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.InstancesSetMachineTypeRequest content = new Data.InstancesSetMachineTypeRequest();
@@ -7071,7 +7071,7 @@ namespace ComputeSample
             string zone = "";
 
             // Name of the instance scoping this request.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Metadata content = new Data.Metadata();
@@ -7137,7 +7137,7 @@ namespace ComputeSample
             string zone = "";
 
             // Instance name.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Scheduling content = new Data.Scheduling();
@@ -7203,7 +7203,7 @@ namespace ComputeSample
             string zone = "";
 
             // Name of the instance scoping this request.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Tags content = new Data.Tags();
@@ -7269,7 +7269,7 @@ namespace ComputeSample
             string zone = "";
 
             // Name of the instance resource to start.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             InstancesResource.StartRequest request = computeService.Instances.Start(project, zone, instance);
             Data.Operation response = request.Execute();
@@ -7332,7 +7332,7 @@ namespace ComputeSample
             string zone = "";
 
             // Name of the instance resource to stop.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             InstancesResource.StopRequest request = computeService.Instances.Stop(project, zone, instance);
             Data.Operation response = request.Execute();
@@ -7392,7 +7392,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the License resource to return.
-            string license = "";
+            string license = "{MY-LICENSE}";
 
             LicensesResource.GetRequest request = computeService.Licenses.Get(project, license);
             Data.License response = request.Execute();
@@ -7450,7 +7450,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the AggregatedList() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             MachineTypesResource.AggregatedListRequest request = computeService.MachineTypes.AggregatedList(project);
             Data.MachineTypeAggregatedList response;
@@ -7526,7 +7526,7 @@ namespace ComputeSample
             string zone = "";
 
             // Name of the machine type to return.
-            string machineType = "";
+            string machineType = "{MY-MACHINE-TYPE}";
 
             MachineTypesResource.GetRequest request = computeService.MachineTypes.Get(project, zone, machineType);
             Data.MachineType response = request.Execute();
@@ -7586,7 +7586,7 @@ namespace ComputeSample
             string project = "";
 
             // The name of the zone for this request.
-            string zone = "";
+            string zone = "us-central1-f";
 
             MachineTypesResource.ListRequest request = computeService.MachineTypes.List(project, zone);
             Data.MachineTypeList response;
@@ -7659,7 +7659,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the network to delete.
-            string network = "";
+            string network = "{MY-NETWORK}";
 
             NetworksResource.DeleteRequest request = computeService.Networks.Delete(project, network);
             Data.Operation response = request.Execute();
@@ -7719,7 +7719,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the network to return.
-            string network = "";
+            string network = "{MY-NETWORK}";
 
             NetworksResource.GetRequest request = computeService.Networks.Get(project, network);
             Data.Network response = request.Execute();
@@ -7776,7 +7776,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Insert() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Network content = new Data.Network();
@@ -7836,7 +7836,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             NetworksResource.ListRequest request = computeService.Networks.List(project);
             Data.NetworkList response;
@@ -7906,7 +7906,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             ProjectsResource.GetRequest request = computeService.Projects.Get(project);
             Data.Project response = request.Execute();
@@ -7963,7 +7963,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the MoveDisk() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.DiskMoveRequest content = new Data.DiskMoveRequest();
@@ -8023,7 +8023,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the MoveInstance() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.InstanceMoveRequest content = new Data.InstanceMoveRequest();
@@ -8083,7 +8083,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the SetCommonInstanceMetadata() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Metadata content = new Data.Metadata();
@@ -8143,7 +8143,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the SetUsageExportBucket() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.UsageExportLocation content = new Data.UsageExportLocation();
@@ -8207,7 +8207,7 @@ namespace ComputeSample
             string region = "";
 
             // Name of the Operations resource to delete.
-            string operation = "";
+            string operation = "{MY-OPERATION}";
 
             RegionOperationsResource.DeleteRequest request = computeService.RegionOperations.Delete(project, region, operation);
             request.Execute();
@@ -8270,7 +8270,7 @@ namespace ComputeSample
             string region = "";
 
             // Name of the Operations resource to return.
-            string operation = "";
+            string operation = "{MY-OPERATION}";
 
             RegionOperationsResource.GetRequest request = computeService.RegionOperations.Get(project, region, operation);
             Data.Operation response = request.Execute();
@@ -8330,7 +8330,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the region for this request.
-            string region = "";
+            string region = "{MY-REGION}";
 
             RegionOperationsResource.ListRequest request = computeService.RegionOperations.List(project, region);
             Data.OperationList response;
@@ -8403,7 +8403,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the region resource to return.
-            string region = "";
+            string region = "{MY-REGION}";
 
             RegionsResource.GetRequest request = computeService.Regions.Get(project, region);
             Data.Region response = request.Execute();
@@ -8460,7 +8460,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             RegionsResource.ListRequest request = computeService.Regions.List(project);
             Data.RegionList response;
@@ -8533,7 +8533,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the Route resource to delete.
-            string route = "";
+            string route = "{MY-ROUTE}";
 
             RoutesResource.DeleteRequest request = computeService.Routes.Delete(project, route);
             Data.Operation response = request.Execute();
@@ -8593,7 +8593,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the Route resource to return.
-            string route = "";
+            string route = "{MY-ROUTE}";
 
             RoutesResource.GetRequest request = computeService.Routes.Get(project, route);
             Data.Route response = request.Execute();
@@ -8650,7 +8650,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Insert() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Route content = new Data.Route();
@@ -8710,7 +8710,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             RoutesResource.ListRequest request = computeService.Routes.List(project);
             Data.RouteList response;
@@ -8783,7 +8783,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the Snapshot resource to delete.
-            string snapshot = "";
+            string snapshot = "{MY-SNAPSHOT}";
 
             SnapshotsResource.DeleteRequest request = computeService.Snapshots.Delete(project, snapshot);
             Data.Operation response = request.Execute();
@@ -8843,7 +8843,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the Snapshot resource to return.
-            string snapshot = "";
+            string snapshot = "{MY-SNAPSHOT}";
 
             SnapshotsResource.GetRequest request = computeService.Snapshots.Get(project, snapshot);
             Data.Snapshot response = request.Execute();
@@ -8900,7 +8900,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             SnapshotsResource.ListRequest request = computeService.Snapshots.List(project);
             Data.SnapshotList response;
@@ -8973,7 +8973,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the SslCertificate resource to delete.
-            string sslCertificate = "";
+            string sslCertificate = "{MY-SSL-CERTIFICATE}";
 
             SslCertificatesResource.DeleteRequest request = computeService.SslCertificates.Delete(project, sslCertificate);
             Data.Operation response = request.Execute();
@@ -9033,7 +9033,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the SslCertificate resource to return.
-            string sslCertificate = "";
+            string sslCertificate = "{MY-SSL-CERTIFICATE}";
 
             SslCertificatesResource.GetRequest request = computeService.SslCertificates.Get(project, sslCertificate);
             Data.SslCertificate response = request.Execute();
@@ -9090,7 +9090,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Insert() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.SslCertificate content = new Data.SslCertificate();
@@ -9150,7 +9150,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             SslCertificatesResource.ListRequest request = computeService.SslCertificates.List(project);
             Data.SslCertificateList response;
@@ -9221,7 +9221,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the AggregatedList() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             SubnetworksResource.AggregatedListRequest request = computeService.Subnetworks.AggregatedList(project);
             Data.SubnetworkAggregatedList response;
@@ -9297,7 +9297,7 @@ namespace ComputeSample
             string region = "";
 
             // Name of the Subnetwork resource to delete.
-            string subnetwork = "";
+            string subnetwork = "{MY-SUBNETWORK}";
 
             SubnetworksResource.DeleteRequest request = computeService.Subnetworks.Delete(project, region, subnetwork);
             Data.Operation response = request.Execute();
@@ -9360,7 +9360,7 @@ namespace ComputeSample
             string region = "";
 
             // Name of the Subnetwork resource to return.
-            string subnetwork = "";
+            string subnetwork = "{MY-SUBNETWORK}";
 
             SubnetworksResource.GetRequest request = computeService.Subnetworks.Get(project, region, subnetwork);
             Data.Subnetwork response = request.Execute();
@@ -9420,7 +9420,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the region scoping this request.
-            string region = "";
+            string region = "{MY-REGION}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Subnetwork content = new Data.Subnetwork();
@@ -9483,7 +9483,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the region scoping this request.
-            string region = "";
+            string region = "{MY-REGION}";
 
             SubnetworksResource.ListRequest request = computeService.Subnetworks.List(project, region);
             Data.SubnetworkList response;
@@ -9556,7 +9556,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the TargetHttpProxy resource to delete.
-            string targetHttpProxy = "";
+            string targetHttpProxy = "{MY-TARGET-HTTP-PROXY}";
 
             TargetHttpProxiesResource.DeleteRequest request = computeService.TargetHttpProxies.Delete(project, targetHttpProxy);
             Data.Operation response = request.Execute();
@@ -9616,7 +9616,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the TargetHttpProxy resource to return.
-            string targetHttpProxy = "";
+            string targetHttpProxy = "{MY-TARGET-HTTP-PROXY}";
 
             TargetHttpProxiesResource.GetRequest request = computeService.TargetHttpProxies.Get(project, targetHttpProxy);
             Data.TargetHttpProxy response = request.Execute();
@@ -9673,7 +9673,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Insert() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.TargetHttpProxy content = new Data.TargetHttpProxy();
@@ -9733,7 +9733,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             TargetHttpProxiesResource.ListRequest request = computeService.TargetHttpProxies.List(project);
             Data.TargetHttpProxyList response;
@@ -9806,7 +9806,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the TargetHttpProxy to set a URL map for.
-            string targetHttpProxy = "";
+            string targetHttpProxy = "{MY-TARGET-HTTP-PROXY}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.UrlMapReference content = new Data.UrlMapReference();
@@ -9869,7 +9869,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the TargetHttpsProxy resource to delete.
-            string targetHttpsProxy = "";
+            string targetHttpsProxy = "{MY-TARGET-HTTPS-PROXY}";
 
             TargetHttpsProxiesResource.DeleteRequest request = computeService.TargetHttpsProxies.Delete(project, targetHttpsProxy);
             Data.Operation response = request.Execute();
@@ -9929,7 +9929,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the TargetHttpsProxy resource to return.
-            string targetHttpsProxy = "";
+            string targetHttpsProxy = "{MY-TARGET-HTTPS-PROXY}";
 
             TargetHttpsProxiesResource.GetRequest request = computeService.TargetHttpsProxies.Get(project, targetHttpsProxy);
             Data.TargetHttpsProxy response = request.Execute();
@@ -9986,7 +9986,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Insert() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.TargetHttpsProxy content = new Data.TargetHttpsProxy();
@@ -10046,7 +10046,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             TargetHttpsProxiesResource.ListRequest request = computeService.TargetHttpsProxies.List(project);
             Data.TargetHttpsProxyList response;
@@ -10119,7 +10119,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the TargetHttpsProxy resource to set an SslCertificates resource for.
-            string targetHttpsProxy = "";
+            string targetHttpsProxy = "{MY-TARGET-HTTPS-PROXY}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.TargetHttpsProxiesSetSslCertificatesRequest content = new Data.TargetHttpsProxiesSetSslCertificatesRequest();
@@ -10182,7 +10182,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the TargetHttpsProxy resource whose URL map is to be set.
-            string targetHttpsProxy = "";
+            string targetHttpsProxy = "{MY-TARGET-HTTPS-PROXY}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.UrlMapReference content = new Data.UrlMapReference();
@@ -10243,7 +10243,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the AggregatedList() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             TargetInstancesResource.AggregatedListRequest request = computeService.TargetInstances.AggregatedList(project);
             Data.TargetInstanceAggregatedList response;
@@ -10319,7 +10319,7 @@ namespace ComputeSample
             string zone = "";
 
             // Name of the TargetInstance resource to delete.
-            string targetInstance = "";
+            string targetInstance = "{MY-TARGET-INSTANCE}";
 
             TargetInstancesResource.DeleteRequest request = computeService.TargetInstances.Delete(project, zone, targetInstance);
             Data.Operation response = request.Execute();
@@ -10382,7 +10382,7 @@ namespace ComputeSample
             string zone = "";
 
             // Name of the TargetInstance resource to return.
-            string targetInstance = "";
+            string targetInstance = "{MY-TARGET-INSTANCE}";
 
             TargetInstancesResource.GetRequest request = computeService.TargetInstances.Get(project, zone, targetInstance);
             Data.TargetInstance response = request.Execute();
@@ -10442,7 +10442,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the zone scoping this request.
-            string zone = "";
+            string zone = "us-central1-f";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.TargetInstance content = new Data.TargetInstance();
@@ -10505,7 +10505,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the zone scoping this request.
-            string zone = "";
+            string zone = "us-central1-f";
 
             TargetInstancesResource.ListRequest request = computeService.TargetInstances.List(project, zone);
             Data.TargetInstanceList response;
@@ -10581,7 +10581,7 @@ namespace ComputeSample
             string region = "";
 
             // Name of the target pool to add a health check to.
-            string targetPool = "";
+            string targetPool = "{MY-TARGET-POOL}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.TargetPoolsAddHealthCheckRequest content = new Data.TargetPoolsAddHealthCheckRequest();
@@ -10647,7 +10647,7 @@ namespace ComputeSample
             string region = "";
 
             // Name of the TargetPool resource to add instances to.
-            string targetPool = "";
+            string targetPool = "{MY-TARGET-POOL}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.TargetPoolsAddInstanceRequest content = new Data.TargetPoolsAddInstanceRequest();
@@ -10708,7 +10708,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the AggregatedList() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             TargetPoolsResource.AggregatedListRequest request = computeService.TargetPools.AggregatedList(project);
             Data.TargetPoolAggregatedList response;
@@ -10784,7 +10784,7 @@ namespace ComputeSample
             string region = "";
 
             // Name of the TargetPool resource to delete.
-            string targetPool = "";
+            string targetPool = "{MY-TARGET-POOL}";
 
             TargetPoolsResource.DeleteRequest request = computeService.TargetPools.Delete(project, region, targetPool);
             Data.Operation response = request.Execute();
@@ -10847,7 +10847,7 @@ namespace ComputeSample
             string region = "";
 
             // Name of the TargetPool resource to return.
-            string targetPool = "";
+            string targetPool = "{MY-TARGET-POOL}";
 
             TargetPoolsResource.GetRequest request = computeService.TargetPools.Get(project, region, targetPool);
             Data.TargetPool response = request.Execute();
@@ -10910,7 +10910,7 @@ namespace ComputeSample
             string region = "";
 
             // Name of the TargetPool resource to which the queried instance belongs.
-            string targetPool = "";
+            string targetPool = "{MY-TARGET-POOL}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.InstanceReference content = new Data.InstanceReference();
@@ -10973,7 +10973,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the region scoping this request.
-            string region = "";
+            string region = "{MY-REGION}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.TargetPool content = new Data.TargetPool();
@@ -11036,7 +11036,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the region scoping this request.
-            string region = "";
+            string region = "{MY-REGION}";
 
             TargetPoolsResource.ListRequest request = computeService.TargetPools.List(project, region);
             Data.TargetPoolList response;
@@ -11112,7 +11112,7 @@ namespace ComputeSample
             string region = "";
 
             // Name of the target pool to remove health checks from.
-            string targetPool = "";
+            string targetPool = "{MY-TARGET-POOL}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.TargetPoolsRemoveHealthCheckRequest content = new Data.TargetPoolsRemoveHealthCheckRequest();
@@ -11178,7 +11178,7 @@ namespace ComputeSample
             string region = "";
 
             // Name of the TargetPool resource to remove instances from.
-            string targetPool = "";
+            string targetPool = "{MY-TARGET-POOL}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.TargetPoolsRemoveInstanceRequest content = new Data.TargetPoolsRemoveInstanceRequest();
@@ -11244,7 +11244,7 @@ namespace ComputeSample
             string region = "";
 
             // Name of the TargetPool resource to set a backup pool for.
-            string targetPool = "";
+            string targetPool = "{MY-TARGET-POOL}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.TargetReference content = new Data.TargetReference();
@@ -11305,7 +11305,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the AggregatedList() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             TargetVpnGatewaysResource.AggregatedListRequest request = computeService.TargetVpnGateways.AggregatedList(project);
             Data.TargetVpnGatewayAggregatedList response;
@@ -11381,7 +11381,7 @@ namespace ComputeSample
             string region = "";
 
             // Name of the target VPN gateway to delete.
-            string targetVpnGateway = "";
+            string targetVpnGateway = "{MY-TARGET-VPN-GATEWAY}";
 
             TargetVpnGatewaysResource.DeleteRequest request = computeService.TargetVpnGateways.Delete(project, region, targetVpnGateway);
             Data.Operation response = request.Execute();
@@ -11444,7 +11444,7 @@ namespace ComputeSample
             string region = "";
 
             // Name of the target VPN gateway to return.
-            string targetVpnGateway = "";
+            string targetVpnGateway = "{MY-TARGET-VPN-GATEWAY}";
 
             TargetVpnGatewaysResource.GetRequest request = computeService.TargetVpnGateways.Get(project, region, targetVpnGateway);
             Data.TargetVpnGateway response = request.Execute();
@@ -11504,7 +11504,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the region for this request.
-            string region = "";
+            string region = "{MY-REGION}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.TargetVpnGateway content = new Data.TargetVpnGateway();
@@ -11567,7 +11567,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the region for this request.
-            string region = "";
+            string region = "{MY-REGION}";
 
             TargetVpnGatewaysResource.ListRequest request = computeService.TargetVpnGateways.List(project, region);
             Data.TargetVpnGatewayList response;
@@ -11640,7 +11640,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the UrlMap resource to delete.
-            string urlMap = "";
+            string urlMap = "{MY-URL-MAP}";
 
             UrlMapsResource.DeleteRequest request = computeService.UrlMaps.Delete(project, urlMap);
             Data.Operation response = request.Execute();
@@ -11700,7 +11700,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the UrlMap resource to return.
-            string urlMap = "";
+            string urlMap = "{MY-URL-MAP}";
 
             UrlMapsResource.GetRequest request = computeService.UrlMaps.Get(project, urlMap);
             Data.UrlMap response = request.Execute();
@@ -11757,7 +11757,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the Insert() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.UrlMap content = new Data.UrlMap();
@@ -11817,7 +11817,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             UrlMapsResource.ListRequest request = computeService.UrlMaps.List(project);
             Data.UrlMapList response;
@@ -11890,7 +11890,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the UrlMap resource to update.
-            string urlMap = "";
+            string urlMap = "{MY-URL-MAP}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.UrlMap content = new Data.UrlMap();
@@ -11953,7 +11953,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the UrlMap resource to update.
-            string urlMap = "";
+            string urlMap = "{MY-URL-MAP}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.UrlMap content = new Data.UrlMap();
@@ -12016,7 +12016,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the UrlMap resource to be validated as.
-            string urlMap = "";
+            string urlMap = "{MY-URL-MAP}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.UrlMapsValidateRequest content = new Data.UrlMapsValidateRequest();
@@ -12077,7 +12077,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the AggregatedList() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             VpnTunnelsResource.AggregatedListRequest request = computeService.VpnTunnels.AggregatedList(project);
             Data.VpnTunnelAggregatedList response;
@@ -12153,7 +12153,7 @@ namespace ComputeSample
             string region = "";
 
             // Name of the VpnTunnel resource to delete.
-            string vpnTunnel = "";
+            string vpnTunnel = "{MY-VPN-TUNNEL}";
 
             VpnTunnelsResource.DeleteRequest request = computeService.VpnTunnels.Delete(project, region, vpnTunnel);
             Data.Operation response = request.Execute();
@@ -12216,7 +12216,7 @@ namespace ComputeSample
             string region = "";
 
             // Name of the VpnTunnel resource to return.
-            string vpnTunnel = "";
+            string vpnTunnel = "{MY-VPN-TUNNEL}";
 
             VpnTunnelsResource.GetRequest request = computeService.VpnTunnels.Get(project, region, vpnTunnel);
             Data.VpnTunnel response = request.Execute();
@@ -12276,7 +12276,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the region for this request.
-            string region = "";
+            string region = "{MY-REGION}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.VpnTunnel content = new Data.VpnTunnel();
@@ -12339,7 +12339,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the region for this request.
-            string region = "";
+            string region = "{MY-REGION}";
 
             VpnTunnelsResource.ListRequest request = computeService.VpnTunnels.List(project, region);
             Data.VpnTunnelList response;
@@ -12413,7 +12413,7 @@ namespace ComputeSample
             string zone = "";
 
             // Name of the Operations resource to delete.
-            string operation = "";
+            string operation = "{MY-OPERATION}";
 
             ZoneOperationsResource.DeleteRequest request = computeService.ZoneOperations.Delete(project, zone, operation);
             request.Execute();
@@ -12476,7 +12476,7 @@ namespace ComputeSample
             string zone = "";
 
             // Name of the Operations resource to return.
-            string operation = "";
+            string operation = "{MY-OPERATION}";
 
             ZoneOperationsResource.GetRequest request = computeService.ZoneOperations.Get(project, zone, operation);
             Data.Operation response = request.Execute();
@@ -12536,7 +12536,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the zone for request.
-            string zone = "";
+            string zone = "us-central1-f";
 
             ZoneOperationsResource.ListRequest request = computeService.ZoneOperations.List(project, zone);
             Data.OperationList response;
@@ -12609,7 +12609,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the zone resource to return.
-            string zone = "";
+            string zone = "us-central1-f";
 
             ZonesResource.GetRequest request = computeService.Zones.Get(project, zone);
             Data.Zone response = request.Execute();
@@ -12666,7 +12666,7 @@ namespace ComputeSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             ZonesResource.ListRequest request = computeService.Zones.List(project);
             Data.ZoneList response;

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_compute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_compute.v1.json.baseline
@@ -579,7 +579,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the zone for this request.
-            string zone = "us-central1-f";
+            string zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Autoscaler content = new Data.Autoscaler();
@@ -642,7 +642,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the zone for this request.
-            string zone = "us-central1-f";
+            string zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
             AutoscalersResource.ListRequest request = computeService.Autoscalers.List(project, zone);
             Data.AutoscalerList response;
@@ -781,7 +781,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the zone for this request.
-            string zone = "us-central1-f";
+            string zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Autoscaler content = new Data.Autoscaler();
@@ -1416,7 +1416,7 @@ namespace ComputeSample
             string project = "";
 
             // The name of the zone for this request.
-            string zone = "us-central1-f";
+            string zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
             DiskTypesResource.ListRequest request = computeService.DiskTypes.List(project, zone);
             Data.DiskTypeList response;
@@ -1752,7 +1752,7 @@ namespace ComputeSample
             string project = "";
 
             // The name of the zone for this request.
-            string zone = "us-central1-f";
+            string zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Disk content = new Data.Disk();
@@ -1815,7 +1815,7 @@ namespace ComputeSample
             string project = "";
 
             // The name of the zone for this request.
-            string zone = "us-central1-f";
+            string zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
             DisksResource.ListRequest request = computeService.Disks.List(project, zone);
             Data.DiskList response;
@@ -6734,7 +6734,7 @@ namespace ComputeSample
             string project = "";
 
             // The name of the zone for this request.
-            string zone = "us-central1-f";
+            string zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Instance content = new Data.Instance();
@@ -6797,7 +6797,7 @@ namespace ComputeSample
             string project = "";
 
             // The name of the zone for this request.
-            string zone = "us-central1-f";
+            string zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
             InstancesResource.ListRequest request = computeService.Instances.List(project, zone);
             Data.InstanceList response;
@@ -7586,7 +7586,7 @@ namespace ComputeSample
             string project = "";
 
             // The name of the zone for this request.
-            string zone = "us-central1-f";
+            string zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
             MachineTypesResource.ListRequest request = computeService.MachineTypes.List(project, zone);
             Data.MachineTypeList response;
@@ -10442,7 +10442,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the zone scoping this request.
-            string zone = "us-central1-f";
+            string zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.TargetInstance content = new Data.TargetInstance();
@@ -10505,7 +10505,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the zone scoping this request.
-            string zone = "us-central1-f";
+            string zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
             TargetInstancesResource.ListRequest request = computeService.TargetInstances.List(project, zone);
             Data.TargetInstanceList response;
@@ -12536,7 +12536,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the zone for request.
-            string zone = "us-central1-f";
+            string zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
             ZoneOperationsResource.ListRequest request = computeService.ZoneOperations.List(project, zone);
             Data.OperationList response;
@@ -12609,7 +12609,7 @@ namespace ComputeSample
             string project = "";
 
             // Name of the zone resource to return.
-            string zone = "us-central1-f";
+            string zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
             ZonesResource.GetRequest request = computeService.Zones.Get(project, zone);
             Data.Zone response = request.Execute();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_container.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_container.v1.json.baseline
@@ -47,7 +47,7 @@ namespace ContainerSample
 
             // The Google Developers Console [project ID or project
             // number](https://developers.google.com/console/help/new/#projectnumber).
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
             // resides.
@@ -112,11 +112,11 @@ namespace ContainerSample
 
             // The Google Developers Console [project ID or project
             // number](https://developers.google.com/console/help/new/#projectnumber).
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
             // resides.
-            string zone = "";
+            string zone = "{MY-ZONE}";
 
             // The name of the cluster to delete.
             string clusterId = "{MY-CLUSTER-ID}";
@@ -177,11 +177,11 @@ namespace ContainerSample
 
             // The Google Developers Console [project ID or project
             // number](https://developers.google.com/console/help/new/#projectnumber).
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
             // resides.
-            string zone = "";
+            string zone = "{MY-ZONE}";
 
             // The name of the cluster to retrieve.
             string clusterId = "{MY-CLUSTER-ID}";
@@ -242,7 +242,7 @@ namespace ContainerSample
 
             // The Google Developers Console [project ID or project
             // number](https://developers.google.com/console/help/new/#projectnumber).
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
             // resides, or "-" for all zones.
@@ -304,11 +304,11 @@ namespace ContainerSample
 
             // The Google Developers Console [project ID or project
             // number](https://developers.google.com/console/help/new/#projectnumber).
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
             // resides.
-            string zone = "";
+            string zone = "{MY-ZONE}";
 
             // The name of the cluster to upgrade.
             string clusterId = "{MY-CLUSTER-ID}";
@@ -372,7 +372,7 @@ namespace ContainerSample
 
             // The Google Developers Console [project ID or project
             // number](https://developers.google.com/console/help/new/#projectnumber).
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // The name of the Google Compute Engine [zone](/compute/docs/zones#available) to return operations
             // for, or "-" for all zones.
@@ -434,11 +434,11 @@ namespace ContainerSample
 
             // The Google Developers Console [project ID or project
             // number](https://developers.google.com/console/help/new/#projectnumber).
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
             // resides.
-            string zone = "";
+            string zone = "{MY-ZONE}";
 
             // The server-assigned `name` of the operation.
             string operationId = "{MY-OPERATION-ID}";
@@ -499,7 +499,7 @@ namespace ContainerSample
 
             // The Google Developers Console [project ID or project
             // number](https://developers.google.com/console/help/new/#projectnumber).
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // The name of the Google Compute Engine [zone](/compute/docs/zones#available) to return operations
             // for, or "-" for all zones.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_container.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_container.v1.json.baseline
@@ -51,7 +51,7 @@ namespace ContainerSample
 
             // The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
             // resides.
-            string zone = "";
+            string zone = "{MY-ZONE}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.CreateClusterRequest content = new Data.CreateClusterRequest();
@@ -119,7 +119,7 @@ namespace ContainerSample
             string zone = "";
 
             // The name of the cluster to delete.
-            string clusterId = "";
+            string clusterId = "{MY-CLUSTER-ID}";
 
             ProjectsResource.ZonesResource.ClustersResource.DeleteRequest request = containerService.Projects.Zones.Clusters.Delete(projectId, zone, clusterId);
             Data.Operation response = request.Execute();
@@ -184,7 +184,7 @@ namespace ContainerSample
             string zone = "";
 
             // The name of the cluster to retrieve.
-            string clusterId = "";
+            string clusterId = "{MY-CLUSTER-ID}";
 
             ProjectsResource.ZonesResource.ClustersResource.GetRequest request = containerService.Projects.Zones.Clusters.Get(projectId, zone, clusterId);
             Data.Cluster response = request.Execute();
@@ -246,7 +246,7 @@ namespace ContainerSample
 
             // The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
             // resides, or "-" for all zones.
-            string zone = "";
+            string zone = "{MY-ZONE}";
 
             ProjectsResource.ZonesResource.ClustersResource.ListRequest request = containerService.Projects.Zones.Clusters.List(projectId, zone);
             Data.ListClustersResponse response = request.Execute();
@@ -311,7 +311,7 @@ namespace ContainerSample
             string zone = "";
 
             // The name of the cluster to upgrade.
-            string clusterId = "";
+            string clusterId = "{MY-CLUSTER-ID}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.UpdateClusterRequest content = new Data.UpdateClusterRequest();
@@ -376,7 +376,7 @@ namespace ContainerSample
 
             // The name of the Google Compute Engine [zone](/compute/docs/zones#available) to return operations
             // for, or "-" for all zones.
-            string zone = "";
+            string zone = "{MY-ZONE}";
 
             ProjectsResource.ZonesResource.GetServerconfigRequest request = containerService.Projects.Zones.GetServerconfig(projectId, zone);
             Data.ServerConfig response = request.Execute();
@@ -441,7 +441,7 @@ namespace ContainerSample
             string zone = "";
 
             // The server-assigned `name` of the operation.
-            string operationId = "";
+            string operationId = "{MY-OPERATION-ID}";
 
             ProjectsResource.ZonesResource.OperationsResource.GetRequest request = containerService.Projects.Zones.Operations.Get(projectId, zone, operationId);
             Data.Operation response = request.Execute();
@@ -503,7 +503,7 @@ namespace ContainerSample
 
             // The name of the Google Compute Engine [zone](/compute/docs/zones#available) to return operations
             // for, or "-" for all zones.
-            string zone = "";
+            string zone = "{MY-ZONE}";
 
             ProjectsResource.ZonesResource.OperationsResource.ListRequest request = containerService.Projects.Zones.Operations.List(projectId, zone);
             Data.ListOperationsResponse response = request.Execute();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_dataflow.v1b3.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_dataflow.v1b3.json.baseline
@@ -106,7 +106,7 @@ namespace DataflowSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // The project which owns the job.
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // Identifies a single job.
             string jobId = "{MY-JOB-ID}";
@@ -166,7 +166,7 @@ namespace DataflowSample
             // TODO: Change placeholders below to values for parameters to the GetMetrics() method:
 
             // A project id.
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // The job to get messages for.
             string jobId = "{MY-JOB-ID}";
@@ -296,7 +296,7 @@ namespace DataflowSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // A project id.
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // The job to get messages about.
             string jobId = "{MY-JOB-ID}";
@@ -369,7 +369,7 @@ namespace DataflowSample
             // TODO: Change placeholders below to values for parameters to the Update() method:
 
             // The project which owns the job.
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // Identifies a single job.
             string jobId = "{MY-JOB-ID}";
@@ -432,7 +432,7 @@ namespace DataflowSample
             // TODO: Change placeholders below to values for parameters to the Lease() method:
 
             // Identifies the project this worker belongs to.
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // Identifies the workflow job this worker belongs to.
             string jobId = "{MY-JOB-ID}";
@@ -495,7 +495,7 @@ namespace DataflowSample
             // TODO: Change placeholders below to values for parameters to the ReportStatus() method:
 
             // The project which owns the WorkItem's job.
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // The job which the WorkItem is part of.
             string jobId = "{MY-JOB-ID}";

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_dataflow.v1b3.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_dataflow.v1b3.json.baseline
@@ -46,7 +46,7 @@ namespace DataflowSample
             // TODO: Change placeholders below to values for parameters to the Create() method:
 
             // The project which owns the job.
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Job content = new Data.Job();
@@ -109,7 +109,7 @@ namespace DataflowSample
             string projectId = "";
 
             // Identifies a single job.
-            string jobId = "";
+            string jobId = "{MY-JOB-ID}";
 
             ProjectsResource.JobsResource.GetRequest request = dataflowService.Projects.Jobs.Get(projectId, jobId);
             Data.Job response = request.Execute();
@@ -169,7 +169,7 @@ namespace DataflowSample
             string projectId = "";
 
             // The job to get messages for.
-            string jobId = "";
+            string jobId = "{MY-JOB-ID}";
 
             ProjectsResource.JobsResource.GetMetricsRequest request = dataflowService.Projects.Jobs.GetMetrics(projectId, jobId);
             Data.JobMetrics response = request.Execute();
@@ -226,7 +226,7 @@ namespace DataflowSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // The project which owns the jobs.
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             ProjectsResource.JobsResource.ListRequest request = dataflowService.Projects.Jobs.List(projectId);
             Data.ListJobsResponse response;
@@ -299,7 +299,7 @@ namespace DataflowSample
             string projectId = "";
 
             // The job to get messages about.
-            string jobId = "";
+            string jobId = "{MY-JOB-ID}";
 
             ProjectsResource.JobsResource.MessagesResource.ListRequest request = dataflowService.Projects.Jobs.Messages.List(projectId, jobId);
             Data.ListJobMessagesResponse response;
@@ -372,7 +372,7 @@ namespace DataflowSample
             string projectId = "";
 
             // Identifies a single job.
-            string jobId = "";
+            string jobId = "{MY-JOB-ID}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Job content = new Data.Job();
@@ -435,7 +435,7 @@ namespace DataflowSample
             string projectId = "";
 
             // Identifies the workflow job this worker belongs to.
-            string jobId = "";
+            string jobId = "{MY-JOB-ID}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.LeaseWorkItemRequest content = new Data.LeaseWorkItemRequest();
@@ -498,7 +498,7 @@ namespace DataflowSample
             string projectId = "";
 
             // The job which the WorkItem is part of.
-            string jobId = "";
+            string jobId = "{MY-JOB-ID}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.ReportWorkItemStatusRequest content = new Data.ReportWorkItemStatusRequest();
@@ -558,7 +558,7 @@ namespace DataflowSample
             // TODO: Change placeholders below to values for parameters to the WorkerMessages() method:
 
             // The project to send the WorkerMessages to.
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.SendWorkerMessagesRequest content = new Data.SendWorkerMessagesRequest();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_dataproc.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_dataproc.v1.json.baseline
@@ -46,7 +46,7 @@ namespace DataprocSample
             // TODO: Change placeholders below to values for parameters to the Create() method:
 
             // [Required] The ID of the Google Cloud Platform project that the cluster belongs to.
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // [Required] The Cloud Dataproc region in which to handle the request.
             string region = "{MY-REGION}";
@@ -109,10 +109,10 @@ namespace DataprocSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // [Required] The ID of the Google Cloud Platform project that the cluster belongs to.
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // [Required] The Cloud Dataproc region in which to handle the request.
-            string region = "";
+            string region = "{MY-REGION}";
 
             // [Required] The cluster name.
             string clusterName = "{MY-CLUSTER-NAME}";
@@ -172,10 +172,10 @@ namespace DataprocSample
             // TODO: Change placeholders below to values for parameters to the Diagnose() method:
 
             // [Required] The ID of the Google Cloud Platform project that the cluster belongs to.
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // [Required] The Cloud Dataproc region in which to handle the request.
-            string region = "";
+            string region = "{MY-REGION}";
 
             // [Required] The cluster name.
             string clusterName = "{MY-CLUSTER-NAME}";
@@ -238,10 +238,10 @@ namespace DataprocSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // [Required] The ID of the Google Cloud Platform project that the cluster belongs to.
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // [Required] The Cloud Dataproc region in which to handle the request.
-            string region = "";
+            string region = "{MY-REGION}";
 
             // [Required] The cluster name.
             string clusterName = "{MY-CLUSTER-NAME}";
@@ -301,7 +301,7 @@ namespace DataprocSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // [Required] The ID of the Google Cloud Platform project that the cluster belongs to.
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // [Required] The Cloud Dataproc region in which to handle the request.
             string region = "{MY-REGION}";
@@ -374,10 +374,10 @@ namespace DataprocSample
             // TODO: Change placeholders below to values for parameters to the Patch() method:
 
             // [Required] The ID of the Google Cloud Platform project the cluster belongs to.
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // [Required] The Cloud Dataproc region in which to handle the request.
-            string region = "";
+            string region = "{MY-REGION}";
 
             // [Required] The cluster name.
             string clusterName = "{MY-CLUSTER-NAME}";
@@ -440,10 +440,10 @@ namespace DataprocSample
             // TODO: Change placeholders below to values for parameters to the Cancel() method:
 
             // [Required] The ID of the Google Cloud Platform project that the job belongs to.
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // [Required] The Cloud Dataproc region in which to handle the request.
-            string region = "";
+            string region = "{MY-REGION}";
 
             // [Required] The job ID.
             string jobId = "{MY-JOB-ID}";
@@ -506,10 +506,10 @@ namespace DataprocSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // [Required] The ID of the Google Cloud Platform project that the job belongs to.
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // [Required] The Cloud Dataproc region in which to handle the request.
-            string region = "";
+            string region = "{MY-REGION}";
 
             // [Required] The job ID.
             string jobId = "{MY-JOB-ID}";
@@ -569,10 +569,10 @@ namespace DataprocSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // [Required] The ID of the Google Cloud Platform project that the job belongs to.
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // [Required] The Cloud Dataproc region in which to handle the request.
-            string region = "";
+            string region = "{MY-REGION}";
 
             // [Required] The job ID.
             string jobId = "{MY-JOB-ID}";
@@ -632,7 +632,7 @@ namespace DataprocSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // [Required] The ID of the Google Cloud Platform project that the job belongs to.
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // [Required] The Cloud Dataproc region in which to handle the request.
             string region = "{MY-REGION}";
@@ -705,7 +705,7 @@ namespace DataprocSample
             // TODO: Change placeholders below to values for parameters to the Submit() method:
 
             // [Required] The ID of the Google Cloud Platform project that the job belongs to.
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             // [Required] The Cloud Dataproc region in which to handle the request.
             string region = "{MY-REGION}";

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_dataproc.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_dataproc.v1.json.baseline
@@ -49,7 +49,7 @@ namespace DataprocSample
             string projectId = "";
 
             // [Required] The Cloud Dataproc region in which to handle the request.
-            string region = "";
+            string region = "{MY-REGION}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Cluster content = new Data.Cluster();
@@ -115,7 +115,7 @@ namespace DataprocSample
             string region = "";
 
             // [Required] The cluster name.
-            string clusterName = "";
+            string clusterName = "{MY-CLUSTER-NAME}";
 
             ProjectsResource.RegionsResource.ClustersResource.DeleteRequest request = dataprocService.Projects.Regions.Clusters.Delete(projectId, region, clusterName);
             Data.Operation response = request.Execute();
@@ -178,7 +178,7 @@ namespace DataprocSample
             string region = "";
 
             // [Required] The cluster name.
-            string clusterName = "";
+            string clusterName = "{MY-CLUSTER-NAME}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.DiagnoseClusterRequest content = new Data.DiagnoseClusterRequest();
@@ -244,7 +244,7 @@ namespace DataprocSample
             string region = "";
 
             // [Required] The cluster name.
-            string clusterName = "";
+            string clusterName = "{MY-CLUSTER-NAME}";
 
             ProjectsResource.RegionsResource.ClustersResource.GetRequest request = dataprocService.Projects.Regions.Clusters.Get(projectId, region, clusterName);
             Data.Cluster response = request.Execute();
@@ -304,7 +304,7 @@ namespace DataprocSample
             string projectId = "";
 
             // [Required] The Cloud Dataproc region in which to handle the request.
-            string region = "";
+            string region = "{MY-REGION}";
 
             ProjectsResource.RegionsResource.ClustersResource.ListRequest request = dataprocService.Projects.Regions.Clusters.List(projectId, region);
             Data.ListClustersResponse response;
@@ -380,7 +380,7 @@ namespace DataprocSample
             string region = "";
 
             // [Required] The cluster name.
-            string clusterName = "";
+            string clusterName = "{MY-CLUSTER-NAME}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Cluster content = new Data.Cluster();
@@ -446,7 +446,7 @@ namespace DataprocSample
             string region = "";
 
             // [Required] The job ID.
-            string jobId = "";
+            string jobId = "{MY-JOB-ID}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.CancelJobRequest content = new Data.CancelJobRequest();
@@ -512,7 +512,7 @@ namespace DataprocSample
             string region = "";
 
             // [Required] The job ID.
-            string jobId = "";
+            string jobId = "{MY-JOB-ID}";
 
             ProjectsResource.RegionsResource.JobsResource.DeleteRequest request = dataprocService.Projects.Regions.Jobs.Delete(projectId, region, jobId);
             Data.Empty response = request.Execute();
@@ -575,7 +575,7 @@ namespace DataprocSample
             string region = "";
 
             // [Required] The job ID.
-            string jobId = "";
+            string jobId = "{MY-JOB-ID}";
 
             ProjectsResource.RegionsResource.JobsResource.GetRequest request = dataprocService.Projects.Regions.Jobs.Get(projectId, region, jobId);
             Data.Job response = request.Execute();
@@ -635,7 +635,7 @@ namespace DataprocSample
             string projectId = "";
 
             // [Required] The Cloud Dataproc region in which to handle the request.
-            string region = "";
+            string region = "{MY-REGION}";
 
             ProjectsResource.RegionsResource.JobsResource.ListRequest request = dataprocService.Projects.Regions.Jobs.List(projectId, region);
             Data.ListJobsResponse response;
@@ -708,7 +708,7 @@ namespace DataprocSample
             string projectId = "";
 
             // [Required] The Cloud Dataproc region in which to handle the request.
-            string region = "";
+            string region = "{MY-REGION}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.SubmitJobRequest content = new Data.SubmitJobRequest();
@@ -939,7 +939,7 @@ namespace DataprocSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // The name of the operation collection.
-            string name = "";
+            string name = "{MY-NAME}";
 
             ProjectsResource.RegionsResource.OperationsResource.ListRequest request = dataprocService.Projects.Regions.Operations.List(name);
             Data.ListOperationsResponse response;

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_datastore.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_datastore.v1beta2.json.baseline
@@ -46,7 +46,7 @@ namespace DatastoreSample
             // TODO: Change placeholders below to values for parameters to the AllocateIds() method:
 
             // Identifies the dataset.
-            string datasetId = "";
+            string datasetId = "{MY-DATASET-ID}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.AllocateIdsRequest content = new Data.AllocateIdsRequest();
@@ -106,7 +106,7 @@ namespace DatastoreSample
             // TODO: Change placeholders below to values for parameters to the BeginTransaction() method:
 
             // Identifies the dataset.
-            string datasetId = "";
+            string datasetId = "{MY-DATASET-ID}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.BeginTransactionRequest content = new Data.BeginTransactionRequest();
@@ -166,7 +166,7 @@ namespace DatastoreSample
             // TODO: Change placeholders below to values for parameters to the Commit() method:
 
             // Identifies the dataset.
-            string datasetId = "";
+            string datasetId = "{MY-DATASET-ID}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.CommitRequest content = new Data.CommitRequest();
@@ -226,7 +226,7 @@ namespace DatastoreSample
             // TODO: Change placeholders below to values for parameters to the Lookup() method:
 
             // Identifies the dataset.
-            string datasetId = "";
+            string datasetId = "{MY-DATASET-ID}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.LookupRequest content = new Data.LookupRequest();
@@ -286,7 +286,7 @@ namespace DatastoreSample
             // TODO: Change placeholders below to values for parameters to the Rollback() method:
 
             // Identifies the dataset.
-            string datasetId = "";
+            string datasetId = "{MY-DATASET-ID}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.RollbackRequest content = new Data.RollbackRequest();
@@ -346,7 +346,7 @@ namespace DatastoreSample
             // TODO: Change placeholders below to values for parameters to the RunQuery() method:
 
             // Identifies the dataset.
-            string datasetId = "";
+            string datasetId = "{MY-DATASET-ID}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.RunQueryRequest content = new Data.RunQueryRequest();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_deploymentmanager.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_deploymentmanager.v2.json.baseline
@@ -49,7 +49,7 @@ namespace DeploymentManagerSample
             string project = "";
 
             // The name of the deployment for this request.
-            string deployment = "";
+            string deployment = "{MY-DEPLOYMENT}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.DeploymentsCancelPreviewRequest content = new Data.DeploymentsCancelPreviewRequest();
@@ -112,7 +112,7 @@ namespace DeploymentManagerSample
             string project = "";
 
             // The name of the deployment for this request.
-            string deployment = "";
+            string deployment = "{MY-DEPLOYMENT}";
 
             DeploymentsResource.DeleteRequest request = deploymentManagerService.Deployments.Delete(project, deployment);
             Data.Operation response = request.Execute();
@@ -172,7 +172,7 @@ namespace DeploymentManagerSample
             string project = "";
 
             // The name of the deployment for this request.
-            string deployment = "";
+            string deployment = "{MY-DEPLOYMENT}";
 
             DeploymentsResource.GetRequest request = deploymentManagerService.Deployments.Get(project, deployment);
             Data.Deployment response = request.Execute();
@@ -229,7 +229,7 @@ namespace DeploymentManagerSample
             // TODO: Change placeholders below to values for parameters to the Insert() method:
 
             // The project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Deployment content = new Data.Deployment();
@@ -289,7 +289,7 @@ namespace DeploymentManagerSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // The project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             DeploymentsResource.ListRequest request = deploymentManagerService.Deployments.List(project);
             Data.DeploymentsListResponse response;
@@ -362,7 +362,7 @@ namespace DeploymentManagerSample
             string project = "";
 
             // The name of the deployment for this request.
-            string deployment = "";
+            string deployment = "{MY-DEPLOYMENT}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Deployment content = new Data.Deployment();
@@ -425,7 +425,7 @@ namespace DeploymentManagerSample
             string project = "";
 
             // The name of the deployment for this request.
-            string deployment = "";
+            string deployment = "{MY-DEPLOYMENT}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.DeploymentsStopRequest content = new Data.DeploymentsStopRequest();
@@ -488,7 +488,7 @@ namespace DeploymentManagerSample
             string project = "";
 
             // The name of the deployment for this request.
-            string deployment = "";
+            string deployment = "{MY-DEPLOYMENT}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Deployment content = new Data.Deployment();
@@ -554,7 +554,7 @@ namespace DeploymentManagerSample
             string deployment = "";
 
             // The name of the manifest for this request.
-            string manifest = "";
+            string manifest = "{MY-MANIFEST}";
 
             ManifestsResource.GetRequest request = deploymentManagerService.Manifests.Get(project, deployment, manifest);
             Data.Manifest response = request.Execute();
@@ -614,7 +614,7 @@ namespace DeploymentManagerSample
             string project = "";
 
             // The name of the deployment for this request.
-            string deployment = "";
+            string deployment = "{MY-DEPLOYMENT}";
 
             ManifestsResource.ListRequest request = deploymentManagerService.Manifests.List(project, deployment);
             Data.ManifestsListResponse response;
@@ -687,7 +687,7 @@ namespace DeploymentManagerSample
             string project = "";
 
             // The name of the operation for this request.
-            string operation = "";
+            string operation = "{MY-OPERATION}";
 
             OperationsResource.GetRequest request = deploymentManagerService.Operations.Get(project, operation);
             Data.Operation response = request.Execute();
@@ -744,7 +744,7 @@ namespace DeploymentManagerSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // The project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             OperationsResource.ListRequest request = deploymentManagerService.Operations.List(project);
             Data.OperationsListResponse response;
@@ -820,7 +820,7 @@ namespace DeploymentManagerSample
             string deployment = "";
 
             // The name of the resource for this request.
-            string resource = "";
+            string resource = "{MY-RESOURCE}";
 
             ResourcesResource.GetRequest request = deploymentManagerService.Resources.Get(project, deployment, resource);
             Data.Resource response = request.Execute();
@@ -880,7 +880,7 @@ namespace DeploymentManagerSample
             string project = "";
 
             // The name of the deployment for this request.
-            string deployment = "";
+            string deployment = "{MY-DEPLOYMENT}";
 
             ResourcesResource.ListRequest request = deploymentManagerService.Resources.List(project, deployment);
             Data.ResourcesListResponse response;
@@ -950,7 +950,7 @@ namespace DeploymentManagerSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // The project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             TypesResource.ListRequest request = deploymentManagerService.Types.List(project);
             Data.TypesListResponse response;

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_deploymentmanager.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_deploymentmanager.v2.json.baseline
@@ -46,7 +46,7 @@ namespace DeploymentManagerSample
             // TODO: Change placeholders below to values for parameters to the CancelPreview() method:
 
             // The project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the deployment for this request.
             string deployment = "{MY-DEPLOYMENT}";
@@ -109,7 +109,7 @@ namespace DeploymentManagerSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // The project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the deployment for this request.
             string deployment = "{MY-DEPLOYMENT}";
@@ -169,7 +169,7 @@ namespace DeploymentManagerSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // The project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the deployment for this request.
             string deployment = "{MY-DEPLOYMENT}";
@@ -359,7 +359,7 @@ namespace DeploymentManagerSample
             // TODO: Change placeholders below to values for parameters to the Patch() method:
 
             // The project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the deployment for this request.
             string deployment = "{MY-DEPLOYMENT}";
@@ -422,7 +422,7 @@ namespace DeploymentManagerSample
             // TODO: Change placeholders below to values for parameters to the Stop() method:
 
             // The project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the deployment for this request.
             string deployment = "{MY-DEPLOYMENT}";
@@ -485,7 +485,7 @@ namespace DeploymentManagerSample
             // TODO: Change placeholders below to values for parameters to the Update() method:
 
             // The project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the deployment for this request.
             string deployment = "{MY-DEPLOYMENT}";
@@ -548,10 +548,10 @@ namespace DeploymentManagerSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // The project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the deployment for this request.
-            string deployment = "";
+            string deployment = "{MY-DEPLOYMENT}";
 
             // The name of the manifest for this request.
             string manifest = "{MY-MANIFEST}";
@@ -611,7 +611,7 @@ namespace DeploymentManagerSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // The project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the deployment for this request.
             string deployment = "{MY-DEPLOYMENT}";
@@ -684,7 +684,7 @@ namespace DeploymentManagerSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // The project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the operation for this request.
             string operation = "{MY-OPERATION}";
@@ -814,10 +814,10 @@ namespace DeploymentManagerSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // The project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the deployment for this request.
-            string deployment = "";
+            string deployment = "{MY-DEPLOYMENT}";
 
             // The name of the resource for this request.
             string resource = "{MY-RESOURCE}";
@@ -877,7 +877,7 @@ namespace DeploymentManagerSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // The project ID for this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the deployment for this request.
             string deployment = "{MY-DEPLOYMENT}";

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_dns.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_dns.v1.json.baseline
@@ -49,7 +49,7 @@ namespace DnsSample
             string project = "";
 
             // Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-            string managedZone = "";
+            string managedZone = "{MY-MANAGED-ZONE}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Change content = new Data.Change();
@@ -115,7 +115,7 @@ namespace DnsSample
             string managedZone = "";
 
             // The identifier of the requested change, from a previous ResourceRecordSetsChangeResponse.
-            string changeId = "";
+            string changeId = "{MY-CHANGE-ID}";
 
             ChangesResource.GetRequest request = dnsService.Changes.Get(project, managedZone, changeId);
             Data.Change response = request.Execute();
@@ -175,7 +175,7 @@ namespace DnsSample
             string project = "";
 
             // Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-            string managedZone = "";
+            string managedZone = "{MY-MANAGED-ZONE}";
 
             ChangesResource.ListRequest request = dnsService.Changes.List(project, managedZone);
             Data.ChangesListResponse response;
@@ -245,7 +245,7 @@ namespace DnsSample
             // TODO: Change placeholders below to values for parameters to the Create() method:
 
             // Identifies the project addressed by this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.ManagedZone content = new Data.ManagedZone();
@@ -306,7 +306,7 @@ namespace DnsSample
             string project = "";
 
             // Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-            string managedZone = "";
+            string managedZone = "{MY-MANAGED-ZONE}";
 
             ManagedZonesResource.DeleteRequest request = dnsService.ManagedZones.Delete(project, managedZone);
             request.Execute();
@@ -366,7 +366,7 @@ namespace DnsSample
             string project = "";
 
             // Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-            string managedZone = "";
+            string managedZone = "{MY-MANAGED-ZONE}";
 
             ManagedZonesResource.GetRequest request = dnsService.ManagedZones.Get(project, managedZone);
             Data.ManagedZone response = request.Execute();
@@ -423,7 +423,7 @@ namespace DnsSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Identifies the project addressed by this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             ManagedZonesResource.ListRequest request = dnsService.ManagedZones.List(project);
             Data.ManagedZonesListResponse response;
@@ -493,7 +493,7 @@ namespace DnsSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Identifies the project addressed by this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             ProjectsResource.GetRequest request = dnsService.Projects.Get(project);
             Data.Project response = request.Execute();
@@ -553,7 +553,7 @@ namespace DnsSample
             string project = "";
 
             // Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-            string managedZone = "";
+            string managedZone = "{MY-MANAGED-ZONE}";
 
             ResourceRecordSetsResource.ListRequest request = dnsService.ResourceRecordSets.List(project, managedZone);
             Data.ResourceRecordSetsListResponse response;

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_dns.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_dns.v1.json.baseline
@@ -46,7 +46,7 @@ namespace DnsSample
             // TODO: Change placeholders below to values for parameters to the Create() method:
 
             // Identifies the project addressed by this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Identifies the managed zone addressed by this request. Can be the managed zone name or id.
             string managedZone = "{MY-MANAGED-ZONE}";
@@ -109,10 +109,10 @@ namespace DnsSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Identifies the project addressed by this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-            string managedZone = "";
+            string managedZone = "{MY-MANAGED-ZONE}";
 
             // The identifier of the requested change, from a previous ResourceRecordSetsChangeResponse.
             string changeId = "{MY-CHANGE-ID}";
@@ -172,7 +172,7 @@ namespace DnsSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Identifies the project addressed by this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Identifies the managed zone addressed by this request. Can be the managed zone name or id.
             string managedZone = "{MY-MANAGED-ZONE}";
@@ -303,7 +303,7 @@ namespace DnsSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Identifies the project addressed by this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Identifies the managed zone addressed by this request. Can be the managed zone name or id.
             string managedZone = "{MY-MANAGED-ZONE}";
@@ -363,7 +363,7 @@ namespace DnsSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Identifies the project addressed by this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Identifies the managed zone addressed by this request. Can be the managed zone name or id.
             string managedZone = "{MY-MANAGED-ZONE}";
@@ -550,7 +550,7 @@ namespace DnsSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Identifies the project addressed by this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Identifies the managed zone addressed by this request. Can be the managed zone name or id.
             string managedZone = "{MY-MANAGED-ZONE}";

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_prediction.v1.6.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_prediction.v1.6.json.baseline
@@ -46,7 +46,7 @@ namespace PredictionSample
             // TODO: Change placeholders below to values for parameters to the Predict() method:
 
             // The project associated with the model.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of a hosted model.
             string hostedModelName = "{MY-HOSTED-MODEL-NAME}";
@@ -109,7 +109,7 @@ namespace PredictionSample
             // TODO: Change placeholders below to values for parameters to the Analyze() method:
 
             // The project associated with the model.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The unique name for the predictive model.
             string id = "{MY-ID}";
@@ -167,7 +167,7 @@ namespace PredictionSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // The project associated with the model.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The unique name for the predictive model.
             string id = "{MY-ID}";
@@ -227,7 +227,7 @@ namespace PredictionSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // The project associated with the model.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The unique name for the predictive model.
             string id = "{MY-ID}";
@@ -417,7 +417,7 @@ namespace PredictionSample
             // TODO: Change placeholders below to values for parameters to the Predict() method:
 
             // The project associated with the model.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The unique name for the predictive model.
             string id = "{MY-ID}";
@@ -480,7 +480,7 @@ namespace PredictionSample
             // TODO: Change placeholders below to values for parameters to the Update() method:
 
             // The project associated with the model.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The unique name for the predictive model.
             string id = "{MY-ID}";

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_prediction.v1.6.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_prediction.v1.6.json.baseline
@@ -49,7 +49,7 @@ namespace PredictionSample
             string project = "";
 
             // The name of a hosted model.
-            string hostedModelName = "";
+            string hostedModelName = "{MY-HOSTED-MODEL-NAME}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Input content = new Data.Input();
@@ -112,7 +112,7 @@ namespace PredictionSample
             string project = "";
 
             // The unique name for the predictive model.
-            string id = "";
+            string id = "{MY-ID}";
 
             TrainedmodelsResource.AnalyzeRequest request = predictionService.Trainedmodels.Analyze(project, id);
             Data.Analyze response = request.Execute();
@@ -170,7 +170,7 @@ namespace PredictionSample
             string project = "";
 
             // The unique name for the predictive model.
-            string id = "";
+            string id = "{MY-ID}";
 
             TrainedmodelsResource.DeleteRequest request = predictionService.Trainedmodels.Delete(project, id);
             request.Execute();
@@ -230,7 +230,7 @@ namespace PredictionSample
             string project = "";
 
             // The unique name for the predictive model.
-            string id = "";
+            string id = "{MY-ID}";
 
             TrainedmodelsResource.GetRequest request = predictionService.Trainedmodels.Get(project, id);
             Data.Insert2 response = request.Execute();
@@ -287,7 +287,7 @@ namespace PredictionSample
             // TODO: Change placeholders below to values for parameters to the Insert() method:
 
             // The project associated with the model.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Insert content = new Data.Insert();
@@ -347,7 +347,7 @@ namespace PredictionSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // The project associated with the model.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             TrainedmodelsResource.ListRequest request = predictionService.Trainedmodels.List(project);
             Data.List response;
@@ -420,7 +420,7 @@ namespace PredictionSample
             string project = "";
 
             // The unique name for the predictive model.
-            string id = "";
+            string id = "{MY-ID}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Input content = new Data.Input();
@@ -483,7 +483,7 @@ namespace PredictionSample
             string project = "";
 
             // The unique name for the predictive model.
-            string id = "";
+            string id = "{MY-ID}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Update content = new Data.Update();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_replicapoolupdater.v1beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_replicapoolupdater.v1beta1.json.baseline
@@ -52,7 +52,7 @@ namespace ReplicapoolupdaterSample
             string zone = "";
 
             // The name of the update.
-            string rollingUpdate = "";
+            string rollingUpdate = "{MY-ROLLING-UPDATE}";
 
             RollingUpdatesResource.CancelRequest request = replicapoolupdaterService.RollingUpdates.Cancel(project, zone, rollingUpdate);
             Data.Operation response = request.Execute();
@@ -115,7 +115,7 @@ namespace ReplicapoolupdaterSample
             string zone = "";
 
             // The name of the update.
-            string rollingUpdate = "";
+            string rollingUpdate = "{MY-ROLLING-UPDATE}";
 
             RollingUpdatesResource.GetRequest request = replicapoolupdaterService.RollingUpdates.Get(project, zone, rollingUpdate);
             Data.RollingUpdate response = request.Execute();
@@ -175,7 +175,7 @@ namespace ReplicapoolupdaterSample
             string project = "";
 
             // The name of the zone in which the update's target resides.
-            string zone = "";
+            string zone = "{MY-ZONE}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.RollingUpdate content = new Data.RollingUpdate();
@@ -238,7 +238,7 @@ namespace ReplicapoolupdaterSample
             string project = "";
 
             // The name of the zone in which the update's target resides.
-            string zone = "";
+            string zone = "{MY-ZONE}";
 
             RollingUpdatesResource.ListRequest request = replicapoolupdaterService.RollingUpdates.List(project, zone);
             Data.RollingUpdateList response;
@@ -314,7 +314,7 @@ namespace ReplicapoolupdaterSample
             string zone = "";
 
             // The name of the update.
-            string rollingUpdate = "";
+            string rollingUpdate = "{MY-ROLLING-UPDATE}";
 
             RollingUpdatesResource.ListInstanceUpdatesRequest request = replicapoolupdaterService.RollingUpdates.ListInstanceUpdates(project, zone, rollingUpdate);
             Data.InstanceUpdateList response;
@@ -390,7 +390,7 @@ namespace ReplicapoolupdaterSample
             string zone = "";
 
             // The name of the update.
-            string rollingUpdate = "";
+            string rollingUpdate = "{MY-ROLLING-UPDATE}";
 
             RollingUpdatesResource.PauseRequest request = replicapoolupdaterService.RollingUpdates.Pause(project, zone, rollingUpdate);
             Data.Operation response = request.Execute();
@@ -453,7 +453,7 @@ namespace ReplicapoolupdaterSample
             string zone = "";
 
             // The name of the update.
-            string rollingUpdate = "";
+            string rollingUpdate = "{MY-ROLLING-UPDATE}";
 
             RollingUpdatesResource.ResumeRequest request = replicapoolupdaterService.RollingUpdates.Resume(project, zone, rollingUpdate);
             Data.Operation response = request.Execute();
@@ -516,7 +516,7 @@ namespace ReplicapoolupdaterSample
             string zone = "";
 
             // The name of the update.
-            string rollingUpdate = "";
+            string rollingUpdate = "{MY-ROLLING-UPDATE}";
 
             RollingUpdatesResource.RollbackRequest request = replicapoolupdaterService.RollingUpdates.Rollback(project, zone, rollingUpdate);
             Data.Operation response = request.Execute();
@@ -579,7 +579,7 @@ namespace ReplicapoolupdaterSample
             string zone = "";
 
             // Name of the operation resource to return.
-            string operation = "";
+            string operation = "{MY-OPERATION}";
 
             ZoneOperationsResource.GetRequest request = replicapoolupdaterService.ZoneOperations.Get(project, zone, operation);
             Data.Operation response = request.Execute();
@@ -639,7 +639,7 @@ namespace ReplicapoolupdaterSample
             string project = "";
 
             // Name of the zone scoping this request.
-            string zone = "";
+            string zone = "{MY-ZONE}";
 
             ZoneOperationsResource.ListRequest request = replicapoolupdaterService.ZoneOperations.List(project, zone);
             Data.OperationList response;

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_replicapoolupdater.v1beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_replicapoolupdater.v1beta1.json.baseline
@@ -46,10 +46,10 @@ namespace ReplicapoolupdaterSample
             // TODO: Change placeholders below to values for parameters to the Cancel() method:
 
             // The Google Developers Console project name.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone in which the update's target resides.
-            string zone = "";
+            string zone = "{MY-ZONE}";
 
             // The name of the update.
             string rollingUpdate = "{MY-ROLLING-UPDATE}";
@@ -109,10 +109,10 @@ namespace ReplicapoolupdaterSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // The Google Developers Console project name.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone in which the update's target resides.
-            string zone = "";
+            string zone = "{MY-ZONE}";
 
             // The name of the update.
             string rollingUpdate = "{MY-ROLLING-UPDATE}";
@@ -172,7 +172,7 @@ namespace ReplicapoolupdaterSample
             // TODO: Change placeholders below to values for parameters to the Insert() method:
 
             // The Google Developers Console project name.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone in which the update's target resides.
             string zone = "{MY-ZONE}";
@@ -235,7 +235,7 @@ namespace ReplicapoolupdaterSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // The Google Developers Console project name.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone in which the update's target resides.
             string zone = "{MY-ZONE}";
@@ -308,10 +308,10 @@ namespace ReplicapoolupdaterSample
             // TODO: Change placeholders below to values for parameters to the ListInstanceUpdates() method:
 
             // The Google Developers Console project name.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone in which the update's target resides.
-            string zone = "";
+            string zone = "{MY-ZONE}";
 
             // The name of the update.
             string rollingUpdate = "{MY-ROLLING-UPDATE}";
@@ -384,10 +384,10 @@ namespace ReplicapoolupdaterSample
             // TODO: Change placeholders below to values for parameters to the Pause() method:
 
             // The Google Developers Console project name.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone in which the update's target resides.
-            string zone = "";
+            string zone = "{MY-ZONE}";
 
             // The name of the update.
             string rollingUpdate = "{MY-ROLLING-UPDATE}";
@@ -447,10 +447,10 @@ namespace ReplicapoolupdaterSample
             // TODO: Change placeholders below to values for parameters to the Resume() method:
 
             // The Google Developers Console project name.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone in which the update's target resides.
-            string zone = "";
+            string zone = "{MY-ZONE}";
 
             // The name of the update.
             string rollingUpdate = "{MY-ROLLING-UPDATE}";
@@ -510,10 +510,10 @@ namespace ReplicapoolupdaterSample
             // TODO: Change placeholders below to values for parameters to the Rollback() method:
 
             // The Google Developers Console project name.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The name of the zone in which the update's target resides.
-            string zone = "";
+            string zone = "{MY-ZONE}";
 
             // The name of the update.
             string rollingUpdate = "{MY-ROLLING-UPDATE}";
@@ -573,10 +573,10 @@ namespace ReplicapoolupdaterSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Name of the project scoping this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the zone scoping this request.
-            string zone = "";
+            string zone = "{MY-ZONE}";
 
             // Name of the operation resource to return.
             string operation = "{MY-OPERATION}";
@@ -636,7 +636,7 @@ namespace ReplicapoolupdaterSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Name of the project scoping this request.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Name of the zone scoping this request.
             string zone = "{MY-ZONE}";

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_sqladmin.v1beta4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_sqladmin.v1beta4.json.baseline
@@ -175,7 +175,7 @@ namespace SQLAdminSample
             string project = "";
 
             // Cloud SQL instance ID. This does not include the project ID.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             BackupRunsResource.ListRequest request = sQLAdminService.BackupRuns.List(project, instance);
             Data.BackupRunsListResponse response;
@@ -251,7 +251,7 @@ namespace SQLAdminSample
             string instance = "";
 
             // Name of the database to be deleted in the instance.
-            string database = "";
+            string database = "{MY-DATABASE}";
 
             DatabasesResource.DeleteRequest request = sQLAdminService.Databases.Delete(project, instance, database);
             Data.Operation response = request.Execute();
@@ -314,7 +314,7 @@ namespace SQLAdminSample
             string instance = "";
 
             // Name of the database in the instance.
-            string database = "";
+            string database = "{MY-DATABASE}";
 
             DatabasesResource.GetRequest request = sQLAdminService.Databases.Get(project, instance, database);
             Data.Database response = request.Execute();
@@ -374,7 +374,7 @@ namespace SQLAdminSample
             string project = "";
 
             // Database instance ID. This does not include the project ID.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Database content = new Data.Database();
@@ -437,7 +437,7 @@ namespace SQLAdminSample
             string project = "";
 
             // Cloud SQL instance ID. This does not include the project ID.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             DatabasesResource.ListRequest request = sQLAdminService.Databases.List(project, instance);
             Data.DatabasesListResponse response = request.Execute();
@@ -500,7 +500,7 @@ namespace SQLAdminSample
             string instance = "";
 
             // Name of the database to be updated in the instance.
-            string database = "";
+            string database = "{MY-DATABASE}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Database content = new Data.Database();
@@ -566,7 +566,7 @@ namespace SQLAdminSample
             string instance = "";
 
             // Name of the database to be updated in the instance.
-            string database = "";
+            string database = "{MY-DATABASE}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Database content = new Data.Database();
@@ -681,7 +681,7 @@ namespace SQLAdminSample
             string project = "";
 
             // The ID of the Cloud SQL instance to be cloned (source). This does not include the project ID.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.InstancesCloneRequest content = new Data.InstancesCloneRequest();
@@ -744,7 +744,7 @@ namespace SQLAdminSample
             string project = "";
 
             // Cloud SQL instance ID. This does not include the project ID.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             InstancesResource.DeleteRequest request = sQLAdminService.Instances.Delete(project, instance);
             Data.Operation response = request.Execute();
@@ -804,7 +804,7 @@ namespace SQLAdminSample
             string project = "";
 
             // Cloud SQL instance ID. This does not include the project ID.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.InstancesExportRequest content = new Data.InstancesExportRequest();
@@ -867,7 +867,7 @@ namespace SQLAdminSample
             string project = "";
 
             // Cloud SQL instance ID. This does not include the project ID.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.InstancesFailoverRequest content = new Data.InstancesFailoverRequest();
@@ -930,7 +930,7 @@ namespace SQLAdminSample
             string project = "";
 
             // Database instance ID. This does not include the project ID.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             InstancesResource.GetRequest request = sQLAdminService.Instances.Get(project, instance);
             Data.DatabaseInstance response = request.Execute();
@@ -990,7 +990,7 @@ namespace SQLAdminSample
             string project = "";
 
             // Cloud SQL instance ID. This does not include the project ID.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.InstancesImportRequest content = new Data.InstancesImportRequest();
@@ -1050,7 +1050,7 @@ namespace SQLAdminSample
             // TODO: Change placeholders below to values for parameters to the Insert() method:
 
             // Project ID of the project to which the newly created Cloud SQL instances should belong.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.DatabaseInstance content = new Data.DatabaseInstance();
@@ -1110,7 +1110,7 @@ namespace SQLAdminSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID of the project for which to list Cloud SQL instances.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             InstancesResource.ListRequest request = sQLAdminService.Instances.List(project);
             Data.InstancesListResponse response;
@@ -1183,7 +1183,7 @@ namespace SQLAdminSample
             string project = "";
 
             // Cloud SQL instance ID. This does not include the project ID.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.DatabaseInstance content = new Data.DatabaseInstance();
@@ -1246,7 +1246,7 @@ namespace SQLAdminSample
             string project = "";
 
             // Cloud SQL read replica instance name.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             InstancesResource.PromoteReplicaRequest request = sQLAdminService.Instances.PromoteReplica(project, instance);
             Data.Operation response = request.Execute();
@@ -1306,7 +1306,7 @@ namespace SQLAdminSample
             string project = "";
 
             // Cloud SQL instance ID. This does not include the project ID.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             InstancesResource.ResetSslConfigRequest request = sQLAdminService.Instances.ResetSslConfig(project, instance);
             Data.Operation response = request.Execute();
@@ -1366,7 +1366,7 @@ namespace SQLAdminSample
             string project = "";
 
             // Cloud SQL instance ID. This does not include the project ID.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             InstancesResource.RestartRequest request = sQLAdminService.Instances.Restart(project, instance);
             Data.Operation response = request.Execute();
@@ -1426,7 +1426,7 @@ namespace SQLAdminSample
             string project = "";
 
             // Cloud SQL instance ID. This does not include the project ID.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.InstancesRestoreBackupRequest content = new Data.InstancesRestoreBackupRequest();
@@ -1489,7 +1489,7 @@ namespace SQLAdminSample
             string project = "";
 
             // Cloud SQL read replica instance name.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             InstancesResource.StartReplicaRequest request = sQLAdminService.Instances.StartReplica(project, instance);
             Data.Operation response = request.Execute();
@@ -1549,7 +1549,7 @@ namespace SQLAdminSample
             string project = "";
 
             // Cloud SQL read replica instance name.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             InstancesResource.StopReplicaRequest request = sQLAdminService.Instances.StopReplica(project, instance);
             Data.Operation response = request.Execute();
@@ -1609,7 +1609,7 @@ namespace SQLAdminSample
             string project = "";
 
             // Cloud SQL instance ID. This does not include the project ID.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.DatabaseInstance content = new Data.DatabaseInstance();
@@ -1672,7 +1672,7 @@ namespace SQLAdminSample
             string project = "";
 
             // Instance operation ID.
-            string operation = "";
+            string operation = "{MY-OPERATION}";
 
             OperationsResource.GetRequest request = sQLAdminService.Operations.Get(project, operation);
             Data.Operation response = request.Execute();
@@ -1732,7 +1732,7 @@ namespace SQLAdminSample
             string project = "";
 
             // Cloud SQL instance ID. This does not include the project ID.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             OperationsResource.ListRequest request = sQLAdminService.Operations.List(project, instance);
             Data.OperationsListResponse response;
@@ -1805,7 +1805,7 @@ namespace SQLAdminSample
             string project = "";
 
             // Cloud SQL instance ID. This does not include the project ID.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.SslCertsCreateEphemeralRequest content = new Data.SslCertsCreateEphemeralRequest();
@@ -1871,7 +1871,7 @@ namespace SQLAdminSample
             string instance = "";
 
             // Sha1 FingerPrint.
-            string sha1Fingerprint = "";
+            string sha1Fingerprint = "{MY-SHA1-FINGERPRINT}";
 
             SslCertsResource.DeleteRequest request = sQLAdminService.SslCerts.Delete(project, instance, sha1Fingerprint);
             Data.Operation response = request.Execute();
@@ -1934,7 +1934,7 @@ namespace SQLAdminSample
             string instance = "";
 
             // Sha1 FingerPrint.
-            string sha1Fingerprint = "";
+            string sha1Fingerprint = "{MY-SHA1-FINGERPRINT}";
 
             SslCertsResource.GetRequest request = sQLAdminService.SslCerts.Get(project, instance, sha1Fingerprint);
             Data.SslCert response = request.Execute();
@@ -1994,7 +1994,7 @@ namespace SQLAdminSample
             string project = "";
 
             // Cloud SQL instance ID. This does not include the project ID.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.SslCertsInsertRequest content = new Data.SslCertsInsertRequest();
@@ -2057,7 +2057,7 @@ namespace SQLAdminSample
             string project = "";
 
             // Cloud SQL instance ID. This does not include the project ID.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             SslCertsResource.ListRequest request = sQLAdminService.SslCerts.List(project, instance);
             Data.SslCertsListResponse response = request.Execute();
@@ -2114,7 +2114,7 @@ namespace SQLAdminSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID of the project for which to list tiers.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             TiersResource.ListRequest request = sQLAdminService.Tiers.List(project);
             Data.TiersListResponse response = request.Execute();
@@ -2180,7 +2180,7 @@ namespace SQLAdminSample
             string host = "";
 
             // Name of the user in the instance.
-            string name = "";
+            string name = "{MY-NAME}";
 
             UsersResource.DeleteRequest request = sQLAdminService.Users.Delete(project, instance, host, name);
             Data.Operation response = request.Execute();
@@ -2240,7 +2240,7 @@ namespace SQLAdminSample
             string project = "";
 
             // Database instance ID. This does not include the project ID.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.User content = new Data.User();
@@ -2303,7 +2303,7 @@ namespace SQLAdminSample
             string project = "";
 
             // Database instance ID. This does not include the project ID.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             UsersResource.ListRequest request = sQLAdminService.Users.List(project, instance);
             Data.UsersListResponse response = request.Execute();
@@ -2369,7 +2369,7 @@ namespace SQLAdminSample
             string host = "";
 
             // Name of the user in the instance.
-            string name = "";
+            string name = "{MY-NAME}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.User content = new Data.User();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_sqladmin.v1beta4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_sqladmin.v1beta4.json.baseline
@@ -46,10 +46,10 @@ namespace SQLAdminSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Project ID of the project that contains the instance.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Cloud SQL instance ID. This does not include the project ID.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             // The ID of the Backup Run to delete. To find a Backup Run ID, use the list method.
             long id = 0L;
@@ -109,10 +109,10 @@ namespace SQLAdminSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID of the project that contains the instance.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Cloud SQL instance ID. This does not include the project ID.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             // The ID of this Backup Run.
             long id = 0L;
@@ -172,7 +172,7 @@ namespace SQLAdminSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID of the project that contains the instance.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Cloud SQL instance ID. This does not include the project ID.
             string instance = "{MY-INSTANCE}";
@@ -245,10 +245,10 @@ namespace SQLAdminSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Project ID of the project that contains the instance.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Database instance ID. This does not include the project ID.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             // Name of the database to be deleted in the instance.
             string database = "{MY-DATABASE}";
@@ -308,10 +308,10 @@ namespace SQLAdminSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID of the project that contains the instance.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Database instance ID. This does not include the project ID.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             // Name of the database in the instance.
             string database = "{MY-DATABASE}";
@@ -371,7 +371,7 @@ namespace SQLAdminSample
             // TODO: Change placeholders below to values for parameters to the Insert() method:
 
             // Project ID of the project that contains the instance.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Database instance ID. This does not include the project ID.
             string instance = "{MY-INSTANCE}";
@@ -434,7 +434,7 @@ namespace SQLAdminSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID of the project for which to list Cloud SQL instances.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Cloud SQL instance ID. This does not include the project ID.
             string instance = "{MY-INSTANCE}";
@@ -494,10 +494,10 @@ namespace SQLAdminSample
             // TODO: Change placeholders below to values for parameters to the Patch() method:
 
             // Project ID of the project that contains the instance.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Database instance ID. This does not include the project ID.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             // Name of the database to be updated in the instance.
             string database = "{MY-DATABASE}";
@@ -560,10 +560,10 @@ namespace SQLAdminSample
             // TODO: Change placeholders below to values for parameters to the Update() method:
 
             // Project ID of the project that contains the instance.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Database instance ID. This does not include the project ID.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             // Name of the database to be updated in the instance.
             string database = "{MY-DATABASE}";
@@ -678,7 +678,7 @@ namespace SQLAdminSample
             // TODO: Change placeholders below to values for parameters to the Clone() method:
 
             // Project ID of the source as well as the clone Cloud SQL instance.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The ID of the Cloud SQL instance to be cloned (source). This does not include the project ID.
             string instance = "{MY-INSTANCE}";
@@ -741,7 +741,7 @@ namespace SQLAdminSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Project ID of the project that contains the instance to be deleted.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Cloud SQL instance ID. This does not include the project ID.
             string instance = "{MY-INSTANCE}";
@@ -801,7 +801,7 @@ namespace SQLAdminSample
             // TODO: Change placeholders below to values for parameters to the Export() method:
 
             // Project ID of the project that contains the instance to be exported.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Cloud SQL instance ID. This does not include the project ID.
             string instance = "{MY-INSTANCE}";
@@ -864,7 +864,7 @@ namespace SQLAdminSample
             // TODO: Change placeholders below to values for parameters to the Failover() method:
 
             // ID of the project that contains the read replica.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Cloud SQL instance ID. This does not include the project ID.
             string instance = "{MY-INSTANCE}";
@@ -927,7 +927,7 @@ namespace SQLAdminSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID of the project that contains the instance.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Database instance ID. This does not include the project ID.
             string instance = "{MY-INSTANCE}";
@@ -987,7 +987,7 @@ namespace SQLAdminSample
             // TODO: Change placeholders below to values for parameters to the Import() method:
 
             // Project ID of the project that contains the instance.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Cloud SQL instance ID. This does not include the project ID.
             string instance = "{MY-INSTANCE}";
@@ -1180,7 +1180,7 @@ namespace SQLAdminSample
             // TODO: Change placeholders below to values for parameters to the Patch() method:
 
             // Project ID of the project that contains the instance.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Cloud SQL instance ID. This does not include the project ID.
             string instance = "{MY-INSTANCE}";
@@ -1243,7 +1243,7 @@ namespace SQLAdminSample
             // TODO: Change placeholders below to values for parameters to the PromoteReplica() method:
 
             // ID of the project that contains the read replica.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Cloud SQL read replica instance name.
             string instance = "{MY-INSTANCE}";
@@ -1303,7 +1303,7 @@ namespace SQLAdminSample
             // TODO: Change placeholders below to values for parameters to the ResetSslConfig() method:
 
             // Project ID of the project that contains the instance.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Cloud SQL instance ID. This does not include the project ID.
             string instance = "{MY-INSTANCE}";
@@ -1363,7 +1363,7 @@ namespace SQLAdminSample
             // TODO: Change placeholders below to values for parameters to the Restart() method:
 
             // Project ID of the project that contains the instance to be restarted.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Cloud SQL instance ID. This does not include the project ID.
             string instance = "{MY-INSTANCE}";
@@ -1423,7 +1423,7 @@ namespace SQLAdminSample
             // TODO: Change placeholders below to values for parameters to the RestoreBackup() method:
 
             // Project ID of the project that contains the instance.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Cloud SQL instance ID. This does not include the project ID.
             string instance = "{MY-INSTANCE}";
@@ -1486,7 +1486,7 @@ namespace SQLAdminSample
             // TODO: Change placeholders below to values for parameters to the StartReplica() method:
 
             // ID of the project that contains the read replica.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Cloud SQL read replica instance name.
             string instance = "{MY-INSTANCE}";
@@ -1546,7 +1546,7 @@ namespace SQLAdminSample
             // TODO: Change placeholders below to values for parameters to the StopReplica() method:
 
             // ID of the project that contains the read replica.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Cloud SQL read replica instance name.
             string instance = "{MY-INSTANCE}";
@@ -1606,7 +1606,7 @@ namespace SQLAdminSample
             // TODO: Change placeholders below to values for parameters to the Update() method:
 
             // Project ID of the project that contains the instance.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Cloud SQL instance ID. This does not include the project ID.
             string instance = "{MY-INSTANCE}";
@@ -1669,7 +1669,7 @@ namespace SQLAdminSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID of the project that contains the instance.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Instance operation ID.
             string operation = "{MY-OPERATION}";
@@ -1729,7 +1729,7 @@ namespace SQLAdminSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID of the project that contains the instance.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Cloud SQL instance ID. This does not include the project ID.
             string instance = "{MY-INSTANCE}";
@@ -1802,7 +1802,7 @@ namespace SQLAdminSample
             // TODO: Change placeholders below to values for parameters to the CreateEphemeral() method:
 
             // Project ID of the Cloud SQL project.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Cloud SQL instance ID. This does not include the project ID.
             string instance = "{MY-INSTANCE}";
@@ -1865,10 +1865,10 @@ namespace SQLAdminSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Project ID of the project that contains the instance to be deleted.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Cloud SQL instance ID. This does not include the project ID.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             // Sha1 FingerPrint.
             string sha1Fingerprint = "{MY-SHA1-FINGERPRINT}";
@@ -1928,10 +1928,10 @@ namespace SQLAdminSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Project ID of the project that contains the instance.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Cloud SQL instance ID. This does not include the project ID.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             // Sha1 FingerPrint.
             string sha1Fingerprint = "{MY-SHA1-FINGERPRINT}";
@@ -1991,7 +1991,7 @@ namespace SQLAdminSample
             // TODO: Change placeholders below to values for parameters to the Insert() method:
 
             // Project ID of the project to which the newly created Cloud SQL instances should belong.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Cloud SQL instance ID. This does not include the project ID.
             string instance = "{MY-INSTANCE}";
@@ -2054,7 +2054,7 @@ namespace SQLAdminSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID of the project for which to list Cloud SQL instances.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Cloud SQL instance ID. This does not include the project ID.
             string instance = "{MY-INSTANCE}";
@@ -2171,13 +2171,13 @@ namespace SQLAdminSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Project ID of the project that contains the instance.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Database instance ID. This does not include the project ID.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             // Host of the user in the instance.
-            string host = "";
+            string host = "{MY-HOST}";
 
             // Name of the user in the instance.
             string name = "{MY-NAME}";
@@ -2237,7 +2237,7 @@ namespace SQLAdminSample
             // TODO: Change placeholders below to values for parameters to the Insert() method:
 
             // Project ID of the project that contains the instance.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Database instance ID. This does not include the project ID.
             string instance = "{MY-INSTANCE}";
@@ -2300,7 +2300,7 @@ namespace SQLAdminSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Project ID of the project that contains the instance.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Database instance ID. This does not include the project ID.
             string instance = "{MY-INSTANCE}";
@@ -2360,13 +2360,13 @@ namespace SQLAdminSample
             // TODO: Change placeholders below to values for parameters to the Update() method:
 
             // Project ID of the project that contains the instance.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // Database instance ID. This does not include the project ID.
-            string instance = "";
+            string instance = "{MY-INSTANCE}";
 
             // Host of the user in the instance.
-            string host = "";
+            string host = "{MY-HOST}";
 
             // Name of the user in the instance.
             string name = "{MY-NAME}";

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_storage.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_storage.v1.json.baseline
@@ -44,7 +44,7 @@ namespace StorageSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Name of a bucket.
-            string bucket = "";
+            string bucket = "{MY-BUCKET}";
 
             // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
             // group-emailAddress, allUsers, or allAuthenticatedUsers.
@@ -105,7 +105,7 @@ namespace StorageSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Name of a bucket.
-            string bucket = "";
+            string bucket = "{MY-BUCKET}";
 
             // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
             // group-emailAddress, allUsers, or allAuthenticatedUsers.
@@ -283,7 +283,7 @@ namespace StorageSample
             // TODO: Change placeholders below to values for parameters to the Patch() method:
 
             // Name of a bucket.
-            string bucket = "";
+            string bucket = "{MY-BUCKET}";
 
             // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
             // group-emailAddress, allUsers, or allAuthenticatedUsers.
@@ -347,7 +347,7 @@ namespace StorageSample
             // TODO: Change placeholders below to values for parameters to the Update() method:
 
             // Name of a bucket.
-            string bucket = "";
+            string bucket = "{MY-BUCKET}";
 
             // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
             // group-emailAddress, allUsers, or allAuthenticatedUsers.
@@ -826,7 +826,7 @@ namespace StorageSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Name of a bucket.
-            string bucket = "";
+            string bucket = "{MY-BUCKET}";
 
             // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
             // group-emailAddress, allUsers, or allAuthenticatedUsers.
@@ -887,7 +887,7 @@ namespace StorageSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Name of a bucket.
-            string bucket = "";
+            string bucket = "{MY-BUCKET}";
 
             // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
             // group-emailAddress, allUsers, or allAuthenticatedUsers.
@@ -1065,7 +1065,7 @@ namespace StorageSample
             // TODO: Change placeholders below to values for parameters to the Patch() method:
 
             // Name of a bucket.
-            string bucket = "";
+            string bucket = "{MY-BUCKET}";
 
             // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
             // group-emailAddress, allUsers, or allAuthenticatedUsers.
@@ -1129,7 +1129,7 @@ namespace StorageSample
             // TODO: Change placeholders below to values for parameters to the Update() method:
 
             // Name of a bucket.
-            string bucket = "";
+            string bucket = "{MY-BUCKET}";
 
             // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
             // group-emailAddress, allUsers, or allAuthenticatedUsers.
@@ -1191,11 +1191,11 @@ namespace StorageSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Name of a bucket.
-            string bucket = "";
+            string bucket = "{MY-BUCKET}";
 
             // Name of the object. For information about how to URL encode object names to be path safe, see
             // Encoding URI Path Parts.
-            string object_ = "";
+            string object_ = "{MY-OBJECT}";
 
             // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
             // group-emailAddress, allUsers, or allAuthenticatedUsers.
@@ -1256,11 +1256,11 @@ namespace StorageSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Name of a bucket.
-            string bucket = "";
+            string bucket = "{MY-BUCKET}";
 
             // Name of the object. For information about how to URL encode object names to be path safe, see
             // Encoding URI Path Parts.
-            string object_ = "";
+            string object_ = "{MY-OBJECT}";
 
             // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
             // group-emailAddress, allUsers, or allAuthenticatedUsers.
@@ -1321,7 +1321,7 @@ namespace StorageSample
             // TODO: Change placeholders below to values for parameters to the Insert() method:
 
             // Name of a bucket.
-            string bucket = "";
+            string bucket = "{MY-BUCKET}";
 
             // Name of the object. For information about how to URL encode object names to be path safe, see
             // Encoding URI Path Parts.
@@ -1385,7 +1385,7 @@ namespace StorageSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Name of a bucket.
-            string bucket = "";
+            string bucket = "{MY-BUCKET}";
 
             // Name of the object. For information about how to URL encode object names to be path safe, see
             // Encoding URI Path Parts.
@@ -1446,11 +1446,11 @@ namespace StorageSample
             // TODO: Change placeholders below to values for parameters to the Patch() method:
 
             // Name of a bucket.
-            string bucket = "";
+            string bucket = "{MY-BUCKET}";
 
             // Name of the object. For information about how to URL encode object names to be path safe, see
             // Encoding URI Path Parts.
-            string object_ = "";
+            string object_ = "{MY-OBJECT}";
 
             // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
             // group-emailAddress, allUsers, or allAuthenticatedUsers.
@@ -1514,11 +1514,11 @@ namespace StorageSample
             // TODO: Change placeholders below to values for parameters to the Update() method:
 
             // Name of a bucket.
-            string bucket = "";
+            string bucket = "{MY-BUCKET}";
 
             // Name of the object. For information about how to URL encode object names to be path safe, see
             // Encoding URI Path Parts.
-            string object_ = "";
+            string object_ = "{MY-OBJECT}";
 
             // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
             // group-emailAddress, allUsers, or allAuthenticatedUsers.
@@ -1582,7 +1582,7 @@ namespace StorageSample
             // TODO: Change placeholders below to values for parameters to the Compose() method:
 
             // Name of the bucket in which to store the new object.
-            string destinationBucket = "";
+            string destinationBucket = "{MY-DESTINATION-BUCKET}";
 
             // Name of the new object. For information about how to URL encode object names to be path safe, see
             // Encoding URI Path Parts.
@@ -1646,16 +1646,16 @@ namespace StorageSample
             // TODO: Change placeholders below to values for parameters to the Copy() method:
 
             // Name of the bucket in which to find the source object.
-            string sourceBucket = "";
+            string sourceBucket = "{MY-SOURCE-BUCKET}";
 
             // Name of the source object. For information about how to URL encode object names to be path safe, see
             // Encoding URI Path Parts.
-            string sourceObject = "";
+            string sourceObject = "{MY-SOURCE-OBJECT}";
 
             // Name of the bucket in which to store the new object. Overrides the provided object metadata's bucket
             // value, if any.For information about how to URL encode object names to be path safe, see Encoding URI
             // Path Parts.
-            string destinationBucket = "";
+            string destinationBucket = "{MY-DESTINATION-BUCKET}";
 
             // Name of the new object. Required when the object metadata is not otherwise provided. Overrides the
             // object metadata's name value, if any.
@@ -1717,7 +1717,7 @@ namespace StorageSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Name of the bucket in which the object resides.
-            string bucket = "";
+            string bucket = "{MY-BUCKET}";
 
             // Name of the object. For information about how to URL encode object names to be path safe, see
             // Encoding URI Path Parts.
@@ -1778,7 +1778,7 @@ namespace StorageSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Name of the bucket in which the object resides.
-            string bucket = "";
+            string bucket = "{MY-BUCKET}";
 
             // Name of the object. For information about how to URL encode object names to be path safe, see
             // Encoding URI Path Parts.
@@ -1970,7 +1970,7 @@ namespace StorageSample
             // TODO: Change placeholders below to values for parameters to the Patch() method:
 
             // Name of the bucket in which the object resides.
-            string bucket = "";
+            string bucket = "{MY-BUCKET}";
 
             // Name of the object. For information about how to URL encode object names to be path safe, see
             // Encoding URI Path Parts.
@@ -2034,15 +2034,15 @@ namespace StorageSample
             // TODO: Change placeholders below to values for parameters to the Rewrite() method:
 
             // Name of the bucket in which to find the source object.
-            string sourceBucket = "";
+            string sourceBucket = "{MY-SOURCE-BUCKET}";
 
             // Name of the source object. For information about how to URL encode object names to be path safe, see
             // Encoding URI Path Parts.
-            string sourceObject = "";
+            string sourceObject = "{MY-SOURCE-OBJECT}";
 
             // Name of the bucket in which to store the new object. Overrides the provided object metadata's bucket
             // value, if any.
-            string destinationBucket = "";
+            string destinationBucket = "{MY-DESTINATION-BUCKET}";
 
             // Name of the new object. Required when the object metadata is not otherwise provided. Overrides the
             // object metadata's name value, if any. For information about how to URL encode object names to be
@@ -2107,7 +2107,7 @@ namespace StorageSample
             // TODO: Change placeholders below to values for parameters to the Update() method:
 
             // Name of the bucket in which the object resides.
-            string bucket = "";
+            string bucket = "{MY-BUCKET}";
 
             // Name of the object. For information about how to URL encode object names to be path safe, see
             // Encoding URI Path Parts.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_storage.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_storage.v1.json.baseline
@@ -48,7 +48,7 @@ namespace StorageSample
 
             // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
             // group-emailAddress, allUsers, or allAuthenticatedUsers.
-            string entity = "";
+            string entity = "{MY-ENTITY}";
 
             BucketAccessControlsResource.DeleteRequest request = storageService.BucketAccessControls.Delete(bucket, entity);
             request.Execute();
@@ -109,7 +109,7 @@ namespace StorageSample
 
             // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
             // group-emailAddress, allUsers, or allAuthenticatedUsers.
-            string entity = "";
+            string entity = "{MY-ENTITY}";
 
             BucketAccessControlsResource.GetRequest request = storageService.BucketAccessControls.Get(bucket, entity);
             Data.BucketAccessControl response = request.Execute();
@@ -166,7 +166,7 @@ namespace StorageSample
             // TODO: Change placeholders below to values for parameters to the Insert() method:
 
             // Name of a bucket.
-            string bucket = "";
+            string bucket = "{MY-BUCKET}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.BucketAccessControl content = new Data.BucketAccessControl();
@@ -226,7 +226,7 @@ namespace StorageSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Name of a bucket.
-            string bucket = "";
+            string bucket = "{MY-BUCKET}";
 
             BucketAccessControlsResource.ListRequest request = storageService.BucketAccessControls.List(bucket);
             Data.BucketAccessControls response = request.Execute();
@@ -287,7 +287,7 @@ namespace StorageSample
 
             // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
             // group-emailAddress, allUsers, or allAuthenticatedUsers.
-            string entity = "";
+            string entity = "{MY-ENTITY}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.BucketAccessControl content = new Data.BucketAccessControl();
@@ -351,7 +351,7 @@ namespace StorageSample
 
             // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
             // group-emailAddress, allUsers, or allAuthenticatedUsers.
-            string entity = "";
+            string entity = "{MY-ENTITY}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.BucketAccessControl content = new Data.BucketAccessControl();
@@ -409,7 +409,7 @@ namespace StorageSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // Name of a bucket.
-            string bucket = "";
+            string bucket = "{MY-BUCKET}";
 
             BucketsResource.DeleteRequest request = storageService.Buckets.Delete(bucket);
             request.Execute();
@@ -466,7 +466,7 @@ namespace StorageSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // Name of a bucket.
-            string bucket = "";
+            string bucket = "{MY-BUCKET}";
 
             BucketsResource.GetRequest request = storageService.Buckets.Get(bucket);
             Data.Bucket response = request.Execute();
@@ -523,7 +523,7 @@ namespace StorageSample
             // TODO: Change placeholders below to values for parameters to the Insert() method:
 
             // A valid API project identifier.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Bucket content = new Data.Bucket();
@@ -583,7 +583,7 @@ namespace StorageSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // A valid API project identifier.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             BucketsResource.ListRequest request = storageService.Buckets.List(project);
             Data.Buckets response;
@@ -653,7 +653,7 @@ namespace StorageSample
             // TODO: Change placeholders below to values for parameters to the Patch() method:
 
             // Name of a bucket.
-            string bucket = "";
+            string bucket = "{MY-BUCKET}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Bucket content = new Data.Bucket();
@@ -713,7 +713,7 @@ namespace StorageSample
             // TODO: Change placeholders below to values for parameters to the Update() method:
 
             // Name of a bucket.
-            string bucket = "";
+            string bucket = "{MY-BUCKET}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Bucket content = new Data.Bucket();
@@ -830,7 +830,7 @@ namespace StorageSample
 
             // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
             // group-emailAddress, allUsers, or allAuthenticatedUsers.
-            string entity = "";
+            string entity = "{MY-ENTITY}";
 
             DefaultObjectAccessControlsResource.DeleteRequest request = storageService.DefaultObjectAccessControls.Delete(bucket, entity);
             request.Execute();
@@ -891,7 +891,7 @@ namespace StorageSample
 
             // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
             // group-emailAddress, allUsers, or allAuthenticatedUsers.
-            string entity = "";
+            string entity = "{MY-ENTITY}";
 
             DefaultObjectAccessControlsResource.GetRequest request = storageService.DefaultObjectAccessControls.Get(bucket, entity);
             Data.ObjectAccessControl response = request.Execute();
@@ -948,7 +948,7 @@ namespace StorageSample
             // TODO: Change placeholders below to values for parameters to the Insert() method:
 
             // Name of a bucket.
-            string bucket = "";
+            string bucket = "{MY-BUCKET}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.ObjectAccessControl content = new Data.ObjectAccessControl();
@@ -1008,7 +1008,7 @@ namespace StorageSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Name of a bucket.
-            string bucket = "";
+            string bucket = "{MY-BUCKET}";
 
             DefaultObjectAccessControlsResource.ListRequest request = storageService.DefaultObjectAccessControls.List(bucket);
             Data.ObjectAccessControls response = request.Execute();
@@ -1069,7 +1069,7 @@ namespace StorageSample
 
             // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
             // group-emailAddress, allUsers, or allAuthenticatedUsers.
-            string entity = "";
+            string entity = "{MY-ENTITY}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.ObjectAccessControl content = new Data.ObjectAccessControl();
@@ -1133,7 +1133,7 @@ namespace StorageSample
 
             // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
             // group-emailAddress, allUsers, or allAuthenticatedUsers.
-            string entity = "";
+            string entity = "{MY-ENTITY}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.ObjectAccessControl content = new Data.ObjectAccessControl();
@@ -1199,7 +1199,7 @@ namespace StorageSample
 
             // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
             // group-emailAddress, allUsers, or allAuthenticatedUsers.
-            string entity = "";
+            string entity = "{MY-ENTITY}";
 
             ObjectAccessControlsResource.DeleteRequest request = storageService.ObjectAccessControls.Delete(bucket, object_, entity);
             request.Execute();
@@ -1264,7 +1264,7 @@ namespace StorageSample
 
             // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
             // group-emailAddress, allUsers, or allAuthenticatedUsers.
-            string entity = "";
+            string entity = "{MY-ENTITY}";
 
             ObjectAccessControlsResource.GetRequest request = storageService.ObjectAccessControls.Get(bucket, object_, entity);
             Data.ObjectAccessControl response = request.Execute();
@@ -1325,7 +1325,7 @@ namespace StorageSample
 
             // Name of the object. For information about how to URL encode object names to be path safe, see
             // Encoding URI Path Parts.
-            string object_ = "";
+            string object_ = "{MY-OBJECT}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.ObjectAccessControl content = new Data.ObjectAccessControl();
@@ -1389,7 +1389,7 @@ namespace StorageSample
 
             // Name of the object. For information about how to URL encode object names to be path safe, see
             // Encoding URI Path Parts.
-            string object_ = "";
+            string object_ = "{MY-OBJECT}";
 
             ObjectAccessControlsResource.ListRequest request = storageService.ObjectAccessControls.List(bucket, object_);
             Data.ObjectAccessControls response = request.Execute();
@@ -1454,7 +1454,7 @@ namespace StorageSample
 
             // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
             // group-emailAddress, allUsers, or allAuthenticatedUsers.
-            string entity = "";
+            string entity = "{MY-ENTITY}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.ObjectAccessControl content = new Data.ObjectAccessControl();
@@ -1522,7 +1522,7 @@ namespace StorageSample
 
             // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
             // group-emailAddress, allUsers, or allAuthenticatedUsers.
-            string entity = "";
+            string entity = "{MY-ENTITY}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.ObjectAccessControl content = new Data.ObjectAccessControl();
@@ -1586,7 +1586,7 @@ namespace StorageSample
 
             // Name of the new object. For information about how to URL encode object names to be path safe, see
             // Encoding URI Path Parts.
-            string destinationObject = "";
+            string destinationObject = "{MY-DESTINATION-OBJECT}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.ComposeRequest content = new Data.ComposeRequest();
@@ -1659,7 +1659,7 @@ namespace StorageSample
 
             // Name of the new object. Required when the object metadata is not otherwise provided. Overrides the
             // object metadata's name value, if any.
-            string destinationObject = "";
+            string destinationObject = "{MY-DESTINATION-OBJECT}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Object content = new Data.Object();
@@ -1721,7 +1721,7 @@ namespace StorageSample
 
             // Name of the object. For information about how to URL encode object names to be path safe, see
             // Encoding URI Path Parts.
-            string object_ = "";
+            string object_ = "{MY-OBJECT}";
 
             ObjectsResource.DeleteRequest request = storageService.Objects.Delete(bucket, object_);
             request.Execute();
@@ -1782,7 +1782,7 @@ namespace StorageSample
 
             // Name of the object. For information about how to URL encode object names to be path safe, see
             // Encoding URI Path Parts.
-            string object_ = "";
+            string object_ = "{MY-OBJECT}";
 
             ObjectsResource.GetRequest request = storageService.Objects.Get(bucket, object_);
             Data.Object response = request.Execute();
@@ -1840,7 +1840,7 @@ namespace StorageSample
 
             // Name of the bucket in which to store the new object. Overrides the provided object metadata's bucket
             // value, if any.
-            string bucket = "";
+            string bucket = "{MY-BUCKET}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Object content = new Data.Object();
@@ -1900,7 +1900,7 @@ namespace StorageSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // Name of the bucket in which to look for objects.
-            string bucket = "";
+            string bucket = "{MY-BUCKET}";
 
             ObjectsResource.ListRequest request = storageService.Objects.List(bucket);
             Data.Objects response;
@@ -1974,7 +1974,7 @@ namespace StorageSample
 
             // Name of the object. For information about how to URL encode object names to be path safe, see
             // Encoding URI Path Parts.
-            string object_ = "";
+            string object_ = "{MY-OBJECT}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Object content = new Data.Object();
@@ -2047,7 +2047,7 @@ namespace StorageSample
             // Name of the new object. Required when the object metadata is not otherwise provided. Overrides the
             // object metadata's name value, if any. For information about how to URL encode object names to be
             // path safe, see Encoding URI Path Parts.
-            string destinationObject = "";
+            string destinationObject = "{MY-DESTINATION-OBJECT}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Object content = new Data.Object();
@@ -2111,7 +2111,7 @@ namespace StorageSample
 
             // Name of the object. For information about how to URL encode object names to be path safe, see
             // Encoding URI Path Parts.
-            string object_ = "";
+            string object_ = "{MY-OBJECT}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Object content = new Data.Object();
@@ -2171,7 +2171,7 @@ namespace StorageSample
             // TODO: Change placeholders below to values for parameters to the WatchAll() method:
 
             // Name of the bucket in which to look for objects.
-            string bucket = "";
+            string bucket = "{MY-BUCKET}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Channel content = new Data.Channel();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_storagetransfer.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_storagetransfer.v1.json.baseline
@@ -99,7 +99,7 @@ namespace StoragetransferSample
 
             // The ID of the Google Developers Console project that the Google service account is associated with.
             // Required.
-            string projectId = "";
+            string projectId = "{MY-PROJECT-ID}";
 
             GoogleServiceAccountsResource.GetRequest request = storagetransferService.GoogleServiceAccounts.Get(projectId);
             Data.GoogleServiceAccount response = request.Execute();
@@ -211,7 +211,7 @@ namespace StoragetransferSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // The job to get. Required.
-            string jobName = "";
+            string jobName = "{MY-JOB-NAME}";
 
             TransferJobsResource.GetRequest request = storagetransferService.TransferJobs.Get(jobName);
             Data.TransferJob response = request.Execute();
@@ -333,7 +333,7 @@ namespace StoragetransferSample
             // TODO: Change placeholders below to values for parameters to the Patch() method:
 
             // The name of job to update. Required.
-            string jobName = "";
+            string jobName = "{MY-JOB-NAME}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.UpdateTransferJobRequest content = new Data.UpdateTransferJobRequest();
@@ -393,7 +393,7 @@ namespace StoragetransferSample
             // TODO: Change placeholders below to values for parameters to the Cancel() method:
 
             // The name of the operation resource to be cancelled.
-            string name = "";
+            string name = "{MY-NAME}";
 
             TransferOperationsResource.CancelRequest request = storagetransferService.TransferOperations.Cancel(name);
             Data.Empty response = request.Execute();
@@ -450,7 +450,7 @@ namespace StoragetransferSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // The name of the operation resource to be deleted.
-            string name = "";
+            string name = "{MY-NAME}";
 
             TransferOperationsResource.DeleteRequest request = storagetransferService.TransferOperations.Delete(name);
             Data.Empty response = request.Execute();
@@ -507,7 +507,7 @@ namespace StoragetransferSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // The name of the operation resource.
-            string name = "";
+            string name = "{MY-NAME}";
 
             TransferOperationsResource.GetRequest request = storagetransferService.TransferOperations.Get(name);
             Data.Operation response = request.Execute();
@@ -564,7 +564,7 @@ namespace StoragetransferSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // The value `transferOperations`.
-            string name = "";
+            string name = "{MY-NAME}";
 
             TransferOperationsResource.ListRequest request = storagetransferService.TransferOperations.List(name);
             Data.ListOperationsResponse response;
@@ -634,7 +634,7 @@ namespace StoragetransferSample
             // TODO: Change placeholders below to values for parameters to the Pause() method:
 
             // The name of the transfer operation. Required.
-            string name = "";
+            string name = "{MY-NAME}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.PauseTransferOperationRequest content = new Data.PauseTransferOperationRequest();
@@ -694,7 +694,7 @@ namespace StoragetransferSample
             // TODO: Change placeholders below to values for parameters to the Resume() method:
 
             // The name of the transfer operation. Required.
-            string name = "";
+            string name = "{MY-NAME}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.ResumeTransferOperationRequest content = new Data.ResumeTransferOperationRequest();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_taskqueue.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_taskqueue.v1beta2.json.baseline
@@ -46,7 +46,7 @@ namespace TaskqueueSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // The project under which the queue lies.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The id of the taskqueue to get the properties of.
             string taskqueue = "{MY-TASKQUEUE}";
@@ -104,10 +104,10 @@ namespace TaskqueueSample
             // TODO: Change placeholders below to values for parameters to the Delete() method:
 
             // The project under which the queue lies.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The taskqueue to delete a task from.
-            string taskqueue = "";
+            string taskqueue = "{MY-TASKQUEUE}";
 
             // The id of the task to delete.
             string task = "{MY-TASK}";
@@ -167,10 +167,10 @@ namespace TaskqueueSample
             // TODO: Change placeholders below to values for parameters to the Get() method:
 
             // The project under which the queue lies.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The taskqueue in which the task belongs.
-            string taskqueue = "";
+            string taskqueue = "{MY-TASKQUEUE}";
 
             // The task to get properties of.
             string task = "{MY-TASK}";
@@ -230,7 +230,7 @@ namespace TaskqueueSample
             // TODO: Change placeholders below to values for parameters to the Insert() method:
 
             // The project under which the queue lies
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The taskqueue to insert the task into
             string taskqueue = "{MY-TASKQUEUE}";
@@ -293,10 +293,10 @@ namespace TaskqueueSample
             // TODO: Change placeholders below to values for parameters to the Lease() method:
 
             // The project under which the queue lies.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The taskqueue to lease a task from.
-            string taskqueue = "";
+            string taskqueue = "{MY-TASKQUEUE}";
 
             // The number of tasks to lease.
             int numTasks = 0;
@@ -359,7 +359,7 @@ namespace TaskqueueSample
             // TODO: Change placeholders below to values for parameters to the List() method:
 
             // The project under which the queue lies.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
             // The id of the taskqueue to list tasks from.
             string taskqueue = "{MY-TASKQUEUE}";
@@ -423,7 +423,7 @@ namespace TaskqueueSample
 
             string taskqueue = "{MY-TASKQUEUE}";
 
-            string task = "";
+            string task = "{MY-TASK}";
 
             // The new lease in seconds.
             int newLeaseSeconds = 0;
@@ -490,7 +490,7 @@ namespace TaskqueueSample
 
             string taskqueue = "{MY-TASKQUEUE}";
 
-            string task = "";
+            string task = "{MY-TASK}";
 
             // The new lease in seconds.
             int newLeaseSeconds = 0;

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_taskqueue.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_taskqueue.v1beta2.json.baseline
@@ -49,7 +49,7 @@ namespace TaskqueueSample
             string project = "";
 
             // The id of the taskqueue to get the properties of.
-            string taskqueue = "";
+            string taskqueue = "{MY-TASKQUEUE}";
 
             TaskqueuesResource.GetRequest request = taskqueueService.Taskqueues.Get(project, taskqueue);
             Data.TaskQueue response = request.Execute();
@@ -110,7 +110,7 @@ namespace TaskqueueSample
             string taskqueue = "";
 
             // The id of the task to delete.
-            string task = "";
+            string task = "{MY-TASK}";
 
             TasksResource.DeleteRequest request = taskqueueService.Tasks.Delete(project, taskqueue, task);
             request.Execute();
@@ -173,7 +173,7 @@ namespace TaskqueueSample
             string taskqueue = "";
 
             // The task to get properties of.
-            string task = "";
+            string task = "{MY-TASK}";
 
             TasksResource.GetRequest request = taskqueueService.Tasks.Get(project, taskqueue, task);
             Data.Task response = request.Execute();
@@ -233,7 +233,7 @@ namespace TaskqueueSample
             string project = "";
 
             // The taskqueue to insert the task into
-            string taskqueue = "";
+            string taskqueue = "{MY-TASKQUEUE}";
 
             // TODO Add code to assign values to properties of 'content'.
             Data.Task content = new Data.Task();
@@ -362,7 +362,7 @@ namespace TaskqueueSample
             string project = "";
 
             // The id of the taskqueue to list tasks from.
-            string taskqueue = "";
+            string taskqueue = "{MY-TASKQUEUE}";
 
             TasksResource.ListRequest request = taskqueueService.Tasks.List(project, taskqueue);
             Data.Tasks2 response = request.Execute();
@@ -419,9 +419,9 @@ namespace TaskqueueSample
             // TODO: Change placeholders below to values for parameters to the Patch() method:
 
             // The project under which the queue lies.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
-            string taskqueue = "";
+            string taskqueue = "{MY-TASKQUEUE}";
 
             string task = "";
 
@@ -486,9 +486,9 @@ namespace TaskqueueSample
             // TODO: Change placeholders below to values for parameters to the Update() method:
 
             // The project under which the queue lies.
-            string project = "";
+            string project = "{MY-PROJECT}";
 
-            string taskqueue = "";
+            string taskqueue = "{MY-TASKQUEUE}";
 
             string task = "";
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_translate.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_translate.v2.json.baseline
@@ -160,7 +160,7 @@ namespace TranslateSample
             List<string> q = new List<string>();
 
             // The target language into which the text should be translated
-            string target = "";
+            string target = "{MY-TARGET}";
 
             TranslationsResource.ListRequest request = translateService.Translations.List(q, target);
             Data.TranslationsListResponse response = request.Execute();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_adexchangebuyer.v1.4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_adexchangebuyer.v1.4.json.baseline
@@ -32,7 +32,8 @@ func main() {
   }
 
   // The account id
-  id := int64(0) // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  id := int64(0)
 
   resp, err := c.Accounts.Get(id).Context(ctx).Do()
   if err != nil {
@@ -115,7 +116,8 @@ func main() {
   }
 
   // The account id
-  id := int64(0) // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  id := int64(0)
 
   resp, err := c.Accounts.Patch(id, &adexchangebuyer.Account{
                                   // TODO: Fill required fields.
@@ -159,7 +161,8 @@ func main() {
   }
 
   // The account id
-  id := int64(0) // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  id := int64(0)
 
   resp, err := c.Accounts.Update(id, &adexchangebuyer.Account{
                                    // TODO: Fill required fields.
@@ -203,7 +206,8 @@ func main() {
   }
 
   // The account id.
-  accountId := int64(0) // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  accountId := int64(0)
 
   resp, err := c.BillingInfo.Get(accountId).Context(ctx).Do()
   if err != nil {
@@ -286,10 +290,12 @@ func main() {
   }
 
   // The account id to get the budget information for.
-  accountId := int64(0) // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  accountId := int64(0)
 
   // The billing id to get the budget information for.
-  billingId := int64(0) // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  billingId := int64(0)
 
   resp, err := c.Budget.Get(accountId, billingId).Context(ctx).Do()
   if err != nil {
@@ -331,10 +337,12 @@ func main() {
   }
 
   // The account id associated with the budget being updated.
-  accountId := int64(0) // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  accountId := int64(0)
 
   // The billing id associated with the budget being updated.
-  billingId := int64(0) // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  billingId := int64(0)
 
   resp, err := c.Budget.Patch(accountId, billingId, &adexchangebuyer.Budget{
                                 // TODO: Fill required fields.
@@ -378,10 +386,12 @@ func main() {
   }
 
   // The account id associated with the budget being updated.
-  accountId := int64(0) // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  accountId := int64(0)
 
   // The billing id associated with the budget being updated.
-  billingId := int64(0) // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  billingId := int64(0)
 
   resp, err := c.Budget.Update(accountId, billingId, &adexchangebuyer.Budget{
                                  // TODO: Fill required fields.
@@ -425,13 +435,16 @@ func main() {
   }
 
   // The id for the account that will serve this creative.
-  accountId := int64(0) // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  accountId := int64(0)
 
   // The buyer-specific id for this creative.
-  buyerCreativeId := "{MY-BUYER-CREATIVE-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  buyerCreativeId := "{MY-BUYER-CREATIVE-ID}"
 
   // The id of the deal id to associate with this creative.
-  dealId := int64(0) // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  dealId := int64(0)
 
   if err := c.Creatives.AddDeal(accountId, buyerCreativeId, dealId).Context(ctx).Do(); err != nil {
     // TODO: Handle error.
@@ -470,10 +483,12 @@ func main() {
   }
 
   // The id for the account that will serve this creative.
-  accountId := int64(0) // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  accountId := int64(0)
 
   // The buyer-specific id for this creative.
-  buyerCreativeId := "{MY-BUYER-CREATIVE-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  buyerCreativeId := "{MY-BUYER-CREATIVE-ID}"
 
   resp, err := c.Creatives.Get(accountId, buyerCreativeId).Context(ctx).Do()
   if err != nil {
@@ -604,13 +619,16 @@ func main() {
   }
 
   // The id for the account that will serve this creative.
-  accountId := int64(0) // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  accountId := int64(0)
 
   // The buyer-specific id for this creative.
-  buyerCreativeId := "{MY-BUYER-CREATIVE-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  buyerCreativeId := "{MY-BUYER-CREATIVE-ID}"
 
   // The id of the deal id to disassociate with this creative.
-  dealId := int64(0) // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  dealId := int64(0)
 
   if err := c.Creatives.RemoveDeal(accountId, buyerCreativeId, dealId).Context(ctx).Do(); err != nil {
     // TODO: Handle error.
@@ -649,7 +667,8 @@ func main() {
   }
 
   // The proposalId to delete deals from.
-  proposalId := "{MY-PROPOSAL-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  proposalId := "{MY-PROPOSAL-ID}"
 
   resp, err := c.Marketplacedeals.Delete(proposalId, &adexchangebuyer.DeleteOrderDealsRequest{
                                            // TODO: Fill required fields.
@@ -693,7 +712,8 @@ func main() {
   }
 
   // proposalId for which deals need to be added.
-  proposalId := "{MY-PROPOSAL-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  proposalId := "{MY-PROPOSAL-ID}"
 
   resp, err := c.Marketplacedeals.Insert(proposalId, &adexchangebuyer.AddOrderDealsRequest{
                                            // TODO: Fill required fields.
@@ -738,7 +758,8 @@ func main() {
 
   // The proposalId to get deals for. To search across proposals specify order_id = '-' as part of the
   // URL.
-  proposalId := "{MY-PROPOSAL-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  proposalId := "{MY-PROPOSAL-ID}"
 
   resp, err := c.Marketplacedeals.List(proposalId).Context(ctx).Do()
   if err != nil {
@@ -780,7 +801,8 @@ func main() {
   }
 
   // The proposalId to edit deals on.
-  proposalId := "{MY-PROPOSAL-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  proposalId := "{MY-PROPOSAL-ID}"
 
   resp, err := c.Marketplacedeals.Update(proposalId, &adexchangebuyer.EditAllOrderDealsRequest{
                                            // TODO: Fill required fields.
@@ -824,7 +846,8 @@ func main() {
   }
 
   // The proposalId to add notes for.
-  proposalId := "{MY-PROPOSAL-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  proposalId := "{MY-PROPOSAL-ID}"
 
   resp, err := c.Marketplacenotes.Insert(proposalId, &adexchangebuyer.AddOrderNotesRequest{
                                            // TODO: Fill required fields.
@@ -868,7 +891,8 @@ func main() {
   }
 
   // The proposalId to get notes for.
-  proposalId := "{MY-PROPOSAL-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  proposalId := "{MY-PROPOSAL-ID}"
 
   resp, err := c.Marketplacenotes.List(proposalId).Context(ctx).Do()
   if err != nil {
@@ -910,7 +934,8 @@ func main() {
   }
 
   // The private auction id to be updated.
-  privateAuctionId := "{MY-PRIVATE-AUCTION-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  privateAuctionId := "{MY-PRIVATE-AUCTION-ID}"
 
   call := c.Marketplaceprivateauction.Updateproposal(privateAuctionId, &adexchangebuyer.UpdatePrivateAuctionProposalRequest{
                                                        // TODO: Fill required fields.
@@ -952,13 +977,16 @@ func main() {
   }
 
   // The account id to get the reports.
-  accountId := int64(0) // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  accountId := int64(0)
 
   // The end time of the report in ISO 8601 timestamp format using UTC.
-  endDateTime := "{MY-END-DATE-TIME}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  endDateTime := "{MY-END-DATE-TIME}"
 
   // The start time of the report in ISO 8601 timestamp format using UTC.
-  startDateTime := "{MY-START-DATE-TIME}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  startDateTime := "{MY-START-DATE-TIME}"
 
   resp, err := c.PerformanceReport.List(accountId, endDateTime, startDateTime).Context(ctx).Do()
   if err != nil {
@@ -1000,10 +1028,12 @@ func main() {
   }
 
   // The account id to delete the pretargeting config for.
-  accountId := int64(0) // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  accountId := int64(0)
 
   // The specific id of the configuration to delete.
-  configId := int64(0) // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  configId := int64(0)
 
   if err := c.PretargetingConfig.Delete(accountId, configId).Context(ctx).Do(); err != nil {
     // TODO: Handle error.
@@ -1042,10 +1072,12 @@ func main() {
   }
 
   // The account id to get the pretargeting config for.
-  accountId := int64(0) // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  accountId := int64(0)
 
   // The specific id of the configuration to retrieve.
-  configId := int64(0) // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  configId := int64(0)
 
   resp, err := c.PretargetingConfig.Get(accountId, configId).Context(ctx).Do()
   if err != nil {
@@ -1087,7 +1119,8 @@ func main() {
   }
 
   // The account id to insert the pretargeting config for.
-  accountId := int64(0) // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  accountId := int64(0)
 
   resp, err := c.PretargetingConfig.Insert(accountId, &adexchangebuyer.PretargetingConfig{
                                              // TODO: Fill required fields.
@@ -1131,7 +1164,8 @@ func main() {
   }
 
   // The account id to get the pretargeting configs for.
-  accountId := int64(0) // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  accountId := int64(0)
 
   resp, err := c.PretargetingConfig.List(accountId).Context(ctx).Do()
   if err != nil {
@@ -1173,10 +1207,12 @@ func main() {
   }
 
   // The account id to update the pretargeting config for.
-  accountId := int64(0) // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  accountId := int64(0)
 
   // The specific id of the configuration to update.
-  configId := int64(0) // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  configId := int64(0)
 
   resp, err := c.PretargetingConfig.Patch(accountId, configId, &adexchangebuyer.PretargetingConfig{
                                             // TODO: Fill required fields.
@@ -1220,10 +1256,12 @@ func main() {
   }
 
   // The account id to update the pretargeting config for.
-  accountId := int64(0) // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  accountId := int64(0)
 
   // The specific id of the configuration to update.
-  configId := int64(0) // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  configId := int64(0)
 
   resp, err := c.PretargetingConfig.Update(accountId, configId, &adexchangebuyer.PretargetingConfig{
                                              // TODO: Fill required fields.
@@ -1267,7 +1305,8 @@ func main() {
   }
 
   // The id for the product to get the head revision for.
-  productId := "{MY-PRODUCT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  productId := "{MY-PRODUCT-ID}"
 
   resp, err := c.Products.Get(productId).Context(ctx).Do()
   if err != nil {
@@ -1350,7 +1389,8 @@ func main() {
   }
 
   // Id of the proposal to retrieve.
-  proposalId := "{MY-PROPOSAL-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  proposalId := "{MY-PROPOSAL-ID}"
 
   resp, err := c.Proposals.Get(proposalId).Context(ctx).Do()
   if err != nil {
@@ -1435,15 +1475,18 @@ func main() {
   }
 
   // The proposal id to update.
-  proposalId := "{MY-PROPOSAL-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  proposalId := "{MY-PROPOSAL-ID}"
 
   // The last known revision number to update. If the head revision in the marketplace database has since
   // changed, an error will be thrown. The caller should then fetch the latest proposal at head revision
   // and retry the update at that revision.
-  revisionNumber := int64(0) // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  revisionNumber := int64(0)
 
   // The proposed action to take on the proposal.
-  updateAction := "{MY-UPDATE-ACTION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  updateAction := "{MY-UPDATE-ACTION}"
 
   resp, err := c.Proposals.Patch(proposalId, revisionNumber, updateAction, &adexchangebuyer.Proposal{
                                    // TODO: Fill required fields.
@@ -1528,7 +1571,8 @@ func main() {
   }
 
   // The proposal id for which the setup is complete
-  proposalId := "{MY-PROPOSAL-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  proposalId := "{MY-PROPOSAL-ID}"
 
   if err := c.Proposals.Setupcomplete(proposalId).Context(ctx).Do(); err != nil {
     // TODO: Handle error.
@@ -1567,15 +1611,18 @@ func main() {
   }
 
   // The proposal id to update.
-  proposalId := "{MY-PROPOSAL-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  proposalId := "{MY-PROPOSAL-ID}"
 
   // The last known revision number to update. If the head revision in the marketplace database has since
   // changed, an error will be thrown. The caller should then fetch the latest proposal at head revision
   // and retry the update at that revision.
-  revisionNumber := int64(0) // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  revisionNumber := int64(0)
 
   // The proposed action to take on the proposal.
-  updateAction := "{MY-UPDATE-ACTION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  updateAction := "{MY-UPDATE-ACTION}"
 
   resp, err := c.Proposals.Update(proposalId, revisionNumber, updateAction, &adexchangebuyer.Proposal{
                                     // TODO: Fill required fields.
@@ -1619,7 +1666,8 @@ func main() {
   }
 
   // The accountId of the publisher to get profiles for.
-  accountId := int64(0) // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  accountId := int64(0)
 
   resp, err := c.Pubprofiles.List(accountId).Context(ctx).Do()
   if err != nil {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_adexchangebuyer.v1.4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_adexchangebuyer.v1.4.json.baseline
@@ -428,7 +428,7 @@ func main() {
   accountId := int64(0) // TODO: Update placeholder value.
 
   // The buyer-specific id for this creative.
-  buyerCreativeId := "" // TODO: Update placeholder value.
+  buyerCreativeId := "{MY-BUYER-CREATIVE-ID}" // TODO: Update placeholder value.
 
   // The id of the deal id to associate with this creative.
   dealId := int64(0) // TODO: Update placeholder value.
@@ -473,7 +473,7 @@ func main() {
   accountId := int64(0) // TODO: Update placeholder value.
 
   // The buyer-specific id for this creative.
-  buyerCreativeId := "" // TODO: Update placeholder value.
+  buyerCreativeId := "{MY-BUYER-CREATIVE-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Creatives.Get(accountId, buyerCreativeId).Context(ctx).Do()
   if err != nil {
@@ -607,7 +607,7 @@ func main() {
   accountId := int64(0) // TODO: Update placeholder value.
 
   // The buyer-specific id for this creative.
-  buyerCreativeId := "" // TODO: Update placeholder value.
+  buyerCreativeId := "{MY-BUYER-CREATIVE-ID}" // TODO: Update placeholder value.
 
   // The id of the deal id to disassociate with this creative.
   dealId := int64(0) // TODO: Update placeholder value.
@@ -649,7 +649,7 @@ func main() {
   }
 
   // The proposalId to delete deals from.
-  proposalId := "" // TODO: Update placeholder value.
+  proposalId := "{MY-PROPOSAL-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Marketplacedeals.Delete(proposalId, &adexchangebuyer.DeleteOrderDealsRequest{
                                            // TODO: Fill required fields.
@@ -693,7 +693,7 @@ func main() {
   }
 
   // proposalId for which deals need to be added.
-  proposalId := "" // TODO: Update placeholder value.
+  proposalId := "{MY-PROPOSAL-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Marketplacedeals.Insert(proposalId, &adexchangebuyer.AddOrderDealsRequest{
                                            // TODO: Fill required fields.
@@ -738,7 +738,7 @@ func main() {
 
   // The proposalId to get deals for. To search across proposals specify order_id = '-' as part of the
   // URL.
-  proposalId := "" // TODO: Update placeholder value.
+  proposalId := "{MY-PROPOSAL-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Marketplacedeals.List(proposalId).Context(ctx).Do()
   if err != nil {
@@ -780,7 +780,7 @@ func main() {
   }
 
   // The proposalId to edit deals on.
-  proposalId := "" // TODO: Update placeholder value.
+  proposalId := "{MY-PROPOSAL-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Marketplacedeals.Update(proposalId, &adexchangebuyer.EditAllOrderDealsRequest{
                                            // TODO: Fill required fields.
@@ -824,7 +824,7 @@ func main() {
   }
 
   // The proposalId to add notes for.
-  proposalId := "" // TODO: Update placeholder value.
+  proposalId := "{MY-PROPOSAL-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Marketplacenotes.Insert(proposalId, &adexchangebuyer.AddOrderNotesRequest{
                                            // TODO: Fill required fields.
@@ -868,7 +868,7 @@ func main() {
   }
 
   // The proposalId to get notes for.
-  proposalId := "" // TODO: Update placeholder value.
+  proposalId := "{MY-PROPOSAL-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Marketplacenotes.List(proposalId).Context(ctx).Do()
   if err != nil {
@@ -910,7 +910,7 @@ func main() {
   }
 
   // The private auction id to be updated.
-  privateAuctionId := "" // TODO: Update placeholder value.
+  privateAuctionId := "{MY-PRIVATE-AUCTION-ID}" // TODO: Update placeholder value.
 
   call := c.Marketplaceprivateauction.Updateproposal(privateAuctionId, &adexchangebuyer.UpdatePrivateAuctionProposalRequest{
                                                        // TODO: Fill required fields.
@@ -955,10 +955,10 @@ func main() {
   accountId := int64(0) // TODO: Update placeholder value.
 
   // The end time of the report in ISO 8601 timestamp format using UTC.
-  endDateTime := "" // TODO: Update placeholder value.
+  endDateTime := "{MY-END-DATE-TIME}" // TODO: Update placeholder value.
 
   // The start time of the report in ISO 8601 timestamp format using UTC.
-  startDateTime := "" // TODO: Update placeholder value.
+  startDateTime := "{MY-START-DATE-TIME}" // TODO: Update placeholder value.
 
   resp, err := c.PerformanceReport.List(accountId, endDateTime, startDateTime).Context(ctx).Do()
   if err != nil {
@@ -1267,7 +1267,7 @@ func main() {
   }
 
   // The id for the product to get the head revision for.
-  productId := "" // TODO: Update placeholder value.
+  productId := "{MY-PRODUCT-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Products.Get(productId).Context(ctx).Do()
   if err != nil {
@@ -1350,7 +1350,7 @@ func main() {
   }
 
   // Id of the proposal to retrieve.
-  proposalId := "" // TODO: Update placeholder value.
+  proposalId := "{MY-PROPOSAL-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Proposals.Get(proposalId).Context(ctx).Do()
   if err != nil {
@@ -1435,7 +1435,7 @@ func main() {
   }
 
   // The proposal id to update.
-  proposalId := "" // TODO: Update placeholder value.
+  proposalId := "{MY-PROPOSAL-ID}" // TODO: Update placeholder value.
 
   // The last known revision number to update. If the head revision in the marketplace database has since
   // changed, an error will be thrown. The caller should then fetch the latest proposal at head revision
@@ -1443,7 +1443,7 @@ func main() {
   revisionNumber := int64(0) // TODO: Update placeholder value.
 
   // The proposed action to take on the proposal.
-  updateAction := "" // TODO: Update placeholder value.
+  updateAction := "{MY-UPDATE-ACTION}" // TODO: Update placeholder value.
 
   resp, err := c.Proposals.Patch(proposalId, revisionNumber, updateAction, &adexchangebuyer.Proposal{
                                    // TODO: Fill required fields.
@@ -1528,7 +1528,7 @@ func main() {
   }
 
   // The proposal id for which the setup is complete
-  proposalId := "" // TODO: Update placeholder value.
+  proposalId := "{MY-PROPOSAL-ID}" // TODO: Update placeholder value.
 
   if err := c.Proposals.Setupcomplete(proposalId).Context(ctx).Do(); err != nil {
     // TODO: Handle error.
@@ -1567,7 +1567,7 @@ func main() {
   }
 
   // The proposal id to update.
-  proposalId := "" // TODO: Update placeholder value.
+  proposalId := "{MY-PROPOSAL-ID}" // TODO: Update placeholder value.
 
   // The last known revision number to update. If the head revision in the marketplace database has since
   // changed, an error will be thrown. The caller should then fetch the latest proposal at head revision
@@ -1575,7 +1575,7 @@ func main() {
   revisionNumber := int64(0) // TODO: Update placeholder value.
 
   // The proposed action to take on the proposal.
-  updateAction := "" // TODO: Update placeholder value.
+  updateAction := "{MY-UPDATE-ACTION}" // TODO: Update placeholder value.
 
   resp, err := c.Proposals.Update(proposalId, revisionNumber, updateAction, &adexchangebuyer.Proposal{
                                     // TODO: Fill required fields.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_appengine.v1beta5.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_appengine.v1beta5.json.baseline
@@ -32,7 +32,7 @@ func main() {
   }
 
   // Part of `name`. Name of the application to get. For example: "apps/myapp".
-  appsId := "" // TODO: Update placeholder value.
+  appsId := "{MY-APPS-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Apps.Get(appsId).Context(ctx).Do()
   if err != nil {
@@ -74,10 +74,10 @@ func main() {
   }
 
   // Part of `name`. The name of the operation resource.
-  appsId := "" // TODO: Update placeholder value.
+  appsId := "{MY-APPS-ID}" // TODO: Update placeholder value.
 
   // Part of `name`. See documentation of `appsId`.
-  operationsId := "" // TODO: Update placeholder value.
+  operationsId := "{MY-OPERATIONS-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Apps.Operations.Get(appsId, operationsId).Context(ctx).Do()
   if err != nil {
@@ -119,7 +119,7 @@ func main() {
   }
 
   // Part of `name`. The name of the operation collection.
-  appsId := "" // TODO: Update placeholder value.
+  appsId := "{MY-APPS-ID}" // TODO: Update placeholder value.
 
 
   call := c.Apps.Operations.List(appsId)
@@ -166,10 +166,10 @@ func main() {
   }
 
   // Part of `name`. Name of the resource requested. For example: "apps/myapp/services/default".
-  appsId := "" // TODO: Update placeholder value.
+  appsId := "{MY-APPS-ID}" // TODO: Update placeholder value.
 
   // Part of `name`. See documentation of `appsId`.
-  servicesId := "" // TODO: Update placeholder value.
+  servicesId := "{MY-SERVICES-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Apps.Services.Delete(appsId, servicesId).Context(ctx).Do()
   if err != nil {
@@ -211,10 +211,10 @@ func main() {
   }
 
   // Part of `name`. Name of the resource requested. For example: "apps/myapp/services/default".
-  appsId := "" // TODO: Update placeholder value.
+  appsId := "{MY-APPS-ID}" // TODO: Update placeholder value.
 
   // Part of `name`. See documentation of `appsId`.
-  servicesId := "" // TODO: Update placeholder value.
+  servicesId := "{MY-SERVICES-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Apps.Services.Get(appsId, servicesId).Context(ctx).Do()
   if err != nil {
@@ -256,7 +256,7 @@ func main() {
   }
 
   // Part of `name`. Name of the resource requested. For example: "apps/myapp".
-  appsId := "" // TODO: Update placeholder value.
+  appsId := "{MY-APPS-ID}" // TODO: Update placeholder value.
 
 
   call := c.Apps.Services.List(appsId)
@@ -303,10 +303,10 @@ func main() {
   }
 
   // Part of `name`. Name of the resource to update. For example: "apps/myapp/services/default".
-  appsId := "" // TODO: Update placeholder value.
+  appsId := "{MY-APPS-ID}" // TODO: Update placeholder value.
 
   // Part of `name`. See documentation of `appsId`.
-  servicesId := "" // TODO: Update placeholder value.
+  servicesId := "{MY-SERVICES-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Apps.Services.Patch(appsId, servicesId, &appengine.Service{
                                        // TODO: Fill required fields.
@@ -350,10 +350,10 @@ func main() {
   }
 
   // Part of `name`. Name of the resource to update. For example: "apps/myapp/services/default".
-  appsId := "" // TODO: Update placeholder value.
+  appsId := "{MY-APPS-ID}" // TODO: Update placeholder value.
 
   // Part of `name`. See documentation of `appsId`.
-  servicesId := "" // TODO: Update placeholder value.
+  servicesId := "{MY-SERVICES-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Apps.Services.Versions.Create(appsId, servicesId, &appengine.Version{
                                                  // TODO: Fill required fields.
@@ -398,13 +398,13 @@ func main() {
 
   // Part of `name`. Name of the resource requested. For example:
   // "apps/myapp/services/default/versions/v1".
-  appsId := "" // TODO: Update placeholder value.
+  appsId := "{MY-APPS-ID}" // TODO: Update placeholder value.
 
   // Part of `name`. See documentation of `appsId`.
-  servicesId := "" // TODO: Update placeholder value.
+  servicesId := "{MY-SERVICES-ID}" // TODO: Update placeholder value.
 
   // Part of `name`. See documentation of `appsId`.
-  versionsId := "" // TODO: Update placeholder value.
+  versionsId := "{MY-VERSIONS-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Apps.Services.Versions.Delete(appsId, servicesId, versionsId).Context(ctx).Do()
   if err != nil {
@@ -447,13 +447,13 @@ func main() {
 
   // Part of `name`. Name of the resource requested. For example:
   // "apps/myapp/services/default/versions/v1".
-  appsId := "" // TODO: Update placeholder value.
+  appsId := "{MY-APPS-ID}" // TODO: Update placeholder value.
 
   // Part of `name`. See documentation of `appsId`.
-  servicesId := "" // TODO: Update placeholder value.
+  servicesId := "{MY-SERVICES-ID}" // TODO: Update placeholder value.
 
   // Part of `name`. See documentation of `appsId`.
-  versionsId := "" // TODO: Update placeholder value.
+  versionsId := "{MY-VERSIONS-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Apps.Services.Versions.Get(appsId, servicesId, versionsId).Context(ctx).Do()
   if err != nil {
@@ -496,13 +496,13 @@ func main() {
 
   // Part of `name`. Name of the resource requested. For example:
   // "apps/myapp/services/default/versions/v1".
-  appsId := "" // TODO: Update placeholder value.
+  appsId := "{MY-APPS-ID}" // TODO: Update placeholder value.
 
   // Part of `name`. See documentation of `appsId`.
-  servicesId := "" // TODO: Update placeholder value.
+  servicesId := "{MY-SERVICES-ID}" // TODO: Update placeholder value.
 
   // Part of `name`. See documentation of `appsId`.
-  versionsId := "" // TODO: Update placeholder value.
+  versionsId := "{MY-VERSIONS-ID}" // TODO: Update placeholder value.
 
 
   call := c.Apps.Services.Versions.Instances.List(appsId, servicesId, versionsId)
@@ -549,10 +549,10 @@ func main() {
   }
 
   // Part of `name`. Name of the resource requested. For example: "apps/myapp/services/default".
-  appsId := "" // TODO: Update placeholder value.
+  appsId := "{MY-APPS-ID}" // TODO: Update placeholder value.
 
   // Part of `name`. See documentation of `appsId`.
-  servicesId := "" // TODO: Update placeholder value.
+  servicesId := "{MY-SERVICES-ID}" // TODO: Update placeholder value.
 
 
   call := c.Apps.Services.Versions.List(appsId, servicesId)
@@ -600,13 +600,13 @@ func main() {
 
   // Part of `name`. Name of the resource to update. For example:
   // "apps/myapp/services/default/versions/1".
-  appsId := "" // TODO: Update placeholder value.
+  appsId := "{MY-APPS-ID}" // TODO: Update placeholder value.
 
   // Part of `name`. See documentation of `appsId`.
-  servicesId := "" // TODO: Update placeholder value.
+  servicesId := "{MY-SERVICES-ID}" // TODO: Update placeholder value.
 
   // Part of `name`. See documentation of `appsId`.
-  versionsId := "" // TODO: Update placeholder value.
+  versionsId := "{MY-VERSIONS-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Apps.Services.Versions.Patch(appsId, servicesId, versionsId, &appengine.Version{
                                                 // TODO: Fill required fields.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_appengine.v1beta5.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_appengine.v1beta5.json.baseline
@@ -32,7 +32,8 @@ func main() {
   }
 
   // Part of `name`. Name of the application to get. For example: "apps/myapp".
-  appsId := "{MY-APPS-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  appsId := "{MY-APPS-ID}"
 
   resp, err := c.Apps.Get(appsId).Context(ctx).Do()
   if err != nil {
@@ -74,10 +75,12 @@ func main() {
   }
 
   // Part of `name`. The name of the operation resource.
-  appsId := "{MY-APPS-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  appsId := "{MY-APPS-ID}"
 
   // Part of `name`. See documentation of `appsId`.
-  operationsId := "{MY-OPERATIONS-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  operationsId := "{MY-OPERATIONS-ID}"
 
   resp, err := c.Apps.Operations.Get(appsId, operationsId).Context(ctx).Do()
   if err != nil {
@@ -119,7 +122,8 @@ func main() {
   }
 
   // Part of `name`. The name of the operation collection.
-  appsId := "{MY-APPS-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  appsId := "{MY-APPS-ID}"
 
 
   call := c.Apps.Operations.List(appsId)
@@ -166,10 +170,12 @@ func main() {
   }
 
   // Part of `name`. Name of the resource requested. For example: "apps/myapp/services/default".
-  appsId := "{MY-APPS-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  appsId := "{MY-APPS-ID}"
 
   // Part of `name`. See documentation of `appsId`.
-  servicesId := "{MY-SERVICES-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  servicesId := "{MY-SERVICES-ID}"
 
   resp, err := c.Apps.Services.Delete(appsId, servicesId).Context(ctx).Do()
   if err != nil {
@@ -211,10 +217,12 @@ func main() {
   }
 
   // Part of `name`. Name of the resource requested. For example: "apps/myapp/services/default".
-  appsId := "{MY-APPS-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  appsId := "{MY-APPS-ID}"
 
   // Part of `name`. See documentation of `appsId`.
-  servicesId := "{MY-SERVICES-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  servicesId := "{MY-SERVICES-ID}"
 
   resp, err := c.Apps.Services.Get(appsId, servicesId).Context(ctx).Do()
   if err != nil {
@@ -256,7 +264,8 @@ func main() {
   }
 
   // Part of `name`. Name of the resource requested. For example: "apps/myapp".
-  appsId := "{MY-APPS-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  appsId := "{MY-APPS-ID}"
 
 
   call := c.Apps.Services.List(appsId)
@@ -303,10 +312,12 @@ func main() {
   }
 
   // Part of `name`. Name of the resource to update. For example: "apps/myapp/services/default".
-  appsId := "{MY-APPS-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  appsId := "{MY-APPS-ID}"
 
   // Part of `name`. See documentation of `appsId`.
-  servicesId := "{MY-SERVICES-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  servicesId := "{MY-SERVICES-ID}"
 
   resp, err := c.Apps.Services.Patch(appsId, servicesId, &appengine.Service{
                                        // TODO: Fill required fields.
@@ -350,10 +361,12 @@ func main() {
   }
 
   // Part of `name`. Name of the resource to update. For example: "apps/myapp/services/default".
-  appsId := "{MY-APPS-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  appsId := "{MY-APPS-ID}"
 
   // Part of `name`. See documentation of `appsId`.
-  servicesId := "{MY-SERVICES-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  servicesId := "{MY-SERVICES-ID}"
 
   resp, err := c.Apps.Services.Versions.Create(appsId, servicesId, &appengine.Version{
                                                  // TODO: Fill required fields.
@@ -398,13 +411,16 @@ func main() {
 
   // Part of `name`. Name of the resource requested. For example:
   // "apps/myapp/services/default/versions/v1".
-  appsId := "{MY-APPS-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  appsId := "{MY-APPS-ID}"
 
   // Part of `name`. See documentation of `appsId`.
-  servicesId := "{MY-SERVICES-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  servicesId := "{MY-SERVICES-ID}"
 
   // Part of `name`. See documentation of `appsId`.
-  versionsId := "{MY-VERSIONS-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  versionsId := "{MY-VERSIONS-ID}"
 
   resp, err := c.Apps.Services.Versions.Delete(appsId, servicesId, versionsId).Context(ctx).Do()
   if err != nil {
@@ -447,13 +463,16 @@ func main() {
 
   // Part of `name`. Name of the resource requested. For example:
   // "apps/myapp/services/default/versions/v1".
-  appsId := "{MY-APPS-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  appsId := "{MY-APPS-ID}"
 
   // Part of `name`. See documentation of `appsId`.
-  servicesId := "{MY-SERVICES-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  servicesId := "{MY-SERVICES-ID}"
 
   // Part of `name`. See documentation of `appsId`.
-  versionsId := "{MY-VERSIONS-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  versionsId := "{MY-VERSIONS-ID}"
 
   resp, err := c.Apps.Services.Versions.Get(appsId, servicesId, versionsId).Context(ctx).Do()
   if err != nil {
@@ -496,13 +515,16 @@ func main() {
 
   // Part of `name`. Name of the resource requested. For example:
   // "apps/myapp/services/default/versions/v1".
-  appsId := "{MY-APPS-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  appsId := "{MY-APPS-ID}"
 
   // Part of `name`. See documentation of `appsId`.
-  servicesId := "{MY-SERVICES-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  servicesId := "{MY-SERVICES-ID}"
 
   // Part of `name`. See documentation of `appsId`.
-  versionsId := "{MY-VERSIONS-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  versionsId := "{MY-VERSIONS-ID}"
 
 
   call := c.Apps.Services.Versions.Instances.List(appsId, servicesId, versionsId)
@@ -549,10 +571,12 @@ func main() {
   }
 
   // Part of `name`. Name of the resource requested. For example: "apps/myapp/services/default".
-  appsId := "{MY-APPS-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  appsId := "{MY-APPS-ID}"
 
   // Part of `name`. See documentation of `appsId`.
-  servicesId := "{MY-SERVICES-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  servicesId := "{MY-SERVICES-ID}"
 
 
   call := c.Apps.Services.Versions.List(appsId, servicesId)
@@ -600,13 +624,16 @@ func main() {
 
   // Part of `name`. Name of the resource to update. For example:
   // "apps/myapp/services/default/versions/1".
-  appsId := "{MY-APPS-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  appsId := "{MY-APPS-ID}"
 
   // Part of `name`. See documentation of `appsId`.
-  servicesId := "{MY-SERVICES-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  servicesId := "{MY-SERVICES-ID}"
 
   // Part of `name`. See documentation of `appsId`.
-  versionsId := "{MY-VERSIONS-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  versionsId := "{MY-VERSIONS-ID}"
 
   resp, err := c.Apps.Services.Versions.Patch(appsId, servicesId, versionsId, &appengine.Version{
                                                 // TODO: Fill required fields.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_autoscaler.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_autoscaler.v1beta2.json.baseline
@@ -32,13 +32,13 @@ func main() {
   }
 
   // Project ID of Autoscaler resource.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Zone name of Autoscaler resource.
-  zone := "" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}" // TODO: Update placeholder value.
 
   // Name of the Autoscaler resource.
-  autoscaler2 := "" // TODO: Update placeholder value.
+  autoscaler2 := "{MY-AUTOSCALER}" // TODO: Update placeholder value.
 
   resp, err := c.Autoscalers.Delete(project, zone, autoscaler2).Context(ctx).Do()
   if err != nil {
@@ -80,13 +80,13 @@ func main() {
   }
 
   // Project ID of Autoscaler resource.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Zone name of Autoscaler resource.
-  zone := "" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}" // TODO: Update placeholder value.
 
   // Name of the Autoscaler resource.
-  autoscaler2 := "" // TODO: Update placeholder value.
+  autoscaler2 := "{MY-AUTOSCALER}" // TODO: Update placeholder value.
 
   resp, err := c.Autoscalers.Get(project, zone, autoscaler2).Context(ctx).Do()
   if err != nil {
@@ -128,10 +128,10 @@ func main() {
   }
 
   // Project ID of Autoscaler resource.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Zone name of Autoscaler resource.
-  zone := "" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}" // TODO: Update placeholder value.
 
   resp, err := c.Autoscalers.Insert(project, zone, &autoscaler.Autoscaler{
                                       // TODO: Fill required fields.
@@ -175,10 +175,10 @@ func main() {
   }
 
   // Project ID of Autoscaler resource.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Zone name of Autoscaler resource.
-  zone := "" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}" // TODO: Update placeholder value.
 
 
   call := c.Autoscalers.List(project, zone)
@@ -225,13 +225,13 @@ func main() {
   }
 
   // Project ID of Autoscaler resource.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Zone name of Autoscaler resource.
-  zone := "" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}" // TODO: Update placeholder value.
 
   // Name of the Autoscaler resource.
-  autoscaler2 := "" // TODO: Update placeholder value.
+  autoscaler2 := "{MY-AUTOSCALER}" // TODO: Update placeholder value.
 
   resp, err := c.Autoscalers.Patch(project, zone, autoscaler2, &autoscaler.Autoscaler{
                                      // TODO: Fill required fields.
@@ -275,13 +275,13 @@ func main() {
   }
 
   // Project ID of Autoscaler resource.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Zone name of Autoscaler resource.
-  zone := "" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}" // TODO: Update placeholder value.
 
   // Name of the Autoscaler resource.
-  autoscaler2 := "" // TODO: Update placeholder value.
+  autoscaler2 := "{MY-AUTOSCALER}" // TODO: Update placeholder value.
 
   resp, err := c.Autoscalers.Update(project, zone, autoscaler2, &autoscaler.Autoscaler{
                                       // TODO: Fill required fields.
@@ -325,13 +325,13 @@ func main() {
   }
 
 
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
-  zone := "" // TODO: Update placeholder value.
+  zone := "us-central1-f" // TODO: Update placeholder value.
 
 
-  operation := "" // TODO: Update placeholder value.
+  operation := "{MY-OPERATION}" // TODO: Update placeholder value.
 
   if err := c.ZoneOperations.Delete(project, zone, operation).Context(ctx).Do(); err != nil {
     // TODO: Handle error.
@@ -370,13 +370,13 @@ func main() {
   }
 
 
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
-  zone := "" // TODO: Update placeholder value.
+  zone := "us-central1-f" // TODO: Update placeholder value.
 
 
-  operation := "" // TODO: Update placeholder value.
+  operation := "{MY-OPERATION}" // TODO: Update placeholder value.
 
   resp, err := c.ZoneOperations.Get(project, zone, operation).Context(ctx).Do()
   if err != nil {
@@ -418,10 +418,10 @@ func main() {
   }
 
 
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
-  zone := "" // TODO: Update placeholder value.
+  zone := "us-central1-f" // TODO: Update placeholder value.
 
 
   call := c.ZoneOperations.List(project, zone)
@@ -468,7 +468,7 @@ func main() {
   }
 
 
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
   call := c.Zones.List(project)

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_autoscaler.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_autoscaler.v1beta2.json.baseline
@@ -32,13 +32,16 @@ func main() {
   }
 
   // Project ID of Autoscaler resource.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Zone name of Autoscaler resource.
-  zone := "{MY-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"
 
   // Name of the Autoscaler resource.
-  autoscaler2 := "{MY-AUTOSCALER}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  autoscaler2 := "{MY-AUTOSCALER}"
 
   resp, err := c.Autoscalers.Delete(project, zone, autoscaler2).Context(ctx).Do()
   if err != nil {
@@ -80,13 +83,16 @@ func main() {
   }
 
   // Project ID of Autoscaler resource.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Zone name of Autoscaler resource.
-  zone := "{MY-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"
 
   // Name of the Autoscaler resource.
-  autoscaler2 := "{MY-AUTOSCALER}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  autoscaler2 := "{MY-AUTOSCALER}"
 
   resp, err := c.Autoscalers.Get(project, zone, autoscaler2).Context(ctx).Do()
   if err != nil {
@@ -128,10 +134,12 @@ func main() {
   }
 
   // Project ID of Autoscaler resource.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Zone name of Autoscaler resource.
-  zone := "{MY-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"
 
   resp, err := c.Autoscalers.Insert(project, zone, &autoscaler.Autoscaler{
                                       // TODO: Fill required fields.
@@ -175,10 +183,12 @@ func main() {
   }
 
   // Project ID of Autoscaler resource.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Zone name of Autoscaler resource.
-  zone := "{MY-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"
 
 
   call := c.Autoscalers.List(project, zone)
@@ -225,13 +235,16 @@ func main() {
   }
 
   // Project ID of Autoscaler resource.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Zone name of Autoscaler resource.
-  zone := "{MY-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"
 
   // Name of the Autoscaler resource.
-  autoscaler2 := "{MY-AUTOSCALER}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  autoscaler2 := "{MY-AUTOSCALER}"
 
   resp, err := c.Autoscalers.Patch(project, zone, autoscaler2, &autoscaler.Autoscaler{
                                      // TODO: Fill required fields.
@@ -275,13 +288,16 @@ func main() {
   }
 
   // Project ID of Autoscaler resource.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Zone name of Autoscaler resource.
-  zone := "{MY-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"
 
   // Name of the Autoscaler resource.
-  autoscaler2 := "{MY-AUTOSCALER}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  autoscaler2 := "{MY-AUTOSCALER}"
 
   resp, err := c.Autoscalers.Update(project, zone, autoscaler2, &autoscaler.Autoscaler{
                                       // TODO: Fill required fields.
@@ -325,13 +341,16 @@ func main() {
   }
 
 
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
-  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f"
 
 
-  operation := "{MY-OPERATION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  operation := "{MY-OPERATION}"
 
   if err := c.ZoneOperations.Delete(project, zone, operation).Context(ctx).Do(); err != nil {
     // TODO: Handle error.
@@ -370,13 +389,16 @@ func main() {
   }
 
 
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
-  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f"
 
 
-  operation := "{MY-OPERATION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  operation := "{MY-OPERATION}"
 
   resp, err := c.ZoneOperations.Get(project, zone, operation).Context(ctx).Do()
   if err != nil {
@@ -418,10 +440,12 @@ func main() {
   }
 
 
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
-  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f"
 
 
   call := c.ZoneOperations.List(project, zone)
@@ -468,7 +492,8 @@ func main() {
   }
 
 
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
   call := c.Zones.List(project)

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_autoscaler.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_autoscaler.v1beta2.json.baseline
@@ -328,7 +328,7 @@ func main() {
   project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
-  zone := "us-central1-f" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
 
 
   operation := "{MY-OPERATION}" // TODO: Update placeholder value.
@@ -373,7 +373,7 @@ func main() {
   project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
-  zone := "us-central1-f" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
 
 
   operation := "{MY-OPERATION}" // TODO: Update placeholder value.
@@ -421,7 +421,7 @@ func main() {
   project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
-  zone := "us-central1-f" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
 
 
   call := c.ZoneOperations.List(project, zone)

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_bigquery.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_bigquery.v2.json.baseline
@@ -32,10 +32,10 @@ func main() {
   }
 
   // Project ID of the dataset being deleted
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   // Dataset ID of dataset being deleted
-  datasetId := "" // TODO: Update placeholder value.
+  datasetId := "{MY-DATASET-ID}" // TODO: Update placeholder value.
 
   if err := c.Datasets.Delete(projectId, datasetId).Context(ctx).Do(); err != nil {
     // TODO: Handle error.
@@ -74,10 +74,10 @@ func main() {
   }
 
   // Project ID of the requested dataset
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   // Dataset ID of the requested dataset
-  datasetId := "" // TODO: Update placeholder value.
+  datasetId := "{MY-DATASET-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Datasets.Get(projectId, datasetId).Context(ctx).Do()
   if err != nil {
@@ -119,7 +119,7 @@ func main() {
   }
 
   // Project ID of the new dataset
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Datasets.Insert(projectId, &bigquery.Dataset{
                                    // TODO: Fill required fields.
@@ -163,7 +163,7 @@ func main() {
   }
 
   // Project ID of the datasets to be listed
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
 
   call := c.Datasets.List(projectId)
@@ -210,10 +210,10 @@ func main() {
   }
 
   // Project ID of the dataset being updated
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   // Dataset ID of the dataset being updated
-  datasetId := "" // TODO: Update placeholder value.
+  datasetId := "{MY-DATASET-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Datasets.Patch(projectId, datasetId, &bigquery.Dataset{
                                   // TODO: Fill required fields.
@@ -257,10 +257,10 @@ func main() {
   }
 
   // Project ID of the dataset being updated
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   // Dataset ID of the dataset being updated
-  datasetId := "" // TODO: Update placeholder value.
+  datasetId := "{MY-DATASET-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Datasets.Update(projectId, datasetId, &bigquery.Dataset{
                                    // TODO: Fill required fields.
@@ -304,10 +304,10 @@ func main() {
   }
 
   // [Required] Project ID of the job to cancel
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   // [Required] Job ID of the job to cancel
-  jobId := "" // TODO: Update placeholder value.
+  jobId := "{MY-JOB-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Jobs.Cancel(projectId, jobId).Context(ctx).Do()
   if err != nil {
@@ -349,10 +349,10 @@ func main() {
   }
 
   // [Required] Project ID of the requested job
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   // [Required] Job ID of the requested job
-  jobId := "" // TODO: Update placeholder value.
+  jobId := "{MY-JOB-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Jobs.Get(projectId, jobId).Context(ctx).Do()
   if err != nil {
@@ -394,10 +394,10 @@ func main() {
   }
 
   // [Required] Project ID of the query job
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   // [Required] Job ID of the query job
-  jobId := "" // TODO: Update placeholder value.
+  jobId := "{MY-JOB-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Jobs.GetQueryResults(projectId, jobId).Context(ctx).Do()
   if err != nil {
@@ -439,7 +439,7 @@ func main() {
   }
 
   // Project ID of the project that will be billed for the job
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Jobs.Insert(projectId, &bigquery.Job{
                                // TODO: Fill required fields.
@@ -483,7 +483,7 @@ func main() {
   }
 
   // Project ID of the jobs to list
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
 
   call := c.Jobs.List(projectId)
@@ -530,7 +530,7 @@ func main() {
   }
 
   // Project ID of the project billed for the query
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Jobs.Query(projectId, &bigquery.QueryRequest{
                               // TODO: Fill required fields.
@@ -620,13 +620,13 @@ func main() {
   }
 
   // Project ID of the destination table.
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   // Dataset ID of the destination table.
-  datasetId := "" // TODO: Update placeholder value.
+  datasetId := "{MY-DATASET-ID}" // TODO: Update placeholder value.
 
   // Table ID of the destination table.
-  tableId := "" // TODO: Update placeholder value.
+  tableId := "{MY-TABLE-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Tabledata.InsertAll(projectId, datasetId, tableId, &bigquery.TableDataInsertAllRequest{
                                        // TODO: Fill required fields.
@@ -670,13 +670,13 @@ func main() {
   }
 
   // Project ID of the table to read
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   // Dataset ID of the table to read
-  datasetId := "" // TODO: Update placeholder value.
+  datasetId := "{MY-DATASET-ID}" // TODO: Update placeholder value.
 
   // Table ID of the table to read
-  tableId := "" // TODO: Update placeholder value.
+  tableId := "{MY-TABLE-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Tabledata.List(projectId, datasetId, tableId).Context(ctx).Do()
   if err != nil {
@@ -718,13 +718,13 @@ func main() {
   }
 
   // Project ID of the table to delete
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   // Dataset ID of the table to delete
-  datasetId := "" // TODO: Update placeholder value.
+  datasetId := "{MY-DATASET-ID}" // TODO: Update placeholder value.
 
   // Table ID of the table to delete
-  tableId := "" // TODO: Update placeholder value.
+  tableId := "{MY-TABLE-ID}" // TODO: Update placeholder value.
 
   if err := c.Tables.Delete(projectId, datasetId, tableId).Context(ctx).Do(); err != nil {
     // TODO: Handle error.
@@ -763,13 +763,13 @@ func main() {
   }
 
   // Project ID of the requested table
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   // Dataset ID of the requested table
-  datasetId := "" // TODO: Update placeholder value.
+  datasetId := "{MY-DATASET-ID}" // TODO: Update placeholder value.
 
   // Table ID of the requested table
-  tableId := "" // TODO: Update placeholder value.
+  tableId := "{MY-TABLE-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Tables.Get(projectId, datasetId, tableId).Context(ctx).Do()
   if err != nil {
@@ -811,10 +811,10 @@ func main() {
   }
 
   // Project ID of the new table
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   // Dataset ID of the new table
-  datasetId := "" // TODO: Update placeholder value.
+  datasetId := "{MY-DATASET-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Tables.Insert(projectId, datasetId, &bigquery.Table{
                                  // TODO: Fill required fields.
@@ -858,10 +858,10 @@ func main() {
   }
 
   // Project ID of the tables to list
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   // Dataset ID of the tables to list
-  datasetId := "" // TODO: Update placeholder value.
+  datasetId := "{MY-DATASET-ID}" // TODO: Update placeholder value.
 
 
   call := c.Tables.List(projectId, datasetId)
@@ -908,13 +908,13 @@ func main() {
   }
 
   // Project ID of the table to update
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   // Dataset ID of the table to update
-  datasetId := "" // TODO: Update placeholder value.
+  datasetId := "{MY-DATASET-ID}" // TODO: Update placeholder value.
 
   // Table ID of the table to update
-  tableId := "" // TODO: Update placeholder value.
+  tableId := "{MY-TABLE-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Tables.Patch(projectId, datasetId, tableId, &bigquery.Table{
                                 // TODO: Fill required fields.
@@ -958,13 +958,13 @@ func main() {
   }
 
   // Project ID of the table to update
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   // Dataset ID of the table to update
-  datasetId := "" // TODO: Update placeholder value.
+  datasetId := "{MY-DATASET-ID}" // TODO: Update placeholder value.
 
   // Table ID of the table to update
-  tableId := "" // TODO: Update placeholder value.
+  tableId := "{MY-TABLE-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Tables.Update(projectId, datasetId, tableId, &bigquery.Table{
                                  // TODO: Fill required fields.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_bigquery.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_bigquery.v2.json.baseline
@@ -32,10 +32,12 @@ func main() {
   }
 
   // Project ID of the dataset being deleted
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   // Dataset ID of dataset being deleted
-  datasetId := "{MY-DATASET-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  datasetId := "{MY-DATASET-ID}"
 
   if err := c.Datasets.Delete(projectId, datasetId).Context(ctx).Do(); err != nil {
     // TODO: Handle error.
@@ -74,10 +76,12 @@ func main() {
   }
 
   // Project ID of the requested dataset
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   // Dataset ID of the requested dataset
-  datasetId := "{MY-DATASET-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  datasetId := "{MY-DATASET-ID}"
 
   resp, err := c.Datasets.Get(projectId, datasetId).Context(ctx).Do()
   if err != nil {
@@ -119,7 +123,8 @@ func main() {
   }
 
   // Project ID of the new dataset
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   resp, err := c.Datasets.Insert(projectId, &bigquery.Dataset{
                                    // TODO: Fill required fields.
@@ -163,7 +168,8 @@ func main() {
   }
 
   // Project ID of the datasets to be listed
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
 
   call := c.Datasets.List(projectId)
@@ -210,10 +216,12 @@ func main() {
   }
 
   // Project ID of the dataset being updated
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   // Dataset ID of the dataset being updated
-  datasetId := "{MY-DATASET-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  datasetId := "{MY-DATASET-ID}"
 
   resp, err := c.Datasets.Patch(projectId, datasetId, &bigquery.Dataset{
                                   // TODO: Fill required fields.
@@ -257,10 +265,12 @@ func main() {
   }
 
   // Project ID of the dataset being updated
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   // Dataset ID of the dataset being updated
-  datasetId := "{MY-DATASET-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  datasetId := "{MY-DATASET-ID}"
 
   resp, err := c.Datasets.Update(projectId, datasetId, &bigquery.Dataset{
                                    // TODO: Fill required fields.
@@ -304,10 +314,12 @@ func main() {
   }
 
   // [Required] Project ID of the job to cancel
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   // [Required] Job ID of the job to cancel
-  jobId := "{MY-JOB-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  jobId := "{MY-JOB-ID}"
 
   resp, err := c.Jobs.Cancel(projectId, jobId).Context(ctx).Do()
   if err != nil {
@@ -349,10 +361,12 @@ func main() {
   }
 
   // [Required] Project ID of the requested job
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   // [Required] Job ID of the requested job
-  jobId := "{MY-JOB-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  jobId := "{MY-JOB-ID}"
 
   resp, err := c.Jobs.Get(projectId, jobId).Context(ctx).Do()
   if err != nil {
@@ -394,10 +408,12 @@ func main() {
   }
 
   // [Required] Project ID of the query job
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   // [Required] Job ID of the query job
-  jobId := "{MY-JOB-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  jobId := "{MY-JOB-ID}"
 
   resp, err := c.Jobs.GetQueryResults(projectId, jobId).Context(ctx).Do()
   if err != nil {
@@ -439,7 +455,8 @@ func main() {
   }
 
   // Project ID of the project that will be billed for the job
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   resp, err := c.Jobs.Insert(projectId, &bigquery.Job{
                                // TODO: Fill required fields.
@@ -483,7 +500,8 @@ func main() {
   }
 
   // Project ID of the jobs to list
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
 
   call := c.Jobs.List(projectId)
@@ -530,7 +548,8 @@ func main() {
   }
 
   // Project ID of the project billed for the query
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   resp, err := c.Jobs.Query(projectId, &bigquery.QueryRequest{
                               // TODO: Fill required fields.
@@ -620,13 +639,16 @@ func main() {
   }
 
   // Project ID of the destination table.
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   // Dataset ID of the destination table.
-  datasetId := "{MY-DATASET-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  datasetId := "{MY-DATASET-ID}"
 
   // Table ID of the destination table.
-  tableId := "{MY-TABLE-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  tableId := "{MY-TABLE-ID}"
 
   resp, err := c.Tabledata.InsertAll(projectId, datasetId, tableId, &bigquery.TableDataInsertAllRequest{
                                        // TODO: Fill required fields.
@@ -670,13 +692,16 @@ func main() {
   }
 
   // Project ID of the table to read
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   // Dataset ID of the table to read
-  datasetId := "{MY-DATASET-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  datasetId := "{MY-DATASET-ID}"
 
   // Table ID of the table to read
-  tableId := "{MY-TABLE-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  tableId := "{MY-TABLE-ID}"
 
   resp, err := c.Tabledata.List(projectId, datasetId, tableId).Context(ctx).Do()
   if err != nil {
@@ -718,13 +743,16 @@ func main() {
   }
 
   // Project ID of the table to delete
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   // Dataset ID of the table to delete
-  datasetId := "{MY-DATASET-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  datasetId := "{MY-DATASET-ID}"
 
   // Table ID of the table to delete
-  tableId := "{MY-TABLE-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  tableId := "{MY-TABLE-ID}"
 
   if err := c.Tables.Delete(projectId, datasetId, tableId).Context(ctx).Do(); err != nil {
     // TODO: Handle error.
@@ -763,13 +791,16 @@ func main() {
   }
 
   // Project ID of the requested table
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   // Dataset ID of the requested table
-  datasetId := "{MY-DATASET-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  datasetId := "{MY-DATASET-ID}"
 
   // Table ID of the requested table
-  tableId := "{MY-TABLE-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  tableId := "{MY-TABLE-ID}"
 
   resp, err := c.Tables.Get(projectId, datasetId, tableId).Context(ctx).Do()
   if err != nil {
@@ -811,10 +842,12 @@ func main() {
   }
 
   // Project ID of the new table
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   // Dataset ID of the new table
-  datasetId := "{MY-DATASET-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  datasetId := "{MY-DATASET-ID}"
 
   resp, err := c.Tables.Insert(projectId, datasetId, &bigquery.Table{
                                  // TODO: Fill required fields.
@@ -858,10 +891,12 @@ func main() {
   }
 
   // Project ID of the tables to list
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   // Dataset ID of the tables to list
-  datasetId := "{MY-DATASET-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  datasetId := "{MY-DATASET-ID}"
 
 
   call := c.Tables.List(projectId, datasetId)
@@ -908,13 +943,16 @@ func main() {
   }
 
   // Project ID of the table to update
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   // Dataset ID of the table to update
-  datasetId := "{MY-DATASET-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  datasetId := "{MY-DATASET-ID}"
 
   // Table ID of the table to update
-  tableId := "{MY-TABLE-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  tableId := "{MY-TABLE-ID}"
 
   resp, err := c.Tables.Patch(projectId, datasetId, tableId, &bigquery.Table{
                                 // TODO: Fill required fields.
@@ -958,13 +996,16 @@ func main() {
   }
 
   // Project ID of the table to update
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   // Dataset ID of the table to update
-  datasetId := "{MY-DATASET-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  datasetId := "{MY-DATASET-ID}"
 
   // Table ID of the table to update
-  tableId := "{MY-TABLE-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  tableId := "{MY-TABLE-ID}"
 
   resp, err := c.Tables.Update(projectId, datasetId, tableId, &bigquery.Table{
                                  // TODO: Fill required fields.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudbilling.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudbilling.v1.json.baseline
@@ -33,7 +33,8 @@ func main() {
 
   // The resource name of the billing account to retrieve. For example,
   // `billingAccounts/012345-567890-ABCDEF`.
-  name := "billingAccounts/{MY-BILLINGACCOUNT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  name := "billingAccounts/{MY-BILLINGACCOUNT}"
 
   resp, err := c.BillingAccounts.Get(name).Context(ctx).Do()
   if err != nil {
@@ -122,7 +123,8 @@ func main() {
 
   // The resource name of the billing account associated with the projects that you want to list. For
   // example, `billingAccounts/012345-567890-ABCDEF`.
-  name := "billingAccounts/{MY-BILLINGACCOUNT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  name := "billingAccounts/{MY-BILLINGACCOUNT}"
 
 
   call := c.BillingAccounts.Projects.List(name)
@@ -170,7 +172,8 @@ func main() {
 
   // The resource name of the project for which billing information is retrieved. For example,
   // `projects/tokyo-rain-123`.
-  name := "projects/{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  name := "projects/{MY-PROJECT}"
 
   resp, err := c.Projects.GetBillingInfo(name).Context(ctx).Do()
   if err != nil {
@@ -213,7 +216,8 @@ func main() {
 
   // The resource name of the project associated with the billing information that you want to update.
   // For example, `projects/tokyo-rain-123`.
-  name := "projects/{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  name := "projects/{MY-PROJECT}"
 
   resp, err := c.Projects.UpdateBillingInfo(name, &cloudbilling.ProjectBillingInfo{
                                               // TODO: Fill required fields.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_clouddebugger.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_clouddebugger.v2.json.baseline
@@ -32,7 +32,7 @@ func main() {
   }
 
   // Identifies the debuggee.
-  debuggeeId := "" // TODO: Update placeholder value.
+  debuggeeId := "{MY-DEBUGGEE-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Controller.Debuggees.Breakpoints.List(debuggeeId).Context(ctx).Do()
   if err != nil {
@@ -74,10 +74,10 @@ func main() {
   }
 
   // Identifies the debuggee being debugged.
-  debuggeeId := "" // TODO: Update placeholder value.
+  debuggeeId := "{MY-DEBUGGEE-ID}" // TODO: Update placeholder value.
 
   // Breakpoint identifier, unique in the scope of the debuggee.
-  id := "" // TODO: Update placeholder value.
+  id := "{MY-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Controller.Debuggees.Breakpoints.Update(debuggeeId, id, &clouddebugger.UpdateActiveBreakpointRequest{
                                                            // TODO: Fill required fields.
@@ -164,10 +164,10 @@ func main() {
   }
 
   // ID of the debuggee whose breakpoint to delete.
-  debuggeeId := "" // TODO: Update placeholder value.
+  debuggeeId := "{MY-DEBUGGEE-ID}" // TODO: Update placeholder value.
 
   // ID of the breakpoint to delete.
-  breakpointId := "" // TODO: Update placeholder value.
+  breakpointId := "{MY-BREAKPOINT-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Debugger.Debuggees.Breakpoints.Delete(debuggeeId, breakpointId).Context(ctx).Do()
   if err != nil {
@@ -209,10 +209,10 @@ func main() {
   }
 
   // ID of the debuggee whose breakpoint to get.
-  debuggeeId := "" // TODO: Update placeholder value.
+  debuggeeId := "{MY-DEBUGGEE-ID}" // TODO: Update placeholder value.
 
   // ID of the breakpoint to get.
-  breakpointId := "" // TODO: Update placeholder value.
+  breakpointId := "{MY-BREAKPOINT-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Debugger.Debuggees.Breakpoints.Get(debuggeeId, breakpointId).Context(ctx).Do()
   if err != nil {
@@ -254,7 +254,7 @@ func main() {
   }
 
   // ID of the debuggee whose breakpoints to list.
-  debuggeeId := "" // TODO: Update placeholder value.
+  debuggeeId := "{MY-DEBUGGEE-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Debugger.Debuggees.Breakpoints.List(debuggeeId).Context(ctx).Do()
   if err != nil {
@@ -296,7 +296,7 @@ func main() {
   }
 
   // ID of the debuggee where the breakpoint is to be set.
-  debuggeeId := "" // TODO: Update placeholder value.
+  debuggeeId := "{MY-DEBUGGEE-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Debugger.Debuggees.Breakpoints.Set(debuggeeId, &clouddebugger.Breakpoint{
                                                       // TODO: Fill required fields.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_clouddebugger.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_clouddebugger.v2.json.baseline
@@ -32,7 +32,8 @@ func main() {
   }
 
   // Identifies the debuggee.
-  debuggeeId := "{MY-DEBUGGEE-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  debuggeeId := "{MY-DEBUGGEE-ID}"
 
   resp, err := c.Controller.Debuggees.Breakpoints.List(debuggeeId).Context(ctx).Do()
   if err != nil {
@@ -74,10 +75,12 @@ func main() {
   }
 
   // Identifies the debuggee being debugged.
-  debuggeeId := "{MY-DEBUGGEE-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  debuggeeId := "{MY-DEBUGGEE-ID}"
 
   // Breakpoint identifier, unique in the scope of the debuggee.
-  id := "{MY-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  id := "{MY-ID}"
 
   resp, err := c.Controller.Debuggees.Breakpoints.Update(debuggeeId, id, &clouddebugger.UpdateActiveBreakpointRequest{
                                                            // TODO: Fill required fields.
@@ -164,10 +167,12 @@ func main() {
   }
 
   // ID of the debuggee whose breakpoint to delete.
-  debuggeeId := "{MY-DEBUGGEE-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  debuggeeId := "{MY-DEBUGGEE-ID}"
 
   // ID of the breakpoint to delete.
-  breakpointId := "{MY-BREAKPOINT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  breakpointId := "{MY-BREAKPOINT-ID}"
 
   resp, err := c.Debugger.Debuggees.Breakpoints.Delete(debuggeeId, breakpointId).Context(ctx).Do()
   if err != nil {
@@ -209,10 +214,12 @@ func main() {
   }
 
   // ID of the debuggee whose breakpoint to get.
-  debuggeeId := "{MY-DEBUGGEE-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  debuggeeId := "{MY-DEBUGGEE-ID}"
 
   // ID of the breakpoint to get.
-  breakpointId := "{MY-BREAKPOINT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  breakpointId := "{MY-BREAKPOINT-ID}"
 
   resp, err := c.Debugger.Debuggees.Breakpoints.Get(debuggeeId, breakpointId).Context(ctx).Do()
   if err != nil {
@@ -254,7 +261,8 @@ func main() {
   }
 
   // ID of the debuggee whose breakpoints to list.
-  debuggeeId := "{MY-DEBUGGEE-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  debuggeeId := "{MY-DEBUGGEE-ID}"
 
   resp, err := c.Debugger.Debuggees.Breakpoints.List(debuggeeId).Context(ctx).Do()
   if err != nil {
@@ -296,7 +304,8 @@ func main() {
   }
 
   // ID of the debuggee where the breakpoint is to be set.
-  debuggeeId := "{MY-DEBUGGEE-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  debuggeeId := "{MY-DEBUGGEE-ID}"
 
   resp, err := c.Debugger.Debuggees.Breakpoints.Set(debuggeeId, &clouddebugger.Breakpoint{
                                                       // TODO: Fill required fields.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudmonitoring.v2beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudmonitoring.v2beta2.json.baseline
@@ -32,7 +32,7 @@ func main() {
   }
 
   // The project id. The value can be the numeric project ID or string-based project name.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   resp, err := c.MetricDescriptors.Create(project, &cloudmonitoring.MetricDescriptor{
                                             // TODO: Fill required fields.
@@ -76,10 +76,10 @@ func main() {
   }
 
   // The project ID to which the metric belongs.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the metric.
-  metric := "" // TODO: Update placeholder value.
+  metric := "{MY-METRIC}" // TODO: Update placeholder value.
 
   resp, err := c.MetricDescriptors.Delete(project, metric).Context(ctx).Do()
   if err != nil {
@@ -121,7 +121,7 @@ func main() {
   }
 
   // The project id. The value can be the numeric project ID or string-based project name.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   resp, err := c.MetricDescriptors.List(project, &cloudmonitoring.ListMetricDescriptorsRequest{
                                           // TODO: Fill required fields.
@@ -166,14 +166,14 @@ func main() {
 
   // The project ID to which this time series belongs. The value can be the numeric project ID or
   // string-based project name.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Metric names are protocol-free URLs as listed in the Supported Metrics page. For example,
   // compute.googleapis.com/instance/disk/read_ops_count.
-  metric := "" // TODO: Update placeholder value.
+  metric := "{MY-METRIC}" // TODO: Update placeholder value.
 
   // End of the time interval (inclusive), which is expressed as an RFC 3339 timestamp.
-  youngest := "" // TODO: Update placeholder value.
+  youngest := "{MY-YOUNGEST}" // TODO: Update placeholder value.
 
   resp, err := c.Timeseries.List(project, metric, youngest, &cloudmonitoring.ListTimeseriesRequest{
                                    // TODO: Fill required fields.
@@ -217,7 +217,7 @@ func main() {
   }
 
   // The project ID. The value can be the numeric project ID or string-based project name.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   resp, err := c.Timeseries.Write(project, &cloudmonitoring.WriteTimeseriesRequest{
                                     // TODO: Fill required fields.
@@ -262,14 +262,14 @@ func main() {
 
   // The project ID to which this time series belongs. The value can be the numeric project ID or
   // string-based project name.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Metric names are protocol-free URLs as listed in the Supported Metrics page. For example,
   // compute.googleapis.com/instance/disk/read_ops_count.
-  metric := "" // TODO: Update placeholder value.
+  metric := "{MY-METRIC}" // TODO: Update placeholder value.
 
   // End of the time interval (inclusive), which is expressed as an RFC 3339 timestamp.
-  youngest := "" // TODO: Update placeholder value.
+  youngest := "{MY-YOUNGEST}" // TODO: Update placeholder value.
 
   resp, err := c.TimeseriesDescriptors.List(project, metric, youngest, &cloudmonitoring.ListTimeseriesDescriptorsRequest{
                                               // TODO: Fill required fields.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudmonitoring.v2beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudmonitoring.v2beta2.json.baseline
@@ -32,7 +32,8 @@ func main() {
   }
 
   // The project id. The value can be the numeric project ID or string-based project name.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   resp, err := c.MetricDescriptors.Create(project, &cloudmonitoring.MetricDescriptor{
                                             // TODO: Fill required fields.
@@ -76,10 +77,12 @@ func main() {
   }
 
   // The project ID to which the metric belongs.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the metric.
-  metric := "{MY-METRIC}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  metric := "{MY-METRIC}"
 
   resp, err := c.MetricDescriptors.Delete(project, metric).Context(ctx).Do()
   if err != nil {
@@ -121,7 +124,8 @@ func main() {
   }
 
   // The project id. The value can be the numeric project ID or string-based project name.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   resp, err := c.MetricDescriptors.List(project, &cloudmonitoring.ListMetricDescriptorsRequest{
                                           // TODO: Fill required fields.
@@ -166,14 +170,17 @@ func main() {
 
   // The project ID to which this time series belongs. The value can be the numeric project ID or
   // string-based project name.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Metric names are protocol-free URLs as listed in the Supported Metrics page. For example,
   // compute.googleapis.com/instance/disk/read_ops_count.
-  metric := "{MY-METRIC}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  metric := "{MY-METRIC}"
 
   // End of the time interval (inclusive), which is expressed as an RFC 3339 timestamp.
-  youngest := "{MY-YOUNGEST}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  youngest := "{MY-YOUNGEST}"
 
   resp, err := c.Timeseries.List(project, metric, youngest, &cloudmonitoring.ListTimeseriesRequest{
                                    // TODO: Fill required fields.
@@ -217,7 +224,8 @@ func main() {
   }
 
   // The project ID. The value can be the numeric project ID or string-based project name.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   resp, err := c.Timeseries.Write(project, &cloudmonitoring.WriteTimeseriesRequest{
                                     // TODO: Fill required fields.
@@ -262,14 +270,17 @@ func main() {
 
   // The project ID to which this time series belongs. The value can be the numeric project ID or
   // string-based project name.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Metric names are protocol-free URLs as listed in the Supported Metrics page. For example,
   // compute.googleapis.com/instance/disk/read_ops_count.
-  metric := "{MY-METRIC}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  metric := "{MY-METRIC}"
 
   // End of the time interval (inclusive), which is expressed as an RFC 3339 timestamp.
-  youngest := "{MY-YOUNGEST}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  youngest := "{MY-YOUNGEST}"
 
   resp, err := c.TimeseriesDescriptors.List(project, metric, youngest, &cloudmonitoring.ListTimeseriesDescriptorsRequest{
                                               // TODO: Fill required fields.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudresourcemanager.v1beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudresourcemanager.v1beta1.json.baseline
@@ -32,7 +32,8 @@ func main() {
   }
 
   // The id of the Organization resource to fetch.
-  organizationId := "{MY-ORGANIZATION-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  organizationId := "{MY-ORGANIZATION-ID}"
 
   resp, err := c.Organizations.Get(organizationId).Context(ctx).Do()
   if err != nil {
@@ -76,7 +77,8 @@ func main() {
   // REQUIRED: The resource for which the policy is being requested. `resource` is usually specified as a
   // path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
   // this value is resource specific and is specified in the `getIamPolicy` documentation.
-  resource := "{MY-RESOURCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  resource := "{MY-RESOURCE}"
 
   resp, err := c.Organizations.GetIamPolicy(resource, &cloudresourcemanager.GetIamPolicyRequest{
                                               // TODO: Fill required fields.
@@ -168,7 +170,8 @@ func main() {
   // REQUIRED: The resource for which the policy is being specified. `resource` is usually specified as a
   // path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
   // this value is resource specific and is specified in the `setIamPolicy` documentation.
-  resource := "{MY-RESOURCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  resource := "{MY-RESOURCE}"
 
   resp, err := c.Organizations.SetIamPolicy(resource, &cloudresourcemanager.SetIamPolicyRequest{
                                               // TODO: Fill required fields.
@@ -215,7 +218,8 @@ func main() {
   // specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path
   // specified in this value is resource specific and is specified in the `testIamPermissions`
   // documentation.
-  resource := "{MY-RESOURCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  resource := "{MY-RESOURCE}"
 
   resp, err := c.Organizations.TestIamPermissions(resource, &cloudresourcemanager.TestIamPermissionsRequest{
                                                     // TODO: Fill required fields.
@@ -260,7 +264,8 @@ func main() {
 
   // An immutable id for the Organization that is assigned on creation. This should be omitted when
   // creating a new Organization. This field is read-only.
-  organizationId := "{MY-ORGANIZATION-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  organizationId := "{MY-ORGANIZATION-ID}"
 
   resp, err := c.Organizations.Update(organizationId, &cloudresourcemanager.Organization{
                                         // TODO: Fill required fields.
@@ -347,7 +352,8 @@ func main() {
   }
 
   // The Project ID (for example, `foo-bar-123`). Required.
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   resp, err := c.Projects.Delete(projectId).Context(ctx).Do()
   if err != nil {
@@ -389,7 +395,8 @@ func main() {
   }
 
   // The Project ID (for example, `my-project-123`). Required.
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   resp, err := c.Projects.Get(projectId).Context(ctx).Do()
   if err != nil {
@@ -433,7 +440,8 @@ func main() {
   // REQUIRED: The resource for which the policy is being requested. `resource` is usually specified as a
   // path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
   // this value is resource specific and is specified in the `getIamPolicy` documentation.
-  resource := "{MY-RESOURCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  resource := "{MY-RESOURCE}"
 
   resp, err := c.Projects.GetIamPolicy(resource, &cloudresourcemanager.GetIamPolicyRequest{
                                          // TODO: Fill required fields.
@@ -525,7 +533,8 @@ func main() {
   // REQUIRED: The resource for which the policy is being specified. `resource` is usually specified as a
   // path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
   // this value is resource specific and is specified in the `setIamPolicy` documentation.
-  resource := "{MY-RESOURCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  resource := "{MY-RESOURCE}"
 
   resp, err := c.Projects.SetIamPolicy(resource, &cloudresourcemanager.SetIamPolicyRequest{
                                          // TODO: Fill required fields.
@@ -572,7 +581,8 @@ func main() {
   // specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path
   // specified in this value is resource specific and is specified in the `testIamPermissions`
   // documentation.
-  resource := "{MY-RESOURCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  resource := "{MY-RESOURCE}"
 
   resp, err := c.Projects.TestIamPermissions(resource, &cloudresourcemanager.TestIamPermissionsRequest{
                                                // TODO: Fill required fields.
@@ -616,7 +626,8 @@ func main() {
   }
 
   // The project ID (for example, `foo-bar-123`). Required.
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   resp, err := c.Projects.Undelete(projectId, &cloudresourcemanager.UndeleteProjectRequest{
                                      // TODO: Fill required fields.
@@ -660,7 +671,8 @@ func main() {
   }
 
   // The project ID (for example, `my-project-123`). Required.
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   resp, err := c.Projects.Update(projectId, &cloudresourcemanager.Project{
                                    // TODO: Fill required fields.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudresourcemanager.v1beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudresourcemanager.v1beta1.json.baseline
@@ -32,7 +32,7 @@ func main() {
   }
 
   // The id of the Organization resource to fetch.
-  organizationId := "" // TODO: Update placeholder value.
+  organizationId := "{MY-ORGANIZATION-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Organizations.Get(organizationId).Context(ctx).Do()
   if err != nil {
@@ -76,7 +76,7 @@ func main() {
   // REQUIRED: The resource for which the policy is being requested. `resource` is usually specified as a
   // path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
   // this value is resource specific and is specified in the `getIamPolicy` documentation.
-  resource := "" // TODO: Update placeholder value.
+  resource := "{MY-RESOURCE}" // TODO: Update placeholder value.
 
   resp, err := c.Organizations.GetIamPolicy(resource, &cloudresourcemanager.GetIamPolicyRequest{
                                               // TODO: Fill required fields.
@@ -168,7 +168,7 @@ func main() {
   // REQUIRED: The resource for which the policy is being specified. `resource` is usually specified as a
   // path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
   // this value is resource specific and is specified in the `setIamPolicy` documentation.
-  resource := "" // TODO: Update placeholder value.
+  resource := "{MY-RESOURCE}" // TODO: Update placeholder value.
 
   resp, err := c.Organizations.SetIamPolicy(resource, &cloudresourcemanager.SetIamPolicyRequest{
                                               // TODO: Fill required fields.
@@ -215,7 +215,7 @@ func main() {
   // specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path
   // specified in this value is resource specific and is specified in the `testIamPermissions`
   // documentation.
-  resource := "" // TODO: Update placeholder value.
+  resource := "{MY-RESOURCE}" // TODO: Update placeholder value.
 
   resp, err := c.Organizations.TestIamPermissions(resource, &cloudresourcemanager.TestIamPermissionsRequest{
                                                     // TODO: Fill required fields.
@@ -260,7 +260,7 @@ func main() {
 
   // An immutable id for the Organization that is assigned on creation. This should be omitted when
   // creating a new Organization. This field is read-only.
-  organizationId := "" // TODO: Update placeholder value.
+  organizationId := "{MY-ORGANIZATION-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Organizations.Update(organizationId, &cloudresourcemanager.Organization{
                                         // TODO: Fill required fields.
@@ -347,7 +347,7 @@ func main() {
   }
 
   // The Project ID (for example, `foo-bar-123`). Required.
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Projects.Delete(projectId).Context(ctx).Do()
   if err != nil {
@@ -389,7 +389,7 @@ func main() {
   }
 
   // The Project ID (for example, `my-project-123`). Required.
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Projects.Get(projectId).Context(ctx).Do()
   if err != nil {
@@ -433,7 +433,7 @@ func main() {
   // REQUIRED: The resource for which the policy is being requested. `resource` is usually specified as a
   // path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
   // this value is resource specific and is specified in the `getIamPolicy` documentation.
-  resource := "" // TODO: Update placeholder value.
+  resource := "{MY-RESOURCE}" // TODO: Update placeholder value.
 
   resp, err := c.Projects.GetIamPolicy(resource, &cloudresourcemanager.GetIamPolicyRequest{
                                          // TODO: Fill required fields.
@@ -525,7 +525,7 @@ func main() {
   // REQUIRED: The resource for which the policy is being specified. `resource` is usually specified as a
   // path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
   // this value is resource specific and is specified in the `setIamPolicy` documentation.
-  resource := "" // TODO: Update placeholder value.
+  resource := "{MY-RESOURCE}" // TODO: Update placeholder value.
 
   resp, err := c.Projects.SetIamPolicy(resource, &cloudresourcemanager.SetIamPolicyRequest{
                                          // TODO: Fill required fields.
@@ -572,7 +572,7 @@ func main() {
   // specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path
   // specified in this value is resource specific and is specified in the `testIamPermissions`
   // documentation.
-  resource := "" // TODO: Update placeholder value.
+  resource := "{MY-RESOURCE}" // TODO: Update placeholder value.
 
   resp, err := c.Projects.TestIamPermissions(resource, &cloudresourcemanager.TestIamPermissionsRequest{
                                                // TODO: Fill required fields.
@@ -616,7 +616,7 @@ func main() {
   }
 
   // The project ID (for example, `foo-bar-123`). Required.
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Projects.Undelete(projectId, &cloudresourcemanager.UndeleteProjectRequest{
                                      // TODO: Fill required fields.
@@ -660,7 +660,7 @@ func main() {
   }
 
   // The project ID (for example, `my-project-123`). Required.
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Projects.Update(projectId, &cloudresourcemanager.Project{
                                    // TODO: Fill required fields.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudtrace.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudtrace.v1.json.baseline
@@ -32,7 +32,7 @@ func main() {
   }
 
   // ID of the Cloud project where the trace data is stored.
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Projects.PatchTraces(projectId, &cloudtrace.Traces{
                                         // TODO: Fill required fields.
@@ -76,10 +76,10 @@ func main() {
   }
 
   // ID of the Cloud project where the trace data is stored.
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   // ID of the trace to return.
-  traceId := "" // TODO: Update placeholder value.
+  traceId := "{MY-TRACE-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Projects.Traces.Get(projectId, traceId).Context(ctx).Do()
   if err != nil {
@@ -121,7 +121,7 @@ func main() {
   }
 
   // ID of the Cloud project where the trace data is stored.
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
 
   call := c.Projects.Traces.List(projectId)

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudtrace.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudtrace.v1.json.baseline
@@ -32,7 +32,8 @@ func main() {
   }
 
   // ID of the Cloud project where the trace data is stored.
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   resp, err := c.Projects.PatchTraces(projectId, &cloudtrace.Traces{
                                         // TODO: Fill required fields.
@@ -76,10 +77,12 @@ func main() {
   }
 
   // ID of the Cloud project where the trace data is stored.
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   // ID of the trace to return.
-  traceId := "{MY-TRACE-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  traceId := "{MY-TRACE-ID}"
 
   resp, err := c.Projects.Traces.Get(projectId, traceId).Context(ctx).Do()
   if err != nil {
@@ -121,7 +124,8 @@ func main() {
   }
 
   // ID of the Cloud project where the trace data is stored.
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
 
   call := c.Projects.Traces.List(projectId)

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_clouduseraccounts.beta.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_clouduseraccounts.beta.json.baseline
@@ -32,10 +32,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the Operations resource to delete.
-  operation := "" // TODO: Update placeholder value.
+  operation := "{MY-OPERATION}" // TODO: Update placeholder value.
 
   if err := c.GlobalAccountsOperations.Delete(project, operation).Context(ctx).Do(); err != nil {
     // TODO: Handle error.
@@ -74,10 +74,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the Operations resource to return.
-  operation := "" // TODO: Update placeholder value.
+  operation := "{MY-OPERATION}" // TODO: Update placeholder value.
 
   resp, err := c.GlobalAccountsOperations.Get(project, operation).Context(ctx).Do()
   if err != nil {
@@ -119,7 +119,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
   call := c.GlobalAccountsOperations.List(project)
@@ -166,10 +166,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the group for this request.
-  groupName := "" // TODO: Update placeholder value.
+  groupName := "{MY-GROUP-NAME}" // TODO: Update placeholder value.
 
   resp, err := c.Groups.AddMember(project, groupName, &clouduseraccounts.GroupsAddMemberRequest{
                                     // TODO: Fill required fields.
@@ -213,10 +213,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the Group resource to delete.
-  groupName := "" // TODO: Update placeholder value.
+  groupName := "{MY-GROUP-NAME}" // TODO: Update placeholder value.
 
   resp, err := c.Groups.Delete(project, groupName).Context(ctx).Do()
   if err != nil {
@@ -258,10 +258,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the Group resource to return.
-  groupName := "" // TODO: Update placeholder value.
+  groupName := "{MY-GROUP-NAME}" // TODO: Update placeholder value.
 
   resp, err := c.Groups.Get(project, groupName).Context(ctx).Do()
   if err != nil {
@@ -303,7 +303,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   resp, err := c.Groups.Insert(project, &clouduseraccounts.Group{
                                  // TODO: Fill required fields.
@@ -347,7 +347,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
   call := c.Groups.List(project)
@@ -394,10 +394,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the group for this request.
-  groupName := "" // TODO: Update placeholder value.
+  groupName := "{MY-GROUP-NAME}" // TODO: Update placeholder value.
 
   resp, err := c.Groups.RemoveMember(project, groupName, &clouduseraccounts.GroupsRemoveMemberRequest{
                                        // TODO: Fill required fields.
@@ -441,16 +441,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the zone for this request.
-  zone := "" // TODO: Update placeholder value.
+  zone := "us-central1-f" // TODO: Update placeholder value.
 
   // The user account for which you want to get a list of authorized public keys.
-  user := "" // TODO: Update placeholder value.
+  user := "{MY-USER}" // TODO: Update placeholder value.
 
   // The fully-qualified URL of the virtual machine requesting the view.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   resp, err := c.Linux.GetAuthorizedKeysView(project, zone, user, instance).Context(ctx).Do()
   if err != nil {
@@ -492,13 +492,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the zone for this request.
-  zone := "" // TODO: Update placeholder value.
+  zone := "us-central1-f" // TODO: Update placeholder value.
 
   // The fully-qualified URL of the virtual machine requesting the views.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   resp, err := c.Linux.GetLinuxAccountViews(project, zone, instance).Context(ctx).Do()
   if err != nil {
@@ -540,10 +540,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the user for this request.
-  user := "" // TODO: Update placeholder value.
+  user := "{MY-USER}" // TODO: Update placeholder value.
 
   resp, err := c.Users.AddPublicKey(project, user, &clouduseraccounts.PublicKey{
                                       // TODO: Fill required fields.
@@ -587,10 +587,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the user resource to delete.
-  user := "" // TODO: Update placeholder value.
+  user := "{MY-USER}" // TODO: Update placeholder value.
 
   resp, err := c.Users.Delete(project, user).Context(ctx).Do()
   if err != nil {
@@ -632,10 +632,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the user resource to return.
-  user := "" // TODO: Update placeholder value.
+  user := "{MY-USER}" // TODO: Update placeholder value.
 
   resp, err := c.Users.Get(project, user).Context(ctx).Do()
   if err != nil {
@@ -677,7 +677,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   resp, err := c.Users.Insert(project, &clouduseraccounts.User{
                                 // TODO: Fill required fields.
@@ -721,7 +721,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
   call := c.Users.List(project)
@@ -768,14 +768,14 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the user for this request.
-  user := "" // TODO: Update placeholder value.
+  user := "{MY-USER}" // TODO: Update placeholder value.
 
   // The fingerprint of the public key to delete. Public keys are identified by their fingerprint, which
   // is defined by RFC4716 to be the MD5 digest of the public key.
-  fingerprint := "" // TODO: Update placeholder value.
+  fingerprint := "{MY-FINGERPRINT}" // TODO: Update placeholder value.
 
   resp, err := c.Users.RemovePublicKey(project, user, fingerprint).Context(ctx).Do()
   if err != nil {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_clouduseraccounts.beta.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_clouduseraccounts.beta.json.baseline
@@ -444,7 +444,7 @@ func main() {
   project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the zone for this request.
-  zone := "us-central1-f" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
 
   // The user account for which you want to get a list of authorized public keys.
   user := "{MY-USER}" // TODO: Update placeholder value.
@@ -495,7 +495,7 @@ func main() {
   project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the zone for this request.
-  zone := "us-central1-f" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
 
   // The fully-qualified URL of the virtual machine requesting the views.
   instance := "{MY-INSTANCE}" // TODO: Update placeholder value.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_clouduseraccounts.beta.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_clouduseraccounts.beta.json.baseline
@@ -32,10 +32,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the Operations resource to delete.
-  operation := "{MY-OPERATION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  operation := "{MY-OPERATION}"
 
   if err := c.GlobalAccountsOperations.Delete(project, operation).Context(ctx).Do(); err != nil {
     // TODO: Handle error.
@@ -74,10 +76,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the Operations resource to return.
-  operation := "{MY-OPERATION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  operation := "{MY-OPERATION}"
 
   resp, err := c.GlobalAccountsOperations.Get(project, operation).Context(ctx).Do()
   if err != nil {
@@ -119,7 +123,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
   call := c.GlobalAccountsOperations.List(project)
@@ -166,10 +171,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the group for this request.
-  groupName := "{MY-GROUP-NAME}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  groupName := "{MY-GROUP-NAME}"
 
   resp, err := c.Groups.AddMember(project, groupName, &clouduseraccounts.GroupsAddMemberRequest{
                                     // TODO: Fill required fields.
@@ -213,10 +220,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the Group resource to delete.
-  groupName := "{MY-GROUP-NAME}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  groupName := "{MY-GROUP-NAME}"
 
   resp, err := c.Groups.Delete(project, groupName).Context(ctx).Do()
   if err != nil {
@@ -258,10 +267,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the Group resource to return.
-  groupName := "{MY-GROUP-NAME}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  groupName := "{MY-GROUP-NAME}"
 
   resp, err := c.Groups.Get(project, groupName).Context(ctx).Do()
   if err != nil {
@@ -303,7 +314,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   resp, err := c.Groups.Insert(project, &clouduseraccounts.Group{
                                  // TODO: Fill required fields.
@@ -347,7 +359,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
   call := c.Groups.List(project)
@@ -394,10 +407,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the group for this request.
-  groupName := "{MY-GROUP-NAME}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  groupName := "{MY-GROUP-NAME}"
 
   resp, err := c.Groups.RemoveMember(project, groupName, &clouduseraccounts.GroupsRemoveMemberRequest{
                                        // TODO: Fill required fields.
@@ -441,16 +456,20 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the zone for this request.
-  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f"
 
   // The user account for which you want to get a list of authorized public keys.
-  user := "{MY-USER}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  user := "{MY-USER}"
 
   // The fully-qualified URL of the virtual machine requesting the view.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   resp, err := c.Linux.GetAuthorizedKeysView(project, zone, user, instance).Context(ctx).Do()
   if err != nil {
@@ -492,13 +511,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the zone for this request.
-  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f"
 
   // The fully-qualified URL of the virtual machine requesting the views.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   resp, err := c.Linux.GetLinuxAccountViews(project, zone, instance).Context(ctx).Do()
   if err != nil {
@@ -540,10 +562,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the user for this request.
-  user := "{MY-USER}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  user := "{MY-USER}"
 
   resp, err := c.Users.AddPublicKey(project, user, &clouduseraccounts.PublicKey{
                                       // TODO: Fill required fields.
@@ -587,10 +611,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the user resource to delete.
-  user := "{MY-USER}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  user := "{MY-USER}"
 
   resp, err := c.Users.Delete(project, user).Context(ctx).Do()
   if err != nil {
@@ -632,10 +658,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the user resource to return.
-  user := "{MY-USER}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  user := "{MY-USER}"
 
   resp, err := c.Users.Get(project, user).Context(ctx).Do()
   if err != nil {
@@ -677,7 +705,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   resp, err := c.Users.Insert(project, &clouduseraccounts.User{
                                 // TODO: Fill required fields.
@@ -721,7 +750,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
   call := c.Users.List(project)
@@ -768,14 +798,17 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the user for this request.
-  user := "{MY-USER}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  user := "{MY-USER}"
 
   // The fingerprint of the public key to delete. Public keys are identified by their fingerprint, which
   // is defined by RFC4716 to be the MD5 digest of the public key.
-  fingerprint := "{MY-FINGERPRINT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  fingerprint := "{MY-FINGERPRINT}"
 
   resp, err := c.Users.RemovePublicKey(project, user, fingerprint).Context(ctx).Do()
   if err != nil {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_compute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_compute.v1.json.baseline
@@ -322,7 +322,7 @@ func main() {
   project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the zone for this request.
-  zone := "us-central1-f" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
 
   // Name of the autoscaler to delete.
   autoscaler := "{MY-AUTOSCALER}" // TODO: Update placeholder value.
@@ -370,7 +370,7 @@ func main() {
   project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the zone for this request.
-  zone := "us-central1-f" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
 
   // Name of the autoscaler to return.
   autoscaler := "{MY-AUTOSCALER}" // TODO: Update placeholder value.
@@ -418,7 +418,7 @@ func main() {
   project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the zone for this request.
-  zone := "us-central1-f" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
 
   resp, err := c.Autoscalers.Insert(project, zone, &compute.Autoscaler{
                                       // TODO: Fill required fields.
@@ -465,7 +465,7 @@ func main() {
   project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the zone for this request.
-  zone := "us-central1-f" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
 
 
   call := c.Autoscalers.List(project, zone)
@@ -515,7 +515,7 @@ func main() {
   project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the zone for this request.
-  zone := "us-central1-f" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
 
   // Name of the autoscaler to update.
   autoscaler := "{MY-AUTOSCALER}" // TODO: Update placeholder value.
@@ -565,7 +565,7 @@ func main() {
   project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the zone for this request.
-  zone := "us-central1-f" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
 
   resp, err := c.Autoscalers.Update(project, zone, &compute.Autoscaler{
                                       // TODO: Fill required fields.
@@ -981,7 +981,7 @@ func main() {
   project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "us-central1-f" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
 
   // Name of the disk type to return.
   diskType := "{MY-DISK-TYPE}" // TODO: Update placeholder value.
@@ -1029,7 +1029,7 @@ func main() {
   project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "us-central1-f" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
 
 
   call := c.DiskTypes.List(project, zone)
@@ -1126,7 +1126,7 @@ func main() {
   project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "us-central1-f" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
 
   // Name of the persistent disk to snapshot.
   disk := "{MY-DISK}" // TODO: Update placeholder value.
@@ -1176,7 +1176,7 @@ func main() {
   project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "us-central1-f" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
 
   // Name of the persistent disk to delete.
   disk := "{MY-DISK}" // TODO: Update placeholder value.
@@ -1224,7 +1224,7 @@ func main() {
   project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "us-central1-f" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
 
   // Name of the persistent disk to return.
   disk := "{MY-DISK}" // TODO: Update placeholder value.
@@ -1272,7 +1272,7 @@ func main() {
   project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "us-central1-f" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
 
   resp, err := c.Disks.Insert(project, zone, &compute.Disk{
                                 // TODO: Fill required fields.
@@ -1319,7 +1319,7 @@ func main() {
   project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "us-central1-f" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
 
 
   call := c.Disks.List(project, zone)
@@ -4514,7 +4514,7 @@ func main() {
   project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "us-central1-f" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
 
   // The instance name for this request.
   instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
@@ -4614,7 +4614,7 @@ func main() {
   project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "us-central1-f" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
 
   // The instance name for this request.
   instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
@@ -4664,7 +4664,7 @@ func main() {
   project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "us-central1-f" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
 
   // Name of the instance resource to delete.
   instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
@@ -4712,7 +4712,7 @@ func main() {
   project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "us-central1-f" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
 
   // The instance name for this request.
   instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
@@ -4766,7 +4766,7 @@ func main() {
   project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "us-central1-f" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
 
   // Instance name.
   instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
@@ -4817,7 +4817,7 @@ func main() {
   project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "us-central1-f" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
 
   // Name of the instance resource to return.
   instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
@@ -4865,7 +4865,7 @@ func main() {
   project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "us-central1-f" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
 
   // Name of the instance scoping this request.
   instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
@@ -4913,7 +4913,7 @@ func main() {
   project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "us-central1-f" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
 
   resp, err := c.Instances.Insert(project, zone, &compute.Instance{
                                     // TODO: Fill required fields.
@@ -4960,7 +4960,7 @@ func main() {
   project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "us-central1-f" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
 
 
   call := c.Instances.List(project, zone)
@@ -5010,7 +5010,7 @@ func main() {
   project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "us-central1-f" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
 
   // Name of the instance scoping this request.
   instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
@@ -5058,7 +5058,7 @@ func main() {
   project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "us-central1-f" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
 
   // The instance name.
   instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
@@ -5112,7 +5112,7 @@ func main() {
   project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "us-central1-f" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
 
   // Name of the instance scoping this request.
   instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
@@ -5162,7 +5162,7 @@ func main() {
   project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "us-central1-f" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
 
   // Name of the instance scoping this request.
   instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
@@ -5212,7 +5212,7 @@ func main() {
   project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "us-central1-f" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
 
   // Instance name.
   instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
@@ -5262,7 +5262,7 @@ func main() {
   project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "us-central1-f" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
 
   // Name of the instance scoping this request.
   instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
@@ -5312,7 +5312,7 @@ func main() {
   project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "us-central1-f" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
 
   // Name of the instance resource to start.
   instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
@@ -5360,7 +5360,7 @@ func main() {
   project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "us-central1-f" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
 
   // Name of the instance resource to stop.
   instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
@@ -5500,7 +5500,7 @@ func main() {
   project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "us-central1-f" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
 
   // Name of the machine type to return.
   machineType := "{MY-MACHINE-TYPE}" // TODO: Update placeholder value.
@@ -5548,7 +5548,7 @@ func main() {
   project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "us-central1-f" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
 
 
   call := c.MachineTypes.List(project, zone)
@@ -7521,7 +7521,7 @@ func main() {
   project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the zone scoping this request.
-  zone := "us-central1-f" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
 
   // Name of the TargetInstance resource to delete.
   targetInstance := "{MY-TARGET-INSTANCE}" // TODO: Update placeholder value.
@@ -7569,7 +7569,7 @@ func main() {
   project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the zone scoping this request.
-  zone := "us-central1-f" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
 
   // Name of the TargetInstance resource to return.
   targetInstance := "{MY-TARGET-INSTANCE}" // TODO: Update placeholder value.
@@ -7617,7 +7617,7 @@ func main() {
   project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the zone scoping this request.
-  zone := "us-central1-f" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
 
   resp, err := c.TargetInstances.Insert(project, zone, &compute.TargetInstance{
                                           // TODO: Fill required fields.
@@ -7664,7 +7664,7 @@ func main() {
   project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the zone scoping this request.
-  zone := "us-central1-f" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
 
 
   call := c.TargetInstances.List(project, zone)
@@ -9056,7 +9056,7 @@ func main() {
   project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the zone for this request.
-  zone := "us-central1-f" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
 
   // Name of the Operations resource to delete.
   operation := "{MY-OPERATION}" // TODO: Update placeholder value.
@@ -9101,7 +9101,7 @@ func main() {
   project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the zone for this request.
-  zone := "us-central1-f" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
 
   // Name of the Operations resource to return.
   operation := "{MY-OPERATION}" // TODO: Update placeholder value.
@@ -9149,7 +9149,7 @@ func main() {
   project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the zone for request.
-  zone := "us-central1-f" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
 
 
   call := c.ZoneOperations.List(project, zone)
@@ -9199,7 +9199,7 @@ func main() {
   project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the zone resource to return.
-  zone := "us-central1-f" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
 
   resp, err := c.Zones.Get(project, zone).Context(ctx).Do()
   if err != nil {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_compute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_compute.v1.json.baseline
@@ -32,7 +32,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
   call := c.Addresses.AggregatedList(project)
@@ -79,13 +79,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the region for this request.
-  region := "" // TODO: Update placeholder value.
+  region := "{MY-REGION}" // TODO: Update placeholder value.
 
   // Name of the address resource to delete.
-  address := "" // TODO: Update placeholder value.
+  address := "{MY-ADDRESS}" // TODO: Update placeholder value.
 
   resp, err := c.Addresses.Delete(project, region, address).Context(ctx).Do()
   if err != nil {
@@ -127,13 +127,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the region for this request.
-  region := "" // TODO: Update placeholder value.
+  region := "{MY-REGION}" // TODO: Update placeholder value.
 
   // Name of the address resource to return.
-  address := "" // TODO: Update placeholder value.
+  address := "{MY-ADDRESS}" // TODO: Update placeholder value.
 
   resp, err := c.Addresses.Get(project, region, address).Context(ctx).Do()
   if err != nil {
@@ -175,10 +175,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the region for this request.
-  region := "" // TODO: Update placeholder value.
+  region := "{MY-REGION}" // TODO: Update placeholder value.
 
   resp, err := c.Addresses.Insert(project, region, &compute.Address{
                                     // TODO: Fill required fields.
@@ -222,10 +222,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the region for this request.
-  region := "" // TODO: Update placeholder value.
+  region := "{MY-REGION}" // TODO: Update placeholder value.
 
 
   call := c.Addresses.List(project, region)
@@ -272,7 +272,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
   call := c.Autoscalers.AggregatedList(project)
@@ -319,13 +319,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the zone for this request.
-  zone := "" // TODO: Update placeholder value.
+  zone := "us-central1-f" // TODO: Update placeholder value.
 
   // Name of the autoscaler to delete.
-  autoscaler := "" // TODO: Update placeholder value.
+  autoscaler := "{MY-AUTOSCALER}" // TODO: Update placeholder value.
 
   resp, err := c.Autoscalers.Delete(project, zone, autoscaler).Context(ctx).Do()
   if err != nil {
@@ -367,13 +367,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the zone for this request.
-  zone := "" // TODO: Update placeholder value.
+  zone := "us-central1-f" // TODO: Update placeholder value.
 
   // Name of the autoscaler to return.
-  autoscaler := "" // TODO: Update placeholder value.
+  autoscaler := "{MY-AUTOSCALER}" // TODO: Update placeholder value.
 
   resp, err := c.Autoscalers.Get(project, zone, autoscaler).Context(ctx).Do()
   if err != nil {
@@ -415,10 +415,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the zone for this request.
-  zone := "" // TODO: Update placeholder value.
+  zone := "us-central1-f" // TODO: Update placeholder value.
 
   resp, err := c.Autoscalers.Insert(project, zone, &compute.Autoscaler{
                                       // TODO: Fill required fields.
@@ -462,10 +462,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the zone for this request.
-  zone := "" // TODO: Update placeholder value.
+  zone := "us-central1-f" // TODO: Update placeholder value.
 
 
   call := c.Autoscalers.List(project, zone)
@@ -512,13 +512,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the zone for this request.
-  zone := "" // TODO: Update placeholder value.
+  zone := "us-central1-f" // TODO: Update placeholder value.
 
   // Name of the autoscaler to update.
-  autoscaler := "" // TODO: Update placeholder value.
+  autoscaler := "{MY-AUTOSCALER}" // TODO: Update placeholder value.
 
   resp, err := c.Autoscalers.Patch(project, zone, autoscaler, &compute.Autoscaler{
                                      // TODO: Fill required fields.
@@ -562,10 +562,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the zone for this request.
-  zone := "" // TODO: Update placeholder value.
+  zone := "us-central1-f" // TODO: Update placeholder value.
 
   resp, err := c.Autoscalers.Update(project, zone, &compute.Autoscaler{
                                       // TODO: Fill required fields.
@@ -609,10 +609,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the BackendService resource to delete.
-  backendService := "" // TODO: Update placeholder value.
+  backendService := "{MY-BACKEND-SERVICE}" // TODO: Update placeholder value.
 
   resp, err := c.BackendServices.Delete(project, backendService).Context(ctx).Do()
   if err != nil {
@@ -654,10 +654,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the BackendService resource to return.
-  backendService := "" // TODO: Update placeholder value.
+  backendService := "{MY-BACKEND-SERVICE}" // TODO: Update placeholder value.
 
   resp, err := c.BackendServices.Get(project, backendService).Context(ctx).Do()
   if err != nil {
@@ -699,10 +699,10 @@ func main() {
   }
 
 
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the BackendService resource to which the queried instance belongs.
-  backendService := "" // TODO: Update placeholder value.
+  backendService := "{MY-BACKEND-SERVICE}" // TODO: Update placeholder value.
 
   resp, err := c.BackendServices.GetHealth(project, backendService, &compute.ResourceGroupReference{
                                              // TODO: Fill required fields.
@@ -746,7 +746,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   resp, err := c.BackendServices.Insert(project, &compute.BackendService{
                                           // TODO: Fill required fields.
@@ -790,7 +790,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
   call := c.BackendServices.List(project)
@@ -837,10 +837,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the BackendService resource to update.
-  backendService := "" // TODO: Update placeholder value.
+  backendService := "{MY-BACKEND-SERVICE}" // TODO: Update placeholder value.
 
   resp, err := c.BackendServices.Patch(project, backendService, &compute.BackendService{
                                          // TODO: Fill required fields.
@@ -884,10 +884,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the BackendService resource to update.
-  backendService := "" // TODO: Update placeholder value.
+  backendService := "{MY-BACKEND-SERVICE}" // TODO: Update placeholder value.
 
   resp, err := c.BackendServices.Update(project, backendService, &compute.BackendService{
                                           // TODO: Fill required fields.
@@ -931,7 +931,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
   call := c.DiskTypes.AggregatedList(project)
@@ -978,13 +978,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "" // TODO: Update placeholder value.
+  zone := "us-central1-f" // TODO: Update placeholder value.
 
   // Name of the disk type to return.
-  diskType := "" // TODO: Update placeholder value.
+  diskType := "{MY-DISK-TYPE}" // TODO: Update placeholder value.
 
   resp, err := c.DiskTypes.Get(project, zone, diskType).Context(ctx).Do()
   if err != nil {
@@ -1026,10 +1026,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "" // TODO: Update placeholder value.
+  zone := "us-central1-f" // TODO: Update placeholder value.
 
 
   call := c.DiskTypes.List(project, zone)
@@ -1076,7 +1076,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
   call := c.Disks.AggregatedList(project)
@@ -1123,13 +1123,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "" // TODO: Update placeholder value.
+  zone := "us-central1-f" // TODO: Update placeholder value.
 
   // Name of the persistent disk to snapshot.
-  disk := "" // TODO: Update placeholder value.
+  disk := "{MY-DISK}" // TODO: Update placeholder value.
 
   resp, err := c.Disks.CreateSnapshot(project, zone, disk, &compute.Snapshot{
                                         // TODO: Fill required fields.
@@ -1173,13 +1173,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "" // TODO: Update placeholder value.
+  zone := "us-central1-f" // TODO: Update placeholder value.
 
   // Name of the persistent disk to delete.
-  disk := "" // TODO: Update placeholder value.
+  disk := "{MY-DISK}" // TODO: Update placeholder value.
 
   resp, err := c.Disks.Delete(project, zone, disk).Context(ctx).Do()
   if err != nil {
@@ -1221,13 +1221,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "" // TODO: Update placeholder value.
+  zone := "us-central1-f" // TODO: Update placeholder value.
 
   // Name of the persistent disk to return.
-  disk := "" // TODO: Update placeholder value.
+  disk := "{MY-DISK}" // TODO: Update placeholder value.
 
   resp, err := c.Disks.Get(project, zone, disk).Context(ctx).Do()
   if err != nil {
@@ -1269,10 +1269,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "" // TODO: Update placeholder value.
+  zone := "us-central1-f" // TODO: Update placeholder value.
 
   resp, err := c.Disks.Insert(project, zone, &compute.Disk{
                                 // TODO: Fill required fields.
@@ -1316,10 +1316,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "" // TODO: Update placeholder value.
+  zone := "us-central1-f" // TODO: Update placeholder value.
 
 
   call := c.Disks.List(project, zone)
@@ -1366,10 +1366,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the firewall rule to delete.
-  firewall := "" // TODO: Update placeholder value.
+  firewall := "{MY-FIREWALL}" // TODO: Update placeholder value.
 
   resp, err := c.Firewalls.Delete(project, firewall).Context(ctx).Do()
   if err != nil {
@@ -1411,10 +1411,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the firewall rule to return.
-  firewall := "" // TODO: Update placeholder value.
+  firewall := "{MY-FIREWALL}" // TODO: Update placeholder value.
 
   resp, err := c.Firewalls.Get(project, firewall).Context(ctx).Do()
   if err != nil {
@@ -1456,7 +1456,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   resp, err := c.Firewalls.Insert(project, &compute.Firewall{
                                     // TODO: Fill required fields.
@@ -1500,7 +1500,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
   call := c.Firewalls.List(project)
@@ -1547,10 +1547,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the firewall rule to update.
-  firewall := "" // TODO: Update placeholder value.
+  firewall := "{MY-FIREWALL}" // TODO: Update placeholder value.
 
   resp, err := c.Firewalls.Patch(project, firewall, &compute.Firewall{
                                    // TODO: Fill required fields.
@@ -1594,10 +1594,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the firewall rule to update.
-  firewall := "" // TODO: Update placeholder value.
+  firewall := "{MY-FIREWALL}" // TODO: Update placeholder value.
 
   resp, err := c.Firewalls.Update(project, firewall, &compute.Firewall{
                                     // TODO: Fill required fields.
@@ -1641,7 +1641,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
   call := c.ForwardingRules.AggregatedList(project)
@@ -1688,13 +1688,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the region scoping this request.
-  region := "" // TODO: Update placeholder value.
+  region := "{MY-REGION}" // TODO: Update placeholder value.
 
   // Name of the ForwardingRule resource to delete.
-  forwardingRule := "" // TODO: Update placeholder value.
+  forwardingRule := "{MY-FORWARDING-RULE}" // TODO: Update placeholder value.
 
   resp, err := c.ForwardingRules.Delete(project, region, forwardingRule).Context(ctx).Do()
   if err != nil {
@@ -1736,13 +1736,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the region scoping this request.
-  region := "" // TODO: Update placeholder value.
+  region := "{MY-REGION}" // TODO: Update placeholder value.
 
   // Name of the ForwardingRule resource to return.
-  forwardingRule := "" // TODO: Update placeholder value.
+  forwardingRule := "{MY-FORWARDING-RULE}" // TODO: Update placeholder value.
 
   resp, err := c.ForwardingRules.Get(project, region, forwardingRule).Context(ctx).Do()
   if err != nil {
@@ -1784,10 +1784,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the region scoping this request.
-  region := "" // TODO: Update placeholder value.
+  region := "{MY-REGION}" // TODO: Update placeholder value.
 
   resp, err := c.ForwardingRules.Insert(project, region, &compute.ForwardingRule{
                                           // TODO: Fill required fields.
@@ -1831,10 +1831,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the region scoping this request.
-  region := "" // TODO: Update placeholder value.
+  region := "{MY-REGION}" // TODO: Update placeholder value.
 
 
   call := c.ForwardingRules.List(project, region)
@@ -1881,13 +1881,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the region scoping this request.
-  region := "" // TODO: Update placeholder value.
+  region := "{MY-REGION}" // TODO: Update placeholder value.
 
   // Name of the ForwardingRule resource in which target is to be set.
-  forwardingRule := "" // TODO: Update placeholder value.
+  forwardingRule := "{MY-FORWARDING-RULE}" // TODO: Update placeholder value.
 
   resp, err := c.ForwardingRules.SetTarget(project, region, forwardingRule, &compute.TargetReference{
                                              // TODO: Fill required fields.
@@ -1931,10 +1931,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the address resource to delete.
-  address := "" // TODO: Update placeholder value.
+  address := "{MY-ADDRESS}" // TODO: Update placeholder value.
 
   resp, err := c.GlobalAddresses.Delete(project, address).Context(ctx).Do()
   if err != nil {
@@ -1976,10 +1976,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the address resource to return.
-  address := "" // TODO: Update placeholder value.
+  address := "{MY-ADDRESS}" // TODO: Update placeholder value.
 
   resp, err := c.GlobalAddresses.Get(project, address).Context(ctx).Do()
   if err != nil {
@@ -2021,7 +2021,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   resp, err := c.GlobalAddresses.Insert(project, &compute.Address{
                                           // TODO: Fill required fields.
@@ -2065,7 +2065,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
   call := c.GlobalAddresses.List(project)
@@ -2112,10 +2112,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the ForwardingRule resource to delete.
-  forwardingRule := "" // TODO: Update placeholder value.
+  forwardingRule := "{MY-FORWARDING-RULE}" // TODO: Update placeholder value.
 
   resp, err := c.GlobalForwardingRules.Delete(project, forwardingRule).Context(ctx).Do()
   if err != nil {
@@ -2157,10 +2157,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the ForwardingRule resource to return.
-  forwardingRule := "" // TODO: Update placeholder value.
+  forwardingRule := "{MY-FORWARDING-RULE}" // TODO: Update placeholder value.
 
   resp, err := c.GlobalForwardingRules.Get(project, forwardingRule).Context(ctx).Do()
   if err != nil {
@@ -2202,7 +2202,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   resp, err := c.GlobalForwardingRules.Insert(project, &compute.ForwardingRule{
                                                 // TODO: Fill required fields.
@@ -2246,7 +2246,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
   call := c.GlobalForwardingRules.List(project)
@@ -2293,10 +2293,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the ForwardingRule resource in which target is to be set.
-  forwardingRule := "" // TODO: Update placeholder value.
+  forwardingRule := "{MY-FORWARDING-RULE}" // TODO: Update placeholder value.
 
   resp, err := c.GlobalForwardingRules.SetTarget(project, forwardingRule, &compute.TargetReference{
                                                    // TODO: Fill required fields.
@@ -2340,7 +2340,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
   call := c.GlobalOperations.AggregatedList(project)
@@ -2387,10 +2387,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the Operations resource to delete.
-  operation := "" // TODO: Update placeholder value.
+  operation := "{MY-OPERATION}" // TODO: Update placeholder value.
 
   if err := c.GlobalOperations.Delete(project, operation).Context(ctx).Do(); err != nil {
     // TODO: Handle error.
@@ -2429,10 +2429,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the Operations resource to return.
-  operation := "" // TODO: Update placeholder value.
+  operation := "{MY-OPERATION}" // TODO: Update placeholder value.
 
   resp, err := c.GlobalOperations.Get(project, operation).Context(ctx).Do()
   if err != nil {
@@ -2474,7 +2474,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
   call := c.GlobalOperations.List(project)
@@ -2521,10 +2521,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the HttpHealthCheck resource to delete.
-  httpHealthCheck := "" // TODO: Update placeholder value.
+  httpHealthCheck := "{MY-HTTP-HEALTH-CHECK}" // TODO: Update placeholder value.
 
   resp, err := c.HttpHealthChecks.Delete(project, httpHealthCheck).Context(ctx).Do()
   if err != nil {
@@ -2566,10 +2566,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the HttpHealthCheck resource to return.
-  httpHealthCheck := "" // TODO: Update placeholder value.
+  httpHealthCheck := "{MY-HTTP-HEALTH-CHECK}" // TODO: Update placeholder value.
 
   resp, err := c.HttpHealthChecks.Get(project, httpHealthCheck).Context(ctx).Do()
   if err != nil {
@@ -2611,7 +2611,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   resp, err := c.HttpHealthChecks.Insert(project, &compute.HttpHealthCheck{
                                            // TODO: Fill required fields.
@@ -2655,7 +2655,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
   call := c.HttpHealthChecks.List(project)
@@ -2702,10 +2702,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the HttpHealthCheck resource to update.
-  httpHealthCheck := "" // TODO: Update placeholder value.
+  httpHealthCheck := "{MY-HTTP-HEALTH-CHECK}" // TODO: Update placeholder value.
 
   resp, err := c.HttpHealthChecks.Patch(project, httpHealthCheck, &compute.HttpHealthCheck{
                                           // TODO: Fill required fields.
@@ -2749,10 +2749,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the HttpHealthCheck resource to update.
-  httpHealthCheck := "" // TODO: Update placeholder value.
+  httpHealthCheck := "{MY-HTTP-HEALTH-CHECK}" // TODO: Update placeholder value.
 
   resp, err := c.HttpHealthChecks.Update(project, httpHealthCheck, &compute.HttpHealthCheck{
                                            // TODO: Fill required fields.
@@ -2796,10 +2796,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the HttpsHealthCheck resource to delete.
-  httpsHealthCheck := "" // TODO: Update placeholder value.
+  httpsHealthCheck := "{MY-HTTPS-HEALTH-CHECK}" // TODO: Update placeholder value.
 
   resp, err := c.HttpsHealthChecks.Delete(project, httpsHealthCheck).Context(ctx).Do()
   if err != nil {
@@ -2841,10 +2841,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the HttpsHealthCheck resource to return.
-  httpsHealthCheck := "" // TODO: Update placeholder value.
+  httpsHealthCheck := "{MY-HTTPS-HEALTH-CHECK}" // TODO: Update placeholder value.
 
   resp, err := c.HttpsHealthChecks.Get(project, httpsHealthCheck).Context(ctx).Do()
   if err != nil {
@@ -2886,7 +2886,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   resp, err := c.HttpsHealthChecks.Insert(project, &compute.HttpsHealthCheck{
                                             // TODO: Fill required fields.
@@ -2930,7 +2930,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
   call := c.HttpsHealthChecks.List(project)
@@ -2977,10 +2977,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the HttpsHealthCheck resource to update.
-  httpsHealthCheck := "" // TODO: Update placeholder value.
+  httpsHealthCheck := "{MY-HTTPS-HEALTH-CHECK}" // TODO: Update placeholder value.
 
   resp, err := c.HttpsHealthChecks.Patch(project, httpsHealthCheck, &compute.HttpsHealthCheck{
                                            // TODO: Fill required fields.
@@ -3024,10 +3024,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the HttpsHealthCheck resource to update.
-  httpsHealthCheck := "" // TODO: Update placeholder value.
+  httpsHealthCheck := "{MY-HTTPS-HEALTH-CHECK}" // TODO: Update placeholder value.
 
   resp, err := c.HttpsHealthChecks.Update(project, httpsHealthCheck, &compute.HttpsHealthCheck{
                                             // TODO: Fill required fields.
@@ -3071,10 +3071,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the image resource to delete.
-  image := "" // TODO: Update placeholder value.
+  image := "{MY-IMAGE}" // TODO: Update placeholder value.
 
   resp, err := c.Images.Delete(project, image).Context(ctx).Do()
   if err != nil {
@@ -3116,10 +3116,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Image name.
-  image := "" // TODO: Update placeholder value.
+  image := "{MY-IMAGE}" // TODO: Update placeholder value.
 
   resp, err := c.Images.Deprecate(project, image, &compute.DeprecationStatus{
                                     // TODO: Fill required fields.
@@ -3163,10 +3163,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the image resource to return.
-  image := "" // TODO: Update placeholder value.
+  image := "{MY-IMAGE}" // TODO: Update placeholder value.
 
   resp, err := c.Images.Get(project, image).Context(ctx).Do()
   if err != nil {
@@ -3208,7 +3208,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   resp, err := c.Images.Insert(project, &compute.Image{
                                  // TODO: Fill required fields.
@@ -3252,7 +3252,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
   call := c.Images.List(project)
@@ -3299,13 +3299,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone where the managed instance group is located.
-  zone := "" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}" // TODO: Update placeholder value.
 
   // The name of the managed instance group.
-  instanceGroupManager := "" // TODO: Update placeholder value.
+  instanceGroupManager := "{MY-INSTANCE-GROUP-MANAGER}" // TODO: Update placeholder value.
 
   resp, err := c.InstanceGroupManagers.AbandonInstances(project, zone, instanceGroupManager, &compute.InstanceGroupManagersAbandonInstancesRequest{
                                                           // TODO: Fill required fields.
@@ -3349,7 +3349,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
   call := c.InstanceGroupManagers.AggregatedList(project)
@@ -3396,13 +3396,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone where the managed instance group is located.
-  zone := "" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}" // TODO: Update placeholder value.
 
   // The name of the managed instance group to delete.
-  instanceGroupManager := "" // TODO: Update placeholder value.
+  instanceGroupManager := "{MY-INSTANCE-GROUP-MANAGER}" // TODO: Update placeholder value.
 
   resp, err := c.InstanceGroupManagers.Delete(project, zone, instanceGroupManager).Context(ctx).Do()
   if err != nil {
@@ -3444,13 +3444,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone where the managed instance group is located.
-  zone := "" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}" // TODO: Update placeholder value.
 
   // The name of the managed instance group.
-  instanceGroupManager := "" // TODO: Update placeholder value.
+  instanceGroupManager := "{MY-INSTANCE-GROUP-MANAGER}" // TODO: Update placeholder value.
 
   resp, err := c.InstanceGroupManagers.DeleteInstances(project, zone, instanceGroupManager, &compute.InstanceGroupManagersDeleteInstancesRequest{
                                                          // TODO: Fill required fields.
@@ -3494,13 +3494,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone where the managed instance group is located.
-  zone := "" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}" // TODO: Update placeholder value.
 
   // The name of the managed instance group.
-  instanceGroupManager := "" // TODO: Update placeholder value.
+  instanceGroupManager := "{MY-INSTANCE-GROUP-MANAGER}" // TODO: Update placeholder value.
 
   resp, err := c.InstanceGroupManagers.Get(project, zone, instanceGroupManager).Context(ctx).Do()
   if err != nil {
@@ -3542,10 +3542,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone where you want to create the managed instance group.
-  zone := "" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}" // TODO: Update placeholder value.
 
   resp, err := c.InstanceGroupManagers.Insert(project, zone, &compute.InstanceGroupManager{
                                                 // TODO: Fill required fields.
@@ -3589,10 +3589,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone where the managed instance group is located.
-  zone := "" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}" // TODO: Update placeholder value.
 
 
   call := c.InstanceGroupManagers.List(project, zone)
@@ -3639,13 +3639,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone where the managed instance group is located.
-  zone := "" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}" // TODO: Update placeholder value.
 
   // The name of the managed instance group.
-  instanceGroupManager := "" // TODO: Update placeholder value.
+  instanceGroupManager := "{MY-INSTANCE-GROUP-MANAGER}" // TODO: Update placeholder value.
 
   resp, err := c.InstanceGroupManagers.ListManagedInstances(project, zone, instanceGroupManager).Context(ctx).Do()
   if err != nil {
@@ -3687,13 +3687,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone where the managed instance group is located.
-  zone := "" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}" // TODO: Update placeholder value.
 
   // The name of the managed instance group.
-  instanceGroupManager := "" // TODO: Update placeholder value.
+  instanceGroupManager := "{MY-INSTANCE-GROUP-MANAGER}" // TODO: Update placeholder value.
 
   resp, err := c.InstanceGroupManagers.RecreateInstances(project, zone, instanceGroupManager, &compute.InstanceGroupManagersRecreateInstancesRequest{
                                                            // TODO: Fill required fields.
@@ -3737,13 +3737,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone where the managed instance group is located.
-  zone := "" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}" // TODO: Update placeholder value.
 
   // The name of the managed instance group.
-  instanceGroupManager := "" // TODO: Update placeholder value.
+  instanceGroupManager := "{MY-INSTANCE-GROUP-MANAGER}" // TODO: Update placeholder value.
 
   // The number of running instances that the managed instance group should maintain at any given time.
   // The group automatically adds or removes instances to maintain the number of instances specified by
@@ -3790,13 +3790,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone where the managed instance group is located.
-  zone := "" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}" // TODO: Update placeholder value.
 
   // The name of the managed instance group.
-  instanceGroupManager := "" // TODO: Update placeholder value.
+  instanceGroupManager := "{MY-INSTANCE-GROUP-MANAGER}" // TODO: Update placeholder value.
 
   resp, err := c.InstanceGroupManagers.SetInstanceTemplate(project, zone, instanceGroupManager, &compute.InstanceGroupManagersSetInstanceTemplateRequest{
                                                              // TODO: Fill required fields.
@@ -3840,13 +3840,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone where the managed instance group is located.
-  zone := "" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}" // TODO: Update placeholder value.
 
   // The name of the managed instance group.
-  instanceGroupManager := "" // TODO: Update placeholder value.
+  instanceGroupManager := "{MY-INSTANCE-GROUP-MANAGER}" // TODO: Update placeholder value.
 
   resp, err := c.InstanceGroupManagers.SetTargetPools(project, zone, instanceGroupManager, &compute.InstanceGroupManagersSetTargetPoolsRequest{
                                                         // TODO: Fill required fields.
@@ -3890,13 +3890,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone where the instance group is located.
-  zone := "" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}" // TODO: Update placeholder value.
 
   // The name of the instance group where you are adding instances.
-  instanceGroup := "" // TODO: Update placeholder value.
+  instanceGroup := "{MY-INSTANCE-GROUP}" // TODO: Update placeholder value.
 
   resp, err := c.InstanceGroups.AddInstances(project, zone, instanceGroup, &compute.InstanceGroupsAddInstancesRequest{
                                                // TODO: Fill required fields.
@@ -3940,7 +3940,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
   call := c.InstanceGroups.AggregatedList(project)
@@ -3987,13 +3987,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone where the instance group is located.
-  zone := "" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}" // TODO: Update placeholder value.
 
   // The name of the instance group to delete.
-  instanceGroup := "" // TODO: Update placeholder value.
+  instanceGroup := "{MY-INSTANCE-GROUP}" // TODO: Update placeholder value.
 
   resp, err := c.InstanceGroups.Delete(project, zone, instanceGroup).Context(ctx).Do()
   if err != nil {
@@ -4035,13 +4035,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone where the instance group is located.
-  zone := "" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}" // TODO: Update placeholder value.
 
   // The name of the instance group.
-  instanceGroup := "" // TODO: Update placeholder value.
+  instanceGroup := "{MY-INSTANCE-GROUP}" // TODO: Update placeholder value.
 
   resp, err := c.InstanceGroups.Get(project, zone, instanceGroup).Context(ctx).Do()
   if err != nil {
@@ -4083,10 +4083,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone where you want to create the instance group.
-  zone := "" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}" // TODO: Update placeholder value.
 
   resp, err := c.InstanceGroups.Insert(project, zone, &compute.InstanceGroup{
                                          // TODO: Fill required fields.
@@ -4130,10 +4130,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone where the instance group is located.
-  zone := "" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}" // TODO: Update placeholder value.
 
 
   call := c.InstanceGroups.List(project, zone)
@@ -4180,13 +4180,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone where the instance group is located.
-  zone := "" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}" // TODO: Update placeholder value.
 
   // The name of the instance group from which you want to generate a list of included instances.
-  instanceGroup := "" // TODO: Update placeholder value.
+  instanceGroup := "{MY-INSTANCE-GROUP}" // TODO: Update placeholder value.
 
   resp, err := c.InstanceGroups.ListInstances(project, zone, instanceGroup, &compute.InstanceGroupsListInstancesRequest{
                                                 // TODO: Fill required fields.
@@ -4230,13 +4230,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone where the instance group is located.
-  zone := "" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}" // TODO: Update placeholder value.
 
   // The name of the instance group where the specified instances will be removed.
-  instanceGroup := "" // TODO: Update placeholder value.
+  instanceGroup := "{MY-INSTANCE-GROUP}" // TODO: Update placeholder value.
 
   resp, err := c.InstanceGroups.RemoveInstances(project, zone, instanceGroup, &compute.InstanceGroupsRemoveInstancesRequest{
                                                   // TODO: Fill required fields.
@@ -4280,13 +4280,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone where the instance group is located.
-  zone := "" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}" // TODO: Update placeholder value.
 
   // The name of the instance group where the named ports are updated.
-  instanceGroup := "" // TODO: Update placeholder value.
+  instanceGroup := "{MY-INSTANCE-GROUP}" // TODO: Update placeholder value.
 
   resp, err := c.InstanceGroups.SetNamedPorts(project, zone, instanceGroup, &compute.InstanceGroupsSetNamedPortsRequest{
                                                 // TODO: Fill required fields.
@@ -4330,10 +4330,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the instance template to delete.
-  instanceTemplate := "" // TODO: Update placeholder value.
+  instanceTemplate := "{MY-INSTANCE-TEMPLATE}" // TODO: Update placeholder value.
 
   resp, err := c.InstanceTemplates.Delete(project, instanceTemplate).Context(ctx).Do()
   if err != nil {
@@ -4375,10 +4375,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the instance template.
-  instanceTemplate := "" // TODO: Update placeholder value.
+  instanceTemplate := "{MY-INSTANCE-TEMPLATE}" // TODO: Update placeholder value.
 
   resp, err := c.InstanceTemplates.Get(project, instanceTemplate).Context(ctx).Do()
   if err != nil {
@@ -4420,7 +4420,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   resp, err := c.InstanceTemplates.Insert(project, &compute.InstanceTemplate{
                                             // TODO: Fill required fields.
@@ -4464,7 +4464,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
   call := c.InstanceTemplates.List(project)
@@ -4511,16 +4511,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "" // TODO: Update placeholder value.
+  zone := "us-central1-f" // TODO: Update placeholder value.
 
   // The instance name for this request.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   // The name of the network interface to add to this instance.
-  networkInterface := "" // TODO: Update placeholder value.
+  networkInterface := "{MY-NETWORK-INTERFACE}" // TODO: Update placeholder value.
 
   resp, err := c.Instances.AddAccessConfig(project, zone, instance, networkInterface, &compute.AccessConfig{
                                              // TODO: Fill required fields.
@@ -4564,7 +4564,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
   call := c.Instances.AggregatedList(project)
@@ -4611,13 +4611,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "" // TODO: Update placeholder value.
+  zone := "us-central1-f" // TODO: Update placeholder value.
 
   // The instance name for this request.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   resp, err := c.Instances.AttachDisk(project, zone, instance, &compute.AttachedDisk{
                                         // TODO: Fill required fields.
@@ -4661,13 +4661,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "" // TODO: Update placeholder value.
+  zone := "us-central1-f" // TODO: Update placeholder value.
 
   // Name of the instance resource to delete.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   resp, err := c.Instances.Delete(project, zone, instance).Context(ctx).Do()
   if err != nil {
@@ -4709,19 +4709,19 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "" // TODO: Update placeholder value.
+  zone := "us-central1-f" // TODO: Update placeholder value.
 
   // The instance name for this request.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   // The name of the access config to delete.
-  accessConfig := "" // TODO: Update placeholder value.
+  accessConfig := "{MY-ACCESS-CONFIG}" // TODO: Update placeholder value.
 
   // The name of the network interface.
-  networkInterface := "" // TODO: Update placeholder value.
+  networkInterface := "{MY-NETWORK-INTERFACE}" // TODO: Update placeholder value.
 
   resp, err := c.Instances.DeleteAccessConfig(project, zone, instance, accessConfig, networkInterface).Context(ctx).Do()
   if err != nil {
@@ -4763,16 +4763,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "" // TODO: Update placeholder value.
+  zone := "us-central1-f" // TODO: Update placeholder value.
 
   // Instance name.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   // Disk device name to detach.
-  deviceName := "" // TODO: Update placeholder value.
+  deviceName := "{MY-DEVICE-NAME}" // TODO: Update placeholder value.
 
   resp, err := c.Instances.DetachDisk(project, zone, instance, deviceName).Context(ctx).Do()
   if err != nil {
@@ -4814,13 +4814,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "" // TODO: Update placeholder value.
+  zone := "us-central1-f" // TODO: Update placeholder value.
 
   // Name of the instance resource to return.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   resp, err := c.Instances.Get(project, zone, instance).Context(ctx).Do()
   if err != nil {
@@ -4862,13 +4862,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "" // TODO: Update placeholder value.
+  zone := "us-central1-f" // TODO: Update placeholder value.
 
   // Name of the instance scoping this request.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   resp, err := c.Instances.GetSerialPortOutput(project, zone, instance).Context(ctx).Do()
   if err != nil {
@@ -4910,10 +4910,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "" // TODO: Update placeholder value.
+  zone := "us-central1-f" // TODO: Update placeholder value.
 
   resp, err := c.Instances.Insert(project, zone, &compute.Instance{
                                     // TODO: Fill required fields.
@@ -4957,10 +4957,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "" // TODO: Update placeholder value.
+  zone := "us-central1-f" // TODO: Update placeholder value.
 
 
   call := c.Instances.List(project, zone)
@@ -5007,13 +5007,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "" // TODO: Update placeholder value.
+  zone := "us-central1-f" // TODO: Update placeholder value.
 
   // Name of the instance scoping this request.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   resp, err := c.Instances.Reset(project, zone, instance).Context(ctx).Do()
   if err != nil {
@@ -5055,19 +5055,19 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "" // TODO: Update placeholder value.
+  zone := "us-central1-f" // TODO: Update placeholder value.
 
   // The instance name.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   // Whether to auto-delete the disk when the instance is deleted.
   autoDelete := false // TODO: Update placeholder value.
 
   // The device name of the disk to modify.
-  deviceName := "" // TODO: Update placeholder value.
+  deviceName := "{MY-DEVICE-NAME}" // TODO: Update placeholder value.
 
   resp, err := c.Instances.SetDiskAutoDelete(project, zone, instance, autoDelete, deviceName).Context(ctx).Do()
   if err != nil {
@@ -5109,13 +5109,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "" // TODO: Update placeholder value.
+  zone := "us-central1-f" // TODO: Update placeholder value.
 
   // Name of the instance scoping this request.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   resp, err := c.Instances.SetMachineType(project, zone, instance, &compute.InstancesSetMachineTypeRequest{
                                             // TODO: Fill required fields.
@@ -5159,13 +5159,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "" // TODO: Update placeholder value.
+  zone := "us-central1-f" // TODO: Update placeholder value.
 
   // Name of the instance scoping this request.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   resp, err := c.Instances.SetMetadata(project, zone, instance, &compute.Metadata{
                                          // TODO: Fill required fields.
@@ -5209,13 +5209,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "" // TODO: Update placeholder value.
+  zone := "us-central1-f" // TODO: Update placeholder value.
 
   // Instance name.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   resp, err := c.Instances.SetScheduling(project, zone, instance, &compute.Scheduling{
                                            // TODO: Fill required fields.
@@ -5259,13 +5259,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "" // TODO: Update placeholder value.
+  zone := "us-central1-f" // TODO: Update placeholder value.
 
   // Name of the instance scoping this request.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   resp, err := c.Instances.SetTags(project, zone, instance, &compute.Tags{
                                      // TODO: Fill required fields.
@@ -5309,13 +5309,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "" // TODO: Update placeholder value.
+  zone := "us-central1-f" // TODO: Update placeholder value.
 
   // Name of the instance resource to start.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   resp, err := c.Instances.Start(project, zone, instance).Context(ctx).Do()
   if err != nil {
@@ -5357,13 +5357,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "" // TODO: Update placeholder value.
+  zone := "us-central1-f" // TODO: Update placeholder value.
 
   // Name of the instance resource to stop.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   resp, err := c.Instances.Stop(project, zone, instance).Context(ctx).Do()
   if err != nil {
@@ -5405,10 +5405,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the License resource to return.
-  license := "" // TODO: Update placeholder value.
+  license := "{MY-LICENSE}" // TODO: Update placeholder value.
 
   resp, err := c.Licenses.Get(project, license).Context(ctx).Do()
   if err != nil {
@@ -5450,7 +5450,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
   call := c.MachineTypes.AggregatedList(project)
@@ -5497,13 +5497,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "" // TODO: Update placeholder value.
+  zone := "us-central1-f" // TODO: Update placeholder value.
 
   // Name of the machine type to return.
-  machineType := "" // TODO: Update placeholder value.
+  machineType := "{MY-MACHINE-TYPE}" // TODO: Update placeholder value.
 
   resp, err := c.MachineTypes.Get(project, zone, machineType).Context(ctx).Do()
   if err != nil {
@@ -5545,10 +5545,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone for this request.
-  zone := "" // TODO: Update placeholder value.
+  zone := "us-central1-f" // TODO: Update placeholder value.
 
 
   call := c.MachineTypes.List(project, zone)
@@ -5595,10 +5595,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the network to delete.
-  network := "" // TODO: Update placeholder value.
+  network := "{MY-NETWORK}" // TODO: Update placeholder value.
 
   resp, err := c.Networks.Delete(project, network).Context(ctx).Do()
   if err != nil {
@@ -5640,10 +5640,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the network to return.
-  network := "" // TODO: Update placeholder value.
+  network := "{MY-NETWORK}" // TODO: Update placeholder value.
 
   resp, err := c.Networks.Get(project, network).Context(ctx).Do()
   if err != nil {
@@ -5685,7 +5685,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   resp, err := c.Networks.Insert(project, &compute.Network{
                                    // TODO: Fill required fields.
@@ -5729,7 +5729,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
   call := c.Networks.List(project)
@@ -5776,7 +5776,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   resp, err := c.Projects.Get(project).Context(ctx).Do()
   if err != nil {
@@ -5818,7 +5818,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   resp, err := c.Projects.MoveDisk(project, &compute.DiskMoveRequest{
                                      // TODO: Fill required fields.
@@ -5862,7 +5862,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   resp, err := c.Projects.MoveInstance(project, &compute.InstanceMoveRequest{
                                          // TODO: Fill required fields.
@@ -5906,7 +5906,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   resp, err := c.Projects.SetCommonInstanceMetadata(project, &compute.Metadata{
                                                       // TODO: Fill required fields.
@@ -5950,7 +5950,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   resp, err := c.Projects.SetUsageExportBucket(project, &compute.UsageExportLocation{
                                                  // TODO: Fill required fields.
@@ -5994,13 +5994,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the region for this request.
-  region := "" // TODO: Update placeholder value.
+  region := "{MY-REGION}" // TODO: Update placeholder value.
 
   // Name of the Operations resource to delete.
-  operation := "" // TODO: Update placeholder value.
+  operation := "{MY-OPERATION}" // TODO: Update placeholder value.
 
   if err := c.RegionOperations.Delete(project, region, operation).Context(ctx).Do(); err != nil {
     // TODO: Handle error.
@@ -6039,13 +6039,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the region for this request.
-  region := "" // TODO: Update placeholder value.
+  region := "{MY-REGION}" // TODO: Update placeholder value.
 
   // Name of the Operations resource to return.
-  operation := "" // TODO: Update placeholder value.
+  operation := "{MY-OPERATION}" // TODO: Update placeholder value.
 
   resp, err := c.RegionOperations.Get(project, region, operation).Context(ctx).Do()
   if err != nil {
@@ -6087,10 +6087,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the region for this request.
-  region := "" // TODO: Update placeholder value.
+  region := "{MY-REGION}" // TODO: Update placeholder value.
 
 
   call := c.RegionOperations.List(project, region)
@@ -6137,10 +6137,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the region resource to return.
-  region := "" // TODO: Update placeholder value.
+  region := "{MY-REGION}" // TODO: Update placeholder value.
 
   resp, err := c.Regions.Get(project, region).Context(ctx).Do()
   if err != nil {
@@ -6182,7 +6182,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
   call := c.Regions.List(project)
@@ -6229,10 +6229,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the Route resource to delete.
-  route := "" // TODO: Update placeholder value.
+  route := "{MY-ROUTE}" // TODO: Update placeholder value.
 
   resp, err := c.Routes.Delete(project, route).Context(ctx).Do()
   if err != nil {
@@ -6274,10 +6274,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the Route resource to return.
-  route := "" // TODO: Update placeholder value.
+  route := "{MY-ROUTE}" // TODO: Update placeholder value.
 
   resp, err := c.Routes.Get(project, route).Context(ctx).Do()
   if err != nil {
@@ -6319,7 +6319,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   resp, err := c.Routes.Insert(project, &compute.Route{
                                  // TODO: Fill required fields.
@@ -6363,7 +6363,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
   call := c.Routes.List(project)
@@ -6410,10 +6410,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the Snapshot resource to delete.
-  snapshot := "" // TODO: Update placeholder value.
+  snapshot := "{MY-SNAPSHOT}" // TODO: Update placeholder value.
 
   resp, err := c.Snapshots.Delete(project, snapshot).Context(ctx).Do()
   if err != nil {
@@ -6455,10 +6455,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the Snapshot resource to return.
-  snapshot := "" // TODO: Update placeholder value.
+  snapshot := "{MY-SNAPSHOT}" // TODO: Update placeholder value.
 
   resp, err := c.Snapshots.Get(project, snapshot).Context(ctx).Do()
   if err != nil {
@@ -6500,7 +6500,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
   call := c.Snapshots.List(project)
@@ -6547,10 +6547,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the SslCertificate resource to delete.
-  sslCertificate := "" // TODO: Update placeholder value.
+  sslCertificate := "{MY-SSL-CERTIFICATE}" // TODO: Update placeholder value.
 
   resp, err := c.SslCertificates.Delete(project, sslCertificate).Context(ctx).Do()
   if err != nil {
@@ -6592,10 +6592,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the SslCertificate resource to return.
-  sslCertificate := "" // TODO: Update placeholder value.
+  sslCertificate := "{MY-SSL-CERTIFICATE}" // TODO: Update placeholder value.
 
   resp, err := c.SslCertificates.Get(project, sslCertificate).Context(ctx).Do()
   if err != nil {
@@ -6637,7 +6637,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   resp, err := c.SslCertificates.Insert(project, &compute.SslCertificate{
                                           // TODO: Fill required fields.
@@ -6681,7 +6681,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
   call := c.SslCertificates.List(project)
@@ -6728,7 +6728,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
   call := c.Subnetworks.AggregatedList(project)
@@ -6775,13 +6775,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the region scoping this request.
-  region := "" // TODO: Update placeholder value.
+  region := "{MY-REGION}" // TODO: Update placeholder value.
 
   // Name of the Subnetwork resource to delete.
-  subnetwork := "" // TODO: Update placeholder value.
+  subnetwork := "{MY-SUBNETWORK}" // TODO: Update placeholder value.
 
   resp, err := c.Subnetworks.Delete(project, region, subnetwork).Context(ctx).Do()
   if err != nil {
@@ -6823,13 +6823,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the region scoping this request.
-  region := "" // TODO: Update placeholder value.
+  region := "{MY-REGION}" // TODO: Update placeholder value.
 
   // Name of the Subnetwork resource to return.
-  subnetwork := "" // TODO: Update placeholder value.
+  subnetwork := "{MY-SUBNETWORK}" // TODO: Update placeholder value.
 
   resp, err := c.Subnetworks.Get(project, region, subnetwork).Context(ctx).Do()
   if err != nil {
@@ -6871,10 +6871,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the region scoping this request.
-  region := "" // TODO: Update placeholder value.
+  region := "{MY-REGION}" // TODO: Update placeholder value.
 
   resp, err := c.Subnetworks.Insert(project, region, &compute.Subnetwork{
                                       // TODO: Fill required fields.
@@ -6918,10 +6918,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the region scoping this request.
-  region := "" // TODO: Update placeholder value.
+  region := "{MY-REGION}" // TODO: Update placeholder value.
 
 
   call := c.Subnetworks.List(project, region)
@@ -6968,10 +6968,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the TargetHttpProxy resource to delete.
-  targetHttpProxy := "" // TODO: Update placeholder value.
+  targetHttpProxy := "{MY-TARGET-HTTP-PROXY}" // TODO: Update placeholder value.
 
   resp, err := c.TargetHttpProxies.Delete(project, targetHttpProxy).Context(ctx).Do()
   if err != nil {
@@ -7013,10 +7013,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the TargetHttpProxy resource to return.
-  targetHttpProxy := "" // TODO: Update placeholder value.
+  targetHttpProxy := "{MY-TARGET-HTTP-PROXY}" // TODO: Update placeholder value.
 
   resp, err := c.TargetHttpProxies.Get(project, targetHttpProxy).Context(ctx).Do()
   if err != nil {
@@ -7058,7 +7058,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   resp, err := c.TargetHttpProxies.Insert(project, &compute.TargetHttpProxy{
                                             // TODO: Fill required fields.
@@ -7102,7 +7102,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
   call := c.TargetHttpProxies.List(project)
@@ -7149,10 +7149,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the TargetHttpProxy to set a URL map for.
-  targetHttpProxy := "" // TODO: Update placeholder value.
+  targetHttpProxy := "{MY-TARGET-HTTP-PROXY}" // TODO: Update placeholder value.
 
   resp, err := c.TargetHttpProxies.SetUrlMap(project, targetHttpProxy, &compute.UrlMapReference{
                                                // TODO: Fill required fields.
@@ -7196,10 +7196,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the TargetHttpsProxy resource to delete.
-  targetHttpsProxy := "" // TODO: Update placeholder value.
+  targetHttpsProxy := "{MY-TARGET-HTTPS-PROXY}" // TODO: Update placeholder value.
 
   resp, err := c.TargetHttpsProxies.Delete(project, targetHttpsProxy).Context(ctx).Do()
   if err != nil {
@@ -7241,10 +7241,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the TargetHttpsProxy resource to return.
-  targetHttpsProxy := "" // TODO: Update placeholder value.
+  targetHttpsProxy := "{MY-TARGET-HTTPS-PROXY}" // TODO: Update placeholder value.
 
   resp, err := c.TargetHttpsProxies.Get(project, targetHttpsProxy).Context(ctx).Do()
   if err != nil {
@@ -7286,7 +7286,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   resp, err := c.TargetHttpsProxies.Insert(project, &compute.TargetHttpsProxy{
                                              // TODO: Fill required fields.
@@ -7330,7 +7330,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
   call := c.TargetHttpsProxies.List(project)
@@ -7377,10 +7377,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the TargetHttpsProxy resource to set an SslCertificates resource for.
-  targetHttpsProxy := "" // TODO: Update placeholder value.
+  targetHttpsProxy := "{MY-TARGET-HTTPS-PROXY}" // TODO: Update placeholder value.
 
   resp, err := c.TargetHttpsProxies.SetSslCertificates(project, targetHttpsProxy, &compute.TargetHttpsProxiesSetSslCertificatesRequest{
                                                          // TODO: Fill required fields.
@@ -7424,10 +7424,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the TargetHttpsProxy resource whose URL map is to be set.
-  targetHttpsProxy := "" // TODO: Update placeholder value.
+  targetHttpsProxy := "{MY-TARGET-HTTPS-PROXY}" // TODO: Update placeholder value.
 
   resp, err := c.TargetHttpsProxies.SetUrlMap(project, targetHttpsProxy, &compute.UrlMapReference{
                                                 // TODO: Fill required fields.
@@ -7471,7 +7471,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
   call := c.TargetInstances.AggregatedList(project)
@@ -7518,13 +7518,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the zone scoping this request.
-  zone := "" // TODO: Update placeholder value.
+  zone := "us-central1-f" // TODO: Update placeholder value.
 
   // Name of the TargetInstance resource to delete.
-  targetInstance := "" // TODO: Update placeholder value.
+  targetInstance := "{MY-TARGET-INSTANCE}" // TODO: Update placeholder value.
 
   resp, err := c.TargetInstances.Delete(project, zone, targetInstance).Context(ctx).Do()
   if err != nil {
@@ -7566,13 +7566,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the zone scoping this request.
-  zone := "" // TODO: Update placeholder value.
+  zone := "us-central1-f" // TODO: Update placeholder value.
 
   // Name of the TargetInstance resource to return.
-  targetInstance := "" // TODO: Update placeholder value.
+  targetInstance := "{MY-TARGET-INSTANCE}" // TODO: Update placeholder value.
 
   resp, err := c.TargetInstances.Get(project, zone, targetInstance).Context(ctx).Do()
   if err != nil {
@@ -7614,10 +7614,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the zone scoping this request.
-  zone := "" // TODO: Update placeholder value.
+  zone := "us-central1-f" // TODO: Update placeholder value.
 
   resp, err := c.TargetInstances.Insert(project, zone, &compute.TargetInstance{
                                           // TODO: Fill required fields.
@@ -7661,10 +7661,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the zone scoping this request.
-  zone := "" // TODO: Update placeholder value.
+  zone := "us-central1-f" // TODO: Update placeholder value.
 
 
   call := c.TargetInstances.List(project, zone)
@@ -7711,13 +7711,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the region scoping this request.
-  region := "" // TODO: Update placeholder value.
+  region := "{MY-REGION}" // TODO: Update placeholder value.
 
   // Name of the target pool to add a health check to.
-  targetPool := "" // TODO: Update placeholder value.
+  targetPool := "{MY-TARGET-POOL}" // TODO: Update placeholder value.
 
   resp, err := c.TargetPools.AddHealthCheck(project, region, targetPool, &compute.TargetPoolsAddHealthCheckRequest{
                                               // TODO: Fill required fields.
@@ -7761,13 +7761,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the region scoping this request.
-  region := "" // TODO: Update placeholder value.
+  region := "{MY-REGION}" // TODO: Update placeholder value.
 
   // Name of the TargetPool resource to add instances to.
-  targetPool := "" // TODO: Update placeholder value.
+  targetPool := "{MY-TARGET-POOL}" // TODO: Update placeholder value.
 
   resp, err := c.TargetPools.AddInstance(project, region, targetPool, &compute.TargetPoolsAddInstanceRequest{
                                            // TODO: Fill required fields.
@@ -7811,7 +7811,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
   call := c.TargetPools.AggregatedList(project)
@@ -7858,13 +7858,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the region scoping this request.
-  region := "" // TODO: Update placeholder value.
+  region := "{MY-REGION}" // TODO: Update placeholder value.
 
   // Name of the TargetPool resource to delete.
-  targetPool := "" // TODO: Update placeholder value.
+  targetPool := "{MY-TARGET-POOL}" // TODO: Update placeholder value.
 
   resp, err := c.TargetPools.Delete(project, region, targetPool).Context(ctx).Do()
   if err != nil {
@@ -7906,13 +7906,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the region scoping this request.
-  region := "" // TODO: Update placeholder value.
+  region := "{MY-REGION}" // TODO: Update placeholder value.
 
   // Name of the TargetPool resource to return.
-  targetPool := "" // TODO: Update placeholder value.
+  targetPool := "{MY-TARGET-POOL}" // TODO: Update placeholder value.
 
   resp, err := c.TargetPools.Get(project, region, targetPool).Context(ctx).Do()
   if err != nil {
@@ -7954,13 +7954,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the region scoping this request.
-  region := "" // TODO: Update placeholder value.
+  region := "{MY-REGION}" // TODO: Update placeholder value.
 
   // Name of the TargetPool resource to which the queried instance belongs.
-  targetPool := "" // TODO: Update placeholder value.
+  targetPool := "{MY-TARGET-POOL}" // TODO: Update placeholder value.
 
   resp, err := c.TargetPools.GetHealth(project, region, targetPool, &compute.InstanceReference{
                                          // TODO: Fill required fields.
@@ -8004,10 +8004,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the region scoping this request.
-  region := "" // TODO: Update placeholder value.
+  region := "{MY-REGION}" // TODO: Update placeholder value.
 
   resp, err := c.TargetPools.Insert(project, region, &compute.TargetPool{
                                       // TODO: Fill required fields.
@@ -8051,10 +8051,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the region scoping this request.
-  region := "" // TODO: Update placeholder value.
+  region := "{MY-REGION}" // TODO: Update placeholder value.
 
 
   call := c.TargetPools.List(project, region)
@@ -8101,13 +8101,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the region for this request.
-  region := "" // TODO: Update placeholder value.
+  region := "{MY-REGION}" // TODO: Update placeholder value.
 
   // Name of the target pool to remove health checks from.
-  targetPool := "" // TODO: Update placeholder value.
+  targetPool := "{MY-TARGET-POOL}" // TODO: Update placeholder value.
 
   resp, err := c.TargetPools.RemoveHealthCheck(project, region, targetPool, &compute.TargetPoolsRemoveHealthCheckRequest{
                                                  // TODO: Fill required fields.
@@ -8151,13 +8151,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the region scoping this request.
-  region := "" // TODO: Update placeholder value.
+  region := "{MY-REGION}" // TODO: Update placeholder value.
 
   // Name of the TargetPool resource to remove instances from.
-  targetPool := "" // TODO: Update placeholder value.
+  targetPool := "{MY-TARGET-POOL}" // TODO: Update placeholder value.
 
   resp, err := c.TargetPools.RemoveInstance(project, region, targetPool, &compute.TargetPoolsRemoveInstanceRequest{
                                               // TODO: Fill required fields.
@@ -8201,13 +8201,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the region scoping this request.
-  region := "" // TODO: Update placeholder value.
+  region := "{MY-REGION}" // TODO: Update placeholder value.
 
   // Name of the TargetPool resource to set a backup pool for.
-  targetPool := "" // TODO: Update placeholder value.
+  targetPool := "{MY-TARGET-POOL}" // TODO: Update placeholder value.
 
   resp, err := c.TargetPools.SetBackup(project, region, targetPool, &compute.TargetReference{
                                          // TODO: Fill required fields.
@@ -8251,7 +8251,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
   call := c.TargetVpnGateways.AggregatedList(project)
@@ -8298,13 +8298,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the region for this request.
-  region := "" // TODO: Update placeholder value.
+  region := "{MY-REGION}" // TODO: Update placeholder value.
 
   // Name of the target VPN gateway to delete.
-  targetVpnGateway := "" // TODO: Update placeholder value.
+  targetVpnGateway := "{MY-TARGET-VPN-GATEWAY}" // TODO: Update placeholder value.
 
   resp, err := c.TargetVpnGateways.Delete(project, region, targetVpnGateway).Context(ctx).Do()
   if err != nil {
@@ -8346,13 +8346,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the region for this request.
-  region := "" // TODO: Update placeholder value.
+  region := "{MY-REGION}" // TODO: Update placeholder value.
 
   // Name of the target VPN gateway to return.
-  targetVpnGateway := "" // TODO: Update placeholder value.
+  targetVpnGateway := "{MY-TARGET-VPN-GATEWAY}" // TODO: Update placeholder value.
 
   resp, err := c.TargetVpnGateways.Get(project, region, targetVpnGateway).Context(ctx).Do()
   if err != nil {
@@ -8394,10 +8394,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the region for this request.
-  region := "" // TODO: Update placeholder value.
+  region := "{MY-REGION}" // TODO: Update placeholder value.
 
   resp, err := c.TargetVpnGateways.Insert(project, region, &compute.TargetVpnGateway{
                                             // TODO: Fill required fields.
@@ -8441,10 +8441,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the region for this request.
-  region := "" // TODO: Update placeholder value.
+  region := "{MY-REGION}" // TODO: Update placeholder value.
 
 
   call := c.TargetVpnGateways.List(project, region)
@@ -8491,10 +8491,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the UrlMap resource to delete.
-  urlMap := "" // TODO: Update placeholder value.
+  urlMap := "{MY-URL-MAP}" // TODO: Update placeholder value.
 
   resp, err := c.UrlMaps.Delete(project, urlMap).Context(ctx).Do()
   if err != nil {
@@ -8536,10 +8536,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the UrlMap resource to return.
-  urlMap := "" // TODO: Update placeholder value.
+  urlMap := "{MY-URL-MAP}" // TODO: Update placeholder value.
 
   resp, err := c.UrlMaps.Get(project, urlMap).Context(ctx).Do()
   if err != nil {
@@ -8581,7 +8581,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   resp, err := c.UrlMaps.Insert(project, &compute.UrlMap{
                                   // TODO: Fill required fields.
@@ -8625,7 +8625,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
   call := c.UrlMaps.List(project)
@@ -8672,10 +8672,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the UrlMap resource to update.
-  urlMap := "" // TODO: Update placeholder value.
+  urlMap := "{MY-URL-MAP}" // TODO: Update placeholder value.
 
   resp, err := c.UrlMaps.Patch(project, urlMap, &compute.UrlMap{
                                  // TODO: Fill required fields.
@@ -8719,10 +8719,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the UrlMap resource to update.
-  urlMap := "" // TODO: Update placeholder value.
+  urlMap := "{MY-URL-MAP}" // TODO: Update placeholder value.
 
   resp, err := c.UrlMaps.Update(project, urlMap, &compute.UrlMap{
                                   // TODO: Fill required fields.
@@ -8766,10 +8766,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the UrlMap resource to be validated as.
-  urlMap := "" // TODO: Update placeholder value.
+  urlMap := "{MY-URL-MAP}" // TODO: Update placeholder value.
 
   resp, err := c.UrlMaps.Validate(project, urlMap, &compute.UrlMapsValidateRequest{
                                     // TODO: Fill required fields.
@@ -8813,7 +8813,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
   call := c.VpnTunnels.AggregatedList(project)
@@ -8860,13 +8860,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the region for this request.
-  region := "" // TODO: Update placeholder value.
+  region := "{MY-REGION}" // TODO: Update placeholder value.
 
   // Name of the VpnTunnel resource to delete.
-  vpnTunnel := "" // TODO: Update placeholder value.
+  vpnTunnel := "{MY-VPN-TUNNEL}" // TODO: Update placeholder value.
 
   resp, err := c.VpnTunnels.Delete(project, region, vpnTunnel).Context(ctx).Do()
   if err != nil {
@@ -8908,13 +8908,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the region for this request.
-  region := "" // TODO: Update placeholder value.
+  region := "{MY-REGION}" // TODO: Update placeholder value.
 
   // Name of the VpnTunnel resource to return.
-  vpnTunnel := "" // TODO: Update placeholder value.
+  vpnTunnel := "{MY-VPN-TUNNEL}" // TODO: Update placeholder value.
 
   resp, err := c.VpnTunnels.Get(project, region, vpnTunnel).Context(ctx).Do()
   if err != nil {
@@ -8956,10 +8956,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the region for this request.
-  region := "" // TODO: Update placeholder value.
+  region := "{MY-REGION}" // TODO: Update placeholder value.
 
   resp, err := c.VpnTunnels.Insert(project, region, &compute.VpnTunnel{
                                      // TODO: Fill required fields.
@@ -9003,10 +9003,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the region for this request.
-  region := "" // TODO: Update placeholder value.
+  region := "{MY-REGION}" // TODO: Update placeholder value.
 
 
   call := c.VpnTunnels.List(project, region)
@@ -9053,13 +9053,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the zone for this request.
-  zone := "" // TODO: Update placeholder value.
+  zone := "us-central1-f" // TODO: Update placeholder value.
 
   // Name of the Operations resource to delete.
-  operation := "" // TODO: Update placeholder value.
+  operation := "{MY-OPERATION}" // TODO: Update placeholder value.
 
   if err := c.ZoneOperations.Delete(project, zone, operation).Context(ctx).Do(); err != nil {
     // TODO: Handle error.
@@ -9098,13 +9098,13 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the zone for this request.
-  zone := "" // TODO: Update placeholder value.
+  zone := "us-central1-f" // TODO: Update placeholder value.
 
   // Name of the Operations resource to return.
-  operation := "" // TODO: Update placeholder value.
+  operation := "{MY-OPERATION}" // TODO: Update placeholder value.
 
   resp, err := c.ZoneOperations.Get(project, zone, operation).Context(ctx).Do()
   if err != nil {
@@ -9146,10 +9146,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the zone for request.
-  zone := "" // TODO: Update placeholder value.
+  zone := "us-central1-f" // TODO: Update placeholder value.
 
 
   call := c.ZoneOperations.List(project, zone)
@@ -9196,10 +9196,10 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the zone resource to return.
-  zone := "" // TODO: Update placeholder value.
+  zone := "us-central1-f" // TODO: Update placeholder value.
 
   resp, err := c.Zones.Get(project, zone).Context(ctx).Do()
   if err != nil {
@@ -9241,7 +9241,7 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
   call := c.Zones.List(project)

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_compute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_compute.v1.json.baseline
@@ -32,7 +32,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
   call := c.Addresses.AggregatedList(project)
@@ -79,13 +80,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the region for this request.
-  region := "{MY-REGION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  region := "{MY-REGION}"
 
   // Name of the address resource to delete.
-  address := "{MY-ADDRESS}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  address := "{MY-ADDRESS}"
 
   resp, err := c.Addresses.Delete(project, region, address).Context(ctx).Do()
   if err != nil {
@@ -127,13 +131,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the region for this request.
-  region := "{MY-REGION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  region := "{MY-REGION}"
 
   // Name of the address resource to return.
-  address := "{MY-ADDRESS}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  address := "{MY-ADDRESS}"
 
   resp, err := c.Addresses.Get(project, region, address).Context(ctx).Do()
   if err != nil {
@@ -175,10 +182,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the region for this request.
-  region := "{MY-REGION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  region := "{MY-REGION}"
 
   resp, err := c.Addresses.Insert(project, region, &compute.Address{
                                     // TODO: Fill required fields.
@@ -222,10 +231,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the region for this request.
-  region := "{MY-REGION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  region := "{MY-REGION}"
 
 
   call := c.Addresses.List(project, region)
@@ -272,7 +283,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
   call := c.Autoscalers.AggregatedList(project)
@@ -319,13 +331,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the zone for this request.
-  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f"
 
   // Name of the autoscaler to delete.
-  autoscaler := "{MY-AUTOSCALER}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  autoscaler := "{MY-AUTOSCALER}"
 
   resp, err := c.Autoscalers.Delete(project, zone, autoscaler).Context(ctx).Do()
   if err != nil {
@@ -367,13 +382,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the zone for this request.
-  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f"
 
   // Name of the autoscaler to return.
-  autoscaler := "{MY-AUTOSCALER}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  autoscaler := "{MY-AUTOSCALER}"
 
   resp, err := c.Autoscalers.Get(project, zone, autoscaler).Context(ctx).Do()
   if err != nil {
@@ -415,10 +433,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the zone for this request.
-  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f"
 
   resp, err := c.Autoscalers.Insert(project, zone, &compute.Autoscaler{
                                       // TODO: Fill required fields.
@@ -462,10 +482,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the zone for this request.
-  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f"
 
 
   call := c.Autoscalers.List(project, zone)
@@ -512,13 +534,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the zone for this request.
-  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f"
 
   // Name of the autoscaler to update.
-  autoscaler := "{MY-AUTOSCALER}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  autoscaler := "{MY-AUTOSCALER}"
 
   resp, err := c.Autoscalers.Patch(project, zone, autoscaler, &compute.Autoscaler{
                                      // TODO: Fill required fields.
@@ -562,10 +587,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the zone for this request.
-  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f"
 
   resp, err := c.Autoscalers.Update(project, zone, &compute.Autoscaler{
                                       // TODO: Fill required fields.
@@ -609,10 +636,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the BackendService resource to delete.
-  backendService := "{MY-BACKEND-SERVICE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  backendService := "{MY-BACKEND-SERVICE}"
 
   resp, err := c.BackendServices.Delete(project, backendService).Context(ctx).Do()
   if err != nil {
@@ -654,10 +683,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the BackendService resource to return.
-  backendService := "{MY-BACKEND-SERVICE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  backendService := "{MY-BACKEND-SERVICE}"
 
   resp, err := c.BackendServices.Get(project, backendService).Context(ctx).Do()
   if err != nil {
@@ -699,10 +730,12 @@ func main() {
   }
 
 
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the BackendService resource to which the queried instance belongs.
-  backendService := "{MY-BACKEND-SERVICE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  backendService := "{MY-BACKEND-SERVICE}"
 
   resp, err := c.BackendServices.GetHealth(project, backendService, &compute.ResourceGroupReference{
                                              // TODO: Fill required fields.
@@ -746,7 +779,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   resp, err := c.BackendServices.Insert(project, &compute.BackendService{
                                           // TODO: Fill required fields.
@@ -790,7 +824,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
   call := c.BackendServices.List(project)
@@ -837,10 +872,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the BackendService resource to update.
-  backendService := "{MY-BACKEND-SERVICE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  backendService := "{MY-BACKEND-SERVICE}"
 
   resp, err := c.BackendServices.Patch(project, backendService, &compute.BackendService{
                                          // TODO: Fill required fields.
@@ -884,10 +921,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the BackendService resource to update.
-  backendService := "{MY-BACKEND-SERVICE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  backendService := "{MY-BACKEND-SERVICE}"
 
   resp, err := c.BackendServices.Update(project, backendService, &compute.BackendService{
                                           // TODO: Fill required fields.
@@ -931,7 +970,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
   call := c.DiskTypes.AggregatedList(project)
@@ -978,13 +1018,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone for this request.
-  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f"
 
   // Name of the disk type to return.
-  diskType := "{MY-DISK-TYPE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  diskType := "{MY-DISK-TYPE}"
 
   resp, err := c.DiskTypes.Get(project, zone, diskType).Context(ctx).Do()
   if err != nil {
@@ -1026,10 +1069,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone for this request.
-  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f"
 
 
   call := c.DiskTypes.List(project, zone)
@@ -1076,7 +1121,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
   call := c.Disks.AggregatedList(project)
@@ -1123,13 +1169,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone for this request.
-  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f"
 
   // Name of the persistent disk to snapshot.
-  disk := "{MY-DISK}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  disk := "{MY-DISK}"
 
   resp, err := c.Disks.CreateSnapshot(project, zone, disk, &compute.Snapshot{
                                         // TODO: Fill required fields.
@@ -1173,13 +1222,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone for this request.
-  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f"
 
   // Name of the persistent disk to delete.
-  disk := "{MY-DISK}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  disk := "{MY-DISK}"
 
   resp, err := c.Disks.Delete(project, zone, disk).Context(ctx).Do()
   if err != nil {
@@ -1221,13 +1273,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone for this request.
-  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f"
 
   // Name of the persistent disk to return.
-  disk := "{MY-DISK}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  disk := "{MY-DISK}"
 
   resp, err := c.Disks.Get(project, zone, disk).Context(ctx).Do()
   if err != nil {
@@ -1269,10 +1324,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone for this request.
-  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f"
 
   resp, err := c.Disks.Insert(project, zone, &compute.Disk{
                                 // TODO: Fill required fields.
@@ -1316,10 +1373,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone for this request.
-  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f"
 
 
   call := c.Disks.List(project, zone)
@@ -1366,10 +1425,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the firewall rule to delete.
-  firewall := "{MY-FIREWALL}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  firewall := "{MY-FIREWALL}"
 
   resp, err := c.Firewalls.Delete(project, firewall).Context(ctx).Do()
   if err != nil {
@@ -1411,10 +1472,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the firewall rule to return.
-  firewall := "{MY-FIREWALL}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  firewall := "{MY-FIREWALL}"
 
   resp, err := c.Firewalls.Get(project, firewall).Context(ctx).Do()
   if err != nil {
@@ -1456,7 +1519,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   resp, err := c.Firewalls.Insert(project, &compute.Firewall{
                                     // TODO: Fill required fields.
@@ -1500,7 +1564,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
   call := c.Firewalls.List(project)
@@ -1547,10 +1612,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the firewall rule to update.
-  firewall := "{MY-FIREWALL}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  firewall := "{MY-FIREWALL}"
 
   resp, err := c.Firewalls.Patch(project, firewall, &compute.Firewall{
                                    // TODO: Fill required fields.
@@ -1594,10 +1661,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the firewall rule to update.
-  firewall := "{MY-FIREWALL}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  firewall := "{MY-FIREWALL}"
 
   resp, err := c.Firewalls.Update(project, firewall, &compute.Firewall{
                                     // TODO: Fill required fields.
@@ -1641,7 +1710,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
   call := c.ForwardingRules.AggregatedList(project)
@@ -1688,13 +1758,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the region scoping this request.
-  region := "{MY-REGION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  region := "{MY-REGION}"
 
   // Name of the ForwardingRule resource to delete.
-  forwardingRule := "{MY-FORWARDING-RULE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  forwardingRule := "{MY-FORWARDING-RULE}"
 
   resp, err := c.ForwardingRules.Delete(project, region, forwardingRule).Context(ctx).Do()
   if err != nil {
@@ -1736,13 +1809,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the region scoping this request.
-  region := "{MY-REGION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  region := "{MY-REGION}"
 
   // Name of the ForwardingRule resource to return.
-  forwardingRule := "{MY-FORWARDING-RULE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  forwardingRule := "{MY-FORWARDING-RULE}"
 
   resp, err := c.ForwardingRules.Get(project, region, forwardingRule).Context(ctx).Do()
   if err != nil {
@@ -1784,10 +1860,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the region scoping this request.
-  region := "{MY-REGION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  region := "{MY-REGION}"
 
   resp, err := c.ForwardingRules.Insert(project, region, &compute.ForwardingRule{
                                           // TODO: Fill required fields.
@@ -1831,10 +1909,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the region scoping this request.
-  region := "{MY-REGION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  region := "{MY-REGION}"
 
 
   call := c.ForwardingRules.List(project, region)
@@ -1881,13 +1961,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the region scoping this request.
-  region := "{MY-REGION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  region := "{MY-REGION}"
 
   // Name of the ForwardingRule resource in which target is to be set.
-  forwardingRule := "{MY-FORWARDING-RULE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  forwardingRule := "{MY-FORWARDING-RULE}"
 
   resp, err := c.ForwardingRules.SetTarget(project, region, forwardingRule, &compute.TargetReference{
                                              // TODO: Fill required fields.
@@ -1931,10 +2014,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the address resource to delete.
-  address := "{MY-ADDRESS}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  address := "{MY-ADDRESS}"
 
   resp, err := c.GlobalAddresses.Delete(project, address).Context(ctx).Do()
   if err != nil {
@@ -1976,10 +2061,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the address resource to return.
-  address := "{MY-ADDRESS}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  address := "{MY-ADDRESS}"
 
   resp, err := c.GlobalAddresses.Get(project, address).Context(ctx).Do()
   if err != nil {
@@ -2021,7 +2108,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   resp, err := c.GlobalAddresses.Insert(project, &compute.Address{
                                           // TODO: Fill required fields.
@@ -2065,7 +2153,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
   call := c.GlobalAddresses.List(project)
@@ -2112,10 +2201,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the ForwardingRule resource to delete.
-  forwardingRule := "{MY-FORWARDING-RULE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  forwardingRule := "{MY-FORWARDING-RULE}"
 
   resp, err := c.GlobalForwardingRules.Delete(project, forwardingRule).Context(ctx).Do()
   if err != nil {
@@ -2157,10 +2248,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the ForwardingRule resource to return.
-  forwardingRule := "{MY-FORWARDING-RULE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  forwardingRule := "{MY-FORWARDING-RULE}"
 
   resp, err := c.GlobalForwardingRules.Get(project, forwardingRule).Context(ctx).Do()
   if err != nil {
@@ -2202,7 +2295,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   resp, err := c.GlobalForwardingRules.Insert(project, &compute.ForwardingRule{
                                                 // TODO: Fill required fields.
@@ -2246,7 +2340,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
   call := c.GlobalForwardingRules.List(project)
@@ -2293,10 +2388,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the ForwardingRule resource in which target is to be set.
-  forwardingRule := "{MY-FORWARDING-RULE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  forwardingRule := "{MY-FORWARDING-RULE}"
 
   resp, err := c.GlobalForwardingRules.SetTarget(project, forwardingRule, &compute.TargetReference{
                                                    // TODO: Fill required fields.
@@ -2340,7 +2437,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
   call := c.GlobalOperations.AggregatedList(project)
@@ -2387,10 +2485,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the Operations resource to delete.
-  operation := "{MY-OPERATION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  operation := "{MY-OPERATION}"
 
   if err := c.GlobalOperations.Delete(project, operation).Context(ctx).Do(); err != nil {
     // TODO: Handle error.
@@ -2429,10 +2529,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the Operations resource to return.
-  operation := "{MY-OPERATION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  operation := "{MY-OPERATION}"
 
   resp, err := c.GlobalOperations.Get(project, operation).Context(ctx).Do()
   if err != nil {
@@ -2474,7 +2576,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
   call := c.GlobalOperations.List(project)
@@ -2521,10 +2624,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the HttpHealthCheck resource to delete.
-  httpHealthCheck := "{MY-HTTP-HEALTH-CHECK}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  httpHealthCheck := "{MY-HTTP-HEALTH-CHECK}"
 
   resp, err := c.HttpHealthChecks.Delete(project, httpHealthCheck).Context(ctx).Do()
   if err != nil {
@@ -2566,10 +2671,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the HttpHealthCheck resource to return.
-  httpHealthCheck := "{MY-HTTP-HEALTH-CHECK}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  httpHealthCheck := "{MY-HTTP-HEALTH-CHECK}"
 
   resp, err := c.HttpHealthChecks.Get(project, httpHealthCheck).Context(ctx).Do()
   if err != nil {
@@ -2611,7 +2718,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   resp, err := c.HttpHealthChecks.Insert(project, &compute.HttpHealthCheck{
                                            // TODO: Fill required fields.
@@ -2655,7 +2763,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
   call := c.HttpHealthChecks.List(project)
@@ -2702,10 +2811,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the HttpHealthCheck resource to update.
-  httpHealthCheck := "{MY-HTTP-HEALTH-CHECK}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  httpHealthCheck := "{MY-HTTP-HEALTH-CHECK}"
 
   resp, err := c.HttpHealthChecks.Patch(project, httpHealthCheck, &compute.HttpHealthCheck{
                                           // TODO: Fill required fields.
@@ -2749,10 +2860,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the HttpHealthCheck resource to update.
-  httpHealthCheck := "{MY-HTTP-HEALTH-CHECK}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  httpHealthCheck := "{MY-HTTP-HEALTH-CHECK}"
 
   resp, err := c.HttpHealthChecks.Update(project, httpHealthCheck, &compute.HttpHealthCheck{
                                            // TODO: Fill required fields.
@@ -2796,10 +2909,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the HttpsHealthCheck resource to delete.
-  httpsHealthCheck := "{MY-HTTPS-HEALTH-CHECK}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  httpsHealthCheck := "{MY-HTTPS-HEALTH-CHECK}"
 
   resp, err := c.HttpsHealthChecks.Delete(project, httpsHealthCheck).Context(ctx).Do()
   if err != nil {
@@ -2841,10 +2956,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the HttpsHealthCheck resource to return.
-  httpsHealthCheck := "{MY-HTTPS-HEALTH-CHECK}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  httpsHealthCheck := "{MY-HTTPS-HEALTH-CHECK}"
 
   resp, err := c.HttpsHealthChecks.Get(project, httpsHealthCheck).Context(ctx).Do()
   if err != nil {
@@ -2886,7 +3003,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   resp, err := c.HttpsHealthChecks.Insert(project, &compute.HttpsHealthCheck{
                                             // TODO: Fill required fields.
@@ -2930,7 +3048,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
   call := c.HttpsHealthChecks.List(project)
@@ -2977,10 +3096,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the HttpsHealthCheck resource to update.
-  httpsHealthCheck := "{MY-HTTPS-HEALTH-CHECK}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  httpsHealthCheck := "{MY-HTTPS-HEALTH-CHECK}"
 
   resp, err := c.HttpsHealthChecks.Patch(project, httpsHealthCheck, &compute.HttpsHealthCheck{
                                            // TODO: Fill required fields.
@@ -3024,10 +3145,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the HttpsHealthCheck resource to update.
-  httpsHealthCheck := "{MY-HTTPS-HEALTH-CHECK}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  httpsHealthCheck := "{MY-HTTPS-HEALTH-CHECK}"
 
   resp, err := c.HttpsHealthChecks.Update(project, httpsHealthCheck, &compute.HttpsHealthCheck{
                                             // TODO: Fill required fields.
@@ -3071,10 +3194,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the image resource to delete.
-  image := "{MY-IMAGE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  image := "{MY-IMAGE}"
 
   resp, err := c.Images.Delete(project, image).Context(ctx).Do()
   if err != nil {
@@ -3116,10 +3241,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Image name.
-  image := "{MY-IMAGE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  image := "{MY-IMAGE}"
 
   resp, err := c.Images.Deprecate(project, image, &compute.DeprecationStatus{
                                     // TODO: Fill required fields.
@@ -3163,10 +3290,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the image resource to return.
-  image := "{MY-IMAGE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  image := "{MY-IMAGE}"
 
   resp, err := c.Images.Get(project, image).Context(ctx).Do()
   if err != nil {
@@ -3208,7 +3337,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   resp, err := c.Images.Insert(project, &compute.Image{
                                  // TODO: Fill required fields.
@@ -3252,7 +3382,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
   call := c.Images.List(project)
@@ -3299,13 +3430,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone where the managed instance group is located.
-  zone := "{MY-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"
 
   // The name of the managed instance group.
-  instanceGroupManager := "{MY-INSTANCE-GROUP-MANAGER}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instanceGroupManager := "{MY-INSTANCE-GROUP-MANAGER}"
 
   resp, err := c.InstanceGroupManagers.AbandonInstances(project, zone, instanceGroupManager, &compute.InstanceGroupManagersAbandonInstancesRequest{
                                                           // TODO: Fill required fields.
@@ -3349,7 +3483,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
   call := c.InstanceGroupManagers.AggregatedList(project)
@@ -3396,13 +3531,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone where the managed instance group is located.
-  zone := "{MY-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"
 
   // The name of the managed instance group to delete.
-  instanceGroupManager := "{MY-INSTANCE-GROUP-MANAGER}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instanceGroupManager := "{MY-INSTANCE-GROUP-MANAGER}"
 
   resp, err := c.InstanceGroupManagers.Delete(project, zone, instanceGroupManager).Context(ctx).Do()
   if err != nil {
@@ -3444,13 +3582,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone where the managed instance group is located.
-  zone := "{MY-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"
 
   // The name of the managed instance group.
-  instanceGroupManager := "{MY-INSTANCE-GROUP-MANAGER}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instanceGroupManager := "{MY-INSTANCE-GROUP-MANAGER}"
 
   resp, err := c.InstanceGroupManagers.DeleteInstances(project, zone, instanceGroupManager, &compute.InstanceGroupManagersDeleteInstancesRequest{
                                                          // TODO: Fill required fields.
@@ -3494,13 +3635,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone where the managed instance group is located.
-  zone := "{MY-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"
 
   // The name of the managed instance group.
-  instanceGroupManager := "{MY-INSTANCE-GROUP-MANAGER}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instanceGroupManager := "{MY-INSTANCE-GROUP-MANAGER}"
 
   resp, err := c.InstanceGroupManagers.Get(project, zone, instanceGroupManager).Context(ctx).Do()
   if err != nil {
@@ -3542,10 +3686,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone where you want to create the managed instance group.
-  zone := "{MY-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"
 
   resp, err := c.InstanceGroupManagers.Insert(project, zone, &compute.InstanceGroupManager{
                                                 // TODO: Fill required fields.
@@ -3589,10 +3735,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone where the managed instance group is located.
-  zone := "{MY-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"
 
 
   call := c.InstanceGroupManagers.List(project, zone)
@@ -3639,13 +3787,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone where the managed instance group is located.
-  zone := "{MY-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"
 
   // The name of the managed instance group.
-  instanceGroupManager := "{MY-INSTANCE-GROUP-MANAGER}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instanceGroupManager := "{MY-INSTANCE-GROUP-MANAGER}"
 
   resp, err := c.InstanceGroupManagers.ListManagedInstances(project, zone, instanceGroupManager).Context(ctx).Do()
   if err != nil {
@@ -3687,13 +3838,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone where the managed instance group is located.
-  zone := "{MY-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"
 
   // The name of the managed instance group.
-  instanceGroupManager := "{MY-INSTANCE-GROUP-MANAGER}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instanceGroupManager := "{MY-INSTANCE-GROUP-MANAGER}"
 
   resp, err := c.InstanceGroupManagers.RecreateInstances(project, zone, instanceGroupManager, &compute.InstanceGroupManagersRecreateInstancesRequest{
                                                            // TODO: Fill required fields.
@@ -3737,18 +3891,22 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone where the managed instance group is located.
-  zone := "{MY-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"
 
   // The name of the managed instance group.
-  instanceGroupManager := "{MY-INSTANCE-GROUP-MANAGER}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instanceGroupManager := "{MY-INSTANCE-GROUP-MANAGER}"
 
   // The number of running instances that the managed instance group should maintain at any given time.
   // The group automatically adds or removes instances to maintain the number of instances specified by
   // this parameter.
-  size := int64(0) // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  size := int64(0)
 
   resp, err := c.InstanceGroupManagers.Resize(project, zone, instanceGroupManager, size).Context(ctx).Do()
   if err != nil {
@@ -3790,13 +3948,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone where the managed instance group is located.
-  zone := "{MY-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"
 
   // The name of the managed instance group.
-  instanceGroupManager := "{MY-INSTANCE-GROUP-MANAGER}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instanceGroupManager := "{MY-INSTANCE-GROUP-MANAGER}"
 
   resp, err := c.InstanceGroupManagers.SetInstanceTemplate(project, zone, instanceGroupManager, &compute.InstanceGroupManagersSetInstanceTemplateRequest{
                                                              // TODO: Fill required fields.
@@ -3840,13 +4001,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone where the managed instance group is located.
-  zone := "{MY-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"
 
   // The name of the managed instance group.
-  instanceGroupManager := "{MY-INSTANCE-GROUP-MANAGER}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instanceGroupManager := "{MY-INSTANCE-GROUP-MANAGER}"
 
   resp, err := c.InstanceGroupManagers.SetTargetPools(project, zone, instanceGroupManager, &compute.InstanceGroupManagersSetTargetPoolsRequest{
                                                         // TODO: Fill required fields.
@@ -3890,13 +4054,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone where the instance group is located.
-  zone := "{MY-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"
 
   // The name of the instance group where you are adding instances.
-  instanceGroup := "{MY-INSTANCE-GROUP}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instanceGroup := "{MY-INSTANCE-GROUP}"
 
   resp, err := c.InstanceGroups.AddInstances(project, zone, instanceGroup, &compute.InstanceGroupsAddInstancesRequest{
                                                // TODO: Fill required fields.
@@ -3940,7 +4107,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
   call := c.InstanceGroups.AggregatedList(project)
@@ -3987,13 +4155,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone where the instance group is located.
-  zone := "{MY-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"
 
   // The name of the instance group to delete.
-  instanceGroup := "{MY-INSTANCE-GROUP}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instanceGroup := "{MY-INSTANCE-GROUP}"
 
   resp, err := c.InstanceGroups.Delete(project, zone, instanceGroup).Context(ctx).Do()
   if err != nil {
@@ -4035,13 +4206,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone where the instance group is located.
-  zone := "{MY-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"
 
   // The name of the instance group.
-  instanceGroup := "{MY-INSTANCE-GROUP}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instanceGroup := "{MY-INSTANCE-GROUP}"
 
   resp, err := c.InstanceGroups.Get(project, zone, instanceGroup).Context(ctx).Do()
   if err != nil {
@@ -4083,10 +4257,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone where you want to create the instance group.
-  zone := "{MY-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"
 
   resp, err := c.InstanceGroups.Insert(project, zone, &compute.InstanceGroup{
                                          // TODO: Fill required fields.
@@ -4130,10 +4306,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone where the instance group is located.
-  zone := "{MY-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"
 
 
   call := c.InstanceGroups.List(project, zone)
@@ -4180,13 +4358,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone where the instance group is located.
-  zone := "{MY-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"
 
   // The name of the instance group from which you want to generate a list of included instances.
-  instanceGroup := "{MY-INSTANCE-GROUP}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instanceGroup := "{MY-INSTANCE-GROUP}"
 
   resp, err := c.InstanceGroups.ListInstances(project, zone, instanceGroup, &compute.InstanceGroupsListInstancesRequest{
                                                 // TODO: Fill required fields.
@@ -4230,13 +4411,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone where the instance group is located.
-  zone := "{MY-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"
 
   // The name of the instance group where the specified instances will be removed.
-  instanceGroup := "{MY-INSTANCE-GROUP}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instanceGroup := "{MY-INSTANCE-GROUP}"
 
   resp, err := c.InstanceGroups.RemoveInstances(project, zone, instanceGroup, &compute.InstanceGroupsRemoveInstancesRequest{
                                                   // TODO: Fill required fields.
@@ -4280,13 +4464,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone where the instance group is located.
-  zone := "{MY-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"
 
   // The name of the instance group where the named ports are updated.
-  instanceGroup := "{MY-INSTANCE-GROUP}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instanceGroup := "{MY-INSTANCE-GROUP}"
 
   resp, err := c.InstanceGroups.SetNamedPorts(project, zone, instanceGroup, &compute.InstanceGroupsSetNamedPortsRequest{
                                                 // TODO: Fill required fields.
@@ -4330,10 +4517,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the instance template to delete.
-  instanceTemplate := "{MY-INSTANCE-TEMPLATE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instanceTemplate := "{MY-INSTANCE-TEMPLATE}"
 
   resp, err := c.InstanceTemplates.Delete(project, instanceTemplate).Context(ctx).Do()
   if err != nil {
@@ -4375,10 +4564,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the instance template.
-  instanceTemplate := "{MY-INSTANCE-TEMPLATE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instanceTemplate := "{MY-INSTANCE-TEMPLATE}"
 
   resp, err := c.InstanceTemplates.Get(project, instanceTemplate).Context(ctx).Do()
   if err != nil {
@@ -4420,7 +4611,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   resp, err := c.InstanceTemplates.Insert(project, &compute.InstanceTemplate{
                                             // TODO: Fill required fields.
@@ -4464,7 +4656,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
   call := c.InstanceTemplates.List(project)
@@ -4511,16 +4704,20 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone for this request.
-  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f"
 
   // The instance name for this request.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   // The name of the network interface to add to this instance.
-  networkInterface := "{MY-NETWORK-INTERFACE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  networkInterface := "{MY-NETWORK-INTERFACE}"
 
   resp, err := c.Instances.AddAccessConfig(project, zone, instance, networkInterface, &compute.AccessConfig{
                                              // TODO: Fill required fields.
@@ -4564,7 +4761,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
   call := c.Instances.AggregatedList(project)
@@ -4611,13 +4809,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone for this request.
-  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f"
 
   // The instance name for this request.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   resp, err := c.Instances.AttachDisk(project, zone, instance, &compute.AttachedDisk{
                                         // TODO: Fill required fields.
@@ -4661,13 +4862,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone for this request.
-  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f"
 
   // Name of the instance resource to delete.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   resp, err := c.Instances.Delete(project, zone, instance).Context(ctx).Do()
   if err != nil {
@@ -4709,19 +4913,24 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone for this request.
-  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f"
 
   // The instance name for this request.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   // The name of the access config to delete.
-  accessConfig := "{MY-ACCESS-CONFIG}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  accessConfig := "{MY-ACCESS-CONFIG}"
 
   // The name of the network interface.
-  networkInterface := "{MY-NETWORK-INTERFACE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  networkInterface := "{MY-NETWORK-INTERFACE}"
 
   resp, err := c.Instances.DeleteAccessConfig(project, zone, instance, accessConfig, networkInterface).Context(ctx).Do()
   if err != nil {
@@ -4763,16 +4972,20 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone for this request.
-  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f"
 
   // Instance name.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   // Disk device name to detach.
-  deviceName := "{MY-DEVICE-NAME}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  deviceName := "{MY-DEVICE-NAME}"
 
   resp, err := c.Instances.DetachDisk(project, zone, instance, deviceName).Context(ctx).Do()
   if err != nil {
@@ -4814,13 +5027,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone for this request.
-  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f"
 
   // Name of the instance resource to return.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   resp, err := c.Instances.Get(project, zone, instance).Context(ctx).Do()
   if err != nil {
@@ -4862,13 +5078,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone for this request.
-  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f"
 
   // Name of the instance scoping this request.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   resp, err := c.Instances.GetSerialPortOutput(project, zone, instance).Context(ctx).Do()
   if err != nil {
@@ -4910,10 +5129,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone for this request.
-  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f"
 
   resp, err := c.Instances.Insert(project, zone, &compute.Instance{
                                     // TODO: Fill required fields.
@@ -4957,10 +5178,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone for this request.
-  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f"
 
 
   call := c.Instances.List(project, zone)
@@ -5007,13 +5230,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone for this request.
-  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f"
 
   // Name of the instance scoping this request.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   resp, err := c.Instances.Reset(project, zone, instance).Context(ctx).Do()
   if err != nil {
@@ -5055,19 +5281,24 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone for this request.
-  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f"
 
   // The instance name.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   // Whether to auto-delete the disk when the instance is deleted.
-  autoDelete := false // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  autoDelete := false
 
   // The device name of the disk to modify.
-  deviceName := "{MY-DEVICE-NAME}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  deviceName := "{MY-DEVICE-NAME}"
 
   resp, err := c.Instances.SetDiskAutoDelete(project, zone, instance, autoDelete, deviceName).Context(ctx).Do()
   if err != nil {
@@ -5109,13 +5340,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone for this request.
-  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f"
 
   // Name of the instance scoping this request.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   resp, err := c.Instances.SetMachineType(project, zone, instance, &compute.InstancesSetMachineTypeRequest{
                                             // TODO: Fill required fields.
@@ -5159,13 +5393,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone for this request.
-  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f"
 
   // Name of the instance scoping this request.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   resp, err := c.Instances.SetMetadata(project, zone, instance, &compute.Metadata{
                                          // TODO: Fill required fields.
@@ -5209,13 +5446,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone for this request.
-  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f"
 
   // Instance name.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   resp, err := c.Instances.SetScheduling(project, zone, instance, &compute.Scheduling{
                                            // TODO: Fill required fields.
@@ -5259,13 +5499,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone for this request.
-  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f"
 
   // Name of the instance scoping this request.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   resp, err := c.Instances.SetTags(project, zone, instance, &compute.Tags{
                                      // TODO: Fill required fields.
@@ -5309,13 +5552,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone for this request.
-  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f"
 
   // Name of the instance resource to start.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   resp, err := c.Instances.Start(project, zone, instance).Context(ctx).Do()
   if err != nil {
@@ -5357,13 +5603,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone for this request.
-  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f"
 
   // Name of the instance resource to stop.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   resp, err := c.Instances.Stop(project, zone, instance).Context(ctx).Do()
   if err != nil {
@@ -5405,10 +5654,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the License resource to return.
-  license := "{MY-LICENSE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  license := "{MY-LICENSE}"
 
   resp, err := c.Licenses.Get(project, license).Context(ctx).Do()
   if err != nil {
@@ -5450,7 +5701,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
   call := c.MachineTypes.AggregatedList(project)
@@ -5497,13 +5749,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone for this request.
-  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f"
 
   // Name of the machine type to return.
-  machineType := "{MY-MACHINE-TYPE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  machineType := "{MY-MACHINE-TYPE}"
 
   resp, err := c.MachineTypes.Get(project, zone, machineType).Context(ctx).Do()
   if err != nil {
@@ -5545,10 +5800,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone for this request.
-  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f"
 
 
   call := c.MachineTypes.List(project, zone)
@@ -5595,10 +5852,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the network to delete.
-  network := "{MY-NETWORK}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  network := "{MY-NETWORK}"
 
   resp, err := c.Networks.Delete(project, network).Context(ctx).Do()
   if err != nil {
@@ -5640,10 +5899,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the network to return.
-  network := "{MY-NETWORK}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  network := "{MY-NETWORK}"
 
   resp, err := c.Networks.Get(project, network).Context(ctx).Do()
   if err != nil {
@@ -5685,7 +5946,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   resp, err := c.Networks.Insert(project, &compute.Network{
                                    // TODO: Fill required fields.
@@ -5729,7 +5991,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
   call := c.Networks.List(project)
@@ -5776,7 +6039,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   resp, err := c.Projects.Get(project).Context(ctx).Do()
   if err != nil {
@@ -5818,7 +6082,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   resp, err := c.Projects.MoveDisk(project, &compute.DiskMoveRequest{
                                      // TODO: Fill required fields.
@@ -5862,7 +6127,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   resp, err := c.Projects.MoveInstance(project, &compute.InstanceMoveRequest{
                                          // TODO: Fill required fields.
@@ -5906,7 +6172,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   resp, err := c.Projects.SetCommonInstanceMetadata(project, &compute.Metadata{
                                                       // TODO: Fill required fields.
@@ -5950,7 +6217,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   resp, err := c.Projects.SetUsageExportBucket(project, &compute.UsageExportLocation{
                                                  // TODO: Fill required fields.
@@ -5994,13 +6262,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the region for this request.
-  region := "{MY-REGION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  region := "{MY-REGION}"
 
   // Name of the Operations resource to delete.
-  operation := "{MY-OPERATION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  operation := "{MY-OPERATION}"
 
   if err := c.RegionOperations.Delete(project, region, operation).Context(ctx).Do(); err != nil {
     // TODO: Handle error.
@@ -6039,13 +6310,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the region for this request.
-  region := "{MY-REGION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  region := "{MY-REGION}"
 
   // Name of the Operations resource to return.
-  operation := "{MY-OPERATION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  operation := "{MY-OPERATION}"
 
   resp, err := c.RegionOperations.Get(project, region, operation).Context(ctx).Do()
   if err != nil {
@@ -6087,10 +6361,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the region for this request.
-  region := "{MY-REGION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  region := "{MY-REGION}"
 
 
   call := c.RegionOperations.List(project, region)
@@ -6137,10 +6413,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the region resource to return.
-  region := "{MY-REGION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  region := "{MY-REGION}"
 
   resp, err := c.Regions.Get(project, region).Context(ctx).Do()
   if err != nil {
@@ -6182,7 +6460,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
   call := c.Regions.List(project)
@@ -6229,10 +6508,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the Route resource to delete.
-  route := "{MY-ROUTE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  route := "{MY-ROUTE}"
 
   resp, err := c.Routes.Delete(project, route).Context(ctx).Do()
   if err != nil {
@@ -6274,10 +6555,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the Route resource to return.
-  route := "{MY-ROUTE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  route := "{MY-ROUTE}"
 
   resp, err := c.Routes.Get(project, route).Context(ctx).Do()
   if err != nil {
@@ -6319,7 +6602,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   resp, err := c.Routes.Insert(project, &compute.Route{
                                  // TODO: Fill required fields.
@@ -6363,7 +6647,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
   call := c.Routes.List(project)
@@ -6410,10 +6695,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the Snapshot resource to delete.
-  snapshot := "{MY-SNAPSHOT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  snapshot := "{MY-SNAPSHOT}"
 
   resp, err := c.Snapshots.Delete(project, snapshot).Context(ctx).Do()
   if err != nil {
@@ -6455,10 +6742,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the Snapshot resource to return.
-  snapshot := "{MY-SNAPSHOT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  snapshot := "{MY-SNAPSHOT}"
 
   resp, err := c.Snapshots.Get(project, snapshot).Context(ctx).Do()
   if err != nil {
@@ -6500,7 +6789,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
   call := c.Snapshots.List(project)
@@ -6547,10 +6837,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the SslCertificate resource to delete.
-  sslCertificate := "{MY-SSL-CERTIFICATE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  sslCertificate := "{MY-SSL-CERTIFICATE}"
 
   resp, err := c.SslCertificates.Delete(project, sslCertificate).Context(ctx).Do()
   if err != nil {
@@ -6592,10 +6884,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the SslCertificate resource to return.
-  sslCertificate := "{MY-SSL-CERTIFICATE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  sslCertificate := "{MY-SSL-CERTIFICATE}"
 
   resp, err := c.SslCertificates.Get(project, sslCertificate).Context(ctx).Do()
   if err != nil {
@@ -6637,7 +6931,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   resp, err := c.SslCertificates.Insert(project, &compute.SslCertificate{
                                           // TODO: Fill required fields.
@@ -6681,7 +6976,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
   call := c.SslCertificates.List(project)
@@ -6728,7 +7024,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
   call := c.Subnetworks.AggregatedList(project)
@@ -6775,13 +7072,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the region scoping this request.
-  region := "{MY-REGION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  region := "{MY-REGION}"
 
   // Name of the Subnetwork resource to delete.
-  subnetwork := "{MY-SUBNETWORK}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  subnetwork := "{MY-SUBNETWORK}"
 
   resp, err := c.Subnetworks.Delete(project, region, subnetwork).Context(ctx).Do()
   if err != nil {
@@ -6823,13 +7123,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the region scoping this request.
-  region := "{MY-REGION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  region := "{MY-REGION}"
 
   // Name of the Subnetwork resource to return.
-  subnetwork := "{MY-SUBNETWORK}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  subnetwork := "{MY-SUBNETWORK}"
 
   resp, err := c.Subnetworks.Get(project, region, subnetwork).Context(ctx).Do()
   if err != nil {
@@ -6871,10 +7174,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the region scoping this request.
-  region := "{MY-REGION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  region := "{MY-REGION}"
 
   resp, err := c.Subnetworks.Insert(project, region, &compute.Subnetwork{
                                       // TODO: Fill required fields.
@@ -6918,10 +7223,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the region scoping this request.
-  region := "{MY-REGION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  region := "{MY-REGION}"
 
 
   call := c.Subnetworks.List(project, region)
@@ -6968,10 +7275,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the TargetHttpProxy resource to delete.
-  targetHttpProxy := "{MY-TARGET-HTTP-PROXY}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  targetHttpProxy := "{MY-TARGET-HTTP-PROXY}"
 
   resp, err := c.TargetHttpProxies.Delete(project, targetHttpProxy).Context(ctx).Do()
   if err != nil {
@@ -7013,10 +7322,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the TargetHttpProxy resource to return.
-  targetHttpProxy := "{MY-TARGET-HTTP-PROXY}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  targetHttpProxy := "{MY-TARGET-HTTP-PROXY}"
 
   resp, err := c.TargetHttpProxies.Get(project, targetHttpProxy).Context(ctx).Do()
   if err != nil {
@@ -7058,7 +7369,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   resp, err := c.TargetHttpProxies.Insert(project, &compute.TargetHttpProxy{
                                             // TODO: Fill required fields.
@@ -7102,7 +7414,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
   call := c.TargetHttpProxies.List(project)
@@ -7149,10 +7462,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the TargetHttpProxy to set a URL map for.
-  targetHttpProxy := "{MY-TARGET-HTTP-PROXY}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  targetHttpProxy := "{MY-TARGET-HTTP-PROXY}"
 
   resp, err := c.TargetHttpProxies.SetUrlMap(project, targetHttpProxy, &compute.UrlMapReference{
                                                // TODO: Fill required fields.
@@ -7196,10 +7511,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the TargetHttpsProxy resource to delete.
-  targetHttpsProxy := "{MY-TARGET-HTTPS-PROXY}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  targetHttpsProxy := "{MY-TARGET-HTTPS-PROXY}"
 
   resp, err := c.TargetHttpsProxies.Delete(project, targetHttpsProxy).Context(ctx).Do()
   if err != nil {
@@ -7241,10 +7558,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the TargetHttpsProxy resource to return.
-  targetHttpsProxy := "{MY-TARGET-HTTPS-PROXY}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  targetHttpsProxy := "{MY-TARGET-HTTPS-PROXY}"
 
   resp, err := c.TargetHttpsProxies.Get(project, targetHttpsProxy).Context(ctx).Do()
   if err != nil {
@@ -7286,7 +7605,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   resp, err := c.TargetHttpsProxies.Insert(project, &compute.TargetHttpsProxy{
                                              // TODO: Fill required fields.
@@ -7330,7 +7650,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
   call := c.TargetHttpsProxies.List(project)
@@ -7377,10 +7698,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the TargetHttpsProxy resource to set an SslCertificates resource for.
-  targetHttpsProxy := "{MY-TARGET-HTTPS-PROXY}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  targetHttpsProxy := "{MY-TARGET-HTTPS-PROXY}"
 
   resp, err := c.TargetHttpsProxies.SetSslCertificates(project, targetHttpsProxy, &compute.TargetHttpsProxiesSetSslCertificatesRequest{
                                                          // TODO: Fill required fields.
@@ -7424,10 +7747,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the TargetHttpsProxy resource whose URL map is to be set.
-  targetHttpsProxy := "{MY-TARGET-HTTPS-PROXY}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  targetHttpsProxy := "{MY-TARGET-HTTPS-PROXY}"
 
   resp, err := c.TargetHttpsProxies.SetUrlMap(project, targetHttpsProxy, &compute.UrlMapReference{
                                                 // TODO: Fill required fields.
@@ -7471,7 +7796,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
   call := c.TargetInstances.AggregatedList(project)
@@ -7518,13 +7844,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the zone scoping this request.
-  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f"
 
   // Name of the TargetInstance resource to delete.
-  targetInstance := "{MY-TARGET-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  targetInstance := "{MY-TARGET-INSTANCE}"
 
   resp, err := c.TargetInstances.Delete(project, zone, targetInstance).Context(ctx).Do()
   if err != nil {
@@ -7566,13 +7895,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the zone scoping this request.
-  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f"
 
   // Name of the TargetInstance resource to return.
-  targetInstance := "{MY-TARGET-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  targetInstance := "{MY-TARGET-INSTANCE}"
 
   resp, err := c.TargetInstances.Get(project, zone, targetInstance).Context(ctx).Do()
   if err != nil {
@@ -7614,10 +7946,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the zone scoping this request.
-  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f"
 
   resp, err := c.TargetInstances.Insert(project, zone, &compute.TargetInstance{
                                           // TODO: Fill required fields.
@@ -7661,10 +7995,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the zone scoping this request.
-  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f"
 
 
   call := c.TargetInstances.List(project, zone)
@@ -7711,13 +8047,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the region scoping this request.
-  region := "{MY-REGION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  region := "{MY-REGION}"
 
   // Name of the target pool to add a health check to.
-  targetPool := "{MY-TARGET-POOL}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  targetPool := "{MY-TARGET-POOL}"
 
   resp, err := c.TargetPools.AddHealthCheck(project, region, targetPool, &compute.TargetPoolsAddHealthCheckRequest{
                                               // TODO: Fill required fields.
@@ -7761,13 +8100,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the region scoping this request.
-  region := "{MY-REGION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  region := "{MY-REGION}"
 
   // Name of the TargetPool resource to add instances to.
-  targetPool := "{MY-TARGET-POOL}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  targetPool := "{MY-TARGET-POOL}"
 
   resp, err := c.TargetPools.AddInstance(project, region, targetPool, &compute.TargetPoolsAddInstanceRequest{
                                            // TODO: Fill required fields.
@@ -7811,7 +8153,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
   call := c.TargetPools.AggregatedList(project)
@@ -7858,13 +8201,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the region scoping this request.
-  region := "{MY-REGION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  region := "{MY-REGION}"
 
   // Name of the TargetPool resource to delete.
-  targetPool := "{MY-TARGET-POOL}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  targetPool := "{MY-TARGET-POOL}"
 
   resp, err := c.TargetPools.Delete(project, region, targetPool).Context(ctx).Do()
   if err != nil {
@@ -7906,13 +8252,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the region scoping this request.
-  region := "{MY-REGION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  region := "{MY-REGION}"
 
   // Name of the TargetPool resource to return.
-  targetPool := "{MY-TARGET-POOL}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  targetPool := "{MY-TARGET-POOL}"
 
   resp, err := c.TargetPools.Get(project, region, targetPool).Context(ctx).Do()
   if err != nil {
@@ -7954,13 +8303,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the region scoping this request.
-  region := "{MY-REGION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  region := "{MY-REGION}"
 
   // Name of the TargetPool resource to which the queried instance belongs.
-  targetPool := "{MY-TARGET-POOL}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  targetPool := "{MY-TARGET-POOL}"
 
   resp, err := c.TargetPools.GetHealth(project, region, targetPool, &compute.InstanceReference{
                                          // TODO: Fill required fields.
@@ -8004,10 +8356,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the region scoping this request.
-  region := "{MY-REGION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  region := "{MY-REGION}"
 
   resp, err := c.TargetPools.Insert(project, region, &compute.TargetPool{
                                       // TODO: Fill required fields.
@@ -8051,10 +8405,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the region scoping this request.
-  region := "{MY-REGION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  region := "{MY-REGION}"
 
 
   call := c.TargetPools.List(project, region)
@@ -8101,13 +8457,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the region for this request.
-  region := "{MY-REGION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  region := "{MY-REGION}"
 
   // Name of the target pool to remove health checks from.
-  targetPool := "{MY-TARGET-POOL}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  targetPool := "{MY-TARGET-POOL}"
 
   resp, err := c.TargetPools.RemoveHealthCheck(project, region, targetPool, &compute.TargetPoolsRemoveHealthCheckRequest{
                                                  // TODO: Fill required fields.
@@ -8151,13 +8510,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the region scoping this request.
-  region := "{MY-REGION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  region := "{MY-REGION}"
 
   // Name of the TargetPool resource to remove instances from.
-  targetPool := "{MY-TARGET-POOL}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  targetPool := "{MY-TARGET-POOL}"
 
   resp, err := c.TargetPools.RemoveInstance(project, region, targetPool, &compute.TargetPoolsRemoveInstanceRequest{
                                               // TODO: Fill required fields.
@@ -8201,13 +8563,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the region scoping this request.
-  region := "{MY-REGION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  region := "{MY-REGION}"
 
   // Name of the TargetPool resource to set a backup pool for.
-  targetPool := "{MY-TARGET-POOL}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  targetPool := "{MY-TARGET-POOL}"
 
   resp, err := c.TargetPools.SetBackup(project, region, targetPool, &compute.TargetReference{
                                          // TODO: Fill required fields.
@@ -8251,7 +8616,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
   call := c.TargetVpnGateways.AggregatedList(project)
@@ -8298,13 +8664,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the region for this request.
-  region := "{MY-REGION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  region := "{MY-REGION}"
 
   // Name of the target VPN gateway to delete.
-  targetVpnGateway := "{MY-TARGET-VPN-GATEWAY}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  targetVpnGateway := "{MY-TARGET-VPN-GATEWAY}"
 
   resp, err := c.TargetVpnGateways.Delete(project, region, targetVpnGateway).Context(ctx).Do()
   if err != nil {
@@ -8346,13 +8715,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the region for this request.
-  region := "{MY-REGION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  region := "{MY-REGION}"
 
   // Name of the target VPN gateway to return.
-  targetVpnGateway := "{MY-TARGET-VPN-GATEWAY}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  targetVpnGateway := "{MY-TARGET-VPN-GATEWAY}"
 
   resp, err := c.TargetVpnGateways.Get(project, region, targetVpnGateway).Context(ctx).Do()
   if err != nil {
@@ -8394,10 +8766,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the region for this request.
-  region := "{MY-REGION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  region := "{MY-REGION}"
 
   resp, err := c.TargetVpnGateways.Insert(project, region, &compute.TargetVpnGateway{
                                             // TODO: Fill required fields.
@@ -8441,10 +8815,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the region for this request.
-  region := "{MY-REGION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  region := "{MY-REGION}"
 
 
   call := c.TargetVpnGateways.List(project, region)
@@ -8491,10 +8867,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the UrlMap resource to delete.
-  urlMap := "{MY-URL-MAP}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  urlMap := "{MY-URL-MAP}"
 
   resp, err := c.UrlMaps.Delete(project, urlMap).Context(ctx).Do()
   if err != nil {
@@ -8536,10 +8914,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the UrlMap resource to return.
-  urlMap := "{MY-URL-MAP}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  urlMap := "{MY-URL-MAP}"
 
   resp, err := c.UrlMaps.Get(project, urlMap).Context(ctx).Do()
   if err != nil {
@@ -8581,7 +8961,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   resp, err := c.UrlMaps.Insert(project, &compute.UrlMap{
                                   // TODO: Fill required fields.
@@ -8625,7 +9006,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
   call := c.UrlMaps.List(project)
@@ -8672,10 +9054,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the UrlMap resource to update.
-  urlMap := "{MY-URL-MAP}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  urlMap := "{MY-URL-MAP}"
 
   resp, err := c.UrlMaps.Patch(project, urlMap, &compute.UrlMap{
                                  // TODO: Fill required fields.
@@ -8719,10 +9103,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the UrlMap resource to update.
-  urlMap := "{MY-URL-MAP}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  urlMap := "{MY-URL-MAP}"
 
   resp, err := c.UrlMaps.Update(project, urlMap, &compute.UrlMap{
                                   // TODO: Fill required fields.
@@ -8766,10 +9152,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the UrlMap resource to be validated as.
-  urlMap := "{MY-URL-MAP}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  urlMap := "{MY-URL-MAP}"
 
   resp, err := c.UrlMaps.Validate(project, urlMap, &compute.UrlMapsValidateRequest{
                                     // TODO: Fill required fields.
@@ -8813,7 +9201,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
   call := c.VpnTunnels.AggregatedList(project)
@@ -8860,13 +9249,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the region for this request.
-  region := "{MY-REGION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  region := "{MY-REGION}"
 
   // Name of the VpnTunnel resource to delete.
-  vpnTunnel := "{MY-VPN-TUNNEL}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  vpnTunnel := "{MY-VPN-TUNNEL}"
 
   resp, err := c.VpnTunnels.Delete(project, region, vpnTunnel).Context(ctx).Do()
   if err != nil {
@@ -8908,13 +9300,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the region for this request.
-  region := "{MY-REGION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  region := "{MY-REGION}"
 
   // Name of the VpnTunnel resource to return.
-  vpnTunnel := "{MY-VPN-TUNNEL}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  vpnTunnel := "{MY-VPN-TUNNEL}"
 
   resp, err := c.VpnTunnels.Get(project, region, vpnTunnel).Context(ctx).Do()
   if err != nil {
@@ -8956,10 +9351,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the region for this request.
-  region := "{MY-REGION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  region := "{MY-REGION}"
 
   resp, err := c.VpnTunnels.Insert(project, region, &compute.VpnTunnel{
                                      // TODO: Fill required fields.
@@ -9003,10 +9400,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the region for this request.
-  region := "{MY-REGION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  region := "{MY-REGION}"
 
 
   call := c.VpnTunnels.List(project, region)
@@ -9053,13 +9452,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the zone for this request.
-  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f"
 
   // Name of the Operations resource to delete.
-  operation := "{MY-OPERATION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  operation := "{MY-OPERATION}"
 
   if err := c.ZoneOperations.Delete(project, zone, operation).Context(ctx).Do(); err != nil {
     // TODO: Handle error.
@@ -9098,13 +9500,16 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the zone for this request.
-  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f"
 
   // Name of the Operations resource to return.
-  operation := "{MY-OPERATION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  operation := "{MY-OPERATION}"
 
   resp, err := c.ZoneOperations.Get(project, zone, operation).Context(ctx).Do()
   if err != nil {
@@ -9146,10 +9551,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the zone for request.
-  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f"
 
 
   call := c.ZoneOperations.List(project, zone)
@@ -9196,10 +9603,12 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the zone resource to return.
-  zone := "{MY-ZONE}"  // eg. "us-central1-f" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"  // eg. "us-central1-f"
 
   resp, err := c.Zones.Get(project, zone).Context(ctx).Do()
   if err != nil {
@@ -9241,7 +9650,8 @@ func main() {
   }
 
   // Project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
   call := c.Zones.List(project)

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_container.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_container.v1.json.baseline
@@ -33,11 +33,13 @@ func main() {
 
   // The Google Developers Console [project ID or project number]
   // (https://developers.google.com/console/help/new/#projectnumber).
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   // The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
   // resides.
-  zone := "{MY-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"
 
   resp, err := c.Projects.Zones.Clusters.Create(projectId, zone, &container.CreateClusterRequest{
                                                   // TODO: Fill required fields.
@@ -82,14 +84,17 @@ func main() {
 
   // The Google Developers Console [project ID or project number]
   // (https://developers.google.com/console/help/new/#projectnumber).
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   // The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
   // resides.
-  zone := "{MY-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"
 
   // The name of the cluster to delete.
-  clusterId := "{MY-CLUSTER-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  clusterId := "{MY-CLUSTER-ID}"
 
   resp, err := c.Projects.Zones.Clusters.Delete(projectId, zone, clusterId).Context(ctx).Do()
   if err != nil {
@@ -132,14 +137,17 @@ func main() {
 
   // The Google Developers Console [project ID or project number]
   // (https://developers.google.com/console/help/new/#projectnumber).
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   // The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
   // resides.
-  zone := "{MY-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"
 
   // The name of the cluster to retrieve.
-  clusterId := "{MY-CLUSTER-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  clusterId := "{MY-CLUSTER-ID}"
 
   resp, err := c.Projects.Zones.Clusters.Get(projectId, zone, clusterId).Context(ctx).Do()
   if err != nil {
@@ -182,11 +190,13 @@ func main() {
 
   // The Google Developers Console [project ID or project number]
   // (https://developers.google.com/console/help/new/#projectnumber).
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   // The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
   // resides, or "-" for all zones.
-  zone := "{MY-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"
 
   resp, err := c.Projects.Zones.Clusters.List(projectId, zone).Context(ctx).Do()
   if err != nil {
@@ -229,14 +239,17 @@ func main() {
 
   // The Google Developers Console [project ID or project number]
   // (https://developers.google.com/console/help/new/#projectnumber).
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   // The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
   // resides.
-  zone := "{MY-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"
 
   // The name of the cluster to upgrade.
-  clusterId := "{MY-CLUSTER-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  clusterId := "{MY-CLUSTER-ID}"
 
   resp, err := c.Projects.Zones.Clusters.Update(projectId, zone, clusterId, &container.UpdateClusterRequest{
                                                   // TODO: Fill required fields.
@@ -281,11 +294,13 @@ func main() {
 
   // The Google Developers Console [project ID or project number]
   // (https://developers.google.com/console/help/new/#projectnumber).
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   // The name of the Google Compute Engine [zone](/compute/docs/zones#available) to return operations
   // for, or "-" for all zones.
-  zone := "{MY-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"
 
   resp, err := c.Projects.Zones.GetServerconfig(projectId, zone).Context(ctx).Do()
   if err != nil {
@@ -328,14 +343,17 @@ func main() {
 
   // The Google Developers Console [project ID or project number]
   // (https://developers.google.com/console/help/new/#projectnumber).
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   // The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
   // resides.
-  zone := "{MY-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"
 
   // The server-assigned `name` of the operation.
-  operationId := "{MY-OPERATION-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  operationId := "{MY-OPERATION-ID}"
 
   resp, err := c.Projects.Zones.Operations.Get(projectId, zone, operationId).Context(ctx).Do()
   if err != nil {
@@ -378,11 +396,13 @@ func main() {
 
   // The Google Developers Console [project ID or project number]
   // (https://developers.google.com/console/help/new/#projectnumber).
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   // The name of the Google Compute Engine [zone](/compute/docs/zones#available) to return operations
   // for, or "-" for all zones.
-  zone := "{MY-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"
 
   resp, err := c.Projects.Zones.Operations.List(projectId, zone).Context(ctx).Do()
   if err != nil {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_container.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_container.v1.json.baseline
@@ -33,11 +33,11 @@ func main() {
 
   // The Google Developers Console [project ID or project number]
   // (https://developers.google.com/console/help/new/#projectnumber).
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   // The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
   // resides.
-  zone := "" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}" // TODO: Update placeholder value.
 
   resp, err := c.Projects.Zones.Clusters.Create(projectId, zone, &container.CreateClusterRequest{
                                                   // TODO: Fill required fields.
@@ -82,14 +82,14 @@ func main() {
 
   // The Google Developers Console [project ID or project number]
   // (https://developers.google.com/console/help/new/#projectnumber).
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   // The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
   // resides.
-  zone := "" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}" // TODO: Update placeholder value.
 
   // The name of the cluster to delete.
-  clusterId := "" // TODO: Update placeholder value.
+  clusterId := "{MY-CLUSTER-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Projects.Zones.Clusters.Delete(projectId, zone, clusterId).Context(ctx).Do()
   if err != nil {
@@ -132,14 +132,14 @@ func main() {
 
   // The Google Developers Console [project ID or project number]
   // (https://developers.google.com/console/help/new/#projectnumber).
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   // The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
   // resides.
-  zone := "" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}" // TODO: Update placeholder value.
 
   // The name of the cluster to retrieve.
-  clusterId := "" // TODO: Update placeholder value.
+  clusterId := "{MY-CLUSTER-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Projects.Zones.Clusters.Get(projectId, zone, clusterId).Context(ctx).Do()
   if err != nil {
@@ -182,11 +182,11 @@ func main() {
 
   // The Google Developers Console [project ID or project number]
   // (https://developers.google.com/console/help/new/#projectnumber).
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   // The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
   // resides, or "-" for all zones.
-  zone := "" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}" // TODO: Update placeholder value.
 
   resp, err := c.Projects.Zones.Clusters.List(projectId, zone).Context(ctx).Do()
   if err != nil {
@@ -229,14 +229,14 @@ func main() {
 
   // The Google Developers Console [project ID or project number]
   // (https://developers.google.com/console/help/new/#projectnumber).
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   // The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
   // resides.
-  zone := "" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}" // TODO: Update placeholder value.
 
   // The name of the cluster to upgrade.
-  clusterId := "" // TODO: Update placeholder value.
+  clusterId := "{MY-CLUSTER-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Projects.Zones.Clusters.Update(projectId, zone, clusterId, &container.UpdateClusterRequest{
                                                   // TODO: Fill required fields.
@@ -281,11 +281,11 @@ func main() {
 
   // The Google Developers Console [project ID or project number]
   // (https://developers.google.com/console/help/new/#projectnumber).
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   // The name of the Google Compute Engine [zone](/compute/docs/zones#available) to return operations
   // for, or "-" for all zones.
-  zone := "" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}" // TODO: Update placeholder value.
 
   resp, err := c.Projects.Zones.GetServerconfig(projectId, zone).Context(ctx).Do()
   if err != nil {
@@ -328,14 +328,14 @@ func main() {
 
   // The Google Developers Console [project ID or project number]
   // (https://developers.google.com/console/help/new/#projectnumber).
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   // The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
   // resides.
-  zone := "" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}" // TODO: Update placeholder value.
 
   // The server-assigned `name` of the operation.
-  operationId := "" // TODO: Update placeholder value.
+  operationId := "{MY-OPERATION-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Projects.Zones.Operations.Get(projectId, zone, operationId).Context(ctx).Do()
   if err != nil {
@@ -378,11 +378,11 @@ func main() {
 
   // The Google Developers Console [project ID or project number]
   // (https://developers.google.com/console/help/new/#projectnumber).
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   // The name of the Google Compute Engine [zone](/compute/docs/zones#available) to return operations
   // for, or "-" for all zones.
-  zone := "" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}" // TODO: Update placeholder value.
 
   resp, err := c.Projects.Zones.Operations.List(projectId, zone).Context(ctx).Do()
   if err != nil {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_dataflow.v1b3.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_dataflow.v1b3.json.baseline
@@ -32,7 +32,7 @@ func main() {
   }
 
   // The project which owns the job.
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Projects.Jobs.Create(projectId, &dataflow.Job{
                                         // TODO: Fill required fields.
@@ -76,10 +76,10 @@ func main() {
   }
 
   // The project which owns the job.
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   // Identifies a single job.
-  jobId := "" // TODO: Update placeholder value.
+  jobId := "{MY-JOB-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Projects.Jobs.Get(projectId, jobId).Context(ctx).Do()
   if err != nil {
@@ -121,10 +121,10 @@ func main() {
   }
 
   // A project id.
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   // The job to get messages for.
-  jobId := "" // TODO: Update placeholder value.
+  jobId := "{MY-JOB-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Projects.Jobs.GetMetrics(projectId, jobId).Context(ctx).Do()
   if err != nil {
@@ -166,7 +166,7 @@ func main() {
   }
 
   // The project which owns the jobs.
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
 
   call := c.Projects.Jobs.List(projectId)
@@ -213,10 +213,10 @@ func main() {
   }
 
   // A project id.
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   // The job to get messages about.
-  jobId := "" // TODO: Update placeholder value.
+  jobId := "{MY-JOB-ID}" // TODO: Update placeholder value.
 
 
   call := c.Projects.Jobs.Messages.List(projectId, jobId)
@@ -263,10 +263,10 @@ func main() {
   }
 
   // The project which owns the job.
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   // Identifies a single job.
-  jobId := "" // TODO: Update placeholder value.
+  jobId := "{MY-JOB-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Projects.Jobs.Update(projectId, jobId, &dataflow.Job{
                                         // TODO: Fill required fields.
@@ -310,10 +310,10 @@ func main() {
   }
 
   // Identifies the project this worker belongs to.
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   // Identifies the workflow job this worker belongs to.
-  jobId := "" // TODO: Update placeholder value.
+  jobId := "{MY-JOB-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Projects.Jobs.WorkItems.Lease(projectId, jobId, &dataflow.LeaseWorkItemRequest{
                                                  // TODO: Fill required fields.
@@ -357,10 +357,10 @@ func main() {
   }
 
   // The project which owns the WorkItem's job.
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   // The job which the WorkItem is part of.
-  jobId := "" // TODO: Update placeholder value.
+  jobId := "{MY-JOB-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Projects.Jobs.WorkItems.ReportStatus(projectId, jobId, &dataflow.ReportWorkItemStatusRequest{
                                                         // TODO: Fill required fields.
@@ -404,7 +404,7 @@ func main() {
   }
 
   // The project to send the WorkerMessages to.
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Projects.WorkerMessages(projectId, &dataflow.SendWorkerMessagesRequest{
                                            // TODO: Fill required fields.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_dataflow.v1b3.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_dataflow.v1b3.json.baseline
@@ -32,7 +32,8 @@ func main() {
   }
 
   // The project which owns the job.
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   resp, err := c.Projects.Jobs.Create(projectId, &dataflow.Job{
                                         // TODO: Fill required fields.
@@ -76,10 +77,12 @@ func main() {
   }
 
   // The project which owns the job.
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   // Identifies a single job.
-  jobId := "{MY-JOB-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  jobId := "{MY-JOB-ID}"
 
   resp, err := c.Projects.Jobs.Get(projectId, jobId).Context(ctx).Do()
   if err != nil {
@@ -121,10 +124,12 @@ func main() {
   }
 
   // A project id.
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   // The job to get messages for.
-  jobId := "{MY-JOB-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  jobId := "{MY-JOB-ID}"
 
   resp, err := c.Projects.Jobs.GetMetrics(projectId, jobId).Context(ctx).Do()
   if err != nil {
@@ -166,7 +171,8 @@ func main() {
   }
 
   // The project which owns the jobs.
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
 
   call := c.Projects.Jobs.List(projectId)
@@ -213,10 +219,12 @@ func main() {
   }
 
   // A project id.
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   // The job to get messages about.
-  jobId := "{MY-JOB-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  jobId := "{MY-JOB-ID}"
 
 
   call := c.Projects.Jobs.Messages.List(projectId, jobId)
@@ -263,10 +271,12 @@ func main() {
   }
 
   // The project which owns the job.
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   // Identifies a single job.
-  jobId := "{MY-JOB-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  jobId := "{MY-JOB-ID}"
 
   resp, err := c.Projects.Jobs.Update(projectId, jobId, &dataflow.Job{
                                         // TODO: Fill required fields.
@@ -310,10 +320,12 @@ func main() {
   }
 
   // Identifies the project this worker belongs to.
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   // Identifies the workflow job this worker belongs to.
-  jobId := "{MY-JOB-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  jobId := "{MY-JOB-ID}"
 
   resp, err := c.Projects.Jobs.WorkItems.Lease(projectId, jobId, &dataflow.LeaseWorkItemRequest{
                                                  // TODO: Fill required fields.
@@ -357,10 +369,12 @@ func main() {
   }
 
   // The project which owns the WorkItem's job.
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   // The job which the WorkItem is part of.
-  jobId := "{MY-JOB-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  jobId := "{MY-JOB-ID}"
 
   resp, err := c.Projects.Jobs.WorkItems.ReportStatus(projectId, jobId, &dataflow.ReportWorkItemStatusRequest{
                                                         // TODO: Fill required fields.
@@ -404,7 +418,8 @@ func main() {
   }
 
   // The project to send the WorkerMessages to.
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   resp, err := c.Projects.WorkerMessages(projectId, &dataflow.SendWorkerMessagesRequest{
                                            // TODO: Fill required fields.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_dataproc.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_dataproc.v1.json.baseline
@@ -32,10 +32,10 @@ func main() {
   }
 
   // [Required] The ID of the Google Cloud Platform project that the cluster belongs to.
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   // [Required] The Cloud Dataproc region in which to handle the request.
-  region := "" // TODO: Update placeholder value.
+  region := "{MY-REGION}" // TODO: Update placeholder value.
 
   resp, err := c.Projects.Regions.Clusters.Create(projectId, region, &dataproc.Cluster{
                                                     // TODO: Fill required fields.
@@ -79,13 +79,13 @@ func main() {
   }
 
   // [Required] The ID of the Google Cloud Platform project that the cluster belongs to.
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   // [Required] The Cloud Dataproc region in which to handle the request.
-  region := "" // TODO: Update placeholder value.
+  region := "{MY-REGION}" // TODO: Update placeholder value.
 
   // [Required] The cluster name.
-  clusterName := "" // TODO: Update placeholder value.
+  clusterName := "{MY-CLUSTER-NAME}" // TODO: Update placeholder value.
 
   resp, err := c.Projects.Regions.Clusters.Delete(projectId, region, clusterName).Context(ctx).Do()
   if err != nil {
@@ -127,13 +127,13 @@ func main() {
   }
 
   // [Required] The ID of the Google Cloud Platform project that the cluster belongs to.
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   // [Required] The Cloud Dataproc region in which to handle the request.
-  region := "" // TODO: Update placeholder value.
+  region := "{MY-REGION}" // TODO: Update placeholder value.
 
   // [Required] The cluster name.
-  clusterName := "" // TODO: Update placeholder value.
+  clusterName := "{MY-CLUSTER-NAME}" // TODO: Update placeholder value.
 
   resp, err := c.Projects.Regions.Clusters.Diagnose(projectId, region, clusterName, &dataproc.DiagnoseClusterRequest{
                                                       // TODO: Fill required fields.
@@ -177,13 +177,13 @@ func main() {
   }
 
   // [Required] The ID of the Google Cloud Platform project that the cluster belongs to.
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   // [Required] The Cloud Dataproc region in which to handle the request.
-  region := "" // TODO: Update placeholder value.
+  region := "{MY-REGION}" // TODO: Update placeholder value.
 
   // [Required] The cluster name.
-  clusterName := "" // TODO: Update placeholder value.
+  clusterName := "{MY-CLUSTER-NAME}" // TODO: Update placeholder value.
 
   resp, err := c.Projects.Regions.Clusters.Get(projectId, region, clusterName).Context(ctx).Do()
   if err != nil {
@@ -225,10 +225,10 @@ func main() {
   }
 
   // [Required] The ID of the Google Cloud Platform project that the cluster belongs to.
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   // [Required] The Cloud Dataproc region in which to handle the request.
-  region := "" // TODO: Update placeholder value.
+  region := "{MY-REGION}" // TODO: Update placeholder value.
 
 
   call := c.Projects.Regions.Clusters.List(projectId, region)
@@ -275,13 +275,13 @@ func main() {
   }
 
   // [Required] The ID of the Google Cloud Platform project the cluster belongs to.
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   // [Required] The Cloud Dataproc region in which to handle the request.
-  region := "" // TODO: Update placeholder value.
+  region := "{MY-REGION}" // TODO: Update placeholder value.
 
   // [Required] The cluster name.
-  clusterName := "" // TODO: Update placeholder value.
+  clusterName := "{MY-CLUSTER-NAME}" // TODO: Update placeholder value.
 
   resp, err := c.Projects.Regions.Clusters.Patch(projectId, region, clusterName, &dataproc.Cluster{
                                                    // TODO: Fill required fields.
@@ -325,13 +325,13 @@ func main() {
   }
 
   // [Required] The ID of the Google Cloud Platform project that the job belongs to.
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   // [Required] The Cloud Dataproc region in which to handle the request.
-  region := "" // TODO: Update placeholder value.
+  region := "{MY-REGION}" // TODO: Update placeholder value.
 
   // [Required] The job ID.
-  jobId := "" // TODO: Update placeholder value.
+  jobId := "{MY-JOB-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Projects.Regions.Jobs.Cancel(projectId, region, jobId, &dataproc.CancelJobRequest{
                                                 // TODO: Fill required fields.
@@ -375,13 +375,13 @@ func main() {
   }
 
   // [Required] The ID of the Google Cloud Platform project that the job belongs to.
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   // [Required] The Cloud Dataproc region in which to handle the request.
-  region := "" // TODO: Update placeholder value.
+  region := "{MY-REGION}" // TODO: Update placeholder value.
 
   // [Required] The job ID.
-  jobId := "" // TODO: Update placeholder value.
+  jobId := "{MY-JOB-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Projects.Regions.Jobs.Delete(projectId, region, jobId).Context(ctx).Do()
   if err != nil {
@@ -423,13 +423,13 @@ func main() {
   }
 
   // [Required] The ID of the Google Cloud Platform project that the job belongs to.
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   // [Required] The Cloud Dataproc region in which to handle the request.
-  region := "" // TODO: Update placeholder value.
+  region := "{MY-REGION}" // TODO: Update placeholder value.
 
   // [Required] The job ID.
-  jobId := "" // TODO: Update placeholder value.
+  jobId := "{MY-JOB-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Projects.Regions.Jobs.Get(projectId, region, jobId).Context(ctx).Do()
   if err != nil {
@@ -471,10 +471,10 @@ func main() {
   }
 
   // [Required] The ID of the Google Cloud Platform project that the job belongs to.
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   // [Required] The Cloud Dataproc region in which to handle the request.
-  region := "" // TODO: Update placeholder value.
+  region := "{MY-REGION}" // TODO: Update placeholder value.
 
 
   call := c.Projects.Regions.Jobs.List(projectId, region)
@@ -521,10 +521,10 @@ func main() {
   }
 
   // [Required] The ID of the Google Cloud Platform project that the job belongs to.
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   // [Required] The Cloud Dataproc region in which to handle the request.
-  region := "" // TODO: Update placeholder value.
+  region := "{MY-REGION}" // TODO: Update placeholder value.
 
   resp, err := c.Projects.Regions.Jobs.Submit(projectId, region, &dataproc.SubmitJobRequest{
                                                 // TODO: Fill required fields.
@@ -694,7 +694,7 @@ func main() {
   }
 
   // The name of the operation collection.
-  name := "" // TODO: Update placeholder value.
+  name := "{MY-NAME}" // TODO: Update placeholder value.
 
 
   call := c.Projects.Regions.Operations.List(name)

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_dataproc.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_dataproc.v1.json.baseline
@@ -32,10 +32,12 @@ func main() {
   }
 
   // [Required] The ID of the Google Cloud Platform project that the cluster belongs to.
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   // [Required] The Cloud Dataproc region in which to handle the request.
-  region := "{MY-REGION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  region := "{MY-REGION}"
 
   resp, err := c.Projects.Regions.Clusters.Create(projectId, region, &dataproc.Cluster{
                                                     // TODO: Fill required fields.
@@ -79,13 +81,16 @@ func main() {
   }
 
   // [Required] The ID of the Google Cloud Platform project that the cluster belongs to.
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   // [Required] The Cloud Dataproc region in which to handle the request.
-  region := "{MY-REGION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  region := "{MY-REGION}"
 
   // [Required] The cluster name.
-  clusterName := "{MY-CLUSTER-NAME}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  clusterName := "{MY-CLUSTER-NAME}"
 
   resp, err := c.Projects.Regions.Clusters.Delete(projectId, region, clusterName).Context(ctx).Do()
   if err != nil {
@@ -127,13 +132,16 @@ func main() {
   }
 
   // [Required] The ID of the Google Cloud Platform project that the cluster belongs to.
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   // [Required] The Cloud Dataproc region in which to handle the request.
-  region := "{MY-REGION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  region := "{MY-REGION}"
 
   // [Required] The cluster name.
-  clusterName := "{MY-CLUSTER-NAME}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  clusterName := "{MY-CLUSTER-NAME}"
 
   resp, err := c.Projects.Regions.Clusters.Diagnose(projectId, region, clusterName, &dataproc.DiagnoseClusterRequest{
                                                       // TODO: Fill required fields.
@@ -177,13 +185,16 @@ func main() {
   }
 
   // [Required] The ID of the Google Cloud Platform project that the cluster belongs to.
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   // [Required] The Cloud Dataproc region in which to handle the request.
-  region := "{MY-REGION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  region := "{MY-REGION}"
 
   // [Required] The cluster name.
-  clusterName := "{MY-CLUSTER-NAME}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  clusterName := "{MY-CLUSTER-NAME}"
 
   resp, err := c.Projects.Regions.Clusters.Get(projectId, region, clusterName).Context(ctx).Do()
   if err != nil {
@@ -225,10 +236,12 @@ func main() {
   }
 
   // [Required] The ID of the Google Cloud Platform project that the cluster belongs to.
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   // [Required] The Cloud Dataproc region in which to handle the request.
-  region := "{MY-REGION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  region := "{MY-REGION}"
 
 
   call := c.Projects.Regions.Clusters.List(projectId, region)
@@ -275,13 +288,16 @@ func main() {
   }
 
   // [Required] The ID of the Google Cloud Platform project the cluster belongs to.
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   // [Required] The Cloud Dataproc region in which to handle the request.
-  region := "{MY-REGION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  region := "{MY-REGION}"
 
   // [Required] The cluster name.
-  clusterName := "{MY-CLUSTER-NAME}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  clusterName := "{MY-CLUSTER-NAME}"
 
   resp, err := c.Projects.Regions.Clusters.Patch(projectId, region, clusterName, &dataproc.Cluster{
                                                    // TODO: Fill required fields.
@@ -325,13 +341,16 @@ func main() {
   }
 
   // [Required] The ID of the Google Cloud Platform project that the job belongs to.
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   // [Required] The Cloud Dataproc region in which to handle the request.
-  region := "{MY-REGION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  region := "{MY-REGION}"
 
   // [Required] The job ID.
-  jobId := "{MY-JOB-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  jobId := "{MY-JOB-ID}"
 
   resp, err := c.Projects.Regions.Jobs.Cancel(projectId, region, jobId, &dataproc.CancelJobRequest{
                                                 // TODO: Fill required fields.
@@ -375,13 +394,16 @@ func main() {
   }
 
   // [Required] The ID of the Google Cloud Platform project that the job belongs to.
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   // [Required] The Cloud Dataproc region in which to handle the request.
-  region := "{MY-REGION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  region := "{MY-REGION}"
 
   // [Required] The job ID.
-  jobId := "{MY-JOB-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  jobId := "{MY-JOB-ID}"
 
   resp, err := c.Projects.Regions.Jobs.Delete(projectId, region, jobId).Context(ctx).Do()
   if err != nil {
@@ -423,13 +445,16 @@ func main() {
   }
 
   // [Required] The ID of the Google Cloud Platform project that the job belongs to.
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   // [Required] The Cloud Dataproc region in which to handle the request.
-  region := "{MY-REGION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  region := "{MY-REGION}"
 
   // [Required] The job ID.
-  jobId := "{MY-JOB-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  jobId := "{MY-JOB-ID}"
 
   resp, err := c.Projects.Regions.Jobs.Get(projectId, region, jobId).Context(ctx).Do()
   if err != nil {
@@ -471,10 +496,12 @@ func main() {
   }
 
   // [Required] The ID of the Google Cloud Platform project that the job belongs to.
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   // [Required] The Cloud Dataproc region in which to handle the request.
-  region := "{MY-REGION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  region := "{MY-REGION}"
 
 
   call := c.Projects.Regions.Jobs.List(projectId, region)
@@ -521,10 +548,12 @@ func main() {
   }
 
   // [Required] The ID of the Google Cloud Platform project that the job belongs to.
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   // [Required] The Cloud Dataproc region in which to handle the request.
-  region := "{MY-REGION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  region := "{MY-REGION}"
 
   resp, err := c.Projects.Regions.Jobs.Submit(projectId, region, &dataproc.SubmitJobRequest{
                                                 // TODO: Fill required fields.
@@ -568,7 +597,8 @@ func main() {
   }
 
   // The name of the operation resource to be cancelled.
-  name := "projects/{MY-PROJECT}/regions/{MY-REGION}/operations/{MY-OPERATION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  name := "projects/{MY-PROJECT}/regions/{MY-REGION}/operations/{MY-OPERATION}"
 
   resp, err := c.Projects.Regions.Operations.Cancel(name).Context(ctx).Do()
   if err != nil {
@@ -610,7 +640,8 @@ func main() {
   }
 
   // The name of the operation resource to be deleted.
-  name := "projects/{MY-PROJECT}/regions/{MY-REGION}/operations/{MY-OPERATION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  name := "projects/{MY-PROJECT}/regions/{MY-REGION}/operations/{MY-OPERATION}"
 
   resp, err := c.Projects.Regions.Operations.Delete(name).Context(ctx).Do()
   if err != nil {
@@ -652,7 +683,8 @@ func main() {
   }
 
   // The name of the operation resource.
-  name := "projects/{MY-PROJECT}/regions/{MY-REGION}/operations/{MY-OPERATION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  name := "projects/{MY-PROJECT}/regions/{MY-REGION}/operations/{MY-OPERATION}"
 
   resp, err := c.Projects.Regions.Operations.Get(name).Context(ctx).Do()
   if err != nil {
@@ -694,7 +726,8 @@ func main() {
   }
 
   // The name of the operation collection.
-  name := "{MY-NAME}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  name := "{MY-NAME}"
 
 
   call := c.Projects.Regions.Operations.List(name)

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_datastore.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_datastore.v1beta2.json.baseline
@@ -32,7 +32,7 @@ func main() {
   }
 
   // Identifies the dataset.
-  datasetId := "" // TODO: Update placeholder value.
+  datasetId := "{MY-DATASET-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Datasets.AllocateIds(datasetId, &datastore.AllocateIdsRequest{
                                         // TODO: Fill required fields.
@@ -76,7 +76,7 @@ func main() {
   }
 
   // Identifies the dataset.
-  datasetId := "" // TODO: Update placeholder value.
+  datasetId := "{MY-DATASET-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Datasets.BeginTransaction(datasetId, &datastore.BeginTransactionRequest{
                                              // TODO: Fill required fields.
@@ -120,7 +120,7 @@ func main() {
   }
 
   // Identifies the dataset.
-  datasetId := "" // TODO: Update placeholder value.
+  datasetId := "{MY-DATASET-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Datasets.Commit(datasetId, &datastore.CommitRequest{
                                    // TODO: Fill required fields.
@@ -164,7 +164,7 @@ func main() {
   }
 
   // Identifies the dataset.
-  datasetId := "" // TODO: Update placeholder value.
+  datasetId := "{MY-DATASET-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Datasets.Lookup(datasetId, &datastore.LookupRequest{
                                    // TODO: Fill required fields.
@@ -208,7 +208,7 @@ func main() {
   }
 
   // Identifies the dataset.
-  datasetId := "" // TODO: Update placeholder value.
+  datasetId := "{MY-DATASET-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Datasets.Rollback(datasetId, &datastore.RollbackRequest{
                                      // TODO: Fill required fields.
@@ -252,7 +252,7 @@ func main() {
   }
 
   // Identifies the dataset.
-  datasetId := "" // TODO: Update placeholder value.
+  datasetId := "{MY-DATASET-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Datasets.RunQuery(datasetId, &datastore.RunQueryRequest{
                                      // TODO: Fill required fields.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_datastore.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_datastore.v1beta2.json.baseline
@@ -32,7 +32,8 @@ func main() {
   }
 
   // Identifies the dataset.
-  datasetId := "{MY-DATASET-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  datasetId := "{MY-DATASET-ID}"
 
   resp, err := c.Datasets.AllocateIds(datasetId, &datastore.AllocateIdsRequest{
                                         // TODO: Fill required fields.
@@ -76,7 +77,8 @@ func main() {
   }
 
   // Identifies the dataset.
-  datasetId := "{MY-DATASET-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  datasetId := "{MY-DATASET-ID}"
 
   resp, err := c.Datasets.BeginTransaction(datasetId, &datastore.BeginTransactionRequest{
                                              // TODO: Fill required fields.
@@ -120,7 +122,8 @@ func main() {
   }
 
   // Identifies the dataset.
-  datasetId := "{MY-DATASET-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  datasetId := "{MY-DATASET-ID}"
 
   resp, err := c.Datasets.Commit(datasetId, &datastore.CommitRequest{
                                    // TODO: Fill required fields.
@@ -164,7 +167,8 @@ func main() {
   }
 
   // Identifies the dataset.
-  datasetId := "{MY-DATASET-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  datasetId := "{MY-DATASET-ID}"
 
   resp, err := c.Datasets.Lookup(datasetId, &datastore.LookupRequest{
                                    // TODO: Fill required fields.
@@ -208,7 +212,8 @@ func main() {
   }
 
   // Identifies the dataset.
-  datasetId := "{MY-DATASET-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  datasetId := "{MY-DATASET-ID}"
 
   resp, err := c.Datasets.Rollback(datasetId, &datastore.RollbackRequest{
                                      // TODO: Fill required fields.
@@ -252,7 +257,8 @@ func main() {
   }
 
   // Identifies the dataset.
-  datasetId := "{MY-DATASET-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  datasetId := "{MY-DATASET-ID}"
 
   resp, err := c.Datasets.RunQuery(datasetId, &datastore.RunQueryRequest{
                                      // TODO: Fill required fields.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_deploymentmanager.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_deploymentmanager.v2.json.baseline
@@ -32,10 +32,12 @@ func main() {
   }
 
   // The project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the deployment for this request.
-  deployment := "{MY-DEPLOYMENT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  deployment := "{MY-DEPLOYMENT}"
 
   resp, err := c.Deployments.CancelPreview(project, deployment, &deploymentmanager.DeploymentsCancelPreviewRequest{
                                              // TODO: Fill required fields.
@@ -79,10 +81,12 @@ func main() {
   }
 
   // The project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the deployment for this request.
-  deployment := "{MY-DEPLOYMENT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  deployment := "{MY-DEPLOYMENT}"
 
   resp, err := c.Deployments.Delete(project, deployment).Context(ctx).Do()
   if err != nil {
@@ -124,10 +128,12 @@ func main() {
   }
 
   // The project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the deployment for this request.
-  deployment := "{MY-DEPLOYMENT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  deployment := "{MY-DEPLOYMENT}"
 
   resp, err := c.Deployments.Get(project, deployment).Context(ctx).Do()
   if err != nil {
@@ -169,7 +175,8 @@ func main() {
   }
 
   // The project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   resp, err := c.Deployments.Insert(project, &deploymentmanager.Deployment{
                                       // TODO: Fill required fields.
@@ -213,7 +220,8 @@ func main() {
   }
 
   // The project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
   call := c.Deployments.List(project)
@@ -260,10 +268,12 @@ func main() {
   }
 
   // The project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the deployment for this request.
-  deployment := "{MY-DEPLOYMENT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  deployment := "{MY-DEPLOYMENT}"
 
   resp, err := c.Deployments.Patch(project, deployment, &deploymentmanager.Deployment{
                                      // TODO: Fill required fields.
@@ -307,10 +317,12 @@ func main() {
   }
 
   // The project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the deployment for this request.
-  deployment := "{MY-DEPLOYMENT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  deployment := "{MY-DEPLOYMENT}"
 
   resp, err := c.Deployments.Stop(project, deployment, &deploymentmanager.DeploymentsStopRequest{
                                     // TODO: Fill required fields.
@@ -354,10 +366,12 @@ func main() {
   }
 
   // The project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the deployment for this request.
-  deployment := "{MY-DEPLOYMENT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  deployment := "{MY-DEPLOYMENT}"
 
   resp, err := c.Deployments.Update(project, deployment, &deploymentmanager.Deployment{
                                       // TODO: Fill required fields.
@@ -401,13 +415,16 @@ func main() {
   }
 
   // The project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the deployment for this request.
-  deployment := "{MY-DEPLOYMENT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  deployment := "{MY-DEPLOYMENT}"
 
   // The name of the manifest for this request.
-  manifest := "{MY-MANIFEST}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  manifest := "{MY-MANIFEST}"
 
   resp, err := c.Manifests.Get(project, deployment, manifest).Context(ctx).Do()
   if err != nil {
@@ -449,10 +466,12 @@ func main() {
   }
 
   // The project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the deployment for this request.
-  deployment := "{MY-DEPLOYMENT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  deployment := "{MY-DEPLOYMENT}"
 
 
   call := c.Manifests.List(project, deployment)
@@ -499,10 +518,12 @@ func main() {
   }
 
   // The project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the operation for this request.
-  operation := "{MY-OPERATION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  operation := "{MY-OPERATION}"
 
   resp, err := c.Operations.Get(project, operation).Context(ctx).Do()
   if err != nil {
@@ -544,7 +565,8 @@ func main() {
   }
 
   // The project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
   call := c.Operations.List(project)
@@ -591,13 +613,16 @@ func main() {
   }
 
   // The project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the deployment for this request.
-  deployment := "{MY-DEPLOYMENT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  deployment := "{MY-DEPLOYMENT}"
 
   // The name of the resource for this request.
-  resource := "{MY-RESOURCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  resource := "{MY-RESOURCE}"
 
   resp, err := c.Resources.Get(project, deployment, resource).Context(ctx).Do()
   if err != nil {
@@ -639,10 +664,12 @@ func main() {
   }
 
   // The project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the deployment for this request.
-  deployment := "{MY-DEPLOYMENT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  deployment := "{MY-DEPLOYMENT}"
 
 
   call := c.Resources.List(project, deployment)
@@ -689,7 +716,8 @@ func main() {
   }
 
   // The project ID for this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
   call := c.Types.List(project)

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_deploymentmanager.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_deploymentmanager.v2.json.baseline
@@ -32,10 +32,10 @@ func main() {
   }
 
   // The project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the deployment for this request.
-  deployment := "" // TODO: Update placeholder value.
+  deployment := "{MY-DEPLOYMENT}" // TODO: Update placeholder value.
 
   resp, err := c.Deployments.CancelPreview(project, deployment, &deploymentmanager.DeploymentsCancelPreviewRequest{
                                              // TODO: Fill required fields.
@@ -79,10 +79,10 @@ func main() {
   }
 
   // The project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the deployment for this request.
-  deployment := "" // TODO: Update placeholder value.
+  deployment := "{MY-DEPLOYMENT}" // TODO: Update placeholder value.
 
   resp, err := c.Deployments.Delete(project, deployment).Context(ctx).Do()
   if err != nil {
@@ -124,10 +124,10 @@ func main() {
   }
 
   // The project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the deployment for this request.
-  deployment := "" // TODO: Update placeholder value.
+  deployment := "{MY-DEPLOYMENT}" // TODO: Update placeholder value.
 
   resp, err := c.Deployments.Get(project, deployment).Context(ctx).Do()
   if err != nil {
@@ -169,7 +169,7 @@ func main() {
   }
 
   // The project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   resp, err := c.Deployments.Insert(project, &deploymentmanager.Deployment{
                                       // TODO: Fill required fields.
@@ -213,7 +213,7 @@ func main() {
   }
 
   // The project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
   call := c.Deployments.List(project)
@@ -260,10 +260,10 @@ func main() {
   }
 
   // The project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the deployment for this request.
-  deployment := "" // TODO: Update placeholder value.
+  deployment := "{MY-DEPLOYMENT}" // TODO: Update placeholder value.
 
   resp, err := c.Deployments.Patch(project, deployment, &deploymentmanager.Deployment{
                                      // TODO: Fill required fields.
@@ -307,10 +307,10 @@ func main() {
   }
 
   // The project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the deployment for this request.
-  deployment := "" // TODO: Update placeholder value.
+  deployment := "{MY-DEPLOYMENT}" // TODO: Update placeholder value.
 
   resp, err := c.Deployments.Stop(project, deployment, &deploymentmanager.DeploymentsStopRequest{
                                     // TODO: Fill required fields.
@@ -354,10 +354,10 @@ func main() {
   }
 
   // The project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the deployment for this request.
-  deployment := "" // TODO: Update placeholder value.
+  deployment := "{MY-DEPLOYMENT}" // TODO: Update placeholder value.
 
   resp, err := c.Deployments.Update(project, deployment, &deploymentmanager.Deployment{
                                       // TODO: Fill required fields.
@@ -401,13 +401,13 @@ func main() {
   }
 
   // The project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the deployment for this request.
-  deployment := "" // TODO: Update placeholder value.
+  deployment := "{MY-DEPLOYMENT}" // TODO: Update placeholder value.
 
   // The name of the manifest for this request.
-  manifest := "" // TODO: Update placeholder value.
+  manifest := "{MY-MANIFEST}" // TODO: Update placeholder value.
 
   resp, err := c.Manifests.Get(project, deployment, manifest).Context(ctx).Do()
   if err != nil {
@@ -449,10 +449,10 @@ func main() {
   }
 
   // The project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the deployment for this request.
-  deployment := "" // TODO: Update placeholder value.
+  deployment := "{MY-DEPLOYMENT}" // TODO: Update placeholder value.
 
 
   call := c.Manifests.List(project, deployment)
@@ -499,10 +499,10 @@ func main() {
   }
 
   // The project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the operation for this request.
-  operation := "" // TODO: Update placeholder value.
+  operation := "{MY-OPERATION}" // TODO: Update placeholder value.
 
   resp, err := c.Operations.Get(project, operation).Context(ctx).Do()
   if err != nil {
@@ -544,7 +544,7 @@ func main() {
   }
 
   // The project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
   call := c.Operations.List(project)
@@ -591,13 +591,13 @@ func main() {
   }
 
   // The project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the deployment for this request.
-  deployment := "" // TODO: Update placeholder value.
+  deployment := "{MY-DEPLOYMENT}" // TODO: Update placeholder value.
 
   // The name of the resource for this request.
-  resource := "" // TODO: Update placeholder value.
+  resource := "{MY-RESOURCE}" // TODO: Update placeholder value.
 
   resp, err := c.Resources.Get(project, deployment, resource).Context(ctx).Do()
   if err != nil {
@@ -639,10 +639,10 @@ func main() {
   }
 
   // The project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the deployment for this request.
-  deployment := "" // TODO: Update placeholder value.
+  deployment := "{MY-DEPLOYMENT}" // TODO: Update placeholder value.
 
 
   call := c.Resources.List(project, deployment)
@@ -689,7 +689,7 @@ func main() {
   }
 
   // The project ID for this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
   call := c.Types.List(project)

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_dns.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_dns.v1.json.baseline
@@ -32,10 +32,10 @@ func main() {
   }
 
   // Identifies the project addressed by this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-  managedZone := "" // TODO: Update placeholder value.
+  managedZone := "{MY-MANAGED-ZONE}" // TODO: Update placeholder value.
 
   resp, err := c.Changes.Create(project, managedZone, &dns.Change{
                                   // TODO: Fill required fields.
@@ -79,13 +79,13 @@ func main() {
   }
 
   // Identifies the project addressed by this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-  managedZone := "" // TODO: Update placeholder value.
+  managedZone := "{MY-MANAGED-ZONE}" // TODO: Update placeholder value.
 
   // The identifier of the requested change, from a previous ResourceRecordSetsChangeResponse.
-  changeId := "" // TODO: Update placeholder value.
+  changeId := "{MY-CHANGE-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Changes.Get(project, managedZone, changeId).Context(ctx).Do()
   if err != nil {
@@ -127,10 +127,10 @@ func main() {
   }
 
   // Identifies the project addressed by this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-  managedZone := "" // TODO: Update placeholder value.
+  managedZone := "{MY-MANAGED-ZONE}" // TODO: Update placeholder value.
 
 
   call := c.Changes.List(project, managedZone)
@@ -177,7 +177,7 @@ func main() {
   }
 
   // Identifies the project addressed by this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   resp, err := c.ManagedZones.Create(project, &dns.ManagedZone{
                                        // TODO: Fill required fields.
@@ -221,10 +221,10 @@ func main() {
   }
 
   // Identifies the project addressed by this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-  managedZone := "" // TODO: Update placeholder value.
+  managedZone := "{MY-MANAGED-ZONE}" // TODO: Update placeholder value.
 
   if err := c.ManagedZones.Delete(project, managedZone).Context(ctx).Do(); err != nil {
     // TODO: Handle error.
@@ -263,10 +263,10 @@ func main() {
   }
 
   // Identifies the project addressed by this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-  managedZone := "" // TODO: Update placeholder value.
+  managedZone := "{MY-MANAGED-ZONE}" // TODO: Update placeholder value.
 
   resp, err := c.ManagedZones.Get(project, managedZone).Context(ctx).Do()
   if err != nil {
@@ -308,7 +308,7 @@ func main() {
   }
 
   // Identifies the project addressed by this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
   call := c.ManagedZones.List(project)
@@ -355,7 +355,7 @@ func main() {
   }
 
   // Identifies the project addressed by this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   resp, err := c.Projects.Get(project).Context(ctx).Do()
   if err != nil {
@@ -397,10 +397,10 @@ func main() {
   }
 
   // Identifies the project addressed by this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-  managedZone := "" // TODO: Update placeholder value.
+  managedZone := "{MY-MANAGED-ZONE}" // TODO: Update placeholder value.
 
 
   call := c.ResourceRecordSets.List(project, managedZone)

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_dns.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_dns.v1.json.baseline
@@ -32,10 +32,12 @@ func main() {
   }
 
   // Identifies the project addressed by this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-  managedZone := "{MY-MANAGED-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  managedZone := "{MY-MANAGED-ZONE}"
 
   resp, err := c.Changes.Create(project, managedZone, &dns.Change{
                                   // TODO: Fill required fields.
@@ -79,13 +81,16 @@ func main() {
   }
 
   // Identifies the project addressed by this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-  managedZone := "{MY-MANAGED-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  managedZone := "{MY-MANAGED-ZONE}"
 
   // The identifier of the requested change, from a previous ResourceRecordSetsChangeResponse.
-  changeId := "{MY-CHANGE-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  changeId := "{MY-CHANGE-ID}"
 
   resp, err := c.Changes.Get(project, managedZone, changeId).Context(ctx).Do()
   if err != nil {
@@ -127,10 +132,12 @@ func main() {
   }
 
   // Identifies the project addressed by this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-  managedZone := "{MY-MANAGED-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  managedZone := "{MY-MANAGED-ZONE}"
 
 
   call := c.Changes.List(project, managedZone)
@@ -177,7 +184,8 @@ func main() {
   }
 
   // Identifies the project addressed by this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   resp, err := c.ManagedZones.Create(project, &dns.ManagedZone{
                                        // TODO: Fill required fields.
@@ -221,10 +229,12 @@ func main() {
   }
 
   // Identifies the project addressed by this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-  managedZone := "{MY-MANAGED-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  managedZone := "{MY-MANAGED-ZONE}"
 
   if err := c.ManagedZones.Delete(project, managedZone).Context(ctx).Do(); err != nil {
     // TODO: Handle error.
@@ -263,10 +273,12 @@ func main() {
   }
 
   // Identifies the project addressed by this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-  managedZone := "{MY-MANAGED-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  managedZone := "{MY-MANAGED-ZONE}"
 
   resp, err := c.ManagedZones.Get(project, managedZone).Context(ctx).Do()
   if err != nil {
@@ -308,7 +320,8 @@ func main() {
   }
 
   // Identifies the project addressed by this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
   call := c.ManagedZones.List(project)
@@ -355,7 +368,8 @@ func main() {
   }
 
   // Identifies the project addressed by this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   resp, err := c.Projects.Get(project).Context(ctx).Do()
   if err != nil {
@@ -397,10 +411,12 @@ func main() {
   }
 
   // Identifies the project addressed by this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-  managedZone := "{MY-MANAGED-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  managedZone := "{MY-MANAGED-ZONE}"
 
 
   call := c.ResourceRecordSets.List(project, managedZone)

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_logging.v2beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_logging.v2beta1.json.baseline
@@ -164,7 +164,8 @@ func main() {
   }
 
   // Required. The resource name of the log to delete. Example: `"projects/my-project/logs/syslog"`.
-  logName := "projects/{MY-PROJECT}/logs/{MY-LOG}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  logName := "projects/{MY-PROJECT}/logs/{MY-LOG}"
 
   resp, err := c.Projects.Logs.Delete(logName).Context(ctx).Do()
   if err != nil {
@@ -207,7 +208,8 @@ func main() {
 
   // The resource name of the project in which to create the metric. Example: `"projects/my-project-id"`.
   // The new metric must be provided in the request.
-  projectName := "projects/{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectName := "projects/{MY-PROJECT}"
 
   resp, err := c.Projects.Metrics.Create(projectName, &logging.LogMetric{
                                            // TODO: Fill required fields.
@@ -251,7 +253,8 @@ func main() {
   }
 
   // The resource name of the metric to delete. Example: `"projects/my-project-id/metrics/my-metric-id"`.
-  metricName := "projects/{MY-PROJECT}/metrics/{MY-METRIC}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  metricName := "projects/{MY-PROJECT}/metrics/{MY-METRIC}"
 
   resp, err := c.Projects.Metrics.Delete(metricName).Context(ctx).Do()
   if err != nil {
@@ -293,7 +296,8 @@ func main() {
   }
 
   // The resource name of the desired metric. Example: `"projects/my-project-id/metrics/my-metric-id"`.
-  metricName := "projects/{MY-PROJECT}/metrics/{MY-METRIC}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  metricName := "projects/{MY-PROJECT}/metrics/{MY-METRIC}"
 
   resp, err := c.Projects.Metrics.Get(metricName).Context(ctx).Do()
   if err != nil {
@@ -336,7 +340,8 @@ func main() {
 
   // Required. The resource name of the project containing the metrics. Example:
   // `"projects/my-project-id"`.
-  projectName := "projects/{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectName := "projects/{MY-PROJECT}"
 
 
   call := c.Projects.Metrics.List(projectName)
@@ -385,7 +390,8 @@ func main() {
   // The resource name of the metric to update. Example: `"projects/my-project-id/metrics/my-metric-id"`.
   // The updated metric must be provided in the request and have the same identifier that is specified in
   // `metricName`. If the metric does not exist, it is created.
-  metricName := "projects/{MY-PROJECT}/metrics/{MY-METRIC}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  metricName := "projects/{MY-PROJECT}/metrics/{MY-METRIC}"
 
   resp, err := c.Projects.Metrics.Update(metricName, &logging.LogMetric{
                                            // TODO: Fill required fields.
@@ -430,7 +436,8 @@ func main() {
 
   // The resource name of the project in which to create the sink. Example: `"projects/my-project-id"`.
   // The new sink must be provided in the request.
-  projectName := "projects/{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectName := "projects/{MY-PROJECT}"
 
   resp, err := c.Projects.Sinks.Create(projectName, &logging.LogSink{
                                          // TODO: Fill required fields.
@@ -474,7 +481,8 @@ func main() {
   }
 
   // The resource name of the sink to delete. Example: `"projects/my-project-id/sinks/my-sink-id"`.
-  sinkName := "projects/{MY-PROJECT}/sinks/{MY-SINK}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  sinkName := "projects/{MY-PROJECT}/sinks/{MY-SINK}"
 
   resp, err := c.Projects.Sinks.Delete(sinkName).Context(ctx).Do()
   if err != nil {
@@ -516,7 +524,8 @@ func main() {
   }
 
   // The resource name of the sink to return. Example: `"projects/my-project-id/sinks/my-sink-id"`.
-  sinkName := "projects/{MY-PROJECT}/sinks/{MY-SINK}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  sinkName := "projects/{MY-PROJECT}/sinks/{MY-SINK}"
 
   resp, err := c.Projects.Sinks.Get(sinkName).Context(ctx).Do()
   if err != nil {
@@ -559,7 +568,8 @@ func main() {
 
   // Required. The resource name of the project containing the sinks. Example:
   // `"projects/my-logging-project"`, `"projects/01234567890"`.
-  projectName := "projects/{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectName := "projects/{MY-PROJECT}"
 
 
   call := c.Projects.Sinks.List(projectName)
@@ -608,7 +618,8 @@ func main() {
   // The resource name of the sink to update. Example: `"projects/my-project-id/sinks/my-sink-id"`. The
   // updated sink must be provided in the request and have the same name that is specified in `sinkName`.
   // If the sink does not exist, it is created.
-  sinkName := "projects/{MY-PROJECT}/sinks/{MY-SINK}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  sinkName := "projects/{MY-PROJECT}/sinks/{MY-SINK}"
 
   resp, err := c.Projects.Sinks.Update(sinkName, &logging.LogSink{
                                          // TODO: Fill required fields.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_prediction.v1.6.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_prediction.v1.6.json.baseline
@@ -32,10 +32,12 @@ func main() {
   }
 
   // The project associated with the model.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of a hosted model.
-  hostedModelName := "{MY-HOSTED-MODEL-NAME}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  hostedModelName := "{MY-HOSTED-MODEL-NAME}"
 
   resp, err := c.Hostedmodels.Predict(project, hostedModelName, &prediction.Input{
                                         // TODO: Fill required fields.
@@ -79,10 +81,12 @@ func main() {
   }
 
   // The project associated with the model.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The unique name for the predictive model.
-  id := "{MY-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  id := "{MY-ID}"
 
   resp, err := c.Trainedmodels.Analyze(project, id).Context(ctx).Do()
   if err != nil {
@@ -124,10 +128,12 @@ func main() {
   }
 
   // The project associated with the model.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The unique name for the predictive model.
-  id := "{MY-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  id := "{MY-ID}"
 
   if err := c.Trainedmodels.Delete(project, id).Context(ctx).Do(); err != nil {
     // TODO: Handle error.
@@ -166,10 +172,12 @@ func main() {
   }
 
   // The project associated with the model.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The unique name for the predictive model.
-  id := "{MY-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  id := "{MY-ID}"
 
   resp, err := c.Trainedmodels.Get(project, id).Context(ctx).Do()
   if err != nil {
@@ -211,7 +219,8 @@ func main() {
   }
 
   // The project associated with the model.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   resp, err := c.Trainedmodels.Insert(project, &prediction.Insert{
                                         // TODO: Fill required fields.
@@ -255,7 +264,8 @@ func main() {
   }
 
   // The project associated with the model.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
   call := c.Trainedmodels.List(project)
@@ -302,10 +312,12 @@ func main() {
   }
 
   // The project associated with the model.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The unique name for the predictive model.
-  id := "{MY-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  id := "{MY-ID}"
 
   resp, err := c.Trainedmodels.Predict(project, id, &prediction.Input{
                                          // TODO: Fill required fields.
@@ -349,10 +361,12 @@ func main() {
   }
 
   // The project associated with the model.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The unique name for the predictive model.
-  id := "{MY-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  id := "{MY-ID}"
 
   resp, err := c.Trainedmodels.Update(project, id, &prediction.Update{
                                         // TODO: Fill required fields.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_prediction.v1.6.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_prediction.v1.6.json.baseline
@@ -32,10 +32,10 @@ func main() {
   }
 
   // The project associated with the model.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of a hosted model.
-  hostedModelName := "" // TODO: Update placeholder value.
+  hostedModelName := "{MY-HOSTED-MODEL-NAME}" // TODO: Update placeholder value.
 
   resp, err := c.Hostedmodels.Predict(project, hostedModelName, &prediction.Input{
                                         // TODO: Fill required fields.
@@ -79,10 +79,10 @@ func main() {
   }
 
   // The project associated with the model.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The unique name for the predictive model.
-  id := "" // TODO: Update placeholder value.
+  id := "{MY-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Trainedmodels.Analyze(project, id).Context(ctx).Do()
   if err != nil {
@@ -124,10 +124,10 @@ func main() {
   }
 
   // The project associated with the model.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The unique name for the predictive model.
-  id := "" // TODO: Update placeholder value.
+  id := "{MY-ID}" // TODO: Update placeholder value.
 
   if err := c.Trainedmodels.Delete(project, id).Context(ctx).Do(); err != nil {
     // TODO: Handle error.
@@ -166,10 +166,10 @@ func main() {
   }
 
   // The project associated with the model.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The unique name for the predictive model.
-  id := "" // TODO: Update placeholder value.
+  id := "{MY-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Trainedmodels.Get(project, id).Context(ctx).Do()
   if err != nil {
@@ -211,7 +211,7 @@ func main() {
   }
 
   // The project associated with the model.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   resp, err := c.Trainedmodels.Insert(project, &prediction.Insert{
                                         // TODO: Fill required fields.
@@ -255,7 +255,7 @@ func main() {
   }
 
   // The project associated with the model.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
   call := c.Trainedmodels.List(project)
@@ -302,10 +302,10 @@ func main() {
   }
 
   // The project associated with the model.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The unique name for the predictive model.
-  id := "" // TODO: Update placeholder value.
+  id := "{MY-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Trainedmodels.Predict(project, id, &prediction.Input{
                                          // TODO: Fill required fields.
@@ -349,10 +349,10 @@ func main() {
   }
 
   // The project associated with the model.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The unique name for the predictive model.
-  id := "" // TODO: Update placeholder value.
+  id := "{MY-ID}" // TODO: Update placeholder value.
 
   resp, err := c.Trainedmodels.Update(project, id, &prediction.Update{
                                         // TODO: Fill required fields.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_pubsub.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_pubsub.v1.json.baseline
@@ -32,7 +32,8 @@ func main() {
   }
 
   // The subscription whose message is being acknowledged.
-  subscription := "projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  subscription := "projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}"
 
   resp, err := c.Projects.Subscriptions.Acknowledge(subscription, &pubsub.AcknowledgeRequest{
                                                       // TODO: Fill required fields.
@@ -80,7 +81,8 @@ func main() {
   // contain only letters (`[A-Za-z]`), numbers (`[0-9]`), dashes (`-`), underscores (`_`), periods
   // (`.`), tildes (`~`), plus (`+`) or percent signs (`%`). It must be between 3 and 255 characters in
   // length, and it must not start with `"goog"`.
-  name := "projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  name := "projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}"
 
   resp, err := c.Projects.Subscriptions.Create(name, &pubsub.Subscription{
                                                  // TODO: Fill required fields.
@@ -124,7 +126,8 @@ func main() {
   }
 
   // The subscription to delete.
-  subscription := "projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  subscription := "projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}"
 
   resp, err := c.Projects.Subscriptions.Delete(subscription).Context(ctx).Do()
   if err != nil {
@@ -166,7 +169,8 @@ func main() {
   }
 
   // The name of the subscription to get.
-  subscription := "projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  subscription := "projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}"
 
   resp, err := c.Projects.Subscriptions.Get(subscription).Context(ctx).Do()
   if err != nil {
@@ -211,7 +215,8 @@ func main() {
   // path, such as, `projects/{project}/zones/{zone}/disks/{disk}`. The format for the path specified in
   // this value is resource specific and is specified in the documentation for the respective
   // GetIamPolicy rpc.
-  resource := "projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  resource := "projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}"
 
   resp, err := c.Projects.Subscriptions.GetIamPolicy(resource).Context(ctx).Do()
   if err != nil {
@@ -253,7 +258,8 @@ func main() {
   }
 
   // The name of the cloud project that subscriptions belong to.
-  project := "projects/{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "projects/{MY-PROJECT}"
 
 
   call := c.Projects.Subscriptions.List(project)
@@ -300,7 +306,8 @@ func main() {
   }
 
   // The name of the subscription.
-  subscription := "projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  subscription := "projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}"
 
   resp, err := c.Projects.Subscriptions.ModifyAckDeadline(subscription, &pubsub.ModifyAckDeadlineRequest{
                                                             // TODO: Fill required fields.
@@ -344,7 +351,8 @@ func main() {
   }
 
   // The name of the subscription.
-  subscription := "projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  subscription := "projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}"
 
   resp, err := c.Projects.Subscriptions.ModifyPushConfig(subscription, &pubsub.ModifyPushConfigRequest{
                                                            // TODO: Fill required fields.
@@ -388,7 +396,8 @@ func main() {
   }
 
   // The subscription from which messages should be pulled.
-  subscription := "projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  subscription := "projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}"
 
   resp, err := c.Projects.Subscriptions.Pull(subscription, &pubsub.PullRequest{
                                                // TODO: Fill required fields.
@@ -435,7 +444,8 @@ func main() {
   // path, such as, `projects/{project}/zones/{zone}/disks/{disk}`. The format for the path specified in
   // this value is resource specific and is specified in the documentation for the respective
   // SetIamPolicy rpc.
-  resource := "projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  resource := "projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}"
 
   resp, err := c.Projects.Subscriptions.SetIamPolicy(resource, &pubsub.SetIamPolicyRequest{
                                                        // TODO: Fill required fields.
@@ -482,7 +492,8 @@ func main() {
   // as a path, such as, `projects/{project}/zones/{zone}/disks/{disk}`. The format for the path
   // specified in this value is resource specific and is specified in the documentation for the
   // respective TestIamPermissions rpc.
-  resource := "projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  resource := "projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}"
 
   resp, err := c.Projects.Subscriptions.TestIamPermissions(resource, &pubsub.TestIamPermissionsRequest{
                                                              // TODO: Fill required fields.
@@ -529,7 +540,8 @@ func main() {
   // start with a letter, and contain only letters (`[A-Za-z]`), numbers (`[0-9]`), dashes (`-`),
   // underscores (`_`), periods (`.`), tildes (`~`), plus (`+`) or percent signs (`%`). It must be
   // between 3 and 255 characters in length, and it must not start with `"goog"`.
-  name := "projects/{MY-PROJECT}/topics/{MY-TOPIC}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  name := "projects/{MY-PROJECT}/topics/{MY-TOPIC}"
 
   resp, err := c.Projects.Topics.Create(name, &pubsub.Topic{
                                           // TODO: Fill required fields.
@@ -573,7 +585,8 @@ func main() {
   }
 
   // Name of the topic to delete.
-  topic := "projects/{MY-PROJECT}/topics/{MY-TOPIC}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  topic := "projects/{MY-PROJECT}/topics/{MY-TOPIC}"
 
   resp, err := c.Projects.Topics.Delete(topic).Context(ctx).Do()
   if err != nil {
@@ -615,7 +628,8 @@ func main() {
   }
 
   // The name of the topic to get.
-  topic := "projects/{MY-PROJECT}/topics/{MY-TOPIC}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  topic := "projects/{MY-PROJECT}/topics/{MY-TOPIC}"
 
   resp, err := c.Projects.Topics.Get(topic).Context(ctx).Do()
   if err != nil {
@@ -660,7 +674,8 @@ func main() {
   // path, such as, `projects/{project}/zones/{zone}/disks/{disk}`. The format for the path specified in
   // this value is resource specific and is specified in the documentation for the respective
   // GetIamPolicy rpc.
-  resource := "projects/{MY-PROJECT}/topics/{MY-TOPIC}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  resource := "projects/{MY-PROJECT}/topics/{MY-TOPIC}"
 
   resp, err := c.Projects.Topics.GetIamPolicy(resource).Context(ctx).Do()
   if err != nil {
@@ -702,7 +717,8 @@ func main() {
   }
 
   // The name of the cloud project that topics belong to.
-  project := "projects/{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "projects/{MY-PROJECT}"
 
 
   call := c.Projects.Topics.List(project)
@@ -749,7 +765,8 @@ func main() {
   }
 
   // The messages in the request will be published on this topic.
-  topic := "projects/{MY-PROJECT}/topics/{MY-TOPIC}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  topic := "projects/{MY-PROJECT}/topics/{MY-TOPIC}"
 
   resp, err := c.Projects.Topics.Publish(topic, &pubsub.PublishRequest{
                                            // TODO: Fill required fields.
@@ -796,7 +813,8 @@ func main() {
   // path, such as, `projects/{project}/zones/{zone}/disks/{disk}`. The format for the path specified in
   // this value is resource specific and is specified in the documentation for the respective
   // SetIamPolicy rpc.
-  resource := "projects/{MY-PROJECT}/topics/{MY-TOPIC}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  resource := "projects/{MY-PROJECT}/topics/{MY-TOPIC}"
 
   resp, err := c.Projects.Topics.SetIamPolicy(resource, &pubsub.SetIamPolicyRequest{
                                                 // TODO: Fill required fields.
@@ -840,7 +858,8 @@ func main() {
   }
 
   // The name of the topic that subscriptions are attached to.
-  topic := "projects/{MY-PROJECT}/topics/{MY-TOPIC}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  topic := "projects/{MY-PROJECT}/topics/{MY-TOPIC}"
 
 
   call := c.Projects.Topics.Subscriptions.List(topic)
@@ -890,7 +909,8 @@ func main() {
   // as a path, such as, `projects/{project}/zones/{zone}/disks/{disk}`. The format for the path
   // specified in this value is resource specific and is specified in the documentation for the
   // respective TestIamPermissions rpc.
-  resource := "projects/{MY-PROJECT}/topics/{MY-TOPIC}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  resource := "projects/{MY-PROJECT}/topics/{MY-TOPIC}"
 
   resp, err := c.Projects.Topics.TestIamPermissions(resource, &pubsub.TestIamPermissionsRequest{
                                                       // TODO: Fill required fields.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_replicapoolupdater.v1beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_replicapoolupdater.v1beta1.json.baseline
@@ -32,13 +32,13 @@ func main() {
   }
 
   // The Google Developers Console project name.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone in which the update's target resides.
-  zone := "" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}" // TODO: Update placeholder value.
 
   // The name of the update.
-  rollingUpdate := "" // TODO: Update placeholder value.
+  rollingUpdate := "{MY-ROLLING-UPDATE}" // TODO: Update placeholder value.
 
   resp, err := c.RollingUpdates.Cancel(project, zone, rollingUpdate).Context(ctx).Do()
   if err != nil {
@@ -80,13 +80,13 @@ func main() {
   }
 
   // The Google Developers Console project name.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone in which the update's target resides.
-  zone := "" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}" // TODO: Update placeholder value.
 
   // The name of the update.
-  rollingUpdate := "" // TODO: Update placeholder value.
+  rollingUpdate := "{MY-ROLLING-UPDATE}" // TODO: Update placeholder value.
 
   resp, err := c.RollingUpdates.Get(project, zone, rollingUpdate).Context(ctx).Do()
   if err != nil {
@@ -128,10 +128,10 @@ func main() {
   }
 
   // The Google Developers Console project name.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone in which the update's target resides.
-  zone := "" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}" // TODO: Update placeholder value.
 
   resp, err := c.RollingUpdates.Insert(project, zone, &replicapoolupdater.RollingUpdate{
                                          // TODO: Fill required fields.
@@ -175,10 +175,10 @@ func main() {
   }
 
   // The Google Developers Console project name.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone in which the update's target resides.
-  zone := "" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}" // TODO: Update placeholder value.
 
 
   call := c.RollingUpdates.List(project, zone)
@@ -225,13 +225,13 @@ func main() {
   }
 
   // The Google Developers Console project name.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone in which the update's target resides.
-  zone := "" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}" // TODO: Update placeholder value.
 
   // The name of the update.
-  rollingUpdate := "" // TODO: Update placeholder value.
+  rollingUpdate := "{MY-ROLLING-UPDATE}" // TODO: Update placeholder value.
 
 
   call := c.RollingUpdates.ListInstanceUpdates(project, zone, rollingUpdate)
@@ -278,13 +278,13 @@ func main() {
   }
 
   // The Google Developers Console project name.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone in which the update's target resides.
-  zone := "" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}" // TODO: Update placeholder value.
 
   // The name of the update.
-  rollingUpdate := "" // TODO: Update placeholder value.
+  rollingUpdate := "{MY-ROLLING-UPDATE}" // TODO: Update placeholder value.
 
   resp, err := c.RollingUpdates.Pause(project, zone, rollingUpdate).Context(ctx).Do()
   if err != nil {
@@ -326,13 +326,13 @@ func main() {
   }
 
   // The Google Developers Console project name.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone in which the update's target resides.
-  zone := "" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}" // TODO: Update placeholder value.
 
   // The name of the update.
-  rollingUpdate := "" // TODO: Update placeholder value.
+  rollingUpdate := "{MY-ROLLING-UPDATE}" // TODO: Update placeholder value.
 
   resp, err := c.RollingUpdates.Resume(project, zone, rollingUpdate).Context(ctx).Do()
   if err != nil {
@@ -374,13 +374,13 @@ func main() {
   }
 
   // The Google Developers Console project name.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The name of the zone in which the update's target resides.
-  zone := "" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}" // TODO: Update placeholder value.
 
   // The name of the update.
-  rollingUpdate := "" // TODO: Update placeholder value.
+  rollingUpdate := "{MY-ROLLING-UPDATE}" // TODO: Update placeholder value.
 
   resp, err := c.RollingUpdates.Rollback(project, zone, rollingUpdate).Context(ctx).Do()
   if err != nil {
@@ -422,13 +422,13 @@ func main() {
   }
 
   // Name of the project scoping this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the zone scoping this request.
-  zone := "" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}" // TODO: Update placeholder value.
 
   // Name of the operation resource to return.
-  operation := "" // TODO: Update placeholder value.
+  operation := "{MY-OPERATION}" // TODO: Update placeholder value.
 
   resp, err := c.ZoneOperations.Get(project, zone, operation).Context(ctx).Do()
   if err != nil {
@@ -470,10 +470,10 @@ func main() {
   }
 
   // Name of the project scoping this request.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Name of the zone scoping this request.
-  zone := "" // TODO: Update placeholder value.
+  zone := "{MY-ZONE}" // TODO: Update placeholder value.
 
 
   call := c.ZoneOperations.List(project, zone)

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_replicapoolupdater.v1beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_replicapoolupdater.v1beta1.json.baseline
@@ -32,13 +32,16 @@ func main() {
   }
 
   // The Google Developers Console project name.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone in which the update's target resides.
-  zone := "{MY-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"
 
   // The name of the update.
-  rollingUpdate := "{MY-ROLLING-UPDATE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  rollingUpdate := "{MY-ROLLING-UPDATE}"
 
   resp, err := c.RollingUpdates.Cancel(project, zone, rollingUpdate).Context(ctx).Do()
   if err != nil {
@@ -80,13 +83,16 @@ func main() {
   }
 
   // The Google Developers Console project name.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone in which the update's target resides.
-  zone := "{MY-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"
 
   // The name of the update.
-  rollingUpdate := "{MY-ROLLING-UPDATE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  rollingUpdate := "{MY-ROLLING-UPDATE}"
 
   resp, err := c.RollingUpdates.Get(project, zone, rollingUpdate).Context(ctx).Do()
   if err != nil {
@@ -128,10 +134,12 @@ func main() {
   }
 
   // The Google Developers Console project name.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone in which the update's target resides.
-  zone := "{MY-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"
 
   resp, err := c.RollingUpdates.Insert(project, zone, &replicapoolupdater.RollingUpdate{
                                          // TODO: Fill required fields.
@@ -175,10 +183,12 @@ func main() {
   }
 
   // The Google Developers Console project name.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone in which the update's target resides.
-  zone := "{MY-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"
 
 
   call := c.RollingUpdates.List(project, zone)
@@ -225,13 +235,16 @@ func main() {
   }
 
   // The Google Developers Console project name.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone in which the update's target resides.
-  zone := "{MY-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"
 
   // The name of the update.
-  rollingUpdate := "{MY-ROLLING-UPDATE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  rollingUpdate := "{MY-ROLLING-UPDATE}"
 
 
   call := c.RollingUpdates.ListInstanceUpdates(project, zone, rollingUpdate)
@@ -278,13 +291,16 @@ func main() {
   }
 
   // The Google Developers Console project name.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone in which the update's target resides.
-  zone := "{MY-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"
 
   // The name of the update.
-  rollingUpdate := "{MY-ROLLING-UPDATE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  rollingUpdate := "{MY-ROLLING-UPDATE}"
 
   resp, err := c.RollingUpdates.Pause(project, zone, rollingUpdate).Context(ctx).Do()
   if err != nil {
@@ -326,13 +342,16 @@ func main() {
   }
 
   // The Google Developers Console project name.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone in which the update's target resides.
-  zone := "{MY-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"
 
   // The name of the update.
-  rollingUpdate := "{MY-ROLLING-UPDATE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  rollingUpdate := "{MY-ROLLING-UPDATE}"
 
   resp, err := c.RollingUpdates.Resume(project, zone, rollingUpdate).Context(ctx).Do()
   if err != nil {
@@ -374,13 +393,16 @@ func main() {
   }
 
   // The Google Developers Console project name.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The name of the zone in which the update's target resides.
-  zone := "{MY-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"
 
   // The name of the update.
-  rollingUpdate := "{MY-ROLLING-UPDATE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  rollingUpdate := "{MY-ROLLING-UPDATE}"
 
   resp, err := c.RollingUpdates.Rollback(project, zone, rollingUpdate).Context(ctx).Do()
   if err != nil {
@@ -422,13 +444,16 @@ func main() {
   }
 
   // Name of the project scoping this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the zone scoping this request.
-  zone := "{MY-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"
 
   // Name of the operation resource to return.
-  operation := "{MY-OPERATION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  operation := "{MY-OPERATION}"
 
   resp, err := c.ZoneOperations.Get(project, zone, operation).Context(ctx).Do()
   if err != nil {
@@ -470,10 +495,12 @@ func main() {
   }
 
   // Name of the project scoping this request.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Name of the zone scoping this request.
-  zone := "{MY-ZONE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  zone := "{MY-ZONE}"
 
 
   call := c.ZoneOperations.List(project, zone)

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_sqladmin.v1beta4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_sqladmin.v1beta4.json.baseline
@@ -32,13 +32,16 @@ func main() {
   }
 
   // Project ID of the project that contains the instance.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Cloud SQL instance ID. This does not include the project ID.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   // The ID of the Backup Run to delete. To find a Backup Run ID, use the list method.
-  id := int64(0) // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  id := int64(0)
 
   resp, err := c.BackupRuns.Delete(project, instance, id).Context(ctx).Do()
   if err != nil {
@@ -80,13 +83,16 @@ func main() {
   }
 
   // Project ID of the project that contains the instance.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Cloud SQL instance ID. This does not include the project ID.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   // The ID of this Backup Run.
-  id := int64(0) // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  id := int64(0)
 
   resp, err := c.BackupRuns.Get(project, instance, id).Context(ctx).Do()
   if err != nil {
@@ -128,10 +134,12 @@ func main() {
   }
 
   // Project ID of the project that contains the instance.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Cloud SQL instance ID. This does not include the project ID.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
 
   call := c.BackupRuns.List(project, instance)
@@ -178,13 +186,16 @@ func main() {
   }
 
   // Project ID of the project that contains the instance.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Database instance ID. This does not include the project ID.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   // Name of the database to be deleted in the instance.
-  database := "{MY-DATABASE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  database := "{MY-DATABASE}"
 
   resp, err := c.Databases.Delete(project, instance, database).Context(ctx).Do()
   if err != nil {
@@ -226,13 +237,16 @@ func main() {
   }
 
   // Project ID of the project that contains the instance.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Database instance ID. This does not include the project ID.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   // Name of the database in the instance.
-  database := "{MY-DATABASE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  database := "{MY-DATABASE}"
 
   resp, err := c.Databases.Get(project, instance, database).Context(ctx).Do()
   if err != nil {
@@ -274,10 +288,12 @@ func main() {
   }
 
   // Project ID of the project that contains the instance.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Database instance ID. This does not include the project ID.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   resp, err := c.Databases.Insert(project, instance, &sqladmin.Database{
                                     // TODO: Fill required fields.
@@ -321,10 +337,12 @@ func main() {
   }
 
   // Project ID of the project for which to list Cloud SQL instances.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Cloud SQL instance ID. This does not include the project ID.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   resp, err := c.Databases.List(project, instance).Context(ctx).Do()
   if err != nil {
@@ -366,13 +384,16 @@ func main() {
   }
 
   // Project ID of the project that contains the instance.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Database instance ID. This does not include the project ID.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   // Name of the database to be updated in the instance.
-  database := "{MY-DATABASE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  database := "{MY-DATABASE}"
 
   resp, err := c.Databases.Patch(project, instance, database, &sqladmin.Database{
                                    // TODO: Fill required fields.
@@ -416,13 +437,16 @@ func main() {
   }
 
   // Project ID of the project that contains the instance.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Database instance ID. This does not include the project ID.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   // Name of the database to be updated in the instance.
-  database := "{MY-DATABASE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  database := "{MY-DATABASE}"
 
   resp, err := c.Databases.Update(project, instance, database, &sqladmin.Database{
                                     // TODO: Fill required fields.
@@ -507,10 +531,12 @@ func main() {
   }
 
   // Project ID of the source as well as the clone Cloud SQL instance.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The ID of the Cloud SQL instance to be cloned (source). This does not include the project ID.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   resp, err := c.Instances.Clone(project, instance, &sqladmin.InstancesCloneRequest{
                                    // TODO: Fill required fields.
@@ -554,10 +580,12 @@ func main() {
   }
 
   // Project ID of the project that contains the instance to be deleted.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Cloud SQL instance ID. This does not include the project ID.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   resp, err := c.Instances.Delete(project, instance).Context(ctx).Do()
   if err != nil {
@@ -599,10 +627,12 @@ func main() {
   }
 
   // Project ID of the project that contains the instance to be exported.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Cloud SQL instance ID. This does not include the project ID.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   resp, err := c.Instances.Export(project, instance, &sqladmin.InstancesExportRequest{
                                     // TODO: Fill required fields.
@@ -646,10 +676,12 @@ func main() {
   }
 
   // ID of the project that contains the read replica.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Cloud SQL instance ID. This does not include the project ID.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   resp, err := c.Instances.Failover(project, instance, &sqladmin.InstancesFailoverRequest{
                                       // TODO: Fill required fields.
@@ -693,10 +725,12 @@ func main() {
   }
 
   // Project ID of the project that contains the instance.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Database instance ID. This does not include the project ID.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   resp, err := c.Instances.Get(project, instance).Context(ctx).Do()
   if err != nil {
@@ -738,10 +772,12 @@ func main() {
   }
 
   // Project ID of the project that contains the instance.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Cloud SQL instance ID. This does not include the project ID.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   resp, err := c.Instances.Import(project, instance, &sqladmin.InstancesImportRequest{
                                     // TODO: Fill required fields.
@@ -785,7 +821,8 @@ func main() {
   }
 
   // Project ID of the project to which the newly created Cloud SQL instances should belong.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   resp, err := c.Instances.Insert(project, &sqladmin.DatabaseInstance{
                                     // TODO: Fill required fields.
@@ -829,7 +866,8 @@ func main() {
   }
 
   // Project ID of the project for which to list Cloud SQL instances.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
   call := c.Instances.List(project)
@@ -876,10 +914,12 @@ func main() {
   }
 
   // Project ID of the project that contains the instance.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Cloud SQL instance ID. This does not include the project ID.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   resp, err := c.Instances.Patch(project, instance, &sqladmin.DatabaseInstance{
                                    // TODO: Fill required fields.
@@ -923,10 +963,12 @@ func main() {
   }
 
   // ID of the project that contains the read replica.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Cloud SQL read replica instance name.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   resp, err := c.Instances.PromoteReplica(project, instance).Context(ctx).Do()
   if err != nil {
@@ -968,10 +1010,12 @@ func main() {
   }
 
   // Project ID of the project that contains the instance.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Cloud SQL instance ID. This does not include the project ID.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   resp, err := c.Instances.ResetSslConfig(project, instance).Context(ctx).Do()
   if err != nil {
@@ -1013,10 +1057,12 @@ func main() {
   }
 
   // Project ID of the project that contains the instance to be restarted.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Cloud SQL instance ID. This does not include the project ID.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   resp, err := c.Instances.Restart(project, instance).Context(ctx).Do()
   if err != nil {
@@ -1058,10 +1104,12 @@ func main() {
   }
 
   // Project ID of the project that contains the instance.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Cloud SQL instance ID. This does not include the project ID.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   resp, err := c.Instances.RestoreBackup(project, instance, &sqladmin.InstancesRestoreBackupRequest{
                                            // TODO: Fill required fields.
@@ -1105,10 +1153,12 @@ func main() {
   }
 
   // ID of the project that contains the read replica.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Cloud SQL read replica instance name.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   resp, err := c.Instances.StartReplica(project, instance).Context(ctx).Do()
   if err != nil {
@@ -1150,10 +1200,12 @@ func main() {
   }
 
   // ID of the project that contains the read replica.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Cloud SQL read replica instance name.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   resp, err := c.Instances.StopReplica(project, instance).Context(ctx).Do()
   if err != nil {
@@ -1195,10 +1247,12 @@ func main() {
   }
 
   // Project ID of the project that contains the instance.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Cloud SQL instance ID. This does not include the project ID.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   resp, err := c.Instances.Update(project, instance, &sqladmin.DatabaseInstance{
                                     // TODO: Fill required fields.
@@ -1242,10 +1296,12 @@ func main() {
   }
 
   // Project ID of the project that contains the instance.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Instance operation ID.
-  operation := "{MY-OPERATION}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  operation := "{MY-OPERATION}"
 
   resp, err := c.Operations.Get(project, operation).Context(ctx).Do()
   if err != nil {
@@ -1287,10 +1343,12 @@ func main() {
   }
 
   // Project ID of the project that contains the instance.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Cloud SQL instance ID. This does not include the project ID.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
 
   call := c.Operations.List(project, instance)
@@ -1337,10 +1395,12 @@ func main() {
   }
 
   // Project ID of the Cloud SQL project.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Cloud SQL instance ID. This does not include the project ID.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   resp, err := c.SslCerts.CreateEphemeral(project, instance, &sqladmin.SslCertsCreateEphemeralRequest{
                                             // TODO: Fill required fields.
@@ -1384,13 +1444,16 @@ func main() {
   }
 
   // Project ID of the project that contains the instance to be deleted.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Cloud SQL instance ID. This does not include the project ID.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   // Sha1 FingerPrint.
-  sha1Fingerprint := "{MY-SHA1-FINGERPRINT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  sha1Fingerprint := "{MY-SHA1-FINGERPRINT}"
 
   resp, err := c.SslCerts.Delete(project, instance, sha1Fingerprint).Context(ctx).Do()
   if err != nil {
@@ -1432,13 +1495,16 @@ func main() {
   }
 
   // Project ID of the project that contains the instance.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Cloud SQL instance ID. This does not include the project ID.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   // Sha1 FingerPrint.
-  sha1Fingerprint := "{MY-SHA1-FINGERPRINT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  sha1Fingerprint := "{MY-SHA1-FINGERPRINT}"
 
   resp, err := c.SslCerts.Get(project, instance, sha1Fingerprint).Context(ctx).Do()
   if err != nil {
@@ -1480,10 +1546,12 @@ func main() {
   }
 
   // Project ID of the project to which the newly created Cloud SQL instances should belong.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Cloud SQL instance ID. This does not include the project ID.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   resp, err := c.SslCerts.Insert(project, instance, &sqladmin.SslCertsInsertRequest{
                                    // TODO: Fill required fields.
@@ -1527,10 +1595,12 @@ func main() {
   }
 
   // Project ID of the project for which to list Cloud SQL instances.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Cloud SQL instance ID. This does not include the project ID.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   resp, err := c.SslCerts.List(project, instance).Context(ctx).Do()
   if err != nil {
@@ -1572,7 +1642,8 @@ func main() {
   }
 
   // Project ID of the project for which to list tiers.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   resp, err := c.Tiers.List(project).Context(ctx).Do()
   if err != nil {
@@ -1614,16 +1685,20 @@ func main() {
   }
 
   // Project ID of the project that contains the instance.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Database instance ID. This does not include the project ID.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   // Host of the user in the instance.
-  host := "{MY-HOST}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  host := "{MY-HOST}"
 
   // Name of the user in the instance.
-  name := "{MY-NAME}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  name := "{MY-NAME}"
 
   resp, err := c.Users.Delete(project, instance, host, name).Context(ctx).Do()
   if err != nil {
@@ -1665,10 +1740,12 @@ func main() {
   }
 
   // Project ID of the project that contains the instance.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Database instance ID. This does not include the project ID.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   resp, err := c.Users.Insert(project, instance, &sqladmin.User{
                                 // TODO: Fill required fields.
@@ -1712,10 +1789,12 @@ func main() {
   }
 
   // Project ID of the project that contains the instance.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Database instance ID. This does not include the project ID.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   resp, err := c.Users.List(project, instance).Context(ctx).Do()
   if err != nil {
@@ -1757,16 +1836,20 @@ func main() {
   }
 
   // Project ID of the project that contains the instance.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // Database instance ID. This does not include the project ID.
-  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}"
 
   // Host of the user in the instance.
-  host := "{MY-HOST}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  host := "{MY-HOST}"
 
   // Name of the user in the instance.
-  name := "{MY-NAME}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  name := "{MY-NAME}"
 
   resp, err := c.Users.Update(project, instance, host, name, &sqladmin.User{
                                 // TODO: Fill required fields.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_sqladmin.v1beta4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_sqladmin.v1beta4.json.baseline
@@ -32,10 +32,10 @@ func main() {
   }
 
   // Project ID of the project that contains the instance.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Cloud SQL instance ID. This does not include the project ID.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   // The ID of the Backup Run to delete. To find a Backup Run ID, use the list method.
   id := int64(0) // TODO: Update placeholder value.
@@ -80,10 +80,10 @@ func main() {
   }
 
   // Project ID of the project that contains the instance.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Cloud SQL instance ID. This does not include the project ID.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   // The ID of this Backup Run.
   id := int64(0) // TODO: Update placeholder value.
@@ -128,10 +128,10 @@ func main() {
   }
 
   // Project ID of the project that contains the instance.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Cloud SQL instance ID. This does not include the project ID.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
 
   call := c.BackupRuns.List(project, instance)
@@ -178,13 +178,13 @@ func main() {
   }
 
   // Project ID of the project that contains the instance.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Database instance ID. This does not include the project ID.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   // Name of the database to be deleted in the instance.
-  database := "" // TODO: Update placeholder value.
+  database := "{MY-DATABASE}" // TODO: Update placeholder value.
 
   resp, err := c.Databases.Delete(project, instance, database).Context(ctx).Do()
   if err != nil {
@@ -226,13 +226,13 @@ func main() {
   }
 
   // Project ID of the project that contains the instance.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Database instance ID. This does not include the project ID.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   // Name of the database in the instance.
-  database := "" // TODO: Update placeholder value.
+  database := "{MY-DATABASE}" // TODO: Update placeholder value.
 
   resp, err := c.Databases.Get(project, instance, database).Context(ctx).Do()
   if err != nil {
@@ -274,10 +274,10 @@ func main() {
   }
 
   // Project ID of the project that contains the instance.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Database instance ID. This does not include the project ID.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   resp, err := c.Databases.Insert(project, instance, &sqladmin.Database{
                                     // TODO: Fill required fields.
@@ -321,10 +321,10 @@ func main() {
   }
 
   // Project ID of the project for which to list Cloud SQL instances.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Cloud SQL instance ID. This does not include the project ID.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   resp, err := c.Databases.List(project, instance).Context(ctx).Do()
   if err != nil {
@@ -366,13 +366,13 @@ func main() {
   }
 
   // Project ID of the project that contains the instance.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Database instance ID. This does not include the project ID.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   // Name of the database to be updated in the instance.
-  database := "" // TODO: Update placeholder value.
+  database := "{MY-DATABASE}" // TODO: Update placeholder value.
 
   resp, err := c.Databases.Patch(project, instance, database, &sqladmin.Database{
                                    // TODO: Fill required fields.
@@ -416,13 +416,13 @@ func main() {
   }
 
   // Project ID of the project that contains the instance.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Database instance ID. This does not include the project ID.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   // Name of the database to be updated in the instance.
-  database := "" // TODO: Update placeholder value.
+  database := "{MY-DATABASE}" // TODO: Update placeholder value.
 
   resp, err := c.Databases.Update(project, instance, database, &sqladmin.Database{
                                     // TODO: Fill required fields.
@@ -507,10 +507,10 @@ func main() {
   }
 
   // Project ID of the source as well as the clone Cloud SQL instance.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The ID of the Cloud SQL instance to be cloned (source). This does not include the project ID.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   resp, err := c.Instances.Clone(project, instance, &sqladmin.InstancesCloneRequest{
                                    // TODO: Fill required fields.
@@ -554,10 +554,10 @@ func main() {
   }
 
   // Project ID of the project that contains the instance to be deleted.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Cloud SQL instance ID. This does not include the project ID.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   resp, err := c.Instances.Delete(project, instance).Context(ctx).Do()
   if err != nil {
@@ -599,10 +599,10 @@ func main() {
   }
 
   // Project ID of the project that contains the instance to be exported.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Cloud SQL instance ID. This does not include the project ID.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   resp, err := c.Instances.Export(project, instance, &sqladmin.InstancesExportRequest{
                                     // TODO: Fill required fields.
@@ -646,10 +646,10 @@ func main() {
   }
 
   // ID of the project that contains the read replica.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Cloud SQL instance ID. This does not include the project ID.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   resp, err := c.Instances.Failover(project, instance, &sqladmin.InstancesFailoverRequest{
                                       // TODO: Fill required fields.
@@ -693,10 +693,10 @@ func main() {
   }
 
   // Project ID of the project that contains the instance.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Database instance ID. This does not include the project ID.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   resp, err := c.Instances.Get(project, instance).Context(ctx).Do()
   if err != nil {
@@ -738,10 +738,10 @@ func main() {
   }
 
   // Project ID of the project that contains the instance.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Cloud SQL instance ID. This does not include the project ID.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   resp, err := c.Instances.Import(project, instance, &sqladmin.InstancesImportRequest{
                                     // TODO: Fill required fields.
@@ -785,7 +785,7 @@ func main() {
   }
 
   // Project ID of the project to which the newly created Cloud SQL instances should belong.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   resp, err := c.Instances.Insert(project, &sqladmin.DatabaseInstance{
                                     // TODO: Fill required fields.
@@ -829,7 +829,7 @@ func main() {
   }
 
   // Project ID of the project for which to list Cloud SQL instances.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
   call := c.Instances.List(project)
@@ -876,10 +876,10 @@ func main() {
   }
 
   // Project ID of the project that contains the instance.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Cloud SQL instance ID. This does not include the project ID.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   resp, err := c.Instances.Patch(project, instance, &sqladmin.DatabaseInstance{
                                    // TODO: Fill required fields.
@@ -923,10 +923,10 @@ func main() {
   }
 
   // ID of the project that contains the read replica.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Cloud SQL read replica instance name.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   resp, err := c.Instances.PromoteReplica(project, instance).Context(ctx).Do()
   if err != nil {
@@ -968,10 +968,10 @@ func main() {
   }
 
   // Project ID of the project that contains the instance.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Cloud SQL instance ID. This does not include the project ID.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   resp, err := c.Instances.ResetSslConfig(project, instance).Context(ctx).Do()
   if err != nil {
@@ -1013,10 +1013,10 @@ func main() {
   }
 
   // Project ID of the project that contains the instance to be restarted.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Cloud SQL instance ID. This does not include the project ID.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   resp, err := c.Instances.Restart(project, instance).Context(ctx).Do()
   if err != nil {
@@ -1058,10 +1058,10 @@ func main() {
   }
 
   // Project ID of the project that contains the instance.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Cloud SQL instance ID. This does not include the project ID.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   resp, err := c.Instances.RestoreBackup(project, instance, &sqladmin.InstancesRestoreBackupRequest{
                                            // TODO: Fill required fields.
@@ -1105,10 +1105,10 @@ func main() {
   }
 
   // ID of the project that contains the read replica.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Cloud SQL read replica instance name.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   resp, err := c.Instances.StartReplica(project, instance).Context(ctx).Do()
   if err != nil {
@@ -1150,10 +1150,10 @@ func main() {
   }
 
   // ID of the project that contains the read replica.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Cloud SQL read replica instance name.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   resp, err := c.Instances.StopReplica(project, instance).Context(ctx).Do()
   if err != nil {
@@ -1195,10 +1195,10 @@ func main() {
   }
 
   // Project ID of the project that contains the instance.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Cloud SQL instance ID. This does not include the project ID.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   resp, err := c.Instances.Update(project, instance, &sqladmin.DatabaseInstance{
                                     // TODO: Fill required fields.
@@ -1242,10 +1242,10 @@ func main() {
   }
 
   // Project ID of the project that contains the instance.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Instance operation ID.
-  operation := "" // TODO: Update placeholder value.
+  operation := "{MY-OPERATION}" // TODO: Update placeholder value.
 
   resp, err := c.Operations.Get(project, operation).Context(ctx).Do()
   if err != nil {
@@ -1287,10 +1287,10 @@ func main() {
   }
 
   // Project ID of the project that contains the instance.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Cloud SQL instance ID. This does not include the project ID.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
 
   call := c.Operations.List(project, instance)
@@ -1337,10 +1337,10 @@ func main() {
   }
 
   // Project ID of the Cloud SQL project.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Cloud SQL instance ID. This does not include the project ID.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   resp, err := c.SslCerts.CreateEphemeral(project, instance, &sqladmin.SslCertsCreateEphemeralRequest{
                                             // TODO: Fill required fields.
@@ -1384,13 +1384,13 @@ func main() {
   }
 
   // Project ID of the project that contains the instance to be deleted.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Cloud SQL instance ID. This does not include the project ID.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   // Sha1 FingerPrint.
-  sha1Fingerprint := "" // TODO: Update placeholder value.
+  sha1Fingerprint := "{MY-SHA1-FINGERPRINT}" // TODO: Update placeholder value.
 
   resp, err := c.SslCerts.Delete(project, instance, sha1Fingerprint).Context(ctx).Do()
   if err != nil {
@@ -1432,13 +1432,13 @@ func main() {
   }
 
   // Project ID of the project that contains the instance.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Cloud SQL instance ID. This does not include the project ID.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   // Sha1 FingerPrint.
-  sha1Fingerprint := "" // TODO: Update placeholder value.
+  sha1Fingerprint := "{MY-SHA1-FINGERPRINT}" // TODO: Update placeholder value.
 
   resp, err := c.SslCerts.Get(project, instance, sha1Fingerprint).Context(ctx).Do()
   if err != nil {
@@ -1480,10 +1480,10 @@ func main() {
   }
 
   // Project ID of the project to which the newly created Cloud SQL instances should belong.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Cloud SQL instance ID. This does not include the project ID.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   resp, err := c.SslCerts.Insert(project, instance, &sqladmin.SslCertsInsertRequest{
                                    // TODO: Fill required fields.
@@ -1527,10 +1527,10 @@ func main() {
   }
 
   // Project ID of the project for which to list Cloud SQL instances.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Cloud SQL instance ID. This does not include the project ID.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   resp, err := c.SslCerts.List(project, instance).Context(ctx).Do()
   if err != nil {
@@ -1572,7 +1572,7 @@ func main() {
   }
 
   // Project ID of the project for which to list tiers.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   resp, err := c.Tiers.List(project).Context(ctx).Do()
   if err != nil {
@@ -1614,16 +1614,16 @@ func main() {
   }
 
   // Project ID of the project that contains the instance.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Database instance ID. This does not include the project ID.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   // Host of the user in the instance.
-  host := "" // TODO: Update placeholder value.
+  host := "{MY-HOST}" // TODO: Update placeholder value.
 
   // Name of the user in the instance.
-  name := "" // TODO: Update placeholder value.
+  name := "{MY-NAME}" // TODO: Update placeholder value.
 
   resp, err := c.Users.Delete(project, instance, host, name).Context(ctx).Do()
   if err != nil {
@@ -1665,10 +1665,10 @@ func main() {
   }
 
   // Project ID of the project that contains the instance.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Database instance ID. This does not include the project ID.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   resp, err := c.Users.Insert(project, instance, &sqladmin.User{
                                 // TODO: Fill required fields.
@@ -1712,10 +1712,10 @@ func main() {
   }
 
   // Project ID of the project that contains the instance.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Database instance ID. This does not include the project ID.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   resp, err := c.Users.List(project, instance).Context(ctx).Do()
   if err != nil {
@@ -1757,16 +1757,16 @@ func main() {
   }
 
   // Project ID of the project that contains the instance.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // Database instance ID. This does not include the project ID.
-  instance := "" // TODO: Update placeholder value.
+  instance := "{MY-INSTANCE}" // TODO: Update placeholder value.
 
   // Host of the user in the instance.
-  host := "" // TODO: Update placeholder value.
+  host := "{MY-HOST}" // TODO: Update placeholder value.
 
   // Name of the user in the instance.
-  name := "" // TODO: Update placeholder value.
+  name := "{MY-NAME}" // TODO: Update placeholder value.
 
   resp, err := c.Users.Update(project, instance, host, name, &sqladmin.User{
                                 // TODO: Fill required fields.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_storage.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_storage.v1.json.baseline
@@ -32,11 +32,11 @@ func main() {
   }
 
   // Name of a bucket.
-  bucket := "" // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
 
   // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
   // group-emailAddress, allUsers, or allAuthenticatedUsers.
-  entity := "" // TODO: Update placeholder value.
+  entity := "{MY-ENTITY}" // TODO: Update placeholder value.
 
   if err := c.BucketAccessControls.Delete(bucket, entity).Context(ctx).Do(); err != nil {
     // TODO: Handle error.
@@ -75,11 +75,11 @@ func main() {
   }
 
   // Name of a bucket.
-  bucket := "" // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
 
   // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
   // group-emailAddress, allUsers, or allAuthenticatedUsers.
-  entity := "" // TODO: Update placeholder value.
+  entity := "{MY-ENTITY}" // TODO: Update placeholder value.
 
   resp, err := c.BucketAccessControls.Get(bucket, entity).Context(ctx).Do()
   if err != nil {
@@ -121,7 +121,7 @@ func main() {
   }
 
   // Name of a bucket.
-  bucket := "" // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
 
   resp, err := c.BucketAccessControls.Insert(bucket, &storage.BucketAccessControl{
                                                // TODO: Fill required fields.
@@ -165,7 +165,7 @@ func main() {
   }
 
   // Name of a bucket.
-  bucket := "" // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
 
   resp, err := c.BucketAccessControls.List(bucket).Context(ctx).Do()
   if err != nil {
@@ -207,11 +207,11 @@ func main() {
   }
 
   // Name of a bucket.
-  bucket := "" // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
 
   // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
   // group-emailAddress, allUsers, or allAuthenticatedUsers.
-  entity := "" // TODO: Update placeholder value.
+  entity := "{MY-ENTITY}" // TODO: Update placeholder value.
 
   resp, err := c.BucketAccessControls.Patch(bucket, entity, &storage.BucketAccessControl{
                                               // TODO: Fill required fields.
@@ -255,11 +255,11 @@ func main() {
   }
 
   // Name of a bucket.
-  bucket := "" // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
 
   // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
   // group-emailAddress, allUsers, or allAuthenticatedUsers.
-  entity := "" // TODO: Update placeholder value.
+  entity := "{MY-ENTITY}" // TODO: Update placeholder value.
 
   resp, err := c.BucketAccessControls.Update(bucket, entity, &storage.BucketAccessControl{
                                                // TODO: Fill required fields.
@@ -303,7 +303,7 @@ func main() {
   }
 
   // Name of a bucket.
-  bucket := "" // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
 
   if err := c.Buckets.Delete(bucket).Context(ctx).Do(); err != nil {
     // TODO: Handle error.
@@ -342,7 +342,7 @@ func main() {
   }
 
   // Name of a bucket.
-  bucket := "" // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
 
   resp, err := c.Buckets.Get(bucket).Context(ctx).Do()
   if err != nil {
@@ -384,7 +384,7 @@ func main() {
   }
 
   // A valid API project identifier.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   resp, err := c.Buckets.Insert(project, &storage.Bucket{
                                   // TODO: Fill required fields.
@@ -428,7 +428,7 @@ func main() {
   }
 
   // A valid API project identifier.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
   call := c.Buckets.List(project)
@@ -475,7 +475,7 @@ func main() {
   }
 
   // Name of a bucket.
-  bucket := "" // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
 
   resp, err := c.Buckets.Patch(bucket, &storage.Bucket{
                                  // TODO: Fill required fields.
@@ -519,7 +519,7 @@ func main() {
   }
 
   // Name of a bucket.
-  bucket := "" // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
 
   resp, err := c.Buckets.Update(bucket, &storage.Bucket{
                                   // TODO: Fill required fields.
@@ -604,11 +604,11 @@ func main() {
   }
 
   // Name of a bucket.
-  bucket := "" // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
 
   // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
   // group-emailAddress, allUsers, or allAuthenticatedUsers.
-  entity := "" // TODO: Update placeholder value.
+  entity := "{MY-ENTITY}" // TODO: Update placeholder value.
 
   if err := c.DefaultObjectAccessControls.Delete(bucket, entity).Context(ctx).Do(); err != nil {
     // TODO: Handle error.
@@ -647,11 +647,11 @@ func main() {
   }
 
   // Name of a bucket.
-  bucket := "" // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
 
   // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
   // group-emailAddress, allUsers, or allAuthenticatedUsers.
-  entity := "" // TODO: Update placeholder value.
+  entity := "{MY-ENTITY}" // TODO: Update placeholder value.
 
   resp, err := c.DefaultObjectAccessControls.Get(bucket, entity).Context(ctx).Do()
   if err != nil {
@@ -693,7 +693,7 @@ func main() {
   }
 
   // Name of a bucket.
-  bucket := "" // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
 
   resp, err := c.DefaultObjectAccessControls.Insert(bucket, &storage.ObjectAccessControl{
                                                       // TODO: Fill required fields.
@@ -737,7 +737,7 @@ func main() {
   }
 
   // Name of a bucket.
-  bucket := "" // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
 
   resp, err := c.DefaultObjectAccessControls.List(bucket).Context(ctx).Do()
   if err != nil {
@@ -779,11 +779,11 @@ func main() {
   }
 
   // Name of a bucket.
-  bucket := "" // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
 
   // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
   // group-emailAddress, allUsers, or allAuthenticatedUsers.
-  entity := "" // TODO: Update placeholder value.
+  entity := "{MY-ENTITY}" // TODO: Update placeholder value.
 
   resp, err := c.DefaultObjectAccessControls.Patch(bucket, entity, &storage.ObjectAccessControl{
                                                      // TODO: Fill required fields.
@@ -827,11 +827,11 @@ func main() {
   }
 
   // Name of a bucket.
-  bucket := "" // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
 
   // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
   // group-emailAddress, allUsers, or allAuthenticatedUsers.
-  entity := "" // TODO: Update placeholder value.
+  entity := "{MY-ENTITY}" // TODO: Update placeholder value.
 
   resp, err := c.DefaultObjectAccessControls.Update(bucket, entity, &storage.ObjectAccessControl{
                                                       // TODO: Fill required fields.
@@ -875,15 +875,15 @@ func main() {
   }
 
   // Name of a bucket.
-  bucket := "" // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
 
   // Name of the object. For information about how to URL encode object names to be path safe, see
   // Encoding URI Path Parts.
-  object := "" // TODO: Update placeholder value.
+  object := "{MY-OBJECT}" // TODO: Update placeholder value.
 
   // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
   // group-emailAddress, allUsers, or allAuthenticatedUsers.
-  entity := "" // TODO: Update placeholder value.
+  entity := "{MY-ENTITY}" // TODO: Update placeholder value.
 
   if err := c.ObjectAccessControls.Delete(bucket, object, entity).Context(ctx).Do(); err != nil {
     // TODO: Handle error.
@@ -922,15 +922,15 @@ func main() {
   }
 
   // Name of a bucket.
-  bucket := "" // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
 
   // Name of the object. For information about how to URL encode object names to be path safe, see
   // Encoding URI Path Parts.
-  object := "" // TODO: Update placeholder value.
+  object := "{MY-OBJECT}" // TODO: Update placeholder value.
 
   // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
   // group-emailAddress, allUsers, or allAuthenticatedUsers.
-  entity := "" // TODO: Update placeholder value.
+  entity := "{MY-ENTITY}" // TODO: Update placeholder value.
 
   resp, err := c.ObjectAccessControls.Get(bucket, object, entity).Context(ctx).Do()
   if err != nil {
@@ -972,11 +972,11 @@ func main() {
   }
 
   // Name of a bucket.
-  bucket := "" // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
 
   // Name of the object. For information about how to URL encode object names to be path safe, see
   // Encoding URI Path Parts.
-  object := "" // TODO: Update placeholder value.
+  object := "{MY-OBJECT}" // TODO: Update placeholder value.
 
   resp, err := c.ObjectAccessControls.Insert(bucket, object, &storage.ObjectAccessControl{
                                                // TODO: Fill required fields.
@@ -1020,11 +1020,11 @@ func main() {
   }
 
   // Name of a bucket.
-  bucket := "" // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
 
   // Name of the object. For information about how to URL encode object names to be path safe, see
   // Encoding URI Path Parts.
-  object := "" // TODO: Update placeholder value.
+  object := "{MY-OBJECT}" // TODO: Update placeholder value.
 
   resp, err := c.ObjectAccessControls.List(bucket, object).Context(ctx).Do()
   if err != nil {
@@ -1066,15 +1066,15 @@ func main() {
   }
 
   // Name of a bucket.
-  bucket := "" // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
 
   // Name of the object. For information about how to URL encode object names to be path safe, see
   // Encoding URI Path Parts.
-  object := "" // TODO: Update placeholder value.
+  object := "{MY-OBJECT}" // TODO: Update placeholder value.
 
   // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
   // group-emailAddress, allUsers, or allAuthenticatedUsers.
-  entity := "" // TODO: Update placeholder value.
+  entity := "{MY-ENTITY}" // TODO: Update placeholder value.
 
   resp, err := c.ObjectAccessControls.Patch(bucket, object, entity, &storage.ObjectAccessControl{
                                               // TODO: Fill required fields.
@@ -1118,15 +1118,15 @@ func main() {
   }
 
   // Name of a bucket.
-  bucket := "" // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
 
   // Name of the object. For information about how to URL encode object names to be path safe, see
   // Encoding URI Path Parts.
-  object := "" // TODO: Update placeholder value.
+  object := "{MY-OBJECT}" // TODO: Update placeholder value.
 
   // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
   // group-emailAddress, allUsers, or allAuthenticatedUsers.
-  entity := "" // TODO: Update placeholder value.
+  entity := "{MY-ENTITY}" // TODO: Update placeholder value.
 
   resp, err := c.ObjectAccessControls.Update(bucket, object, entity, &storage.ObjectAccessControl{
                                                // TODO: Fill required fields.
@@ -1170,11 +1170,11 @@ func main() {
   }
 
   // Name of the bucket in which to store the new object.
-  destinationBucket := "" // TODO: Update placeholder value.
+  destinationBucket := "{MY-DESTINATION-BUCKET}" // TODO: Update placeholder value.
 
   // Name of the new object. For information about how to URL encode object names to be path safe, see
   // Encoding URI Path Parts.
-  destinationObject := "" // TODO: Update placeholder value.
+  destinationObject := "{MY-DESTINATION-OBJECT}" // TODO: Update placeholder value.
 
   resp, err := c.Objects.Compose(destinationBucket, destinationObject, &storage.ComposeRequest{
                                    // TODO: Fill required fields.
@@ -1218,20 +1218,20 @@ func main() {
   }
 
   // Name of the bucket in which to find the source object.
-  sourceBucket := "" // TODO: Update placeholder value.
+  sourceBucket := "{MY-SOURCE-BUCKET}" // TODO: Update placeholder value.
 
   // Name of the source object. For information about how to URL encode object names to be path safe, see
   // Encoding URI Path Parts.
-  sourceObject := "" // TODO: Update placeholder value.
+  sourceObject := "{MY-SOURCE-OBJECT}" // TODO: Update placeholder value.
 
   // Name of the bucket in which to store the new object. Overrides the provided object metadata's bucket
   // value, if any.For information about how to URL encode object names to be path safe, see Encoding URI
   // Path Parts.
-  destinationBucket := "" // TODO: Update placeholder value.
+  destinationBucket := "{MY-DESTINATION-BUCKET}" // TODO: Update placeholder value.
 
   // Name of the new object. Required when the object metadata is not otherwise provided. Overrides the
   // object metadata's name value, if any.
-  destinationObject := "" // TODO: Update placeholder value.
+  destinationObject := "{MY-DESTINATION-OBJECT}" // TODO: Update placeholder value.
 
   resp, err := c.Objects.Copy(sourceBucket, sourceObject, destinationBucket, destinationObject, &storage.Object{
                                 // TODO: Fill required fields.
@@ -1275,11 +1275,11 @@ func main() {
   }
 
   // Name of the bucket in which the object resides.
-  bucket := "" // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
 
   // Name of the object. For information about how to URL encode object names to be path safe, see
   // Encoding URI Path Parts.
-  object := "" // TODO: Update placeholder value.
+  object := "{MY-OBJECT}" // TODO: Update placeholder value.
 
   if err := c.Objects.Delete(bucket, object).Context(ctx).Do(); err != nil {
     // TODO: Handle error.
@@ -1318,11 +1318,11 @@ func main() {
   }
 
   // Name of the bucket in which the object resides.
-  bucket := "" // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
 
   // Name of the object. For information about how to URL encode object names to be path safe, see
   // Encoding URI Path Parts.
-  object := "" // TODO: Update placeholder value.
+  object := "{MY-OBJECT}" // TODO: Update placeholder value.
 
   resp, err := c.Objects.Get(bucket, object).Context(ctx).Do()
   if err != nil {
@@ -1365,7 +1365,7 @@ func main() {
 
   // Name of the bucket in which to store the new object. Overrides the provided object metadata's bucket
   // value, if any.
-  bucket := "" // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
 
   resp, err := c.Objects.Insert(bucket, &storage.Object{
                                   // TODO: Fill required fields.
@@ -1409,7 +1409,7 @@ func main() {
   }
 
   // Name of the bucket in which to look for objects.
-  bucket := "" // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
 
 
   call := c.Objects.List(bucket)
@@ -1456,11 +1456,11 @@ func main() {
   }
 
   // Name of the bucket in which the object resides.
-  bucket := "" // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
 
   // Name of the object. For information about how to URL encode object names to be path safe, see
   // Encoding URI Path Parts.
-  object := "" // TODO: Update placeholder value.
+  object := "{MY-OBJECT}" // TODO: Update placeholder value.
 
   resp, err := c.Objects.Patch(bucket, object, &storage.Object{
                                  // TODO: Fill required fields.
@@ -1504,20 +1504,20 @@ func main() {
   }
 
   // Name of the bucket in which to find the source object.
-  sourceBucket := "" // TODO: Update placeholder value.
+  sourceBucket := "{MY-SOURCE-BUCKET}" // TODO: Update placeholder value.
 
   // Name of the source object. For information about how to URL encode object names to be path safe, see
   // Encoding URI Path Parts.
-  sourceObject := "" // TODO: Update placeholder value.
+  sourceObject := "{MY-SOURCE-OBJECT}" // TODO: Update placeholder value.
 
   // Name of the bucket in which to store the new object. Overrides the provided object metadata's bucket
   // value, if any.
-  destinationBucket := "" // TODO: Update placeholder value.
+  destinationBucket := "{MY-DESTINATION-BUCKET}" // TODO: Update placeholder value.
 
   // Name of the new object. Required when the object metadata is not otherwise provided. Overrides the
   // object metadata's name value, if any. For information about how to URL encode object names to be
   // path safe, see Encoding URI Path Parts.
-  destinationObject := "" // TODO: Update placeholder value.
+  destinationObject := "{MY-DESTINATION-OBJECT}" // TODO: Update placeholder value.
 
   resp, err := c.Objects.Rewrite(sourceBucket, sourceObject, destinationBucket, destinationObject, &storage.Object{
                                    // TODO: Fill required fields.
@@ -1561,11 +1561,11 @@ func main() {
   }
 
   // Name of the bucket in which the object resides.
-  bucket := "" // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
 
   // Name of the object. For information about how to URL encode object names to be path safe, see
   // Encoding URI Path Parts.
-  object := "" // TODO: Update placeholder value.
+  object := "{MY-OBJECT}" // TODO: Update placeholder value.
 
   resp, err := c.Objects.Update(bucket, object, &storage.Object{
                                   // TODO: Fill required fields.
@@ -1609,7 +1609,7 @@ func main() {
   }
 
   // Name of the bucket in which to look for objects.
-  bucket := "" // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
 
   resp, err := c.Objects.WatchAll(bucket, &storage.Channel{
                                     // TODO: Fill required fields.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_storage.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_storage.v1.json.baseline
@@ -32,11 +32,13 @@ func main() {
   }
 
   // Name of a bucket.
-  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}"
 
   // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
   // group-emailAddress, allUsers, or allAuthenticatedUsers.
-  entity := "{MY-ENTITY}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  entity := "{MY-ENTITY}"
 
   if err := c.BucketAccessControls.Delete(bucket, entity).Context(ctx).Do(); err != nil {
     // TODO: Handle error.
@@ -75,11 +77,13 @@ func main() {
   }
 
   // Name of a bucket.
-  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}"
 
   // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
   // group-emailAddress, allUsers, or allAuthenticatedUsers.
-  entity := "{MY-ENTITY}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  entity := "{MY-ENTITY}"
 
   resp, err := c.BucketAccessControls.Get(bucket, entity).Context(ctx).Do()
   if err != nil {
@@ -121,7 +125,8 @@ func main() {
   }
 
   // Name of a bucket.
-  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}"
 
   resp, err := c.BucketAccessControls.Insert(bucket, &storage.BucketAccessControl{
                                                // TODO: Fill required fields.
@@ -165,7 +170,8 @@ func main() {
   }
 
   // Name of a bucket.
-  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}"
 
   resp, err := c.BucketAccessControls.List(bucket).Context(ctx).Do()
   if err != nil {
@@ -207,11 +213,13 @@ func main() {
   }
 
   // Name of a bucket.
-  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}"
 
   // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
   // group-emailAddress, allUsers, or allAuthenticatedUsers.
-  entity := "{MY-ENTITY}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  entity := "{MY-ENTITY}"
 
   resp, err := c.BucketAccessControls.Patch(bucket, entity, &storage.BucketAccessControl{
                                               // TODO: Fill required fields.
@@ -255,11 +263,13 @@ func main() {
   }
 
   // Name of a bucket.
-  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}"
 
   // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
   // group-emailAddress, allUsers, or allAuthenticatedUsers.
-  entity := "{MY-ENTITY}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  entity := "{MY-ENTITY}"
 
   resp, err := c.BucketAccessControls.Update(bucket, entity, &storage.BucketAccessControl{
                                                // TODO: Fill required fields.
@@ -303,7 +313,8 @@ func main() {
   }
 
   // Name of a bucket.
-  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}"
 
   if err := c.Buckets.Delete(bucket).Context(ctx).Do(); err != nil {
     // TODO: Handle error.
@@ -342,7 +353,8 @@ func main() {
   }
 
   // Name of a bucket.
-  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}"
 
   resp, err := c.Buckets.Get(bucket).Context(ctx).Do()
   if err != nil {
@@ -384,7 +396,8 @@ func main() {
   }
 
   // A valid API project identifier.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   resp, err := c.Buckets.Insert(project, &storage.Bucket{
                                   // TODO: Fill required fields.
@@ -428,7 +441,8 @@ func main() {
   }
 
   // A valid API project identifier.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
   call := c.Buckets.List(project)
@@ -475,7 +489,8 @@ func main() {
   }
 
   // Name of a bucket.
-  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}"
 
   resp, err := c.Buckets.Patch(bucket, &storage.Bucket{
                                  // TODO: Fill required fields.
@@ -519,7 +534,8 @@ func main() {
   }
 
   // Name of a bucket.
-  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}"
 
   resp, err := c.Buckets.Update(bucket, &storage.Bucket{
                                   // TODO: Fill required fields.
@@ -604,11 +620,13 @@ func main() {
   }
 
   // Name of a bucket.
-  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}"
 
   // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
   // group-emailAddress, allUsers, or allAuthenticatedUsers.
-  entity := "{MY-ENTITY}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  entity := "{MY-ENTITY}"
 
   if err := c.DefaultObjectAccessControls.Delete(bucket, entity).Context(ctx).Do(); err != nil {
     // TODO: Handle error.
@@ -647,11 +665,13 @@ func main() {
   }
 
   // Name of a bucket.
-  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}"
 
   // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
   // group-emailAddress, allUsers, or allAuthenticatedUsers.
-  entity := "{MY-ENTITY}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  entity := "{MY-ENTITY}"
 
   resp, err := c.DefaultObjectAccessControls.Get(bucket, entity).Context(ctx).Do()
   if err != nil {
@@ -693,7 +713,8 @@ func main() {
   }
 
   // Name of a bucket.
-  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}"
 
   resp, err := c.DefaultObjectAccessControls.Insert(bucket, &storage.ObjectAccessControl{
                                                       // TODO: Fill required fields.
@@ -737,7 +758,8 @@ func main() {
   }
 
   // Name of a bucket.
-  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}"
 
   resp, err := c.DefaultObjectAccessControls.List(bucket).Context(ctx).Do()
   if err != nil {
@@ -779,11 +801,13 @@ func main() {
   }
 
   // Name of a bucket.
-  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}"
 
   // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
   // group-emailAddress, allUsers, or allAuthenticatedUsers.
-  entity := "{MY-ENTITY}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  entity := "{MY-ENTITY}"
 
   resp, err := c.DefaultObjectAccessControls.Patch(bucket, entity, &storage.ObjectAccessControl{
                                                      // TODO: Fill required fields.
@@ -827,11 +851,13 @@ func main() {
   }
 
   // Name of a bucket.
-  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}"
 
   // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
   // group-emailAddress, allUsers, or allAuthenticatedUsers.
-  entity := "{MY-ENTITY}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  entity := "{MY-ENTITY}"
 
   resp, err := c.DefaultObjectAccessControls.Update(bucket, entity, &storage.ObjectAccessControl{
                                                       // TODO: Fill required fields.
@@ -875,15 +901,18 @@ func main() {
   }
 
   // Name of a bucket.
-  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}"
 
   // Name of the object. For information about how to URL encode object names to be path safe, see
   // Encoding URI Path Parts.
-  object := "{MY-OBJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  object := "{MY-OBJECT}"
 
   // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
   // group-emailAddress, allUsers, or allAuthenticatedUsers.
-  entity := "{MY-ENTITY}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  entity := "{MY-ENTITY}"
 
   if err := c.ObjectAccessControls.Delete(bucket, object, entity).Context(ctx).Do(); err != nil {
     // TODO: Handle error.
@@ -922,15 +951,18 @@ func main() {
   }
 
   // Name of a bucket.
-  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}"
 
   // Name of the object. For information about how to URL encode object names to be path safe, see
   // Encoding URI Path Parts.
-  object := "{MY-OBJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  object := "{MY-OBJECT}"
 
   // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
   // group-emailAddress, allUsers, or allAuthenticatedUsers.
-  entity := "{MY-ENTITY}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  entity := "{MY-ENTITY}"
 
   resp, err := c.ObjectAccessControls.Get(bucket, object, entity).Context(ctx).Do()
   if err != nil {
@@ -972,11 +1004,13 @@ func main() {
   }
 
   // Name of a bucket.
-  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}"
 
   // Name of the object. For information about how to URL encode object names to be path safe, see
   // Encoding URI Path Parts.
-  object := "{MY-OBJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  object := "{MY-OBJECT}"
 
   resp, err := c.ObjectAccessControls.Insert(bucket, object, &storage.ObjectAccessControl{
                                                // TODO: Fill required fields.
@@ -1020,11 +1054,13 @@ func main() {
   }
 
   // Name of a bucket.
-  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}"
 
   // Name of the object. For information about how to URL encode object names to be path safe, see
   // Encoding URI Path Parts.
-  object := "{MY-OBJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  object := "{MY-OBJECT}"
 
   resp, err := c.ObjectAccessControls.List(bucket, object).Context(ctx).Do()
   if err != nil {
@@ -1066,15 +1102,18 @@ func main() {
   }
 
   // Name of a bucket.
-  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}"
 
   // Name of the object. For information about how to URL encode object names to be path safe, see
   // Encoding URI Path Parts.
-  object := "{MY-OBJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  object := "{MY-OBJECT}"
 
   // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
   // group-emailAddress, allUsers, or allAuthenticatedUsers.
-  entity := "{MY-ENTITY}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  entity := "{MY-ENTITY}"
 
   resp, err := c.ObjectAccessControls.Patch(bucket, object, entity, &storage.ObjectAccessControl{
                                               // TODO: Fill required fields.
@@ -1118,15 +1157,18 @@ func main() {
   }
 
   // Name of a bucket.
-  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}"
 
   // Name of the object. For information about how to URL encode object names to be path safe, see
   // Encoding URI Path Parts.
-  object := "{MY-OBJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  object := "{MY-OBJECT}"
 
   // The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
   // group-emailAddress, allUsers, or allAuthenticatedUsers.
-  entity := "{MY-ENTITY}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  entity := "{MY-ENTITY}"
 
   resp, err := c.ObjectAccessControls.Update(bucket, object, entity, &storage.ObjectAccessControl{
                                                // TODO: Fill required fields.
@@ -1170,11 +1212,13 @@ func main() {
   }
 
   // Name of the bucket in which to store the new object.
-  destinationBucket := "{MY-DESTINATION-BUCKET}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  destinationBucket := "{MY-DESTINATION-BUCKET}"
 
   // Name of the new object. For information about how to URL encode object names to be path safe, see
   // Encoding URI Path Parts.
-  destinationObject := "{MY-DESTINATION-OBJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  destinationObject := "{MY-DESTINATION-OBJECT}"
 
   resp, err := c.Objects.Compose(destinationBucket, destinationObject, &storage.ComposeRequest{
                                    // TODO: Fill required fields.
@@ -1218,20 +1262,24 @@ func main() {
   }
 
   // Name of the bucket in which to find the source object.
-  sourceBucket := "{MY-SOURCE-BUCKET}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  sourceBucket := "{MY-SOURCE-BUCKET}"
 
   // Name of the source object. For information about how to URL encode object names to be path safe, see
   // Encoding URI Path Parts.
-  sourceObject := "{MY-SOURCE-OBJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  sourceObject := "{MY-SOURCE-OBJECT}"
 
   // Name of the bucket in which to store the new object. Overrides the provided object metadata's bucket
   // value, if any.For information about how to URL encode object names to be path safe, see Encoding URI
   // Path Parts.
-  destinationBucket := "{MY-DESTINATION-BUCKET}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  destinationBucket := "{MY-DESTINATION-BUCKET}"
 
   // Name of the new object. Required when the object metadata is not otherwise provided. Overrides the
   // object metadata's name value, if any.
-  destinationObject := "{MY-DESTINATION-OBJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  destinationObject := "{MY-DESTINATION-OBJECT}"
 
   resp, err := c.Objects.Copy(sourceBucket, sourceObject, destinationBucket, destinationObject, &storage.Object{
                                 // TODO: Fill required fields.
@@ -1275,11 +1323,13 @@ func main() {
   }
 
   // Name of the bucket in which the object resides.
-  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}"
 
   // Name of the object. For information about how to URL encode object names to be path safe, see
   // Encoding URI Path Parts.
-  object := "{MY-OBJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  object := "{MY-OBJECT}"
 
   if err := c.Objects.Delete(bucket, object).Context(ctx).Do(); err != nil {
     // TODO: Handle error.
@@ -1318,11 +1368,13 @@ func main() {
   }
 
   // Name of the bucket in which the object resides.
-  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}"
 
   // Name of the object. For information about how to URL encode object names to be path safe, see
   // Encoding URI Path Parts.
-  object := "{MY-OBJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  object := "{MY-OBJECT}"
 
   resp, err := c.Objects.Get(bucket, object).Context(ctx).Do()
   if err != nil {
@@ -1365,7 +1417,8 @@ func main() {
 
   // Name of the bucket in which to store the new object. Overrides the provided object metadata's bucket
   // value, if any.
-  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}"
 
   resp, err := c.Objects.Insert(bucket, &storage.Object{
                                   // TODO: Fill required fields.
@@ -1409,7 +1462,8 @@ func main() {
   }
 
   // Name of the bucket in which to look for objects.
-  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}"
 
 
   call := c.Objects.List(bucket)
@@ -1456,11 +1510,13 @@ func main() {
   }
 
   // Name of the bucket in which the object resides.
-  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}"
 
   // Name of the object. For information about how to URL encode object names to be path safe, see
   // Encoding URI Path Parts.
-  object := "{MY-OBJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  object := "{MY-OBJECT}"
 
   resp, err := c.Objects.Patch(bucket, object, &storage.Object{
                                  // TODO: Fill required fields.
@@ -1504,20 +1560,24 @@ func main() {
   }
 
   // Name of the bucket in which to find the source object.
-  sourceBucket := "{MY-SOURCE-BUCKET}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  sourceBucket := "{MY-SOURCE-BUCKET}"
 
   // Name of the source object. For information about how to URL encode object names to be path safe, see
   // Encoding URI Path Parts.
-  sourceObject := "{MY-SOURCE-OBJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  sourceObject := "{MY-SOURCE-OBJECT}"
 
   // Name of the bucket in which to store the new object. Overrides the provided object metadata's bucket
   // value, if any.
-  destinationBucket := "{MY-DESTINATION-BUCKET}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  destinationBucket := "{MY-DESTINATION-BUCKET}"
 
   // Name of the new object. Required when the object metadata is not otherwise provided. Overrides the
   // object metadata's name value, if any. For information about how to URL encode object names to be
   // path safe, see Encoding URI Path Parts.
-  destinationObject := "{MY-DESTINATION-OBJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  destinationObject := "{MY-DESTINATION-OBJECT}"
 
   resp, err := c.Objects.Rewrite(sourceBucket, sourceObject, destinationBucket, destinationObject, &storage.Object{
                                    // TODO: Fill required fields.
@@ -1561,11 +1621,13 @@ func main() {
   }
 
   // Name of the bucket in which the object resides.
-  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}"
 
   // Name of the object. For information about how to URL encode object names to be path safe, see
   // Encoding URI Path Parts.
-  object := "{MY-OBJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  object := "{MY-OBJECT}"
 
   resp, err := c.Objects.Update(bucket, object, &storage.Object{
                                   // TODO: Fill required fields.
@@ -1609,7 +1671,8 @@ func main() {
   }
 
   // Name of the bucket in which to look for objects.
-  bucket := "{MY-BUCKET}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  bucket := "{MY-BUCKET}"
 
   resp, err := c.Objects.WatchAll(bucket, &storage.Channel{
                                     // TODO: Fill required fields.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_storagetransfer.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_storagetransfer.v1.json.baseline
@@ -74,7 +74,8 @@ func main() {
 
   // The ID of the Google Developers Console project that the Google service account is associated with.
   // Required.
-  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}"
 
   resp, err := c.GoogleServiceAccounts.Get(projectId).Context(ctx).Do()
   if err != nil {
@@ -159,7 +160,8 @@ func main() {
   }
 
   // The job to get. Required.
-  jobName := "{MY-JOB-NAME}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  jobName := "{MY-JOB-NAME}"
 
   resp, err := c.TransferJobs.Get(jobName).Context(ctx).Do()
   if err != nil {
@@ -247,7 +249,8 @@ func main() {
   }
 
   // The name of job to update. Required.
-  jobName := "{MY-JOB-NAME}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  jobName := "{MY-JOB-NAME}"
 
   resp, err := c.TransferJobs.Patch(jobName, &storagetransfer.UpdateTransferJobRequest{
                                       // TODO: Fill required fields.
@@ -291,7 +294,8 @@ func main() {
   }
 
   // The name of the operation resource to be cancelled.
-  name := "{MY-NAME}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  name := "{MY-NAME}"
 
   resp, err := c.TransferOperations.Cancel(name).Context(ctx).Do()
   if err != nil {
@@ -333,7 +337,8 @@ func main() {
   }
 
   // The name of the operation resource to be deleted.
-  name := "{MY-NAME}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  name := "{MY-NAME}"
 
   resp, err := c.TransferOperations.Delete(name).Context(ctx).Do()
   if err != nil {
@@ -375,7 +380,8 @@ func main() {
   }
 
   // The name of the operation resource.
-  name := "{MY-NAME}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  name := "{MY-NAME}"
 
   resp, err := c.TransferOperations.Get(name).Context(ctx).Do()
   if err != nil {
@@ -417,7 +423,8 @@ func main() {
   }
 
   // The value `transferOperations`.
-  name := "{MY-NAME}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  name := "{MY-NAME}"
 
 
   call := c.TransferOperations.List(name)
@@ -464,7 +471,8 @@ func main() {
   }
 
   // The name of the transfer operation. Required.
-  name := "{MY-NAME}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  name := "{MY-NAME}"
 
   resp, err := c.TransferOperations.Pause(name, &storagetransfer.PauseTransferOperationRequest{
                                             // TODO: Fill required fields.
@@ -508,7 +516,8 @@ func main() {
   }
 
   // The name of the transfer operation. Required.
-  name := "{MY-NAME}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  name := "{MY-NAME}"
 
   resp, err := c.TransferOperations.Resume(name, &storagetransfer.ResumeTransferOperationRequest{
                                              // TODO: Fill required fields.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_storagetransfer.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_storagetransfer.v1.json.baseline
@@ -74,7 +74,7 @@ func main() {
 
   // The ID of the Google Developers Console project that the Google service account is associated with.
   // Required.
-  projectId := "" // TODO: Update placeholder value.
+  projectId := "{MY-PROJECT-ID}" // TODO: Update placeholder value.
 
   resp, err := c.GoogleServiceAccounts.Get(projectId).Context(ctx).Do()
   if err != nil {
@@ -159,7 +159,7 @@ func main() {
   }
 
   // The job to get. Required.
-  jobName := "" // TODO: Update placeholder value.
+  jobName := "{MY-JOB-NAME}" // TODO: Update placeholder value.
 
   resp, err := c.TransferJobs.Get(jobName).Context(ctx).Do()
   if err != nil {
@@ -247,7 +247,7 @@ func main() {
   }
 
   // The name of job to update. Required.
-  jobName := "" // TODO: Update placeholder value.
+  jobName := "{MY-JOB-NAME}" // TODO: Update placeholder value.
 
   resp, err := c.TransferJobs.Patch(jobName, &storagetransfer.UpdateTransferJobRequest{
                                       // TODO: Fill required fields.
@@ -291,7 +291,7 @@ func main() {
   }
 
   // The name of the operation resource to be cancelled.
-  name := "" // TODO: Update placeholder value.
+  name := "{MY-NAME}" // TODO: Update placeholder value.
 
   resp, err := c.TransferOperations.Cancel(name).Context(ctx).Do()
   if err != nil {
@@ -333,7 +333,7 @@ func main() {
   }
 
   // The name of the operation resource to be deleted.
-  name := "" // TODO: Update placeholder value.
+  name := "{MY-NAME}" // TODO: Update placeholder value.
 
   resp, err := c.TransferOperations.Delete(name).Context(ctx).Do()
   if err != nil {
@@ -375,7 +375,7 @@ func main() {
   }
 
   // The name of the operation resource.
-  name := "" // TODO: Update placeholder value.
+  name := "{MY-NAME}" // TODO: Update placeholder value.
 
   resp, err := c.TransferOperations.Get(name).Context(ctx).Do()
   if err != nil {
@@ -417,7 +417,7 @@ func main() {
   }
 
   // The value `transferOperations`.
-  name := "" // TODO: Update placeholder value.
+  name := "{MY-NAME}" // TODO: Update placeholder value.
 
 
   call := c.TransferOperations.List(name)
@@ -464,7 +464,7 @@ func main() {
   }
 
   // The name of the transfer operation. Required.
-  name := "" // TODO: Update placeholder value.
+  name := "{MY-NAME}" // TODO: Update placeholder value.
 
   resp, err := c.TransferOperations.Pause(name, &storagetransfer.PauseTransferOperationRequest{
                                             // TODO: Fill required fields.
@@ -508,7 +508,7 @@ func main() {
   }
 
   // The name of the transfer operation. Required.
-  name := "" // TODO: Update placeholder value.
+  name := "{MY-NAME}" // TODO: Update placeholder value.
 
   resp, err := c.TransferOperations.Resume(name, &storagetransfer.ResumeTransferOperationRequest{
                                              // TODO: Fill required fields.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_taskqueue.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_taskqueue.v1beta2.json.baseline
@@ -32,10 +32,12 @@ func main() {
   }
 
   // The project under which the queue lies.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The id of the taskqueue to get the properties of.
-  taskqueue2 := "{MY-TASKQUEUE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  taskqueue2 := "{MY-TASKQUEUE}"
 
   resp, err := c.Taskqueues.Get(project, taskqueue2).Context(ctx).Do()
   if err != nil {
@@ -77,13 +79,16 @@ func main() {
   }
 
   // The project under which the queue lies.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The taskqueue to delete a task from.
-  taskqueue2 := "{MY-TASKQUEUE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  taskqueue2 := "{MY-TASKQUEUE}"
 
   // The id of the task to delete.
-  task := "{MY-TASK}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  task := "{MY-TASK}"
 
   if err := c.Tasks.Delete(project, taskqueue2, task).Context(ctx).Do(); err != nil {
     // TODO: Handle error.
@@ -122,13 +127,16 @@ func main() {
   }
 
   // The project under which the queue lies.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The taskqueue in which the task belongs.
-  taskqueue2 := "{MY-TASKQUEUE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  taskqueue2 := "{MY-TASKQUEUE}"
 
   // The task to get properties of.
-  task := "{MY-TASK}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  task := "{MY-TASK}"
 
   resp, err := c.Tasks.Get(project, taskqueue2, task).Context(ctx).Do()
   if err != nil {
@@ -170,10 +178,12 @@ func main() {
   }
 
   // The project under which the queue lies
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The taskqueue to insert the task into
-  taskqueue2 := "{MY-TASKQUEUE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  taskqueue2 := "{MY-TASKQUEUE}"
 
   resp, err := c.Tasks.Insert(project, taskqueue2, &taskqueue.Task{
                                 // TODO: Fill required fields.
@@ -217,16 +227,20 @@ func main() {
   }
 
   // The project under which the queue lies.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The taskqueue to lease a task from.
-  taskqueue2 := "{MY-TASKQUEUE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  taskqueue2 := "{MY-TASKQUEUE}"
 
   // The number of tasks to lease.
-  numTasks := int64(0) // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  numTasks := int64(0)
 
   // The lease in seconds.
-  leaseSecs := int64(0) // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  leaseSecs := int64(0)
 
   resp, err := c.Tasks.Lease(project, taskqueue2, numTasks, leaseSecs).Context(ctx).Do()
   if err != nil {
@@ -268,10 +282,12 @@ func main() {
   }
 
   // The project under which the queue lies.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
   // The id of the taskqueue to list tasks from.
-  taskqueue2 := "{MY-TASKQUEUE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  taskqueue2 := "{MY-TASKQUEUE}"
 
   resp, err := c.Tasks.List(project, taskqueue2).Context(ctx).Do()
   if err != nil {
@@ -313,16 +329,20 @@ func main() {
   }
 
   // The project under which the queue lies.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
-  taskqueue2 := "{MY-TASKQUEUE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  taskqueue2 := "{MY-TASKQUEUE}"
 
 
-  task := "{MY-TASK}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  task := "{MY-TASK}"
 
   // The new lease in seconds.
-  newLeaseSeconds := int64(0) // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  newLeaseSeconds := int64(0)
 
   resp, err := c.Tasks.Patch(project, taskqueue2, task, newLeaseSeconds, &taskqueue.Task{
                                // TODO: Fill required fields.
@@ -366,16 +386,20 @@ func main() {
   }
 
   // The project under which the queue lies.
-  project := "{MY-PROJECT}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  project := "{MY-PROJECT}"
 
 
-  taskqueue2 := "{MY-TASKQUEUE}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  taskqueue2 := "{MY-TASKQUEUE}"
 
 
-  task := "{MY-TASK}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  task := "{MY-TASK}"
 
   // The new lease in seconds.
-  newLeaseSeconds := int64(0) // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  newLeaseSeconds := int64(0)
 
   resp, err := c.Tasks.Update(project, taskqueue2, task, newLeaseSeconds, &taskqueue.Task{
                                 // TODO: Fill required fields.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_taskqueue.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_taskqueue.v1beta2.json.baseline
@@ -32,10 +32,10 @@ func main() {
   }
 
   // The project under which the queue lies.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The id of the taskqueue to get the properties of.
-  taskqueue2 := "" // TODO: Update placeholder value.
+  taskqueue2 := "{MY-TASKQUEUE}" // TODO: Update placeholder value.
 
   resp, err := c.Taskqueues.Get(project, taskqueue2).Context(ctx).Do()
   if err != nil {
@@ -77,13 +77,13 @@ func main() {
   }
 
   // The project under which the queue lies.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The taskqueue to delete a task from.
-  taskqueue2 := "" // TODO: Update placeholder value.
+  taskqueue2 := "{MY-TASKQUEUE}" // TODO: Update placeholder value.
 
   // The id of the task to delete.
-  task := "" // TODO: Update placeholder value.
+  task := "{MY-TASK}" // TODO: Update placeholder value.
 
   if err := c.Tasks.Delete(project, taskqueue2, task).Context(ctx).Do(); err != nil {
     // TODO: Handle error.
@@ -122,13 +122,13 @@ func main() {
   }
 
   // The project under which the queue lies.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The taskqueue in which the task belongs.
-  taskqueue2 := "" // TODO: Update placeholder value.
+  taskqueue2 := "{MY-TASKQUEUE}" // TODO: Update placeholder value.
 
   // The task to get properties of.
-  task := "" // TODO: Update placeholder value.
+  task := "{MY-TASK}" // TODO: Update placeholder value.
 
   resp, err := c.Tasks.Get(project, taskqueue2, task).Context(ctx).Do()
   if err != nil {
@@ -170,10 +170,10 @@ func main() {
   }
 
   // The project under which the queue lies
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The taskqueue to insert the task into
-  taskqueue2 := "" // TODO: Update placeholder value.
+  taskqueue2 := "{MY-TASKQUEUE}" // TODO: Update placeholder value.
 
   resp, err := c.Tasks.Insert(project, taskqueue2, &taskqueue.Task{
                                 // TODO: Fill required fields.
@@ -217,10 +217,10 @@ func main() {
   }
 
   // The project under which the queue lies.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The taskqueue to lease a task from.
-  taskqueue2 := "" // TODO: Update placeholder value.
+  taskqueue2 := "{MY-TASKQUEUE}" // TODO: Update placeholder value.
 
   // The number of tasks to lease.
   numTasks := int64(0) // TODO: Update placeholder value.
@@ -268,10 +268,10 @@ func main() {
   }
 
   // The project under which the queue lies.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
   // The id of the taskqueue to list tasks from.
-  taskqueue2 := "" // TODO: Update placeholder value.
+  taskqueue2 := "{MY-TASKQUEUE}" // TODO: Update placeholder value.
 
   resp, err := c.Tasks.List(project, taskqueue2).Context(ctx).Do()
   if err != nil {
@@ -313,13 +313,13 @@ func main() {
   }
 
   // The project under which the queue lies.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
-  taskqueue2 := "" // TODO: Update placeholder value.
+  taskqueue2 := "{MY-TASKQUEUE}" // TODO: Update placeholder value.
 
 
-  task := "" // TODO: Update placeholder value.
+  task := "{MY-TASK}" // TODO: Update placeholder value.
 
   // The new lease in seconds.
   newLeaseSeconds := int64(0) // TODO: Update placeholder value.
@@ -366,13 +366,13 @@ func main() {
   }
 
   // The project under which the queue lies.
-  project := "" // TODO: Update placeholder value.
+  project := "{MY-PROJECT}" // TODO: Update placeholder value.
 
 
-  taskqueue2 := "" // TODO: Update placeholder value.
+  taskqueue2 := "{MY-TASKQUEUE}" // TODO: Update placeholder value.
 
 
-  task := "" // TODO: Update placeholder value.
+  task := "{MY-TASK}" // TODO: Update placeholder value.
 
   // The new lease in seconds.
   newLeaseSeconds := int64(0) // TODO: Update placeholder value.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_translate.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_translate.v2.json.baseline
@@ -32,7 +32,8 @@ func main() {
   }
 
   // The text to detect
-  q := []string{} // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  q := []string{}
 
   resp, err := c.Detections.List(q).Context(ctx).Do()
   if err != nil {
@@ -115,10 +116,12 @@ func main() {
   }
 
   // The text to translate
-  q := []string{} // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  q := []string{}
 
   // The target language into which the text should be translated
-  target := "{MY-TARGET}" // TODO: Update placeholder value.
+  // TODO: Update placeholder value.
+  target := "{MY-TARGET}"
 
   resp, err := c.Translations.List(q, target).Context(ctx).Do()
   if err != nil {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_translate.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_translate.v2.json.baseline
@@ -118,7 +118,7 @@ func main() {
   q := []string{} // TODO: Update placeholder value.
 
   // The target language into which the text should be translated
-  target := "" // TODO: Update placeholder value.
+  target := "{MY-TARGET}" // TODO: Update placeholder value.
 
   resp, err := c.Translations.List(q, target).Context(ctx).Do()
   if err != nil {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_adexchangebuyer.v1.4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_adexchangebuyer.v1.4.json.baseline
@@ -616,7 +616,7 @@ public class AdexchangebuyerExample {
     int accountId = 0;
 
     // * The buyer-specific id for this creative.
-    String buyerCreativeId = "";
+    String buyerCreativeId = "{MY-BUYER-CREATIVE-ID}";
 
     // * The id of the deal id to associate with this creative.
     long dealId = 0;
@@ -681,7 +681,7 @@ public class AdexchangebuyerExample {
     int accountId = 0;
 
     // * The buyer-specific id for this creative.
-    String buyerCreativeId = "";
+    String buyerCreativeId = "{MY-BUYER-CREATIVE-ID}";
 
     Adexchangebuyer.Creatives.Get request = adexchangebuyerService.creatives().get(accountId, buyerCreativeId);
     Creative response = request.execute();
@@ -871,7 +871,7 @@ public class AdexchangebuyerExample {
     int accountId = 0;
 
     // * The buyer-specific id for this creative.
-    String buyerCreativeId = "";
+    String buyerCreativeId = "{MY-BUYER-CREATIVE-ID}";
 
     // * The id of the deal id to disassociate with this creative.
     long dealId = 0;
@@ -934,7 +934,7 @@ public class AdexchangebuyerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * The proposalId to delete deals from.
-    String proposalId = "";
+    String proposalId = "{MY-PROPOSAL-ID}";
 
     DeleteOrderDealsRequest content = new DeleteOrderDealsRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -999,7 +999,7 @@ public class AdexchangebuyerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * proposalId for which deals need to be added.
-    String proposalId = "";
+    String proposalId = "{MY-PROPOSAL-ID}";
 
     AddOrderDealsRequest content = new AddOrderDealsRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -1064,7 +1064,7 @@ public class AdexchangebuyerExample {
 
     // * The proposalId to get deals for. To search across proposals specify order_id = '-' as part of the
     //   URL.
-    String proposalId = "";
+    String proposalId = "{MY-PROPOSAL-ID}";
 
     Adexchangebuyer.Marketplacedeals.List request = adexchangebuyerService.marketplacedeals().list(proposalId);
     GetOrderDealsResponse response = request.execute();
@@ -1126,7 +1126,7 @@ public class AdexchangebuyerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * The proposalId to edit deals on.
-    String proposalId = "";
+    String proposalId = "{MY-PROPOSAL-ID}";
 
     EditAllOrderDealsRequest content = new EditAllOrderDealsRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -1191,7 +1191,7 @@ public class AdexchangebuyerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * The proposalId to add notes for.
-    String proposalId = "";
+    String proposalId = "{MY-PROPOSAL-ID}";
 
     AddOrderNotesRequest content = new AddOrderNotesRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -1255,7 +1255,7 @@ public class AdexchangebuyerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * The proposalId to get notes for.
-    String proposalId = "";
+    String proposalId = "{MY-PROPOSAL-ID}";
 
     Adexchangebuyer.Marketplacenotes.List request = adexchangebuyerService.marketplacenotes().list(proposalId);
     GetOrderNotesResponse response = request.execute();
@@ -1316,7 +1316,7 @@ public class AdexchangebuyerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'updateproposal' method:
 
     // * The private auction id to be updated.
-    String privateAuctionId = "";
+    String privateAuctionId = "{MY-PRIVATE-AUCTION-ID}";
 
     UpdatePrivateAuctionProposalRequest content = new UpdatePrivateAuctionProposalRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -1381,10 +1381,10 @@ public class AdexchangebuyerExample {
     long accountId = 0;
 
     // * The end time of the report in ISO 8601 timestamp format using UTC.
-    String endDateTime = "";
+    String endDateTime = "{MY-END-DATE-TIME}";
 
     // * The start time of the report in ISO 8601 timestamp format using UTC.
-    String startDateTime = "";
+    String startDateTime = "{MY-START-DATE-TIME}";
 
     Adexchangebuyer.PerformanceReport.List request = adexchangebuyerService.performanceReport().list(accountId, endDateTime, startDateTime);
     PerformanceReportList response = request.execute();
@@ -1829,7 +1829,7 @@ public class AdexchangebuyerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * The id for the product to get the head revision for.
-    String productId = "";
+    String productId = "{MY-PRODUCT-ID}";
 
     Adexchangebuyer.Products.Get request = adexchangebuyerService.products().get(productId);
     Product response = request.execute();
@@ -1947,7 +1947,7 @@ public class AdexchangebuyerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Id of the proposal to retrieve.
-    String proposalId = "";
+    String proposalId = "{MY-PROPOSAL-ID}";
 
     Adexchangebuyer.Proposals.Get request = adexchangebuyerService.proposals().get(proposalId);
     Proposal response = request.execute();
@@ -2069,7 +2069,7 @@ public class AdexchangebuyerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
     // * The proposal id to update.
-    String proposalId = "";
+    String proposalId = "{MY-PROPOSAL-ID}";
 
     // * The last known revision number to update. If the head revision in the marketplace database has
     //   since changed, an error will be thrown. The caller should then fetch the latest proposal at head
@@ -2077,7 +2077,7 @@ public class AdexchangebuyerExample {
     long revisionNumber = 0;
 
     // * The proposed action to take on the proposal.
-    String updateAction = "";
+    String updateAction = "{MY-UPDATE-ACTION}";
 
     Proposal content = new Proposal();
     // TODO: Add code here to assign values to desired fields of the 'content' object to be changed
@@ -2197,7 +2197,7 @@ public class AdexchangebuyerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'setupcomplete' method:
 
     // * The proposal id for which the setup is complete
-    String proposalId = "";
+    String proposalId = "{MY-PROPOSAL-ID}";
 
     Adexchangebuyer.Proposals.Setupcomplete request = adexchangebuyerService.proposals().setupcomplete(proposalId);
     request.execute();
@@ -2256,7 +2256,7 @@ public class AdexchangebuyerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * The proposal id to update.
-    String proposalId = "";
+    String proposalId = "{MY-PROPOSAL-ID}";
 
     // * The last known revision number to update. If the head revision in the marketplace database has
     //   since changed, an error will be thrown. The caller should then fetch the latest proposal at head
@@ -2264,7 +2264,7 @@ public class AdexchangebuyerExample {
     long revisionNumber = 0;
 
     // * The proposed action to take on the proposal.
-    String updateAction = "";
+    String updateAction = "{MY-UPDATE-ACTION}";
 
     Proposal content = new Proposal();
     // TODO: Add code here to assign values to desired fields of the 'content' object

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_appengine.v1beta5.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_appengine.v1beta5.json.baseline
@@ -52,7 +52,7 @@ public class AppengineExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Part of `name`. Name of the application to get. For example: "apps/myapp".
-    String appsId = "";
+    String appsId = "{MY-APPS-ID}";
 
     Appengine.Apps.Get request = appengineService.apps().get(appsId);
     Application response = request.execute();
@@ -113,10 +113,10 @@ public class AppengineExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Part of `name`. The name of the operation resource.
-    String appsId = "";
+    String appsId = "{MY-APPS-ID}";
 
     // * Part of `name`. See documentation of `appsId`.
-    String operationsId = "";
+    String operationsId = "{MY-OPERATIONS-ID}";
 
     Appengine.Apps.Operations.Get request = appengineService.apps().operations().get(appsId, operationsId);
     Operation response = request.execute();
@@ -178,7 +178,7 @@ public class AppengineExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Part of `name`. The name of the operation collection.
-    String appsId = "";
+    String appsId = "{MY-APPS-ID}";
 
     Appengine.Apps.Operations.List request = appengineService.apps().operations().list(appsId);
     ListOperationsResponse response;
@@ -248,10 +248,10 @@ public class AppengineExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Part of `name`. Name of the resource requested. For example: "apps/myapp/services/default".
-    String appsId = "";
+    String appsId = "{MY-APPS-ID}";
 
     // * Part of `name`. See documentation of `appsId`.
-    String servicesId = "";
+    String servicesId = "{MY-SERVICES-ID}";
 
     Appengine.Apps.Services.Delete request = appengineService.apps().services().delete(appsId, servicesId);
     Operation response = request.execute();
@@ -312,10 +312,10 @@ public class AppengineExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Part of `name`. Name of the resource requested. For example: "apps/myapp/services/default".
-    String appsId = "";
+    String appsId = "{MY-APPS-ID}";
 
     // * Part of `name`. See documentation of `appsId`.
-    String servicesId = "";
+    String servicesId = "{MY-SERVICES-ID}";
 
     Appengine.Apps.Services.Get request = appengineService.apps().services().get(appsId, servicesId);
     Service response = request.execute();
@@ -377,7 +377,7 @@ public class AppengineExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Part of `name`. Name of the resource requested. For example: "apps/myapp".
-    String appsId = "";
+    String appsId = "{MY-APPS-ID}";
 
     Appengine.Apps.Services.List request = appengineService.apps().services().list(appsId);
     ListServicesResponse response;
@@ -448,10 +448,10 @@ public class AppengineExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
     // * Part of `name`. Name of the resource to update. For example: "apps/myapp/services/default".
-    String appsId = "";
+    String appsId = "{MY-APPS-ID}";
 
     // * Part of `name`. See documentation of `appsId`.
-    String servicesId = "";
+    String servicesId = "{MY-SERVICES-ID}";
 
     Service content = new Service();
     // TODO: Add code here to assign values to desired fields of the 'content' object to be changed
@@ -516,10 +516,10 @@ public class AppengineExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'create' method:
 
     // * Part of `name`. Name of the resource to update. For example: "apps/myapp/services/default".
-    String appsId = "";
+    String appsId = "{MY-APPS-ID}";
 
     // * Part of `name`. See documentation of `appsId`.
-    String servicesId = "";
+    String servicesId = "{MY-SERVICES-ID}";
 
     Version content = new Version();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -584,13 +584,13 @@ public class AppengineExample {
 
     // * Part of `name`. Name of the resource requested. For example:
     //   "apps/myapp/services/default/versions/v1".
-    String appsId = "";
+    String appsId = "{MY-APPS-ID}";
 
     // * Part of `name`. See documentation of `appsId`.
-    String servicesId = "";
+    String servicesId = "{MY-SERVICES-ID}";
 
     // * Part of `name`. See documentation of `appsId`.
-    String versionsId = "";
+    String versionsId = "{MY-VERSIONS-ID}";
 
     Appengine.Apps.Services.Versions.Delete request = appengineService.apps().services().versions().delete(appsId, servicesId, versionsId);
     Operation response = request.execute();
@@ -652,13 +652,13 @@ public class AppengineExample {
 
     // * Part of `name`. Name of the resource requested. For example:
     //   "apps/myapp/services/default/versions/v1".
-    String appsId = "";
+    String appsId = "{MY-APPS-ID}";
 
     // * Part of `name`. See documentation of `appsId`.
-    String servicesId = "";
+    String servicesId = "{MY-SERVICES-ID}";
 
     // * Part of `name`. See documentation of `appsId`.
-    String versionsId = "";
+    String versionsId = "{MY-VERSIONS-ID}";
 
     Appengine.Apps.Services.Versions.Get request = appengineService.apps().services().versions().get(appsId, servicesId, versionsId);
     Version response = request.execute();
@@ -721,13 +721,13 @@ public class AppengineExample {
 
     // * Part of `name`. Name of the resource requested. For example:
     //   "apps/myapp/services/default/versions/v1".
-    String appsId = "";
+    String appsId = "{MY-APPS-ID}";
 
     // * Part of `name`. See documentation of `appsId`.
-    String servicesId = "";
+    String servicesId = "{MY-SERVICES-ID}";
 
     // * Part of `name`. See documentation of `appsId`.
-    String versionsId = "";
+    String versionsId = "{MY-VERSIONS-ID}";
 
     Appengine.Apps.Services.Versions.Instances.List request = appengineService.apps().services().versions().instances().list(appsId, servicesId, versionsId);
     ListInstancesResponse response;
@@ -798,10 +798,10 @@ public class AppengineExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Part of `name`. Name of the resource requested. For example: "apps/myapp/services/default".
-    String appsId = "";
+    String appsId = "{MY-APPS-ID}";
 
     // * Part of `name`. See documentation of `appsId`.
-    String servicesId = "";
+    String servicesId = "{MY-SERVICES-ID}";
 
     Appengine.Apps.Services.Versions.List request = appengineService.apps().services().versions().list(appsId, servicesId);
     ListVersionsResponse response;
@@ -873,13 +873,13 @@ public class AppengineExample {
 
     // * Part of `name`. Name of the resource to update. For example:
     //   "apps/myapp/services/default/versions/1".
-    String appsId = "";
+    String appsId = "{MY-APPS-ID}";
 
     // * Part of `name`. See documentation of `appsId`.
-    String servicesId = "";
+    String servicesId = "{MY-SERVICES-ID}";
 
     // * Part of `name`. See documentation of `appsId`.
-    String versionsId = "";
+    String versionsId = "{MY-VERSIONS-ID}";
 
     Version content = new Version();
     // TODO: Add code here to assign values to desired fields of the 'content' object to be changed

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_autoscaler.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_autoscaler.v1beta2.json.baseline
@@ -52,13 +52,13 @@ public class AutoscalerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID of Autoscaler resource.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Zone name of Autoscaler resource.
-    String zone = "";
+    String zone = "{MY-ZONE}";
 
     // * Name of the Autoscaler resource.
-    String autoscaler = "";
+    String autoscaler = "{MY-AUTOSCALER}";
 
     Autoscaler.Autoscalers.Delete request = autoscalerService.autoscalers().delete(project, zone, autoscaler);
     Operation response = request.execute();
@@ -118,13 +118,13 @@ public class AutoscalerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID of Autoscaler resource.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Zone name of Autoscaler resource.
-    String zone = "";
+    String zone = "{MY-ZONE}";
 
     // * Name of the Autoscaler resource.
-    String autoscaler = "";
+    String autoscaler = "{MY-AUTOSCALER}";
 
     Autoscaler.Autoscalers.Get request = autoscalerService.autoscalers().get(project, zone, autoscaler);
     com.google.api.services.autoscaler.model.Autoscaler response = request.execute();
@@ -185,10 +185,10 @@ public class AutoscalerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID of Autoscaler resource.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Zone name of Autoscaler resource.
-    String zone = "";
+    String zone = "{MY-ZONE}";
 
     com.google.api.services.autoscaler.model.Autoscaler content = new com.google.api.services.autoscaler.model.Autoscaler();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -252,10 +252,10 @@ public class AutoscalerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID of Autoscaler resource.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Zone name of Autoscaler resource.
-    String zone = "";
+    String zone = "{MY-ZONE}";
 
     Autoscaler.Autoscalers.List request = autoscalerService.autoscalers().list(project, zone);
     AutoscalerListResponse response;
@@ -325,13 +325,13 @@ public class AutoscalerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
     // * Project ID of Autoscaler resource.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Zone name of Autoscaler resource.
-    String zone = "";
+    String zone = "{MY-ZONE}";
 
     // * Name of the Autoscaler resource.
-    String autoscaler = "";
+    String autoscaler = "{MY-AUTOSCALER}";
 
     com.google.api.services.autoscaler.model.Autoscaler content = new com.google.api.services.autoscaler.model.Autoscaler();
     // TODO: Add code here to assign values to desired fields of the 'content' object to be changed
@@ -395,13 +395,13 @@ public class AutoscalerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * Project ID of Autoscaler resource.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Zone name of Autoscaler resource.
-    String zone = "";
+    String zone = "{MY-ZONE}";
 
     // * Name of the Autoscaler resource.
-    String autoscaler = "";
+    String autoscaler = "{MY-AUTOSCALER}";
 
     com.google.api.services.autoscaler.model.Autoscaler content = new com.google.api.services.autoscaler.model.Autoscaler();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -464,13 +464,13 @@ public class AutoscalerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 
-    String project = "";
+    String project = "{MY-PROJECT}";
 
 
-    String zone = "";
+    String zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
 
-    String operation = "";
+    String operation = "{MY-OPERATION}";
 
     Autoscaler.ZoneOperations.Delete request = autoscalerService.zoneOperations().delete(project, zone, operation);
     request.execute();
@@ -529,13 +529,13 @@ public class AutoscalerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 
-    String project = "";
+    String project = "{MY-PROJECT}";
 
 
-    String zone = "";
+    String zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
 
-    String operation = "";
+    String operation = "{MY-OPERATION}";
 
     Autoscaler.ZoneOperations.Get request = autoscalerService.zoneOperations().get(project, zone, operation);
     Operation response = request.execute();
@@ -597,10 +597,10 @@ public class AutoscalerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 
-    String project = "";
+    String project = "{MY-PROJECT}";
 
 
-    String zone = "";
+    String zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
     Autoscaler.ZoneOperations.List request = autoscalerService.zoneOperations().list(project, zone);
     OperationList response;
@@ -671,7 +671,7 @@ public class AutoscalerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Autoscaler.Zones.List request = autoscalerService.zones().list(project);
     ZoneList response;

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_bigquery.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_bigquery.v2.json.baseline
@@ -51,10 +51,10 @@ public class BigqueryExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID of the dataset being deleted
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     // * Dataset ID of dataset being deleted
-    String datasetId = "";
+    String datasetId = "{MY-DATASET-ID}";
 
     Bigquery.Datasets.Delete request = bigqueryService.datasets().delete(projectId, datasetId);
     request.execute();
@@ -113,10 +113,10 @@ public class BigqueryExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID of the requested dataset
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     // * Dataset ID of the requested dataset
-    String datasetId = "";
+    String datasetId = "{MY-DATASET-ID}";
 
     Bigquery.Datasets.Get request = bigqueryService.datasets().get(projectId, datasetId);
     Dataset response = request.execute();
@@ -177,7 +177,7 @@ public class BigqueryExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID of the new dataset
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     Dataset content = new Dataset();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -242,7 +242,7 @@ public class BigqueryExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID of the datasets to be listed
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     Bigquery.Datasets.List request = bigqueryService.datasets().list(projectId);
     DatasetList response;
@@ -312,10 +312,10 @@ public class BigqueryExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
     // * Project ID of the dataset being updated
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     // * Dataset ID of the dataset being updated
-    String datasetId = "";
+    String datasetId = "{MY-DATASET-ID}";
 
     Dataset content = new Dataset();
     // TODO: Add code here to assign values to desired fields of the 'content' object to be changed
@@ -379,10 +379,10 @@ public class BigqueryExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * Project ID of the dataset being updated
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     // * Dataset ID of the dataset being updated
-    String datasetId = "";
+    String datasetId = "{MY-DATASET-ID}";
 
     Dataset content = new Dataset();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -446,10 +446,10 @@ public class BigqueryExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'cancel' method:
 
     // * [Required] Project ID of the job to cancel
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     // * [Required] Job ID of the job to cancel
-    String jobId = "";
+    String jobId = "{MY-JOB-ID}";
 
     Bigquery.Jobs.Cancel request = bigqueryService.jobs().cancel(projectId, jobId);
     JobCancelResponse response = request.execute();
@@ -510,10 +510,10 @@ public class BigqueryExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * [Required] Project ID of the requested job
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     // * [Required] Job ID of the requested job
-    String jobId = "";
+    String jobId = "{MY-JOB-ID}";
 
     Bigquery.Jobs.Get request = bigqueryService.jobs().get(projectId, jobId);
     Job response = request.execute();
@@ -574,10 +574,10 @@ public class BigqueryExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'getQueryResults' method:
 
     // * [Required] Project ID of the query job
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     // * [Required] Job ID of the query job
-    String jobId = "";
+    String jobId = "{MY-JOB-ID}";
 
     Bigquery.Jobs.GetQueryResults request = bigqueryService.jobs().getQueryResults(projectId, jobId);
     GetQueryResultsResponse response = request.execute();
@@ -638,7 +638,7 @@ public class BigqueryExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID of the project that will be billed for the job
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     Job content = new Job();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -703,7 +703,7 @@ public class BigqueryExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID of the jobs to list
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     Bigquery.Jobs.List request = bigqueryService.jobs().list(projectId);
     JobList response;
@@ -774,7 +774,7 @@ public class BigqueryExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'query' method:
 
     // * Project ID of the project billed for the query
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     QueryRequest content = new QueryRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -906,13 +906,13 @@ public class BigqueryExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insertAll' method:
 
     // * Project ID of the destination table.
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     // * Dataset ID of the destination table.
-    String datasetId = "";
+    String datasetId = "{MY-DATASET-ID}";
 
     // * Table ID of the destination table.
-    String tableId = "";
+    String tableId = "{MY-TABLE-ID}";
 
     TableDataInsertAllRequest content = new TableDataInsertAllRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -976,13 +976,13 @@ public class BigqueryExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID of the table to read
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     // * Dataset ID of the table to read
-    String datasetId = "";
+    String datasetId = "{MY-DATASET-ID}";
 
     // * Table ID of the table to read
-    String tableId = "";
+    String tableId = "{MY-TABLE-ID}";
 
     Bigquery.Tabledata.List request = bigqueryService.tabledata().list(projectId, datasetId, tableId);
     TableDataList response = request.execute();
@@ -1042,13 +1042,13 @@ public class BigqueryExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID of the table to delete
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     // * Dataset ID of the table to delete
-    String datasetId = "";
+    String datasetId = "{MY-DATASET-ID}";
 
     // * Table ID of the table to delete
-    String tableId = "";
+    String tableId = "{MY-TABLE-ID}";
 
     Bigquery.Tables.Delete request = bigqueryService.tables().delete(projectId, datasetId, tableId);
     request.execute();
@@ -1107,13 +1107,13 @@ public class BigqueryExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID of the requested table
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     // * Dataset ID of the requested table
-    String datasetId = "";
+    String datasetId = "{MY-DATASET-ID}";
 
     // * Table ID of the requested table
-    String tableId = "";
+    String tableId = "{MY-TABLE-ID}";
 
     Bigquery.Tables.Get request = bigqueryService.tables().get(projectId, datasetId, tableId);
     Table response = request.execute();
@@ -1174,10 +1174,10 @@ public class BigqueryExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID of the new table
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     // * Dataset ID of the new table
-    String datasetId = "";
+    String datasetId = "{MY-DATASET-ID}";
 
     Table content = new Table();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -1242,10 +1242,10 @@ public class BigqueryExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID of the tables to list
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     // * Dataset ID of the tables to list
-    String datasetId = "";
+    String datasetId = "{MY-DATASET-ID}";
 
     Bigquery.Tables.List request = bigqueryService.tables().list(projectId, datasetId);
     TableList response;
@@ -1315,13 +1315,13 @@ public class BigqueryExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
     // * Project ID of the table to update
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     // * Dataset ID of the table to update
-    String datasetId = "";
+    String datasetId = "{MY-DATASET-ID}";
 
     // * Table ID of the table to update
-    String tableId = "";
+    String tableId = "{MY-TABLE-ID}";
 
     Table content = new Table();
     // TODO: Add code here to assign values to desired fields of the 'content' object to be changed
@@ -1385,13 +1385,13 @@ public class BigqueryExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * Project ID of the table to update
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     // * Dataset ID of the table to update
-    String datasetId = "";
+    String datasetId = "{MY-DATASET-ID}";
 
     // * Table ID of the table to update
-    String tableId = "";
+    String tableId = "{MY-TABLE-ID}";
 
     Table content = new Table();
     // TODO: Add code here to assign values to desired fields of the 'content' object

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_clouddebugger.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_clouddebugger.v2.json.baseline
@@ -52,7 +52,7 @@ public class CloudDebuggerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Identifies the debuggee.
-    String debuggeeId = "";
+    String debuggeeId = "{MY-DEBUGGEE-ID}";
 
     CloudDebugger.Controller.Debuggees.Breakpoints.List request = clouddebuggerService.controller().debuggees().breakpoints().list(debuggeeId);
     ListActiveBreakpointsResponse response = request.execute();
@@ -114,10 +114,10 @@ public class CloudDebuggerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * Identifies the debuggee being debugged.
-    String debuggeeId = "";
+    String debuggeeId = "{MY-DEBUGGEE-ID}";
 
     // * Breakpoint identifier, unique in the scope of the debuggee.
-    String id = "";
+    String id = "{MY-ID}";
 
     UpdateActiveBreakpointRequest content = new UpdateActiveBreakpointRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -241,10 +241,10 @@ public class CloudDebuggerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * ID of the debuggee whose breakpoint to delete.
-    String debuggeeId = "";
+    String debuggeeId = "{MY-DEBUGGEE-ID}";
 
     // * ID of the breakpoint to delete.
-    String breakpointId = "";
+    String breakpointId = "{MY-BREAKPOINT-ID}";
 
     CloudDebugger.Debugger.Debuggees.Breakpoints.Delete request = clouddebuggerService.debugger().debuggees().breakpoints().delete(debuggeeId, breakpointId);
     request.execute();
@@ -303,10 +303,10 @@ public class CloudDebuggerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * ID of the debuggee whose breakpoint to get.
-    String debuggeeId = "";
+    String debuggeeId = "{MY-DEBUGGEE-ID}";
 
     // * ID of the breakpoint to get.
-    String breakpointId = "";
+    String breakpointId = "{MY-BREAKPOINT-ID}";
 
     CloudDebugger.Debugger.Debuggees.Breakpoints.Get request = clouddebuggerService.debugger().debuggees().breakpoints().get(debuggeeId, breakpointId);
     GetBreakpointResponse response = request.execute();
@@ -367,7 +367,7 @@ public class CloudDebuggerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * ID of the debuggee whose breakpoints to list.
-    String debuggeeId = "";
+    String debuggeeId = "{MY-DEBUGGEE-ID}";
 
     CloudDebugger.Debugger.Debuggees.Breakpoints.List request = clouddebuggerService.debugger().debuggees().breakpoints().list(debuggeeId);
     ListBreakpointsResponse response = request.execute();
@@ -429,7 +429,7 @@ public class CloudDebuggerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'set' method:
 
     // * ID of the debuggee where the breakpoint is to be set.
-    String debuggeeId = "";
+    String debuggeeId = "{MY-DEBUGGEE-ID}";
 
     Breakpoint content = new Breakpoint();
     // TODO: Add code here to assign values to desired fields of the 'content' object

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_cloudmonitoring.v2beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_cloudmonitoring.v2beta2.json.baseline
@@ -52,7 +52,7 @@ public class CloudMonitoringExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'create' method:
 
     // * The project id. The value can be the numeric project ID or string-based project name.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     MetricDescriptor content = new MetricDescriptor();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -116,10 +116,10 @@ public class CloudMonitoringExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * The project ID to which the metric belongs.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the metric.
-    String metric = "";
+    String metric = "{MY-METRIC}";
 
     CloudMonitoring.MetricDescriptors.Delete request = cloudmonitoringService.metricDescriptors().delete(project, metric);
     DeleteMetricDescriptorResponse response = request.execute();
@@ -181,7 +181,7 @@ public class CloudMonitoringExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * The project id. The value can be the numeric project ID or string-based project name.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     CloudMonitoring.MetricDescriptors.List request = cloudmonitoringService.metricDescriptors().list(project);
     ListMetricDescriptorsResponse response;
@@ -253,14 +253,14 @@ public class CloudMonitoringExample {
 
     // * The project ID to which this time series belongs. The value can be the numeric project ID or
     //   string-based project name.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Metric names are protocol-free URLs as listed in the Supported Metrics page. For example,
     //   compute.googleapis.com/instance/disk/read_ops_count.
-    String metric = "";
+    String metric = "{MY-METRIC}";
 
     // * End of the time interval (inclusive), which is expressed as an RFC 3339 timestamp.
-    String youngest = "";
+    String youngest = "{MY-YOUNGEST}";
 
     CloudMonitoring.Timeseries.List request = cloudmonitoringService.timeseries().list(project, metric, youngest);
     ListTimeseriesResponse response;
@@ -331,7 +331,7 @@ public class CloudMonitoringExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'write' method:
 
     // * The project ID. The value can be the numeric project ID or string-based project name.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     WriteTimeseriesRequest content = new WriteTimeseriesRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -397,14 +397,14 @@ public class CloudMonitoringExample {
 
     // * The project ID to which this time series belongs. The value can be the numeric project ID or
     //   string-based project name.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Metric names are protocol-free URLs as listed in the Supported Metrics page. For example,
     //   compute.googleapis.com/instance/disk/read_ops_count.
-    String metric = "";
+    String metric = "{MY-METRIC}";
 
     // * End of the time interval (inclusive), which is expressed as an RFC 3339 timestamp.
-    String youngest = "";
+    String youngest = "{MY-YOUNGEST}";
 
     CloudMonitoring.TimeseriesDescriptors.List request = cloudmonitoringService.timeseriesDescriptors().list(project, metric, youngest);
     ListTimeseriesDescriptorsResponse response;

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_cloudresourcemanager.v1beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_cloudresourcemanager.v1beta1.json.baseline
@@ -52,7 +52,7 @@ public class CloudResourceManagerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * The id of the Organization resource to fetch.
-    String organizationId = "";
+    String organizationId = "{MY-ORGANIZATION-ID}";
 
     CloudResourceManager.Organizations.Get request = cloudresourcemanagerService.organizations().get(organizationId);
     Organization response = request.execute();
@@ -116,7 +116,7 @@ public class CloudResourceManagerExample {
     // * REQUIRED: The resource for which the policy is being requested. `resource` is usually specified as
     //   a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified
     //   in this value is resource specific and is specified in the `getIamPolicy` documentation.
-    String resource = "";
+    String resource = "{MY-RESOURCE}";
 
     GetIamPolicyRequest content = new GetIamPolicyRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -250,7 +250,7 @@ public class CloudResourceManagerExample {
     // * REQUIRED: The resource for which the policy is being specified. `resource` is usually specified as
     //   a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified
     //   in this value is resource specific and is specified in the `setIamPolicy` documentation.
-    String resource = "";
+    String resource = "{MY-RESOURCE}";
 
     SetIamPolicyRequest content = new SetIamPolicyRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -318,7 +318,7 @@ public class CloudResourceManagerExample {
     //   specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the
     //   path specified in this value is resource specific and is specified in the `testIamPermissions`
     //   documentation.
-    String resource = "";
+    String resource = "{MY-RESOURCE}";
 
     TestIamPermissionsRequest content = new TestIamPermissionsRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -383,7 +383,7 @@ public class CloudResourceManagerExample {
 
     // * An immutable id for the Organization that is assigned on creation. This should be omitted when
     //   creating a new Organization. This field is read-only.
-    String organizationId = "";
+    String organizationId = "{MY-ORGANIZATION-ID}";
 
     Organization content = new Organization();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -506,7 +506,7 @@ public class CloudResourceManagerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * The Project ID (for example, `foo-bar-123`). Required.
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     CloudResourceManager.Projects.Delete request = cloudresourcemanagerService.projects().delete(projectId);
     request.execute();
@@ -565,7 +565,7 @@ public class CloudResourceManagerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * The Project ID (for example, `my-project-123`). Required.
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     CloudResourceManager.Projects.Get request = cloudresourcemanagerService.projects().get(projectId);
     Project response = request.execute();
@@ -629,7 +629,7 @@ public class CloudResourceManagerExample {
     // * REQUIRED: The resource for which the policy is being requested. `resource` is usually specified as
     //   a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified
     //   in this value is resource specific and is specified in the `getIamPolicy` documentation.
-    String resource = "";
+    String resource = "{MY-RESOURCE}";
 
     GetIamPolicyRequest content = new GetIamPolicyRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -763,7 +763,7 @@ public class CloudResourceManagerExample {
     // * REQUIRED: The resource for which the policy is being specified. `resource` is usually specified as
     //   a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified
     //   in this value is resource specific and is specified in the `setIamPolicy` documentation.
-    String resource = "";
+    String resource = "{MY-RESOURCE}";
 
     SetIamPolicyRequest content = new SetIamPolicyRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -831,7 +831,7 @@ public class CloudResourceManagerExample {
     //   specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the
     //   path specified in this value is resource specific and is specified in the `testIamPermissions`
     //   documentation.
-    String resource = "";
+    String resource = "{MY-RESOURCE}";
 
     TestIamPermissionsRequest content = new TestIamPermissionsRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -895,7 +895,7 @@ public class CloudResourceManagerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'undelete' method:
 
     // * The project ID (for example, `foo-bar-123`). Required.
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     UndeleteProjectRequest content = new UndeleteProjectRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -957,7 +957,7 @@ public class CloudResourceManagerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * The project ID (for example, `my-project-123`). Required.
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     Project content = new Project();
     // TODO: Add code here to assign values to desired fields of the 'content' object

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_cloudtrace.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_cloudtrace.v1.json.baseline
@@ -52,7 +52,7 @@ public class CloudTraceExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'patchTraces' method:
 
     // * ID of the Cloud project where the trace data is stored.
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     Traces content = new Traces();
     // TODO: Add code here to assign values to desired fields of the 'content' object to be changed
@@ -114,10 +114,10 @@ public class CloudTraceExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * ID of the Cloud project where the trace data is stored.
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     // * ID of the trace to return.
-    String traceId = "";
+    String traceId = "{MY-TRACE-ID}";
 
     CloudTrace.Projects.Traces.Get request = cloudtraceService.projects().traces().get(projectId, traceId);
     Trace response = request.execute();
@@ -179,7 +179,7 @@ public class CloudTraceExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * ID of the Cloud project where the trace data is stored.
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     CloudTrace.Projects.Traces.List request = cloudtraceService.projects().traces().list(projectId);
     ListTracesResponse response;

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_clouduseraccounts.beta.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_clouduseraccounts.beta.json.baseline
@@ -51,10 +51,10 @@ public class CloudUserAccountsExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the Operations resource to delete.
-    String operation = "";
+    String operation = "{MY-OPERATION}";
 
     CloudUserAccounts.GlobalAccountsOperations.Delete request = clouduseraccountsService.globalAccountsOperations().delete(project, operation);
     request.execute();
@@ -113,10 +113,10 @@ public class CloudUserAccountsExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the Operations resource to return.
-    String operation = "";
+    String operation = "{MY-OPERATION}";
 
     CloudUserAccounts.GlobalAccountsOperations.Get request = clouduseraccountsService.globalAccountsOperations().get(project, operation);
     Operation response = request.execute();
@@ -178,7 +178,7 @@ public class CloudUserAccountsExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     CloudUserAccounts.GlobalAccountsOperations.List request = clouduseraccountsService.globalAccountsOperations().list(project);
     OperationList response;
@@ -249,10 +249,10 @@ public class CloudUserAccountsExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'addMember' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the group for this request.
-    String groupName = "";
+    String groupName = "{MY-GROUP-NAME}";
 
     GroupsAddMemberRequest content = new GroupsAddMemberRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -316,10 +316,10 @@ public class CloudUserAccountsExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the Group resource to delete.
-    String groupName = "";
+    String groupName = "{MY-GROUP-NAME}";
 
     CloudUserAccounts.Groups.Delete request = clouduseraccountsService.groups().delete(project, groupName);
     Operation response = request.execute();
@@ -380,10 +380,10 @@ public class CloudUserAccountsExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the Group resource to return.
-    String groupName = "";
+    String groupName = "{MY-GROUP-NAME}";
 
     CloudUserAccounts.Groups.Get request = clouduseraccountsService.groups().get(project, groupName);
     Group response = request.execute();
@@ -445,7 +445,7 @@ public class CloudUserAccountsExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Group content = new Group();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -510,7 +510,7 @@ public class CloudUserAccountsExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     CloudUserAccounts.Groups.List request = clouduseraccountsService.groups().list(project);
     GroupList response;
@@ -581,10 +581,10 @@ public class CloudUserAccountsExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'removeMember' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the group for this request.
-    String groupName = "";
+    String groupName = "{MY-GROUP-NAME}";
 
     GroupsRemoveMemberRequest content = new GroupsRemoveMemberRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -648,16 +648,16 @@ public class CloudUserAccountsExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'getAuthorizedKeysView' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the zone for this request.
-    String zone = "";
+    String zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
     // * The user account for which you want to get a list of authorized public keys.
-    String user = "";
+    String user = "{MY-USER}";
 
     // * The fully-qualified URL of the virtual machine requesting the view.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     CloudUserAccounts.Linux.GetAuthorizedKeysView request = clouduseraccountsService.linux().getAuthorizedKeysView(project, zone, user, instance);
     LinuxGetAuthorizedKeysViewResponse response = request.execute();
@@ -718,13 +718,13 @@ public class CloudUserAccountsExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'getLinuxAccountViews' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the zone for this request.
-    String zone = "";
+    String zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
     // * The fully-qualified URL of the virtual machine requesting the views.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     CloudUserAccounts.Linux.GetLinuxAccountViews request = clouduseraccountsService.linux().getLinuxAccountViews(project, zone, instance);
     LinuxGetLinuxAccountViewsResponse response = request.execute();
@@ -786,10 +786,10 @@ public class CloudUserAccountsExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'addPublicKey' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the user for this request.
-    String user = "";
+    String user = "{MY-USER}";
 
     PublicKey content = new PublicKey();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -853,10 +853,10 @@ public class CloudUserAccountsExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the user resource to delete.
-    String user = "";
+    String user = "{MY-USER}";
 
     CloudUserAccounts.Users.Delete request = clouduseraccountsService.users().delete(project, user);
     Operation response = request.execute();
@@ -917,10 +917,10 @@ public class CloudUserAccountsExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the user resource to return.
-    String user = "";
+    String user = "{MY-USER}";
 
     CloudUserAccounts.Users.Get request = clouduseraccountsService.users().get(project, user);
     User response = request.execute();
@@ -982,7 +982,7 @@ public class CloudUserAccountsExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     User content = new User();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -1047,7 +1047,7 @@ public class CloudUserAccountsExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     CloudUserAccounts.Users.List request = clouduseraccountsService.users().list(project);
     UserList response;
@@ -1117,14 +1117,14 @@ public class CloudUserAccountsExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'removePublicKey' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the user for this request.
-    String user = "";
+    String user = "{MY-USER}";
 
     // * The fingerprint of the public key to delete. Public keys are identified by their fingerprint,
     //   which is defined by RFC4716 to be the MD5 digest of the public key.
-    String fingerprint = "";
+    String fingerprint = "{MY-FINGERPRINT}";
 
     CloudUserAccounts.Users.RemovePublicKey request = clouduseraccountsService.users().removePublicKey(project, user, fingerprint);
     Operation response = request.execute();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_compute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_compute.v1.json.baseline
@@ -54,7 +54,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Compute.Addresses.AggregatedList request = computeService.addresses().aggregatedList(project);
     AddressAggregatedList response;
@@ -124,13 +124,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the region for this request.
-    String region = "";
+    String region = "{MY-REGION}";
 
     // * Name of the address resource to delete.
-    String address = "";
+    String address = "{MY-ADDRESS}";
 
     Compute.Addresses.Delete request = computeService.addresses().delete(project, region, address);
     Operation response = request.execute();
@@ -191,13 +191,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the region for this request.
-    String region = "";
+    String region = "{MY-REGION}";
 
     // * Name of the address resource to return.
-    String address = "";
+    String address = "{MY-ADDRESS}";
 
     Compute.Addresses.Get request = computeService.addresses().get(project, region, address);
     Address response = request.execute();
@@ -259,10 +259,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the region for this request.
-    String region = "";
+    String region = "{MY-REGION}";
 
     Address content = new Address();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -327,10 +327,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the region for this request.
-    String region = "";
+    String region = "{MY-REGION}";
 
     Compute.Addresses.List request = computeService.addresses().list(project, region);
     AddressList response;
@@ -402,7 +402,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Compute.Autoscalers.AggregatedList request = computeService.autoscalers().aggregatedList(project);
     AutoscalerAggregatedList response;
@@ -472,13 +472,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the zone for this request.
-    String zone = "";
+    String zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
     // * Name of the autoscaler to delete.
-    String autoscaler = "";
+    String autoscaler = "{MY-AUTOSCALER}";
 
     Compute.Autoscalers.Delete request = computeService.autoscalers().delete(project, zone, autoscaler);
     Operation response = request.execute();
@@ -539,13 +539,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the zone for this request.
-    String zone = "";
+    String zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
     // * Name of the autoscaler to return.
-    String autoscaler = "";
+    String autoscaler = "{MY-AUTOSCALER}";
 
     Compute.Autoscalers.Get request = computeService.autoscalers().get(project, zone, autoscaler);
     Autoscaler response = request.execute();
@@ -607,10 +607,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the zone for this request.
-    String zone = "";
+    String zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
     Autoscaler content = new Autoscaler();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -675,10 +675,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the zone for this request.
-    String zone = "";
+    String zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
     Compute.Autoscalers.List request = computeService.autoscalers().list(project, zone);
     AutoscalerList response;
@@ -749,13 +749,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the zone for this request.
-    String zone = "";
+    String zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
     // * Name of the autoscaler to update.
-    String autoscaler = "";
+    String autoscaler = "{MY-AUTOSCALER}";
 
     Autoscaler content = new Autoscaler();
     // TODO: Add code here to assign values to desired fields of the 'content' object to be changed
@@ -820,10 +820,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the zone for this request.
-    String zone = "";
+    String zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
     Autoscaler content = new Autoscaler();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -887,10 +887,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the BackendService resource to delete.
-    String backendService = "";
+    String backendService = "{MY-BACKEND-SERVICE}";
 
     Compute.BackendServices.Delete request = computeService.backendServices().delete(project, backendService);
     Operation response = request.execute();
@@ -951,10 +951,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the BackendService resource to return.
-    String backendService = "";
+    String backendService = "{MY-BACKEND-SERVICE}";
 
     Compute.BackendServices.Get request = computeService.backendServices().get(project, backendService);
     BackendService response = request.execute();
@@ -1016,10 +1016,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'getHealth' method:
 
 
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the BackendService resource to which the queried instance belongs.
-    String backendService = "";
+    String backendService = "{MY-BACKEND-SERVICE}";
 
     ResourceGroupReference content = new ResourceGroupReference();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -1084,7 +1084,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     BackendService content = new BackendService();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -1149,7 +1149,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Compute.BackendServices.List request = computeService.backendServices().list(project);
     BackendServiceList response;
@@ -1220,10 +1220,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the BackendService resource to update.
-    String backendService = "";
+    String backendService = "{MY-BACKEND-SERVICE}";
 
     BackendService content = new BackendService();
     // TODO: Add code here to assign values to desired fields of the 'content' object to be changed
@@ -1288,10 +1288,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the BackendService resource to update.
-    String backendService = "";
+    String backendService = "{MY-BACKEND-SERVICE}";
 
     BackendService content = new BackendService();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -1357,7 +1357,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Compute.DiskTypes.AggregatedList request = computeService.diskTypes().aggregatedList(project);
     DiskTypeAggregatedList response;
@@ -1427,13 +1427,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone for this request.
-    String zone = "";
+    String zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
     // * Name of the disk type to return.
-    String diskType = "";
+    String diskType = "{MY-DISK-TYPE}";
 
     Compute.DiskTypes.Get request = computeService.diskTypes().get(project, zone, diskType);
     DiskType response = request.execute();
@@ -1495,10 +1495,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone for this request.
-    String zone = "";
+    String zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
     Compute.DiskTypes.List request = computeService.diskTypes().list(project, zone);
     DiskTypeList response;
@@ -1570,7 +1570,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Compute.Disks.AggregatedList request = computeService.disks().aggregatedList(project);
     DiskAggregatedList response;
@@ -1641,13 +1641,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'createSnapshot' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone for this request.
-    String zone = "";
+    String zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
     // * Name of the persistent disk to snapshot.
-    String disk = "";
+    String disk = "{MY-DISK}";
 
     Snapshot content = new Snapshot();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -1711,13 +1711,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone for this request.
-    String zone = "";
+    String zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
     // * Name of the persistent disk to delete.
-    String disk = "";
+    String disk = "{MY-DISK}";
 
     Compute.Disks.Delete request = computeService.disks().delete(project, zone, disk);
     Operation response = request.execute();
@@ -1778,13 +1778,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone for this request.
-    String zone = "";
+    String zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
     // * Name of the persistent disk to return.
-    String disk = "";
+    String disk = "{MY-DISK}";
 
     Compute.Disks.Get request = computeService.disks().get(project, zone, disk);
     Disk response = request.execute();
@@ -1846,10 +1846,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone for this request.
-    String zone = "";
+    String zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
     Disk content = new Disk();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -1914,10 +1914,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone for this request.
-    String zone = "";
+    String zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
     Compute.Disks.List request = computeService.disks().list(project, zone);
     DiskList response;
@@ -1987,10 +1987,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the firewall rule to delete.
-    String firewall = "";
+    String firewall = "{MY-FIREWALL}";
 
     Compute.Firewalls.Delete request = computeService.firewalls().delete(project, firewall);
     Operation response = request.execute();
@@ -2051,10 +2051,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the firewall rule to return.
-    String firewall = "";
+    String firewall = "{MY-FIREWALL}";
 
     Compute.Firewalls.Get request = computeService.firewalls().get(project, firewall);
     Firewall response = request.execute();
@@ -2116,7 +2116,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Firewall content = new Firewall();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -2181,7 +2181,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Compute.Firewalls.List request = computeService.firewalls().list(project);
     FirewallList response;
@@ -2252,10 +2252,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the firewall rule to update.
-    String firewall = "";
+    String firewall = "{MY-FIREWALL}";
 
     Firewall content = new Firewall();
     // TODO: Add code here to assign values to desired fields of the 'content' object to be changed
@@ -2320,10 +2320,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the firewall rule to update.
-    String firewall = "";
+    String firewall = "{MY-FIREWALL}";
 
     Firewall content = new Firewall();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -2389,7 +2389,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Compute.ForwardingRules.AggregatedList request = computeService.forwardingRules().aggregatedList(project);
     ForwardingRuleAggregatedList response;
@@ -2459,13 +2459,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the region scoping this request.
-    String region = "";
+    String region = "{MY-REGION}";
 
     // * Name of the ForwardingRule resource to delete.
-    String forwardingRule = "";
+    String forwardingRule = "{MY-FORWARDING-RULE}";
 
     Compute.ForwardingRules.Delete request = computeService.forwardingRules().delete(project, region, forwardingRule);
     Operation response = request.execute();
@@ -2526,13 +2526,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the region scoping this request.
-    String region = "";
+    String region = "{MY-REGION}";
 
     // * Name of the ForwardingRule resource to return.
-    String forwardingRule = "";
+    String forwardingRule = "{MY-FORWARDING-RULE}";
 
     Compute.ForwardingRules.Get request = computeService.forwardingRules().get(project, region, forwardingRule);
     ForwardingRule response = request.execute();
@@ -2594,10 +2594,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the region scoping this request.
-    String region = "";
+    String region = "{MY-REGION}";
 
     ForwardingRule content = new ForwardingRule();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -2662,10 +2662,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the region scoping this request.
-    String region = "";
+    String region = "{MY-REGION}";
 
     Compute.ForwardingRules.List request = computeService.forwardingRules().list(project, region);
     ForwardingRuleList response;
@@ -2736,13 +2736,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'setTarget' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the region scoping this request.
-    String region = "";
+    String region = "{MY-REGION}";
 
     // * Name of the ForwardingRule resource in which target is to be set.
-    String forwardingRule = "";
+    String forwardingRule = "{MY-FORWARDING-RULE}";
 
     TargetReference content = new TargetReference();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -2806,10 +2806,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the address resource to delete.
-    String address = "";
+    String address = "{MY-ADDRESS}";
 
     Compute.GlobalAddresses.Delete request = computeService.globalAddresses().delete(project, address);
     Operation response = request.execute();
@@ -2870,10 +2870,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the address resource to return.
-    String address = "";
+    String address = "{MY-ADDRESS}";
 
     Compute.GlobalAddresses.Get request = computeService.globalAddresses().get(project, address);
     Address response = request.execute();
@@ -2935,7 +2935,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Address content = new Address();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -3000,7 +3000,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Compute.GlobalAddresses.List request = computeService.globalAddresses().list(project);
     AddressList response;
@@ -3070,10 +3070,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the ForwardingRule resource to delete.
-    String forwardingRule = "";
+    String forwardingRule = "{MY-FORWARDING-RULE}";
 
     Compute.GlobalForwardingRules.Delete request = computeService.globalForwardingRules().delete(project, forwardingRule);
     Operation response = request.execute();
@@ -3134,10 +3134,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the ForwardingRule resource to return.
-    String forwardingRule = "";
+    String forwardingRule = "{MY-FORWARDING-RULE}";
 
     Compute.GlobalForwardingRules.Get request = computeService.globalForwardingRules().get(project, forwardingRule);
     ForwardingRule response = request.execute();
@@ -3199,7 +3199,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     ForwardingRule content = new ForwardingRule();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -3264,7 +3264,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Compute.GlobalForwardingRules.List request = computeService.globalForwardingRules().list(project);
     ForwardingRuleList response;
@@ -3335,10 +3335,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'setTarget' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the ForwardingRule resource in which target is to be set.
-    String forwardingRule = "";
+    String forwardingRule = "{MY-FORWARDING-RULE}";
 
     TargetReference content = new TargetReference();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -3404,7 +3404,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Compute.GlobalOperations.AggregatedList request = computeService.globalOperations().aggregatedList(project);
     OperationAggregatedList response;
@@ -3473,10 +3473,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the Operations resource to delete.
-    String operation = "";
+    String operation = "{MY-OPERATION}";
 
     Compute.GlobalOperations.Delete request = computeService.globalOperations().delete(project, operation);
     request.execute();
@@ -3535,10 +3535,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the Operations resource to return.
-    String operation = "";
+    String operation = "{MY-OPERATION}";
 
     Compute.GlobalOperations.Get request = computeService.globalOperations().get(project, operation);
     Operation response = request.execute();
@@ -3600,7 +3600,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Compute.GlobalOperations.List request = computeService.globalOperations().list(project);
     OperationList response;
@@ -3670,10 +3670,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the HttpHealthCheck resource to delete.
-    String httpHealthCheck = "";
+    String httpHealthCheck = "{MY-HTTP-HEALTH-CHECK}";
 
     Compute.HttpHealthChecks.Delete request = computeService.httpHealthChecks().delete(project, httpHealthCheck);
     Operation response = request.execute();
@@ -3734,10 +3734,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the HttpHealthCheck resource to return.
-    String httpHealthCheck = "";
+    String httpHealthCheck = "{MY-HTTP-HEALTH-CHECK}";
 
     Compute.HttpHealthChecks.Get request = computeService.httpHealthChecks().get(project, httpHealthCheck);
     HttpHealthCheck response = request.execute();
@@ -3799,7 +3799,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     HttpHealthCheck content = new HttpHealthCheck();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -3864,7 +3864,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Compute.HttpHealthChecks.List request = computeService.httpHealthChecks().list(project);
     HttpHealthCheckList response;
@@ -3935,10 +3935,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the HttpHealthCheck resource to update.
-    String httpHealthCheck = "";
+    String httpHealthCheck = "{MY-HTTP-HEALTH-CHECK}";
 
     HttpHealthCheck content = new HttpHealthCheck();
     // TODO: Add code here to assign values to desired fields of the 'content' object to be changed
@@ -4003,10 +4003,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the HttpHealthCheck resource to update.
-    String httpHealthCheck = "";
+    String httpHealthCheck = "{MY-HTTP-HEALTH-CHECK}";
 
     HttpHealthCheck content = new HttpHealthCheck();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -4070,10 +4070,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the HttpsHealthCheck resource to delete.
-    String httpsHealthCheck = "";
+    String httpsHealthCheck = "{MY-HTTPS-HEALTH-CHECK}";
 
     Compute.HttpsHealthChecks.Delete request = computeService.httpsHealthChecks().delete(project, httpsHealthCheck);
     Operation response = request.execute();
@@ -4134,10 +4134,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the HttpsHealthCheck resource to return.
-    String httpsHealthCheck = "";
+    String httpsHealthCheck = "{MY-HTTPS-HEALTH-CHECK}";
 
     Compute.HttpsHealthChecks.Get request = computeService.httpsHealthChecks().get(project, httpsHealthCheck);
     HttpsHealthCheck response = request.execute();
@@ -4199,7 +4199,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     HttpsHealthCheck content = new HttpsHealthCheck();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -4264,7 +4264,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Compute.HttpsHealthChecks.List request = computeService.httpsHealthChecks().list(project);
     HttpsHealthCheckList response;
@@ -4335,10 +4335,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the HttpsHealthCheck resource to update.
-    String httpsHealthCheck = "";
+    String httpsHealthCheck = "{MY-HTTPS-HEALTH-CHECK}";
 
     HttpsHealthCheck content = new HttpsHealthCheck();
     // TODO: Add code here to assign values to desired fields of the 'content' object to be changed
@@ -4403,10 +4403,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the HttpsHealthCheck resource to update.
-    String httpsHealthCheck = "";
+    String httpsHealthCheck = "{MY-HTTPS-HEALTH-CHECK}";
 
     HttpsHealthCheck content = new HttpsHealthCheck();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -4470,10 +4470,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the image resource to delete.
-    String image = "";
+    String image = "{MY-IMAGE}";
 
     Compute.Images.Delete request = computeService.images().delete(project, image);
     Operation response = request.execute();
@@ -4535,10 +4535,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'deprecate' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Image name.
-    String image = "";
+    String image = "{MY-IMAGE}";
 
     DeprecationStatus content = new DeprecationStatus();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -4602,10 +4602,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the image resource to return.
-    String image = "";
+    String image = "{MY-IMAGE}";
 
     Compute.Images.Get request = computeService.images().get(project, image);
     Image response = request.execute();
@@ -4667,7 +4667,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Image content = new Image();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -4732,7 +4732,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Compute.Images.List request = computeService.images().list(project);
     ImageList response;
@@ -4803,13 +4803,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'abandonInstances' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone where the managed instance group is located.
-    String zone = "";
+    String zone = "{MY-ZONE}";
 
     // * The name of the managed instance group.
-    String instanceGroupManager = "";
+    String instanceGroupManager = "{MY-INSTANCE-GROUP-MANAGER}";
 
     InstanceGroupManagersAbandonInstancesRequest content = new InstanceGroupManagersAbandonInstancesRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -4875,7 +4875,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Compute.InstanceGroupManagers.AggregatedList request = computeService.instanceGroupManagers().aggregatedList(project);
     InstanceGroupManagerAggregatedList response;
@@ -4945,13 +4945,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone where the managed instance group is located.
-    String zone = "";
+    String zone = "{MY-ZONE}";
 
     // * The name of the managed instance group to delete.
-    String instanceGroupManager = "";
+    String instanceGroupManager = "{MY-INSTANCE-GROUP-MANAGER}";
 
     Compute.InstanceGroupManagers.Delete request = computeService.instanceGroupManagers().delete(project, zone, instanceGroupManager);
     Operation response = request.execute();
@@ -5013,13 +5013,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'deleteInstances' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone where the managed instance group is located.
-    String zone = "";
+    String zone = "{MY-ZONE}";
 
     // * The name of the managed instance group.
-    String instanceGroupManager = "";
+    String instanceGroupManager = "{MY-INSTANCE-GROUP-MANAGER}";
 
     InstanceGroupManagersDeleteInstancesRequest content = new InstanceGroupManagersDeleteInstancesRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -5083,13 +5083,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone where the managed instance group is located.
-    String zone = "";
+    String zone = "{MY-ZONE}";
 
     // * The name of the managed instance group.
-    String instanceGroupManager = "";
+    String instanceGroupManager = "{MY-INSTANCE-GROUP-MANAGER}";
 
     Compute.InstanceGroupManagers.Get request = computeService.instanceGroupManagers().get(project, zone, instanceGroupManager);
     InstanceGroupManager response = request.execute();
@@ -5151,10 +5151,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone where you want to create the managed instance group.
-    String zone = "";
+    String zone = "{MY-ZONE}";
 
     InstanceGroupManager content = new InstanceGroupManager();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -5219,10 +5219,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone where the managed instance group is located.
-    String zone = "";
+    String zone = "{MY-ZONE}";
 
     Compute.InstanceGroupManagers.List request = computeService.instanceGroupManagers().list(project, zone);
     InstanceGroupManagerList response;
@@ -5292,13 +5292,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'listManagedInstances' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone where the managed instance group is located.
-    String zone = "";
+    String zone = "{MY-ZONE}";
 
     // * The name of the managed instance group.
-    String instanceGroupManager = "";
+    String instanceGroupManager = "{MY-INSTANCE-GROUP-MANAGER}";
 
     Compute.InstanceGroupManagers.ListManagedInstances request = computeService.instanceGroupManagers().listManagedInstances(project, zone, instanceGroupManager);
     InstanceGroupManagersListManagedInstancesResponse response = request.execute();
@@ -5360,13 +5360,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'recreateInstances' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone where the managed instance group is located.
-    String zone = "";
+    String zone = "{MY-ZONE}";
 
     // * The name of the managed instance group.
-    String instanceGroupManager = "";
+    String instanceGroupManager = "{MY-INSTANCE-GROUP-MANAGER}";
 
     InstanceGroupManagersRecreateInstancesRequest content = new InstanceGroupManagersRecreateInstancesRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -5430,13 +5430,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'resize' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone where the managed instance group is located.
-    String zone = "";
+    String zone = "{MY-ZONE}";
 
     // * The name of the managed instance group.
-    String instanceGroupManager = "";
+    String instanceGroupManager = "{MY-INSTANCE-GROUP-MANAGER}";
 
     // * The number of running instances that the managed instance group should maintain at any given time.
     //   The group automatically adds or removes instances to maintain the number of instances specified by
@@ -5503,13 +5503,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'setInstanceTemplate' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone where the managed instance group is located.
-    String zone = "";
+    String zone = "{MY-ZONE}";
 
     // * The name of the managed instance group.
-    String instanceGroupManager = "";
+    String instanceGroupManager = "{MY-INSTANCE-GROUP-MANAGER}";
 
     InstanceGroupManagersSetInstanceTemplateRequest content = new InstanceGroupManagersSetInstanceTemplateRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -5574,13 +5574,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'setTargetPools' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone where the managed instance group is located.
-    String zone = "";
+    String zone = "{MY-ZONE}";
 
     // * The name of the managed instance group.
-    String instanceGroupManager = "";
+    String instanceGroupManager = "{MY-INSTANCE-GROUP-MANAGER}";
 
     InstanceGroupManagersSetTargetPoolsRequest content = new InstanceGroupManagersSetTargetPoolsRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -5645,13 +5645,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'addInstances' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone where the instance group is located.
-    String zone = "";
+    String zone = "{MY-ZONE}";
 
     // * The name of the instance group where you are adding instances.
-    String instanceGroup = "";
+    String instanceGroup = "{MY-INSTANCE-GROUP}";
 
     InstanceGroupsAddInstancesRequest content = new InstanceGroupsAddInstancesRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -5717,7 +5717,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Compute.InstanceGroups.AggregatedList request = computeService.instanceGroups().aggregatedList(project);
     InstanceGroupAggregatedList response;
@@ -5787,13 +5787,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone where the instance group is located.
-    String zone = "";
+    String zone = "{MY-ZONE}";
 
     // * The name of the instance group to delete.
-    String instanceGroup = "";
+    String instanceGroup = "{MY-INSTANCE-GROUP}";
 
     Compute.InstanceGroups.Delete request = computeService.instanceGroups().delete(project, zone, instanceGroup);
     Operation response = request.execute();
@@ -5854,13 +5854,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone where the instance group is located.
-    String zone = "";
+    String zone = "{MY-ZONE}";
 
     // * The name of the instance group.
-    String instanceGroup = "";
+    String instanceGroup = "{MY-INSTANCE-GROUP}";
 
     Compute.InstanceGroups.Get request = computeService.instanceGroups().get(project, zone, instanceGroup);
     InstanceGroup response = request.execute();
@@ -5922,10 +5922,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone where you want to create the instance group.
-    String zone = "";
+    String zone = "{MY-ZONE}";
 
     InstanceGroup content = new InstanceGroup();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -5990,10 +5990,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone where the instance group is located.
-    String zone = "";
+    String zone = "{MY-ZONE}";
 
     Compute.InstanceGroups.List request = computeService.instanceGroups().list(project, zone);
     InstanceGroupList response;
@@ -6065,13 +6065,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'listInstances' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone where the instance group is located.
-    String zone = "";
+    String zone = "{MY-ZONE}";
 
     // * The name of the instance group from which you want to generate a list of included instances.
-    String instanceGroup = "";
+    String instanceGroup = "{MY-INSTANCE-GROUP}";
 
     InstanceGroupsListInstancesRequest content = new InstanceGroupsListInstancesRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -6145,13 +6145,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'removeInstances' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone where the instance group is located.
-    String zone = "";
+    String zone = "{MY-ZONE}";
 
     // * The name of the instance group where the specified instances will be removed.
-    String instanceGroup = "";
+    String instanceGroup = "{MY-INSTANCE-GROUP}";
 
     InstanceGroupsRemoveInstancesRequest content = new InstanceGroupsRemoveInstancesRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -6216,13 +6216,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'setNamedPorts' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone where the instance group is located.
-    String zone = "";
+    String zone = "{MY-ZONE}";
 
     // * The name of the instance group where the named ports are updated.
-    String instanceGroup = "";
+    String instanceGroup = "{MY-INSTANCE-GROUP}";
 
     InstanceGroupsSetNamedPortsRequest content = new InstanceGroupsSetNamedPortsRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -6286,10 +6286,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the instance template to delete.
-    String instanceTemplate = "";
+    String instanceTemplate = "{MY-INSTANCE-TEMPLATE}";
 
     Compute.InstanceTemplates.Delete request = computeService.instanceTemplates().delete(project, instanceTemplate);
     Operation response = request.execute();
@@ -6350,10 +6350,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the instance template.
-    String instanceTemplate = "";
+    String instanceTemplate = "{MY-INSTANCE-TEMPLATE}";
 
     Compute.InstanceTemplates.Get request = computeService.instanceTemplates().get(project, instanceTemplate);
     InstanceTemplate response = request.execute();
@@ -6415,7 +6415,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     InstanceTemplate content = new InstanceTemplate();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -6480,7 +6480,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Compute.InstanceTemplates.List request = computeService.instanceTemplates().list(project);
     InstanceTemplateList response;
@@ -6551,16 +6551,16 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'addAccessConfig' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone for this request.
-    String zone = "";
+    String zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
     // * The instance name for this request.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     // * The name of the network interface to add to this instance.
-    String networkInterface = "";
+    String networkInterface = "{MY-NETWORK-INTERFACE}";
 
     AccessConfig content = new AccessConfig();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -6626,7 +6626,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Compute.Instances.AggregatedList request = computeService.instances().aggregatedList(project);
     InstanceAggregatedList response;
@@ -6697,13 +6697,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'attachDisk' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone for this request.
-    String zone = "";
+    String zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
     // * The instance name for this request.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     AttachedDisk content = new AttachedDisk();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -6767,13 +6767,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone for this request.
-    String zone = "";
+    String zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
     // * Name of the instance resource to delete.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     Compute.Instances.Delete request = computeService.instances().delete(project, zone, instance);
     Operation response = request.execute();
@@ -6834,19 +6834,19 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'deleteAccessConfig' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone for this request.
-    String zone = "";
+    String zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
     // * The instance name for this request.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     // * The name of the access config to delete.
-    String accessConfig = "";
+    String accessConfig = "{MY-ACCESS-CONFIG}";
 
     // * The name of the network interface.
-    String networkInterface = "";
+    String networkInterface = "{MY-NETWORK-INTERFACE}";
 
     Compute.Instances.DeleteAccessConfig request = computeService.instances().deleteAccessConfig(project, zone, instance, accessConfig, networkInterface);
     Operation response = request.execute();
@@ -6907,16 +6907,16 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'detachDisk' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone for this request.
-    String zone = "";
+    String zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
     // * Instance name.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     // * Disk device name to detach.
-    String deviceName = "";
+    String deviceName = "{MY-DEVICE-NAME}";
 
     Compute.Instances.DetachDisk request = computeService.instances().detachDisk(project, zone, instance, deviceName);
     Operation response = request.execute();
@@ -6977,13 +6977,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone for this request.
-    String zone = "";
+    String zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
     // * Name of the instance resource to return.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     Compute.Instances.Get request = computeService.instances().get(project, zone, instance);
     Instance response = request.execute();
@@ -7044,13 +7044,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'getSerialPortOutput' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone for this request.
-    String zone = "";
+    String zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
     // * Name of the instance scoping this request.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     Compute.Instances.GetSerialPortOutput request = computeService.instances().getSerialPortOutput(project, zone, instance);
     SerialPortOutput response = request.execute();
@@ -7112,10 +7112,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone for this request.
-    String zone = "";
+    String zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
     Instance content = new Instance();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -7180,10 +7180,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone for this request.
-    String zone = "";
+    String zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
     Compute.Instances.List request = computeService.instances().list(project, zone);
     InstanceList response;
@@ -7253,13 +7253,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'reset' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone for this request.
-    String zone = "";
+    String zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
     // * Name of the instance scoping this request.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     Compute.Instances.Reset request = computeService.instances().reset(project, zone, instance);
     Operation response = request.execute();
@@ -7320,19 +7320,19 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'setDiskAutoDelete' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone for this request.
-    String zone = "";
+    String zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
     // * The instance name.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     // * Whether to auto-delete the disk when the instance is deleted.
     boolean autoDelete = false;
 
     // * The device name of the disk to modify.
-    String deviceName = "";
+    String deviceName = "{MY-DEVICE-NAME}";
 
     Compute.Instances.SetDiskAutoDelete request = computeService.instances().setDiskAutoDelete(project, zone, instance, autoDelete, deviceName);
     Operation response = request.execute();
@@ -7394,13 +7394,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'setMachineType' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone for this request.
-    String zone = "";
+    String zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
     // * Name of the instance scoping this request.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     InstancesSetMachineTypeRequest content = new InstancesSetMachineTypeRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -7465,13 +7465,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'setMetadata' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone for this request.
-    String zone = "";
+    String zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
     // * Name of the instance scoping this request.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     Metadata content = new Metadata();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -7536,13 +7536,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'setScheduling' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone for this request.
-    String zone = "";
+    String zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
     // * Instance name.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     Scheduling content = new Scheduling();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -7607,13 +7607,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'setTags' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone for this request.
-    String zone = "";
+    String zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
     // * Name of the instance scoping this request.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     Tags content = new Tags();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -7677,13 +7677,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'start' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone for this request.
-    String zone = "";
+    String zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
     // * Name of the instance resource to start.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     Compute.Instances.Start request = computeService.instances().start(project, zone, instance);
     Operation response = request.execute();
@@ -7744,13 +7744,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'stop' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone for this request.
-    String zone = "";
+    String zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
     // * Name of the instance resource to stop.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     Compute.Instances.Stop request = computeService.instances().stop(project, zone, instance);
     Operation response = request.execute();
@@ -7811,10 +7811,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the License resource to return.
-    String license = "";
+    String license = "{MY-LICENSE}";
 
     Compute.Licenses.Get request = computeService.licenses().get(project, license);
     License response = request.execute();
@@ -7877,7 +7877,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Compute.MachineTypes.AggregatedList request = computeService.machineTypes().aggregatedList(project);
     MachineTypeAggregatedList response;
@@ -7947,13 +7947,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone for this request.
-    String zone = "";
+    String zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
     // * Name of the machine type to return.
-    String machineType = "";
+    String machineType = "{MY-MACHINE-TYPE}";
 
     Compute.MachineTypes.Get request = computeService.machineTypes().get(project, zone, machineType);
     MachineType response = request.execute();
@@ -8015,10 +8015,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone for this request.
-    String zone = "";
+    String zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
     Compute.MachineTypes.List request = computeService.machineTypes().list(project, zone);
     MachineTypeList response;
@@ -8088,10 +8088,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the network to delete.
-    String network = "";
+    String network = "{MY-NETWORK}";
 
     Compute.Networks.Delete request = computeService.networks().delete(project, network);
     Operation response = request.execute();
@@ -8152,10 +8152,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the network to return.
-    String network = "";
+    String network = "{MY-NETWORK}";
 
     Compute.Networks.Get request = computeService.networks().get(project, network);
     Network response = request.execute();
@@ -8217,7 +8217,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Network content = new Network();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -8282,7 +8282,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Compute.Networks.List request = computeService.networks().list(project);
     NetworkList response;
@@ -8352,7 +8352,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Compute.Projects.Get request = computeService.projects().get(project);
     Project response = request.execute();
@@ -8414,7 +8414,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'moveDisk' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     DiskMoveRequest content = new DiskMoveRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -8479,7 +8479,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'moveInstance' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     InstanceMoveRequest content = new InstanceMoveRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -8544,7 +8544,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'setCommonInstanceMetadata' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Metadata content = new Metadata();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -8609,7 +8609,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'setUsageExportBucket' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     UsageExportLocation content = new UsageExportLocation();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -8672,13 +8672,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the region for this request.
-    String region = "";
+    String region = "{MY-REGION}";
 
     // * Name of the Operations resource to delete.
-    String operation = "";
+    String operation = "{MY-OPERATION}";
 
     Compute.RegionOperations.Delete request = computeService.regionOperations().delete(project, region, operation);
     request.execute();
@@ -8737,13 +8737,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the region for this request.
-    String region = "";
+    String region = "{MY-REGION}";
 
     // * Name of the Operations resource to return.
-    String operation = "";
+    String operation = "{MY-OPERATION}";
 
     Compute.RegionOperations.Get request = computeService.regionOperations().get(project, region, operation);
     Operation response = request.execute();
@@ -8805,10 +8805,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the region for this request.
-    String region = "";
+    String region = "{MY-REGION}";
 
     Compute.RegionOperations.List request = computeService.regionOperations().list(project, region);
     OperationList response;
@@ -8878,10 +8878,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the region resource to return.
-    String region = "";
+    String region = "{MY-REGION}";
 
     Compute.Regions.Get request = computeService.regions().get(project, region);
     Region response = request.execute();
@@ -8943,7 +8943,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Compute.Regions.List request = computeService.regions().list(project);
     RegionList response;
@@ -9013,10 +9013,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the Route resource to delete.
-    String route = "";
+    String route = "{MY-ROUTE}";
 
     Compute.Routes.Delete request = computeService.routes().delete(project, route);
     Operation response = request.execute();
@@ -9077,10 +9077,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the Route resource to return.
-    String route = "";
+    String route = "{MY-ROUTE}";
 
     Compute.Routes.Get request = computeService.routes().get(project, route);
     Route response = request.execute();
@@ -9142,7 +9142,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Route content = new Route();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -9207,7 +9207,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Compute.Routes.List request = computeService.routes().list(project);
     RouteList response;
@@ -9277,10 +9277,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the Snapshot resource to delete.
-    String snapshot = "";
+    String snapshot = "{MY-SNAPSHOT}";
 
     Compute.Snapshots.Delete request = computeService.snapshots().delete(project, snapshot);
     Operation response = request.execute();
@@ -9341,10 +9341,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the Snapshot resource to return.
-    String snapshot = "";
+    String snapshot = "{MY-SNAPSHOT}";
 
     Compute.Snapshots.Get request = computeService.snapshots().get(project, snapshot);
     Snapshot response = request.execute();
@@ -9406,7 +9406,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Compute.Snapshots.List request = computeService.snapshots().list(project);
     SnapshotList response;
@@ -9476,10 +9476,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the SslCertificate resource to delete.
-    String sslCertificate = "";
+    String sslCertificate = "{MY-SSL-CERTIFICATE}";
 
     Compute.SslCertificates.Delete request = computeService.sslCertificates().delete(project, sslCertificate);
     Operation response = request.execute();
@@ -9540,10 +9540,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the SslCertificate resource to return.
-    String sslCertificate = "";
+    String sslCertificate = "{MY-SSL-CERTIFICATE}";
 
     Compute.SslCertificates.Get request = computeService.sslCertificates().get(project, sslCertificate);
     SslCertificate response = request.execute();
@@ -9605,7 +9605,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     SslCertificate content = new SslCertificate();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -9670,7 +9670,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Compute.SslCertificates.List request = computeService.sslCertificates().list(project);
     SslCertificateList response;
@@ -9742,7 +9742,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Compute.Subnetworks.AggregatedList request = computeService.subnetworks().aggregatedList(project);
     SubnetworkAggregatedList response;
@@ -9812,13 +9812,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the region scoping this request.
-    String region = "";
+    String region = "{MY-REGION}";
 
     // * Name of the Subnetwork resource to delete.
-    String subnetwork = "";
+    String subnetwork = "{MY-SUBNETWORK}";
 
     Compute.Subnetworks.Delete request = computeService.subnetworks().delete(project, region, subnetwork);
     Operation response = request.execute();
@@ -9879,13 +9879,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the region scoping this request.
-    String region = "";
+    String region = "{MY-REGION}";
 
     // * Name of the Subnetwork resource to return.
-    String subnetwork = "";
+    String subnetwork = "{MY-SUBNETWORK}";
 
     Compute.Subnetworks.Get request = computeService.subnetworks().get(project, region, subnetwork);
     Subnetwork response = request.execute();
@@ -9947,10 +9947,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the region scoping this request.
-    String region = "";
+    String region = "{MY-REGION}";
 
     Subnetwork content = new Subnetwork();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -10015,10 +10015,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the region scoping this request.
-    String region = "";
+    String region = "{MY-REGION}";
 
     Compute.Subnetworks.List request = computeService.subnetworks().list(project, region);
     SubnetworkList response;
@@ -10088,10 +10088,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the TargetHttpProxy resource to delete.
-    String targetHttpProxy = "";
+    String targetHttpProxy = "{MY-TARGET-HTTP-PROXY}";
 
     Compute.TargetHttpProxies.Delete request = computeService.targetHttpProxies().delete(project, targetHttpProxy);
     Operation response = request.execute();
@@ -10152,10 +10152,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the TargetHttpProxy resource to return.
-    String targetHttpProxy = "";
+    String targetHttpProxy = "{MY-TARGET-HTTP-PROXY}";
 
     Compute.TargetHttpProxies.Get request = computeService.targetHttpProxies().get(project, targetHttpProxy);
     TargetHttpProxy response = request.execute();
@@ -10217,7 +10217,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     TargetHttpProxy content = new TargetHttpProxy();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -10282,7 +10282,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Compute.TargetHttpProxies.List request = computeService.targetHttpProxies().list(project);
     TargetHttpProxyList response;
@@ -10353,10 +10353,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'setUrlMap' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the TargetHttpProxy to set a URL map for.
-    String targetHttpProxy = "";
+    String targetHttpProxy = "{MY-TARGET-HTTP-PROXY}";
 
     UrlMapReference content = new UrlMapReference();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -10420,10 +10420,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the TargetHttpsProxy resource to delete.
-    String targetHttpsProxy = "";
+    String targetHttpsProxy = "{MY-TARGET-HTTPS-PROXY}";
 
     Compute.TargetHttpsProxies.Delete request = computeService.targetHttpsProxies().delete(project, targetHttpsProxy);
     Operation response = request.execute();
@@ -10484,10 +10484,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the TargetHttpsProxy resource to return.
-    String targetHttpsProxy = "";
+    String targetHttpsProxy = "{MY-TARGET-HTTPS-PROXY}";
 
     Compute.TargetHttpsProxies.Get request = computeService.targetHttpsProxies().get(project, targetHttpsProxy);
     TargetHttpsProxy response = request.execute();
@@ -10549,7 +10549,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     TargetHttpsProxy content = new TargetHttpsProxy();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -10614,7 +10614,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Compute.TargetHttpsProxies.List request = computeService.targetHttpsProxies().list(project);
     TargetHttpsProxyList response;
@@ -10685,10 +10685,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'setSslCertificates' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the TargetHttpsProxy resource to set an SslCertificates resource for.
-    String targetHttpsProxy = "";
+    String targetHttpsProxy = "{MY-TARGET-HTTPS-PROXY}";
 
     TargetHttpsProxiesSetSslCertificatesRequest content = new TargetHttpsProxiesSetSslCertificatesRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -10753,10 +10753,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'setUrlMap' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the TargetHttpsProxy resource whose URL map is to be set.
-    String targetHttpsProxy = "";
+    String targetHttpsProxy = "{MY-TARGET-HTTPS-PROXY}";
 
     UrlMapReference content = new UrlMapReference();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -10822,7 +10822,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Compute.TargetInstances.AggregatedList request = computeService.targetInstances().aggregatedList(project);
     TargetInstanceAggregatedList response;
@@ -10892,13 +10892,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the zone scoping this request.
-    String zone = "";
+    String zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
     // * Name of the TargetInstance resource to delete.
-    String targetInstance = "";
+    String targetInstance = "{MY-TARGET-INSTANCE}";
 
     Compute.TargetInstances.Delete request = computeService.targetInstances().delete(project, zone, targetInstance);
     Operation response = request.execute();
@@ -10959,13 +10959,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the zone scoping this request.
-    String zone = "";
+    String zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
     // * Name of the TargetInstance resource to return.
-    String targetInstance = "";
+    String targetInstance = "{MY-TARGET-INSTANCE}";
 
     Compute.TargetInstances.Get request = computeService.targetInstances().get(project, zone, targetInstance);
     TargetInstance response = request.execute();
@@ -11027,10 +11027,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the zone scoping this request.
-    String zone = "";
+    String zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
     TargetInstance content = new TargetInstance();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -11095,10 +11095,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the zone scoping this request.
-    String zone = "";
+    String zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
     Compute.TargetInstances.List request = computeService.targetInstances().list(project, zone);
     TargetInstanceList response;
@@ -11169,13 +11169,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'addHealthCheck' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the region scoping this request.
-    String region = "";
+    String region = "{MY-REGION}";
 
     // * Name of the target pool to add a health check to.
-    String targetPool = "";
+    String targetPool = "{MY-TARGET-POOL}";
 
     TargetPoolsAddHealthCheckRequest content = new TargetPoolsAddHealthCheckRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -11240,13 +11240,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'addInstance' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the region scoping this request.
-    String region = "";
+    String region = "{MY-REGION}";
 
     // * Name of the TargetPool resource to add instances to.
-    String targetPool = "";
+    String targetPool = "{MY-TARGET-POOL}";
 
     TargetPoolsAddInstanceRequest content = new TargetPoolsAddInstanceRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -11312,7 +11312,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Compute.TargetPools.AggregatedList request = computeService.targetPools().aggregatedList(project);
     TargetPoolAggregatedList response;
@@ -11382,13 +11382,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the region scoping this request.
-    String region = "";
+    String region = "{MY-REGION}";
 
     // * Name of the TargetPool resource to delete.
-    String targetPool = "";
+    String targetPool = "{MY-TARGET-POOL}";
 
     Compute.TargetPools.Delete request = computeService.targetPools().delete(project, region, targetPool);
     Operation response = request.execute();
@@ -11449,13 +11449,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the region scoping this request.
-    String region = "";
+    String region = "{MY-REGION}";
 
     // * Name of the TargetPool resource to return.
-    String targetPool = "";
+    String targetPool = "{MY-TARGET-POOL}";
 
     Compute.TargetPools.Get request = computeService.targetPools().get(project, region, targetPool);
     TargetPool response = request.execute();
@@ -11517,13 +11517,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'getHealth' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the region scoping this request.
-    String region = "";
+    String region = "{MY-REGION}";
 
     // * Name of the TargetPool resource to which the queried instance belongs.
-    String targetPool = "";
+    String targetPool = "{MY-TARGET-POOL}";
 
     InstanceReference content = new InstanceReference();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -11588,10 +11588,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the region scoping this request.
-    String region = "";
+    String region = "{MY-REGION}";
 
     TargetPool content = new TargetPool();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -11656,10 +11656,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the region scoping this request.
-    String region = "";
+    String region = "{MY-REGION}";
 
     Compute.TargetPools.List request = computeService.targetPools().list(project, region);
     TargetPoolList response;
@@ -11730,13 +11730,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'removeHealthCheck' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the region for this request.
-    String region = "";
+    String region = "{MY-REGION}";
 
     // * Name of the target pool to remove health checks from.
-    String targetPool = "";
+    String targetPool = "{MY-TARGET-POOL}";
 
     TargetPoolsRemoveHealthCheckRequest content = new TargetPoolsRemoveHealthCheckRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -11801,13 +11801,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'removeInstance' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the region scoping this request.
-    String region = "";
+    String region = "{MY-REGION}";
 
     // * Name of the TargetPool resource to remove instances from.
-    String targetPool = "";
+    String targetPool = "{MY-TARGET-POOL}";
 
     TargetPoolsRemoveInstanceRequest content = new TargetPoolsRemoveInstanceRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -11872,13 +11872,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'setBackup' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the region scoping this request.
-    String region = "";
+    String region = "{MY-REGION}";
 
     // * Name of the TargetPool resource to set a backup pool for.
-    String targetPool = "";
+    String targetPool = "{MY-TARGET-POOL}";
 
     TargetReference content = new TargetReference();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -11944,7 +11944,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Compute.TargetVpnGateways.AggregatedList request = computeService.targetVpnGateways().aggregatedList(project);
     TargetVpnGatewayAggregatedList response;
@@ -12014,13 +12014,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the region for this request.
-    String region = "";
+    String region = "{MY-REGION}";
 
     // * Name of the target VPN gateway to delete.
-    String targetVpnGateway = "";
+    String targetVpnGateway = "{MY-TARGET-VPN-GATEWAY}";
 
     Compute.TargetVpnGateways.Delete request = computeService.targetVpnGateways().delete(project, region, targetVpnGateway);
     Operation response = request.execute();
@@ -12081,13 +12081,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the region for this request.
-    String region = "";
+    String region = "{MY-REGION}";
 
     // * Name of the target VPN gateway to return.
-    String targetVpnGateway = "";
+    String targetVpnGateway = "{MY-TARGET-VPN-GATEWAY}";
 
     Compute.TargetVpnGateways.Get request = computeService.targetVpnGateways().get(project, region, targetVpnGateway);
     TargetVpnGateway response = request.execute();
@@ -12149,10 +12149,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the region for this request.
-    String region = "";
+    String region = "{MY-REGION}";
 
     TargetVpnGateway content = new TargetVpnGateway();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -12217,10 +12217,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the region for this request.
-    String region = "";
+    String region = "{MY-REGION}";
 
     Compute.TargetVpnGateways.List request = computeService.targetVpnGateways().list(project, region);
     TargetVpnGatewayList response;
@@ -12290,10 +12290,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the UrlMap resource to delete.
-    String urlMap = "";
+    String urlMap = "{MY-URL-MAP}";
 
     Compute.UrlMaps.Delete request = computeService.urlMaps().delete(project, urlMap);
     Operation response = request.execute();
@@ -12354,10 +12354,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the UrlMap resource to return.
-    String urlMap = "";
+    String urlMap = "{MY-URL-MAP}";
 
     Compute.UrlMaps.Get request = computeService.urlMaps().get(project, urlMap);
     UrlMap response = request.execute();
@@ -12419,7 +12419,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     UrlMap content = new UrlMap();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -12484,7 +12484,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Compute.UrlMaps.List request = computeService.urlMaps().list(project);
     UrlMapList response;
@@ -12555,10 +12555,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the UrlMap resource to update.
-    String urlMap = "";
+    String urlMap = "{MY-URL-MAP}";
 
     UrlMap content = new UrlMap();
     // TODO: Add code here to assign values to desired fields of the 'content' object to be changed
@@ -12623,10 +12623,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the UrlMap resource to update.
-    String urlMap = "";
+    String urlMap = "{MY-URL-MAP}";
 
     UrlMap content = new UrlMap();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -12691,10 +12691,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'validate' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the UrlMap resource to be validated as.
-    String urlMap = "";
+    String urlMap = "{MY-URL-MAP}";
 
     UrlMapsValidateRequest content = new UrlMapsValidateRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -12760,7 +12760,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Compute.VpnTunnels.AggregatedList request = computeService.vpnTunnels().aggregatedList(project);
     VpnTunnelAggregatedList response;
@@ -12830,13 +12830,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the region for this request.
-    String region = "";
+    String region = "{MY-REGION}";
 
     // * Name of the VpnTunnel resource to delete.
-    String vpnTunnel = "";
+    String vpnTunnel = "{MY-VPN-TUNNEL}";
 
     Compute.VpnTunnels.Delete request = computeService.vpnTunnels().delete(project, region, vpnTunnel);
     Operation response = request.execute();
@@ -12897,13 +12897,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the region for this request.
-    String region = "";
+    String region = "{MY-REGION}";
 
     // * Name of the VpnTunnel resource to return.
-    String vpnTunnel = "";
+    String vpnTunnel = "{MY-VPN-TUNNEL}";
 
     Compute.VpnTunnels.Get request = computeService.vpnTunnels().get(project, region, vpnTunnel);
     VpnTunnel response = request.execute();
@@ -12965,10 +12965,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the region for this request.
-    String region = "";
+    String region = "{MY-REGION}";
 
     VpnTunnel content = new VpnTunnel();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -13033,10 +13033,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the region for this request.
-    String region = "";
+    String region = "{MY-REGION}";
 
     Compute.VpnTunnels.List request = computeService.vpnTunnels().list(project, region);
     VpnTunnelList response;
@@ -13105,13 +13105,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the zone for this request.
-    String zone = "";
+    String zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
     // * Name of the Operations resource to delete.
-    String operation = "";
+    String operation = "{MY-OPERATION}";
 
     Compute.ZoneOperations.Delete request = computeService.zoneOperations().delete(project, zone, operation);
     request.execute();
@@ -13170,13 +13170,13 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the zone for this request.
-    String zone = "";
+    String zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
     // * Name of the Operations resource to return.
-    String operation = "";
+    String operation = "{MY-OPERATION}";
 
     Compute.ZoneOperations.Get request = computeService.zoneOperations().get(project, zone, operation);
     Operation response = request.execute();
@@ -13238,10 +13238,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the zone for request.
-    String zone = "";
+    String zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
     Compute.ZoneOperations.List request = computeService.zoneOperations().list(project, zone);
     OperationList response;
@@ -13311,10 +13311,10 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the zone resource to return.
-    String zone = "";
+    String zone = "{MY-ZONE}"  // eg. "us-central1-f";
 
     Compute.Zones.Get request = computeService.zones().get(project, zone);
     Zone response = request.execute();
@@ -13376,7 +13376,7 @@ public class ComputeExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Compute.Zones.List request = computeService.zones().list(project);
     ZoneList response;

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_container.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_container.v1.json.baseline
@@ -54,11 +54,11 @@ public class ContainerExample {
 
     // * The Google Developers Console [project ID or project number]
     //   (https://developers.google.com/console/help/new/#projectnumber).
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     // * The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
     //   resides.
-    String zone = "";
+    String zone = "{MY-ZONE}";
 
     CreateClusterRequest content = new CreateClusterRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -123,14 +123,14 @@ public class ContainerExample {
 
     // * The Google Developers Console [project ID or project number]
     //   (https://developers.google.com/console/help/new/#projectnumber).
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     // * The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
     //   resides.
-    String zone = "";
+    String zone = "{MY-ZONE}";
 
     // * The name of the cluster to delete.
-    String clusterId = "";
+    String clusterId = "{MY-CLUSTER-ID}";
 
     Container.Projects.Zones.Clusters.Delete request = containerService.projects().zones().clusters().delete(projectId, zone, clusterId);
     Operation response = request.execute();
@@ -192,14 +192,14 @@ public class ContainerExample {
 
     // * The Google Developers Console [project ID or project number]
     //   (https://developers.google.com/console/help/new/#projectnumber).
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     // * The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
     //   resides.
-    String zone = "";
+    String zone = "{MY-ZONE}";
 
     // * The name of the cluster to retrieve.
-    String clusterId = "";
+    String clusterId = "{MY-CLUSTER-ID}";
 
     Container.Projects.Zones.Clusters.Get request = containerService.projects().zones().clusters().get(projectId, zone, clusterId);
     Cluster response = request.execute();
@@ -261,11 +261,11 @@ public class ContainerExample {
 
     // * The Google Developers Console [project ID or project number]
     //   (https://developers.google.com/console/help/new/#projectnumber).
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     // * The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
     //   resides, or "-" for all zones.
-    String zone = "";
+    String zone = "{MY-ZONE}";
 
     Container.Projects.Zones.Clusters.List request = containerService.projects().zones().clusters().list(projectId, zone);
     ListClustersResponse response = request.execute();
@@ -328,14 +328,14 @@ public class ContainerExample {
 
     // * The Google Developers Console [project ID or project number]
     //   (https://developers.google.com/console/help/new/#projectnumber).
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     // * The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
     //   resides.
-    String zone = "";
+    String zone = "{MY-ZONE}";
 
     // * The name of the cluster to upgrade.
-    String clusterId = "";
+    String clusterId = "{MY-CLUSTER-ID}";
 
     UpdateClusterRequest content = new UpdateClusterRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -400,11 +400,11 @@ public class ContainerExample {
 
     // * The Google Developers Console [project ID or project number]
     //   (https://developers.google.com/console/help/new/#projectnumber).
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     // * The name of the Google Compute Engine [zone](/compute/docs/zones#available) to return operations
     //   for, or "-" for all zones.
-    String zone = "";
+    String zone = "{MY-ZONE}";
 
     Container.Projects.Zones.GetServerconfig request = containerService.projects().zones().getServerconfig(projectId, zone);
     ServerConfig response = request.execute();
@@ -466,14 +466,14 @@ public class ContainerExample {
 
     // * The Google Developers Console [project ID or project number]
     //   (https://developers.google.com/console/help/new/#projectnumber).
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     // * The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
     //   resides.
-    String zone = "";
+    String zone = "{MY-ZONE}";
 
     // * The server-assigned `name` of the operation.
-    String operationId = "";
+    String operationId = "{MY-OPERATION-ID}";
 
     Container.Projects.Zones.Operations.Get request = containerService.projects().zones().operations().get(projectId, zone, operationId);
     Operation response = request.execute();
@@ -535,11 +535,11 @@ public class ContainerExample {
 
     // * The Google Developers Console [project ID or project number]
     //   (https://developers.google.com/console/help/new/#projectnumber).
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     // * The name of the Google Compute Engine [zone](/compute/docs/zones#available) to return operations
     //   for, or "-" for all zones.
-    String zone = "";
+    String zone = "{MY-ZONE}";
 
     Container.Projects.Zones.Operations.List request = containerService.projects().zones().operations().list(projectId, zone);
     ListOperationsResponse response = request.execute();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_dataflow.v1b3.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_dataflow.v1b3.json.baseline
@@ -52,7 +52,7 @@ public class DataflowExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'create' method:
 
     // * The project which owns the job.
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     Job content = new Job();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -116,10 +116,10 @@ public class DataflowExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * The project which owns the job.
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     // * Identifies a single job.
-    String jobId = "";
+    String jobId = "{MY-JOB-ID}";
 
     Dataflow.Projects.Jobs.Get request = dataflowService.projects().jobs().get(projectId, jobId);
     Job response = request.execute();
@@ -180,10 +180,10 @@ public class DataflowExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'getMetrics' method:
 
     // * A project id.
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     // * The job to get messages for.
-    String jobId = "";
+    String jobId = "{MY-JOB-ID}";
 
     Dataflow.Projects.Jobs.GetMetrics request = dataflowService.projects().jobs().getMetrics(projectId, jobId);
     JobMetrics response = request.execute();
@@ -245,7 +245,7 @@ public class DataflowExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * The project which owns the jobs.
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     Dataflow.Projects.Jobs.List request = dataflowService.projects().jobs().list(projectId);
     ListJobsResponse response;
@@ -316,10 +316,10 @@ public class DataflowExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * A project id.
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     // * The job to get messages about.
-    String jobId = "";
+    String jobId = "{MY-JOB-ID}";
 
     Dataflow.Projects.Jobs.Messages.List request = dataflowService.projects().jobs().messages().list(projectId, jobId);
     ListJobMessagesResponse response;
@@ -389,10 +389,10 @@ public class DataflowExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * The project which owns the job.
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     // * Identifies a single job.
-    String jobId = "";
+    String jobId = "{MY-JOB-ID}";
 
     Job content = new Job();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -457,10 +457,10 @@ public class DataflowExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'lease' method:
 
     // * Identifies the project this worker belongs to.
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     // * Identifies the workflow job this worker belongs to.
-    String jobId = "";
+    String jobId = "{MY-JOB-ID}";
 
     LeaseWorkItemRequest content = new LeaseWorkItemRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -525,10 +525,10 @@ public class DataflowExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'reportStatus' method:
 
     // * The project which owns the WorkItem's job.
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     // * The job which the WorkItem is part of.
-    String jobId = "";
+    String jobId = "{MY-JOB-ID}";
 
     ReportWorkItemStatusRequest content = new ReportWorkItemStatusRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -593,7 +593,7 @@ public class DataflowExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'workerMessages' method:
 
     // * The project to send the WorkerMessages to.
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     SendWorkerMessagesRequest content = new SendWorkerMessagesRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_dataproc.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_dataproc.v1.json.baseline
@@ -53,10 +53,10 @@ public class DataprocExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'create' method:
 
     // * [Required] The ID of the Google Cloud Platform project that the cluster belongs to.
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     // * [Required] The Cloud Dataproc region in which to handle the request.
-    String region = "";
+    String region = "{MY-REGION}";
 
     Cluster content = new Cluster();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -120,13 +120,13 @@ public class DataprocExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * [Required] The ID of the Google Cloud Platform project that the cluster belongs to.
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     // * [Required] The Cloud Dataproc region in which to handle the request.
-    String region = "";
+    String region = "{MY-REGION}";
 
     // * [Required] The cluster name.
-    String clusterName = "";
+    String clusterName = "{MY-CLUSTER-NAME}";
 
     Dataproc.Projects.Regions.Clusters.Delete request = dataprocService.projects().regions().clusters().delete(projectId, region, clusterName);
     Operation response = request.execute();
@@ -188,13 +188,13 @@ public class DataprocExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'diagnose' method:
 
     // * [Required] The ID of the Google Cloud Platform project that the cluster belongs to.
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     // * [Required] The Cloud Dataproc region in which to handle the request.
-    String region = "";
+    String region = "{MY-REGION}";
 
     // * [Required] The cluster name.
-    String clusterName = "";
+    String clusterName = "{MY-CLUSTER-NAME}";
 
     DiagnoseClusterRequest content = new DiagnoseClusterRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -258,13 +258,13 @@ public class DataprocExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * [Required] The ID of the Google Cloud Platform project that the cluster belongs to.
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     // * [Required] The Cloud Dataproc region in which to handle the request.
-    String region = "";
+    String region = "{MY-REGION}";
 
     // * [Required] The cluster name.
-    String clusterName = "";
+    String clusterName = "{MY-CLUSTER-NAME}";
 
     Dataproc.Projects.Regions.Clusters.Get request = dataprocService.projects().regions().clusters().get(projectId, region, clusterName);
     Cluster response = request.execute();
@@ -326,10 +326,10 @@ public class DataprocExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * [Required] The ID of the Google Cloud Platform project that the cluster belongs to.
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     // * [Required] The Cloud Dataproc region in which to handle the request.
-    String region = "";
+    String region = "{MY-REGION}";
 
     Dataproc.Projects.Regions.Clusters.List request = dataprocService.projects().regions().clusters().list(projectId, region);
     ListClustersResponse response;
@@ -400,13 +400,13 @@ public class DataprocExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
     // * [Required] The ID of the Google Cloud Platform project the cluster belongs to.
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     // * [Required] The Cloud Dataproc region in which to handle the request.
-    String region = "";
+    String region = "{MY-REGION}";
 
     // * [Required] The cluster name.
-    String clusterName = "";
+    String clusterName = "{MY-CLUSTER-NAME}";
 
     Cluster content = new Cluster();
     // TODO: Add code here to assign values to desired fields of the 'content' object to be changed
@@ -471,13 +471,13 @@ public class DataprocExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'cancel' method:
 
     // * [Required] The ID of the Google Cloud Platform project that the job belongs to.
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     // * [Required] The Cloud Dataproc region in which to handle the request.
-    String region = "";
+    String region = "{MY-REGION}";
 
     // * [Required] The job ID.
-    String jobId = "";
+    String jobId = "{MY-JOB-ID}";
 
     CancelJobRequest content = new CancelJobRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -540,13 +540,13 @@ public class DataprocExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * [Required] The ID of the Google Cloud Platform project that the job belongs to.
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     // * [Required] The Cloud Dataproc region in which to handle the request.
-    String region = "";
+    String region = "{MY-REGION}";
 
     // * [Required] The job ID.
-    String jobId = "";
+    String jobId = "{MY-JOB-ID}";
 
     Dataproc.Projects.Regions.Jobs.Delete request = dataprocService.projects().regions().jobs().delete(projectId, region, jobId);
     request.execute();
@@ -605,13 +605,13 @@ public class DataprocExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * [Required] The ID of the Google Cloud Platform project that the job belongs to.
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     // * [Required] The Cloud Dataproc region in which to handle the request.
-    String region = "";
+    String region = "{MY-REGION}";
 
     // * [Required] The job ID.
-    String jobId = "";
+    String jobId = "{MY-JOB-ID}";
 
     Dataproc.Projects.Regions.Jobs.Get request = dataprocService.projects().regions().jobs().get(projectId, region, jobId);
     Job response = request.execute();
@@ -673,10 +673,10 @@ public class DataprocExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * [Required] The ID of the Google Cloud Platform project that the job belongs to.
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     // * [Required] The Cloud Dataproc region in which to handle the request.
-    String region = "";
+    String region = "{MY-REGION}";
 
     Dataproc.Projects.Regions.Jobs.List request = dataprocService.projects().regions().jobs().list(projectId, region);
     ListJobsResponse response;
@@ -747,10 +747,10 @@ public class DataprocExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'submit' method:
 
     // * [Required] The ID of the Google Cloud Platform project that the job belongs to.
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     // * [Required] The Cloud Dataproc region in which to handle the request.
-    String region = "";
+    String region = "{MY-REGION}";
 
     SubmitJobRequest content = new SubmitJobRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -992,7 +992,7 @@ public class DataprocExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * The name of the operation collection.
-    String name = "";
+    String name = "{MY-NAME}";
 
     Dataproc.Projects.Regions.Operations.List request = dataprocService.projects().regions().operations().list(name);
     ListOperationsResponse response;

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_datastore.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_datastore.v1beta2.json.baseline
@@ -53,7 +53,7 @@ public class DatastoreExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'allocateIds' method:
 
     // * Identifies the dataset.
-    String datasetId = "";
+    String datasetId = "{MY-DATASET-ID}";
 
     AllocateIdsRequest content = new AllocateIdsRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -118,7 +118,7 @@ public class DatastoreExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'beginTransaction' method:
 
     // * Identifies the dataset.
-    String datasetId = "";
+    String datasetId = "{MY-DATASET-ID}";
 
     BeginTransactionRequest content = new BeginTransactionRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -183,7 +183,7 @@ public class DatastoreExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'commit' method:
 
     // * Identifies the dataset.
-    String datasetId = "";
+    String datasetId = "{MY-DATASET-ID}";
 
     CommitRequest content = new CommitRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -248,7 +248,7 @@ public class DatastoreExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'lookup' method:
 
     // * Identifies the dataset.
-    String datasetId = "";
+    String datasetId = "{MY-DATASET-ID}";
 
     LookupRequest content = new LookupRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -313,7 +313,7 @@ public class DatastoreExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'rollback' method:
 
     // * Identifies the dataset.
-    String datasetId = "";
+    String datasetId = "{MY-DATASET-ID}";
 
     RollbackRequest content = new RollbackRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -378,7 +378,7 @@ public class DatastoreExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'runQuery' method:
 
     // * Identifies the dataset.
-    String datasetId = "";
+    String datasetId = "{MY-DATASET-ID}";
 
     RunQueryRequest content = new RunQueryRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_deploymentmanager.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_deploymentmanager.v2.json.baseline
@@ -53,10 +53,10 @@ public class DeploymentManagerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'cancelPreview' method:
 
     // * The project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the deployment for this request.
-    String deployment = "";
+    String deployment = "{MY-DEPLOYMENT}";
 
     DeploymentsCancelPreviewRequest content = new DeploymentsCancelPreviewRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -120,10 +120,10 @@ public class DeploymentManagerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * The project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the deployment for this request.
-    String deployment = "";
+    String deployment = "{MY-DEPLOYMENT}";
 
     DeploymentManager.Deployments.Delete request = deploymentmanagerService.deployments().delete(project, deployment);
     Operation response = request.execute();
@@ -184,10 +184,10 @@ public class DeploymentManagerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * The project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the deployment for this request.
-    String deployment = "";
+    String deployment = "{MY-DEPLOYMENT}";
 
     DeploymentManager.Deployments.Get request = deploymentmanagerService.deployments().get(project, deployment);
     Deployment response = request.execute();
@@ -249,7 +249,7 @@ public class DeploymentManagerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * The project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Deployment content = new Deployment();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -314,7 +314,7 @@ public class DeploymentManagerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * The project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     DeploymentManager.Deployments.List request = deploymentmanagerService.deployments().list(project);
     DeploymentsListResponse response;
@@ -385,10 +385,10 @@ public class DeploymentManagerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
     // * The project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the deployment for this request.
-    String deployment = "";
+    String deployment = "{MY-DEPLOYMENT}";
 
     Deployment content = new Deployment();
     // TODO: Add code here to assign values to desired fields of the 'content' object to be changed
@@ -453,10 +453,10 @@ public class DeploymentManagerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'stop' method:
 
     // * The project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the deployment for this request.
-    String deployment = "";
+    String deployment = "{MY-DEPLOYMENT}";
 
     DeploymentsStopRequest content = new DeploymentsStopRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -521,10 +521,10 @@ public class DeploymentManagerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * The project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the deployment for this request.
-    String deployment = "";
+    String deployment = "{MY-DEPLOYMENT}";
 
     Deployment content = new Deployment();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -588,13 +588,13 @@ public class DeploymentManagerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * The project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the deployment for this request.
-    String deployment = "";
+    String deployment = "{MY-DEPLOYMENT}";
 
     // * The name of the manifest for this request.
-    String manifest = "";
+    String manifest = "{MY-MANIFEST}";
 
     DeploymentManager.Manifests.Get request = deploymentmanagerService.manifests().get(project, deployment, manifest);
     Manifest response = request.execute();
@@ -656,10 +656,10 @@ public class DeploymentManagerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * The project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the deployment for this request.
-    String deployment = "";
+    String deployment = "{MY-DEPLOYMENT}";
 
     DeploymentManager.Manifests.List request = deploymentmanagerService.manifests().list(project, deployment);
     ManifestsListResponse response;
@@ -729,10 +729,10 @@ public class DeploymentManagerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * The project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the operation for this request.
-    String operation = "";
+    String operation = "{MY-OPERATION}";
 
     DeploymentManager.Operations.Get request = deploymentmanagerService.operations().get(project, operation);
     Operation response = request.execute();
@@ -794,7 +794,7 @@ public class DeploymentManagerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * The project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     DeploymentManager.Operations.List request = deploymentmanagerService.operations().list(project);
     OperationsListResponse response;
@@ -864,13 +864,13 @@ public class DeploymentManagerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * The project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the deployment for this request.
-    String deployment = "";
+    String deployment = "{MY-DEPLOYMENT}";
 
     // * The name of the resource for this request.
-    String resource = "";
+    String resource = "{MY-RESOURCE}";
 
     DeploymentManager.Resources.Get request = deploymentmanagerService.resources().get(project, deployment, resource);
     Resource response = request.execute();
@@ -932,10 +932,10 @@ public class DeploymentManagerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * The project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the deployment for this request.
-    String deployment = "";
+    String deployment = "{MY-DEPLOYMENT}";
 
     DeploymentManager.Resources.List request = deploymentmanagerService.resources().list(project, deployment);
     ResourcesListResponse response;
@@ -1006,7 +1006,7 @@ public class DeploymentManagerExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * The project ID for this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     DeploymentManager.Types.List request = deploymentmanagerService.types().list(project);
     TypesListResponse response;

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_dns.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_dns.v1.json.baseline
@@ -52,10 +52,10 @@ public class DnsExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'create' method:
 
     // * Identifies the project addressed by this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-    String managedZone = "";
+    String managedZone = "{MY-MANAGED-ZONE}";
 
     Change content = new Change();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -119,13 +119,13 @@ public class DnsExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Identifies the project addressed by this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-    String managedZone = "";
+    String managedZone = "{MY-MANAGED-ZONE}";
 
     // * The identifier of the requested change, from a previous ResourceRecordSetsChangeResponse.
-    String changeId = "";
+    String changeId = "{MY-CHANGE-ID}";
 
     Dns.Changes.Get request = dnsService.changes().get(project, managedZone, changeId);
     Change response = request.execute();
@@ -187,10 +187,10 @@ public class DnsExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Identifies the project addressed by this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-    String managedZone = "";
+    String managedZone = "{MY-MANAGED-ZONE}";
 
     Dns.Changes.List request = dnsService.changes().list(project, managedZone);
     ChangesListResponse response;
@@ -260,7 +260,7 @@ public class DnsExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'create' method:
 
     // * Identifies the project addressed by this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     ManagedZone content = new ManagedZone();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -323,10 +323,10 @@ public class DnsExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Identifies the project addressed by this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-    String managedZone = "";
+    String managedZone = "{MY-MANAGED-ZONE}";
 
     Dns.ManagedZones.Delete request = dnsService.managedZones().delete(project, managedZone);
     request.execute();
@@ -385,10 +385,10 @@ public class DnsExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Identifies the project addressed by this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-    String managedZone = "";
+    String managedZone = "{MY-MANAGED-ZONE}";
 
     Dns.ManagedZones.Get request = dnsService.managedZones().get(project, managedZone);
     ManagedZone response = request.execute();
@@ -450,7 +450,7 @@ public class DnsExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Identifies the project addressed by this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Dns.ManagedZones.List request = dnsService.managedZones().list(project);
     ManagedZonesListResponse response;
@@ -520,7 +520,7 @@ public class DnsExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Identifies the project addressed by this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Dns.Projects.Get request = dnsService.projects().get(project);
     Project response = request.execute();
@@ -582,10 +582,10 @@ public class DnsExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Identifies the project addressed by this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-    String managedZone = "";
+    String managedZone = "{MY-MANAGED-ZONE}";
 
     Dns.ResourceRecordSets.List request = dnsService.resourceRecordSets().list(project, managedZone);
     ResourceRecordSetsListResponse response;

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_prediction.v1.6.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_prediction.v1.6.json.baseline
@@ -53,10 +53,10 @@ public class PredictionExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'predict' method:
 
     // * The project associated with the model.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of a hosted model.
-    String hostedModelName = "";
+    String hostedModelName = "{MY-HOSTED-MODEL-NAME}";
 
     Input content = new Input();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -120,10 +120,10 @@ public class PredictionExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'analyze' method:
 
     // * The project associated with the model.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The unique name for the predictive model.
-    String id = "";
+    String id = "{MY-ID}";
 
     Prediction.Trainedmodels.Analyze request = predictionService.trainedmodels().analyze(project, id);
     Analyze response = request.execute();
@@ -183,10 +183,10 @@ public class PredictionExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * The project associated with the model.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The unique name for the predictive model.
-    String id = "";
+    String id = "{MY-ID}";
 
     Prediction.Trainedmodels.Delete request = predictionService.trainedmodels().delete(project, id);
     request.execute();
@@ -245,10 +245,10 @@ public class PredictionExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * The project associated with the model.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The unique name for the predictive model.
-    String id = "";
+    String id = "{MY-ID}";
 
     Prediction.Trainedmodels.Get request = predictionService.trainedmodels().get(project, id);
     Insert2 response = request.execute();
@@ -310,7 +310,7 @@ public class PredictionExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * The project associated with the model.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Insert content = new Insert();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -375,7 +375,7 @@ public class PredictionExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * The project associated with the model.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Prediction.Trainedmodels.List request = predictionService.trainedmodels().list(project);
     List response;
@@ -446,10 +446,10 @@ public class PredictionExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'predict' method:
 
     // * The project associated with the model.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The unique name for the predictive model.
-    String id = "";
+    String id = "{MY-ID}";
 
     Input content = new Input();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -514,10 +514,10 @@ public class PredictionExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * The project associated with the model.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The unique name for the predictive model.
-    String id = "";
+    String id = "{MY-ID}";
 
     Update content = new Update();
     // TODO: Add code here to assign values to desired fields of the 'content' object

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_replicapoolupdater.v1beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_replicapoolupdater.v1beta1.json.baseline
@@ -52,13 +52,13 @@ public class ReplicapoolupdaterExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'cancel' method:
 
     // * The Google Developers Console project name.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone in which the update's target resides.
-    String zone = "";
+    String zone = "{MY-ZONE}";
 
     // * The name of the update.
-    String rollingUpdate = "";
+    String rollingUpdate = "{MY-ROLLING-UPDATE}";
 
     Replicapoolupdater.RollingUpdates.Cancel request = replicapoolupdaterService.rollingUpdates().cancel(project, zone, rollingUpdate);
     Operation response = request.execute();
@@ -119,13 +119,13 @@ public class ReplicapoolupdaterExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * The Google Developers Console project name.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone in which the update's target resides.
-    String zone = "";
+    String zone = "{MY-ZONE}";
 
     // * The name of the update.
-    String rollingUpdate = "";
+    String rollingUpdate = "{MY-ROLLING-UPDATE}";
 
     Replicapoolupdater.RollingUpdates.Get request = replicapoolupdaterService.rollingUpdates().get(project, zone, rollingUpdate);
     RollingUpdate response = request.execute();
@@ -187,10 +187,10 @@ public class ReplicapoolupdaterExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * The Google Developers Console project name.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone in which the update's target resides.
-    String zone = "";
+    String zone = "{MY-ZONE}";
 
     RollingUpdate content = new RollingUpdate();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -255,10 +255,10 @@ public class ReplicapoolupdaterExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * The Google Developers Console project name.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone in which the update's target resides.
-    String zone = "";
+    String zone = "{MY-ZONE}";
 
     Replicapoolupdater.RollingUpdates.List request = replicapoolupdaterService.rollingUpdates().list(project, zone);
     RollingUpdateList response;
@@ -329,13 +329,13 @@ public class ReplicapoolupdaterExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'listInstanceUpdates' method:
 
     // * The Google Developers Console project name.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone in which the update's target resides.
-    String zone = "";
+    String zone = "{MY-ZONE}";
 
     // * The name of the update.
-    String rollingUpdate = "";
+    String rollingUpdate = "{MY-ROLLING-UPDATE}";
 
     Replicapoolupdater.RollingUpdates.ListInstanceUpdates request = replicapoolupdaterService.rollingUpdates().listInstanceUpdates(project, zone, rollingUpdate);
     InstanceUpdateList response;
@@ -405,13 +405,13 @@ public class ReplicapoolupdaterExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'pause' method:
 
     // * The Google Developers Console project name.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone in which the update's target resides.
-    String zone = "";
+    String zone = "{MY-ZONE}";
 
     // * The name of the update.
-    String rollingUpdate = "";
+    String rollingUpdate = "{MY-ROLLING-UPDATE}";
 
     Replicapoolupdater.RollingUpdates.Pause request = replicapoolupdaterService.rollingUpdates().pause(project, zone, rollingUpdate);
     Operation response = request.execute();
@@ -472,13 +472,13 @@ public class ReplicapoolupdaterExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'resume' method:
 
     // * The Google Developers Console project name.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone in which the update's target resides.
-    String zone = "";
+    String zone = "{MY-ZONE}";
 
     // * The name of the update.
-    String rollingUpdate = "";
+    String rollingUpdate = "{MY-ROLLING-UPDATE}";
 
     Replicapoolupdater.RollingUpdates.Resume request = replicapoolupdaterService.rollingUpdates().resume(project, zone, rollingUpdate);
     Operation response = request.execute();
@@ -539,13 +539,13 @@ public class ReplicapoolupdaterExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'rollback' method:
 
     // * The Google Developers Console project name.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The name of the zone in which the update's target resides.
-    String zone = "";
+    String zone = "{MY-ZONE}";
 
     // * The name of the update.
-    String rollingUpdate = "";
+    String rollingUpdate = "{MY-ROLLING-UPDATE}";
 
     Replicapoolupdater.RollingUpdates.Rollback request = replicapoolupdaterService.rollingUpdates().rollback(project, zone, rollingUpdate);
     Operation response = request.execute();
@@ -606,13 +606,13 @@ public class ReplicapoolupdaterExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Name of the project scoping this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the zone scoping this request.
-    String zone = "";
+    String zone = "{MY-ZONE}";
 
     // * Name of the operation resource to return.
-    String operation = "";
+    String operation = "{MY-OPERATION}";
 
     Replicapoolupdater.ZoneOperations.Get request = replicapoolupdaterService.zoneOperations().get(project, zone, operation);
     Operation response = request.execute();
@@ -674,10 +674,10 @@ public class ReplicapoolupdaterExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Name of the project scoping this request.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Name of the zone scoping this request.
-    String zone = "";
+    String zone = "{MY-ZONE}";
 
     Replicapoolupdater.ZoneOperations.List request = replicapoolupdaterService.zoneOperations().list(project, zone);
     OperationList response;

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_sqladmin.v1beta4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_sqladmin.v1beta4.json.baseline
@@ -52,10 +52,10 @@ public class SQLAdminExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID of the project that contains the instance.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Cloud SQL instance ID. This does not include the project ID.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     // * The ID of the Backup Run to delete. To find a Backup Run ID, use the list method.
     long id = 0;
@@ -119,10 +119,10 @@ public class SQLAdminExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID of the project that contains the instance.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Cloud SQL instance ID. This does not include the project ID.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     // * The ID of this Backup Run.
     long id = 0;
@@ -187,10 +187,10 @@ public class SQLAdminExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID of the project that contains the instance.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Cloud SQL instance ID. This does not include the project ID.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     SQLAdmin.BackupRuns.List request = sqladminService.backupRuns().list(project, instance);
     BackupRunsListResponse response;
@@ -260,13 +260,13 @@ public class SQLAdminExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID of the project that contains the instance.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Database instance ID. This does not include the project ID.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     // * Name of the database to be deleted in the instance.
-    String database = "";
+    String database = "{MY-DATABASE}";
 
     SQLAdmin.Databases.Delete request = sqladminService.databases().delete(project, instance, database);
     Operation response = request.execute();
@@ -327,13 +327,13 @@ public class SQLAdminExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID of the project that contains the instance.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Database instance ID. This does not include the project ID.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     // * Name of the database in the instance.
-    String database = "";
+    String database = "{MY-DATABASE}";
 
     SQLAdmin.Databases.Get request = sqladminService.databases().get(project, instance, database);
     Database response = request.execute();
@@ -395,10 +395,10 @@ public class SQLAdminExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID of the project that contains the instance.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Database instance ID. This does not include the project ID.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     Database content = new Database();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -462,10 +462,10 @@ public class SQLAdminExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID of the project for which to list Cloud SQL instances.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Cloud SQL instance ID. This does not include the project ID.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     SQLAdmin.Databases.List request = sqladminService.databases().list(project, instance);
     DatabasesListResponse response = request.execute();
@@ -527,13 +527,13 @@ public class SQLAdminExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
     // * Project ID of the project that contains the instance.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Database instance ID. This does not include the project ID.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     // * Name of the database to be updated in the instance.
-    String database = "";
+    String database = "{MY-DATABASE}";
 
     Database content = new Database();
     // TODO: Add code here to assign values to desired fields of the 'content' object to be changed
@@ -598,13 +598,13 @@ public class SQLAdminExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * Project ID of the project that contains the instance.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Database instance ID. This does not include the project ID.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     // * Name of the database to be updated in the instance.
-    String database = "";
+    String database = "{MY-DATABASE}";
 
     Database content = new Database();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -726,10 +726,10 @@ public class SQLAdminExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'clone' method:
 
     // * Project ID of the source as well as the clone Cloud SQL instance.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The ID of the Cloud SQL instance to be cloned (source). This does not include the project ID.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     InstancesCloneRequest content = new InstancesCloneRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -793,10 +793,10 @@ public class SQLAdminExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID of the project that contains the instance to be deleted.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Cloud SQL instance ID. This does not include the project ID.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     SQLAdmin.Instances.Delete request = sqladminService.instances().delete(project, instance);
     Operation response = request.execute();
@@ -858,10 +858,10 @@ public class SQLAdminExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'export' method:
 
     // * Project ID of the project that contains the instance to be exported.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Cloud SQL instance ID. This does not include the project ID.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     InstancesExportRequest content = new InstancesExportRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -926,10 +926,10 @@ public class SQLAdminExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'failover' method:
 
     // * ID of the project that contains the read replica.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Cloud SQL instance ID. This does not include the project ID.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     InstancesFailoverRequest content = new InstancesFailoverRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -993,10 +993,10 @@ public class SQLAdminExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID of the project that contains the instance.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Database instance ID. This does not include the project ID.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     SQLAdmin.Instances.Get request = sqladminService.instances().get(project, instance);
     DatabaseInstance response = request.execute();
@@ -1058,10 +1058,10 @@ public class SQLAdminExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'sqladminImport' method:
 
     // * Project ID of the project that contains the instance.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Cloud SQL instance ID. This does not include the project ID.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     InstancesImportRequest content = new InstancesImportRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -1126,7 +1126,7 @@ public class SQLAdminExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID of the project to which the newly created Cloud SQL instances should belong.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     DatabaseInstance content = new DatabaseInstance();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -1191,7 +1191,7 @@ public class SQLAdminExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID of the project for which to list Cloud SQL instances.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     SQLAdmin.Instances.List request = sqladminService.instances().list(project);
     InstancesListResponse response;
@@ -1262,10 +1262,10 @@ public class SQLAdminExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
     // * Project ID of the project that contains the instance.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Cloud SQL instance ID. This does not include the project ID.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     DatabaseInstance content = new DatabaseInstance();
     // TODO: Add code here to assign values to desired fields of the 'content' object to be changed
@@ -1329,10 +1329,10 @@ public class SQLAdminExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'promoteReplica' method:
 
     // * ID of the project that contains the read replica.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Cloud SQL read replica instance name.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     SQLAdmin.Instances.PromoteReplica request = sqladminService.instances().promoteReplica(project, instance);
     Operation response = request.execute();
@@ -1393,10 +1393,10 @@ public class SQLAdminExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'resetSslConfig' method:
 
     // * Project ID of the project that contains the instance.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Cloud SQL instance ID. This does not include the project ID.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     SQLAdmin.Instances.ResetSslConfig request = sqladminService.instances().resetSslConfig(project, instance);
     Operation response = request.execute();
@@ -1457,10 +1457,10 @@ public class SQLAdminExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'restart' method:
 
     // * Project ID of the project that contains the instance to be restarted.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Cloud SQL instance ID. This does not include the project ID.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     SQLAdmin.Instances.Restart request = sqladminService.instances().restart(project, instance);
     Operation response = request.execute();
@@ -1522,10 +1522,10 @@ public class SQLAdminExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'restoreBackup' method:
 
     // * Project ID of the project that contains the instance.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Cloud SQL instance ID. This does not include the project ID.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     InstancesRestoreBackupRequest content = new InstancesRestoreBackupRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -1589,10 +1589,10 @@ public class SQLAdminExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'startReplica' method:
 
     // * ID of the project that contains the read replica.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Cloud SQL read replica instance name.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     SQLAdmin.Instances.StartReplica request = sqladminService.instances().startReplica(project, instance);
     Operation response = request.execute();
@@ -1653,10 +1653,10 @@ public class SQLAdminExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'stopReplica' method:
 
     // * ID of the project that contains the read replica.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Cloud SQL read replica instance name.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     SQLAdmin.Instances.StopReplica request = sqladminService.instances().stopReplica(project, instance);
     Operation response = request.execute();
@@ -1718,10 +1718,10 @@ public class SQLAdminExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * Project ID of the project that contains the instance.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Cloud SQL instance ID. This does not include the project ID.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     DatabaseInstance content = new DatabaseInstance();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -1785,10 +1785,10 @@ public class SQLAdminExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID of the project that contains the instance.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Instance operation ID.
-    String operation = "";
+    String operation = "{MY-OPERATION}";
 
     SQLAdmin.Operations.Get request = sqladminService.operations().get(project, operation);
     Operation response = request.execute();
@@ -1850,10 +1850,10 @@ public class SQLAdminExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID of the project that contains the instance.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Cloud SQL instance ID. This does not include the project ID.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     SQLAdmin.Operations.List request = sqladminService.operations().list(project, instance);
     OperationsListResponse response;
@@ -1924,10 +1924,10 @@ public class SQLAdminExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'createEphemeral' method:
 
     // * Project ID of the Cloud SQL project.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Cloud SQL instance ID. This does not include the project ID.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     SslCertsCreateEphemeralRequest content = new SslCertsCreateEphemeralRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -1991,13 +1991,13 @@ public class SQLAdminExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID of the project that contains the instance to be deleted.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Cloud SQL instance ID. This does not include the project ID.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     // * Sha1 FingerPrint.
-    String sha1Fingerprint = "";
+    String sha1Fingerprint = "{MY-SHA1-FINGERPRINT}";
 
     SQLAdmin.SslCerts.Delete request = sqladminService.sslCerts().delete(project, instance, sha1Fingerprint);
     Operation response = request.execute();
@@ -2058,13 +2058,13 @@ public class SQLAdminExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID of the project that contains the instance.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Cloud SQL instance ID. This does not include the project ID.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     // * Sha1 FingerPrint.
-    String sha1Fingerprint = "";
+    String sha1Fingerprint = "{MY-SHA1-FINGERPRINT}";
 
     SQLAdmin.SslCerts.Get request = sqladminService.sslCerts().get(project, instance, sha1Fingerprint);
     SslCert response = request.execute();
@@ -2126,10 +2126,10 @@ public class SQLAdminExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID of the project to which the newly created Cloud SQL instances should belong.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Cloud SQL instance ID. This does not include the project ID.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     SslCertsInsertRequest content = new SslCertsInsertRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -2193,10 +2193,10 @@ public class SQLAdminExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID of the project for which to list Cloud SQL instances.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Cloud SQL instance ID. This does not include the project ID.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     SQLAdmin.SslCerts.List request = sqladminService.sslCerts().list(project, instance);
     SslCertsListResponse response = request.execute();
@@ -2257,7 +2257,7 @@ public class SQLAdminExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID of the project for which to list tiers.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     SQLAdmin.Tiers.List request = sqladminService.tiers().list(project);
     TiersListResponse response = request.execute();
@@ -2318,16 +2318,16 @@ public class SQLAdminExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID of the project that contains the instance.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Database instance ID. This does not include the project ID.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     // * Host of the user in the instance.
-    String host = "";
+    String host = "{MY-HOST}";
 
     // * Name of the user in the instance.
-    String name = "";
+    String name = "{MY-NAME}";
 
     SQLAdmin.Users.Delete request = sqladminService.users().delete(project, instance, host, name);
     Operation response = request.execute();
@@ -2389,10 +2389,10 @@ public class SQLAdminExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID of the project that contains the instance.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Database instance ID. This does not include the project ID.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     User content = new User();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -2456,10 +2456,10 @@ public class SQLAdminExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID of the project that contains the instance.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Database instance ID. This does not include the project ID.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     SQLAdmin.Users.List request = sqladminService.users().list(project, instance);
     UsersListResponse response = request.execute();
@@ -2521,16 +2521,16 @@ public class SQLAdminExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * Project ID of the project that contains the instance.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * Database instance ID. This does not include the project ID.
-    String instance = "";
+    String instance = "{MY-INSTANCE}";
 
     // * Host of the user in the instance.
-    String host = "";
+    String host = "{MY-HOST}";
 
     // * Name of the user in the instance.
-    String name = "";
+    String name = "{MY-NAME}";
 
     User content = new User();
     // TODO: Add code here to assign values to desired fields of the 'content' object

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_storage.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_storage.v1.json.baseline
@@ -51,11 +51,11 @@ public class StorageExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Name of a bucket.
-    String bucket = "";
+    String bucket = "{MY-BUCKET}";
 
     // * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
     //   group-emailAddress, allUsers, or allAuthenticatedUsers.
-    String entity = "";
+    String entity = "{MY-ENTITY}";
 
     Storage.BucketAccessControls.Delete request = storageService.bucketAccessControls().delete(bucket, entity);
     request.execute();
@@ -114,11 +114,11 @@ public class StorageExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Name of a bucket.
-    String bucket = "";
+    String bucket = "{MY-BUCKET}";
 
     // * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
     //   group-emailAddress, allUsers, or allAuthenticatedUsers.
-    String entity = "";
+    String entity = "{MY-ENTITY}";
 
     Storage.BucketAccessControls.Get request = storageService.bucketAccessControls().get(bucket, entity);
     BucketAccessControl response = request.execute();
@@ -179,7 +179,7 @@ public class StorageExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Name of a bucket.
-    String bucket = "";
+    String bucket = "{MY-BUCKET}";
 
     BucketAccessControl content = new BucketAccessControl();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -243,7 +243,7 @@ public class StorageExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Name of a bucket.
-    String bucket = "";
+    String bucket = "{MY-BUCKET}";
 
     Storage.BucketAccessControls.List request = storageService.bucketAccessControls().list(bucket);
     BucketAccessControls response = request.execute();
@@ -304,11 +304,11 @@ public class StorageExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
     // * Name of a bucket.
-    String bucket = "";
+    String bucket = "{MY-BUCKET}";
 
     // * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
     //   group-emailAddress, allUsers, or allAuthenticatedUsers.
-    String entity = "";
+    String entity = "{MY-ENTITY}";
 
     BucketAccessControl content = new BucketAccessControl();
     // TODO: Add code here to assign values to desired fields of the 'content' object to be changed
@@ -372,11 +372,11 @@ public class StorageExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * Name of a bucket.
-    String bucket = "";
+    String bucket = "{MY-BUCKET}";
 
     // * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
     //   group-emailAddress, allUsers, or allAuthenticatedUsers.
-    String entity = "";
+    String entity = "{MY-ENTITY}";
 
     BucketAccessControl content = new BucketAccessControl();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -439,7 +439,7 @@ public class StorageExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Name of a bucket.
-    String bucket = "";
+    String bucket = "{MY-BUCKET}";
 
     Storage.Buckets.Delete request = storageService.buckets().delete(bucket);
     request.execute();
@@ -498,7 +498,7 @@ public class StorageExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Name of a bucket.
-    String bucket = "";
+    String bucket = "{MY-BUCKET}";
 
     Storage.Buckets.Get request = storageService.buckets().get(bucket);
     Bucket response = request.execute();
@@ -559,7 +559,7 @@ public class StorageExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * A valid API project identifier.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Bucket content = new Bucket();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -624,7 +624,7 @@ public class StorageExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * A valid API project identifier.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     Storage.Buckets.List request = storageService.buckets().list(project);
     Buckets response;
@@ -694,7 +694,7 @@ public class StorageExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
     // * Name of a bucket.
-    String bucket = "";
+    String bucket = "{MY-BUCKET}";
 
     Bucket content = new Bucket();
     // TODO: Add code here to assign values to desired fields of the 'content' object to be changed
@@ -758,7 +758,7 @@ public class StorageExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * Name of a bucket.
-    String bucket = "";
+    String bucket = "{MY-BUCKET}";
 
     Bucket content = new Bucket();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -879,11 +879,11 @@ public class StorageExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Name of a bucket.
-    String bucket = "";
+    String bucket = "{MY-BUCKET}";
 
     // * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
     //   group-emailAddress, allUsers, or allAuthenticatedUsers.
-    String entity = "";
+    String entity = "{MY-ENTITY}";
 
     Storage.DefaultObjectAccessControls.Delete request = storageService.defaultObjectAccessControls().delete(bucket, entity);
     request.execute();
@@ -942,11 +942,11 @@ public class StorageExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Name of a bucket.
-    String bucket = "";
+    String bucket = "{MY-BUCKET}";
 
     // * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
     //   group-emailAddress, allUsers, or allAuthenticatedUsers.
-    String entity = "";
+    String entity = "{MY-ENTITY}";
 
     Storage.DefaultObjectAccessControls.Get request = storageService.defaultObjectAccessControls().get(bucket, entity);
     ObjectAccessControl response = request.execute();
@@ -1007,7 +1007,7 @@ public class StorageExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Name of a bucket.
-    String bucket = "";
+    String bucket = "{MY-BUCKET}";
 
     ObjectAccessControl content = new ObjectAccessControl();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -1071,7 +1071,7 @@ public class StorageExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Name of a bucket.
-    String bucket = "";
+    String bucket = "{MY-BUCKET}";
 
     Storage.DefaultObjectAccessControls.List request = storageService.defaultObjectAccessControls().list(bucket);
     ObjectAccessControls response = request.execute();
@@ -1132,11 +1132,11 @@ public class StorageExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
     // * Name of a bucket.
-    String bucket = "";
+    String bucket = "{MY-BUCKET}";
 
     // * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
     //   group-emailAddress, allUsers, or allAuthenticatedUsers.
-    String entity = "";
+    String entity = "{MY-ENTITY}";
 
     ObjectAccessControl content = new ObjectAccessControl();
     // TODO: Add code here to assign values to desired fields of the 'content' object to be changed
@@ -1200,11 +1200,11 @@ public class StorageExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * Name of a bucket.
-    String bucket = "";
+    String bucket = "{MY-BUCKET}";
 
     // * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
     //   group-emailAddress, allUsers, or allAuthenticatedUsers.
-    String entity = "";
+    String entity = "{MY-ENTITY}";
 
     ObjectAccessControl content = new ObjectAccessControl();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -1267,15 +1267,15 @@ public class StorageExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Name of a bucket.
-    String bucket = "";
+    String bucket = "{MY-BUCKET}";
 
     // * Name of the object. For information about how to URL encode object names to be path safe, see
     //   Encoding URI Path Parts.
-    String object = "";
+    String object = "{MY-OBJECT}";
 
     // * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
     //   group-emailAddress, allUsers, or allAuthenticatedUsers.
-    String entity = "";
+    String entity = "{MY-ENTITY}";
 
     Storage.ObjectAccessControls.Delete request = storageService.objectAccessControls().delete(bucket, object, entity);
     request.execute();
@@ -1334,15 +1334,15 @@ public class StorageExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Name of a bucket.
-    String bucket = "";
+    String bucket = "{MY-BUCKET}";
 
     // * Name of the object. For information about how to URL encode object names to be path safe, see
     //   Encoding URI Path Parts.
-    String object = "";
+    String object = "{MY-OBJECT}";
 
     // * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
     //   group-emailAddress, allUsers, or allAuthenticatedUsers.
-    String entity = "";
+    String entity = "{MY-ENTITY}";
 
     Storage.ObjectAccessControls.Get request = storageService.objectAccessControls().get(bucket, object, entity);
     ObjectAccessControl response = request.execute();
@@ -1403,11 +1403,11 @@ public class StorageExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Name of a bucket.
-    String bucket = "";
+    String bucket = "{MY-BUCKET}";
 
     // * Name of the object. For information about how to URL encode object names to be path safe, see
     //   Encoding URI Path Parts.
-    String object = "";
+    String object = "{MY-OBJECT}";
 
     ObjectAccessControl content = new ObjectAccessControl();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -1471,11 +1471,11 @@ public class StorageExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Name of a bucket.
-    String bucket = "";
+    String bucket = "{MY-BUCKET}";
 
     // * Name of the object. For information about how to URL encode object names to be path safe, see
     //   Encoding URI Path Parts.
-    String object = "";
+    String object = "{MY-OBJECT}";
 
     Storage.ObjectAccessControls.List request = storageService.objectAccessControls().list(bucket, object);
     ObjectAccessControls response = request.execute();
@@ -1536,15 +1536,15 @@ public class StorageExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
     // * Name of a bucket.
-    String bucket = "";
+    String bucket = "{MY-BUCKET}";
 
     // * Name of the object. For information about how to URL encode object names to be path safe, see
     //   Encoding URI Path Parts.
-    String object = "";
+    String object = "{MY-OBJECT}";
 
     // * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
     //   group-emailAddress, allUsers, or allAuthenticatedUsers.
-    String entity = "";
+    String entity = "{MY-ENTITY}";
 
     ObjectAccessControl content = new ObjectAccessControl();
     // TODO: Add code here to assign values to desired fields of the 'content' object to be changed
@@ -1608,15 +1608,15 @@ public class StorageExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * Name of a bucket.
-    String bucket = "";
+    String bucket = "{MY-BUCKET}";
 
     // * Name of the object. For information about how to URL encode object names to be path safe, see
     //   Encoding URI Path Parts.
-    String object = "";
+    String object = "{MY-OBJECT}";
 
     // * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
     //   group-emailAddress, allUsers, or allAuthenticatedUsers.
-    String entity = "";
+    String entity = "{MY-ENTITY}";
 
     ObjectAccessControl content = new ObjectAccessControl();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -1681,11 +1681,11 @@ public class StorageExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'compose' method:
 
     // * Name of the bucket in which to store the new object.
-    String destinationBucket = "";
+    String destinationBucket = "{MY-DESTINATION-BUCKET}";
 
     // * Name of the new object. For information about how to URL encode object names to be path safe, see
     //   Encoding URI Path Parts.
-    String destinationObject = "";
+    String destinationObject = "{MY-DESTINATION-OBJECT}";
 
     ComposeRequest content = new ComposeRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -1749,20 +1749,20 @@ public class StorageExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'copy' method:
 
     // * Name of the bucket in which to find the source object.
-    String sourceBucket = "";
+    String sourceBucket = "{MY-SOURCE-BUCKET}";
 
     // * Name of the source object. For information about how to URL encode object names to be path safe,
     //   see Encoding URI Path Parts.
-    String sourceObject = "";
+    String sourceObject = "{MY-SOURCE-OBJECT}";
 
     // * Name of the bucket in which to store the new object. Overrides the provided object metadata's
     //   bucket value, if any.For information about how to URL encode object names to be path safe, see
     //   Encoding URI Path Parts.
-    String destinationBucket = "";
+    String destinationBucket = "{MY-DESTINATION-BUCKET}";
 
     // * Name of the new object. Required when the object metadata is not otherwise provided. Overrides the
     //   object metadata's name value, if any.
-    String destinationObject = "";
+    String destinationObject = "{MY-DESTINATION-OBJECT}";
 
     StorageObject content = new StorageObject();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -1825,11 +1825,11 @@ public class StorageExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Name of the bucket in which the object resides.
-    String bucket = "";
+    String bucket = "{MY-BUCKET}";
 
     // * Name of the object. For information about how to URL encode object names to be path safe, see
     //   Encoding URI Path Parts.
-    String object = "";
+    String object = "{MY-OBJECT}";
 
     Storage.Objects.Delete request = storageService.objects().delete(bucket, object);
     request.execute();
@@ -1888,11 +1888,11 @@ public class StorageExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Name of the bucket in which the object resides.
-    String bucket = "";
+    String bucket = "{MY-BUCKET}";
 
     // * Name of the object. For information about how to URL encode object names to be path safe, see
     //   Encoding URI Path Parts.
-    String object = "";
+    String object = "{MY-OBJECT}";
 
     Storage.Objects.Get request = storageService.objects().get(bucket, object);
     StorageObject response = request.execute();
@@ -1954,7 +1954,7 @@ public class StorageExample {
 
     // * Name of the bucket in which to store the new object. Overrides the provided object metadata's
     //   bucket value, if any.
-    String bucket = "";
+    String bucket = "{MY-BUCKET}";
 
     StorageObject content = new StorageObject();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -2019,7 +2019,7 @@ public class StorageExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Name of the bucket in which to look for objects.
-    String bucket = "";
+    String bucket = "{MY-BUCKET}";
 
     Storage.Objects.List request = storageService.objects().list(bucket);
     Objects response;
@@ -2089,11 +2089,11 @@ public class StorageExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
     // * Name of the bucket in which the object resides.
-    String bucket = "";
+    String bucket = "{MY-BUCKET}";
 
     // * Name of the object. For information about how to URL encode object names to be path safe, see
     //   Encoding URI Path Parts.
-    String object = "";
+    String object = "{MY-OBJECT}";
 
     StorageObject content = new StorageObject();
     // TODO: Add code here to assign values to desired fields of the 'content' object to be changed
@@ -2158,20 +2158,20 @@ public class StorageExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'rewrite' method:
 
     // * Name of the bucket in which to find the source object.
-    String sourceBucket = "";
+    String sourceBucket = "{MY-SOURCE-BUCKET}";
 
     // * Name of the source object. For information about how to URL encode object names to be path safe,
     //   see Encoding URI Path Parts.
-    String sourceObject = "";
+    String sourceObject = "{MY-SOURCE-OBJECT}";
 
     // * Name of the bucket in which to store the new object. Overrides the provided object metadata's
     //   bucket value, if any.
-    String destinationBucket = "";
+    String destinationBucket = "{MY-DESTINATION-BUCKET}";
 
     // * Name of the new object. Required when the object metadata is not otherwise provided. Overrides the
     //   object metadata's name value, if any. For information about how to URL encode object names to be
     //   path safe, see Encoding URI Path Parts.
-    String destinationObject = "";
+    String destinationObject = "{MY-DESTINATION-OBJECT}";
 
     StorageObject content = new StorageObject();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -2235,11 +2235,11 @@ public class StorageExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * Name of the bucket in which the object resides.
-    String bucket = "";
+    String bucket = "{MY-BUCKET}";
 
     // * Name of the object. For information about how to URL encode object names to be path safe, see
     //   Encoding URI Path Parts.
-    String object = "";
+    String object = "{MY-OBJECT}";
 
     StorageObject content = new StorageObject();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -2303,7 +2303,7 @@ public class StorageExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'watchAll' method:
 
     // * Name of the bucket in which to look for objects.
-    String bucket = "";
+    String bucket = "{MY-BUCKET}";
 
     Channel content = new Channel();
     // TODO: Add code here to assign values to desired fields of the 'content' object

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_storagetransfer.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_storagetransfer.v1.json.baseline
@@ -110,7 +110,7 @@ public class StoragetransferExample {
 
     // * The ID of the Google Developers Console project that the Google service account is associated
     //   with. Required.
-    String projectId = "";
+    String projectId = "{MY-PROJECT-ID}";
 
     Storagetransfer.GoogleServiceAccounts.Get request = storagetransferService.googleServiceAccounts().get(projectId);
     GoogleServiceAccount response = request.execute();
@@ -231,7 +231,7 @@ public class StoragetransferExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * The job to get. Required.
-    String jobName = "";
+    String jobName = "{MY-JOB-NAME}";
 
     Storagetransfer.TransferJobs.Get request = storagetransferService.transferJobs().get(jobName);
     TransferJob response = request.execute();
@@ -360,7 +360,7 @@ public class StoragetransferExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
     // * The name of job to update. Required.
-    String jobName = "";
+    String jobName = "{MY-JOB-NAME}";
 
     UpdateTransferJobRequest content = new UpdateTransferJobRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object to be changed
@@ -423,7 +423,7 @@ public class StoragetransferExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'cancel' method:
 
     // * The name of the operation resource to be cancelled.
-    String name = "";
+    String name = "{MY-NAME}";
 
     Storagetransfer.TransferOperations.Cancel request = storagetransferService.transferOperations().cancel(name);
     request.execute();
@@ -481,7 +481,7 @@ public class StoragetransferExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * The name of the operation resource to be deleted.
-    String name = "";
+    String name = "{MY-NAME}";
 
     Storagetransfer.TransferOperations.Delete request = storagetransferService.transferOperations().delete(name);
     request.execute();
@@ -540,7 +540,7 @@ public class StoragetransferExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * The name of the operation resource.
-    String name = "";
+    String name = "{MY-NAME}";
 
     Storagetransfer.TransferOperations.Get request = storagetransferService.transferOperations().get(name);
     Operation response = request.execute();
@@ -602,7 +602,7 @@ public class StoragetransferExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * The value `transferOperations`.
-    String name = "";
+    String name = "{MY-NAME}";
 
     Storagetransfer.TransferOperations.List request = storagetransferService.transferOperations().list(name);
     ListOperationsResponse response;
@@ -672,7 +672,7 @@ public class StoragetransferExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'pause' method:
 
     // * The name of the transfer operation. Required.
-    String name = "";
+    String name = "{MY-NAME}";
 
     PauseTransferOperationRequest content = new PauseTransferOperationRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -734,7 +734,7 @@ public class StoragetransferExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'resume' method:
 
     // * The name of the transfer operation. Required.
-    String name = "";
+    String name = "{MY-NAME}";
 
     ResumeTransferOperationRequest content = new ResumeTransferOperationRequest();
     // TODO: Add code here to assign values to desired fields of the 'content' object

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_taskqueue.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_taskqueue.v1beta2.json.baseline
@@ -52,10 +52,10 @@ public class TaskqueueExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * The project under which the queue lies.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The id of the taskqueue to get the properties of.
-    String taskqueue = "";
+    String taskqueue = "{MY-TASKQUEUE}";
 
     Taskqueue.Taskqueues.Get request = taskqueueService.taskqueues().get(project, taskqueue);
     TaskQueue response = request.execute();
@@ -115,13 +115,13 @@ public class TaskqueueExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * The project under which the queue lies.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The taskqueue to delete a task from.
-    String taskqueue = "";
+    String taskqueue = "{MY-TASKQUEUE}";
 
     // * The id of the task to delete.
-    String task = "";
+    String task = "{MY-TASK}";
 
     Taskqueue.Tasks.Delete request = taskqueueService.tasks().delete(project, taskqueue, task);
     request.execute();
@@ -180,13 +180,13 @@ public class TaskqueueExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * The project under which the queue lies.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The taskqueue in which the task belongs.
-    String taskqueue = "";
+    String taskqueue = "{MY-TASKQUEUE}";
 
     // * The task to get properties of.
-    String task = "";
+    String task = "{MY-TASK}";
 
     Taskqueue.Tasks.Get request = taskqueueService.tasks().get(project, taskqueue, task);
     Task response = request.execute();
@@ -247,10 +247,10 @@ public class TaskqueueExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * The project under which the queue lies
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The taskqueue to insert the task into
-    String taskqueue = "";
+    String taskqueue = "{MY-TASKQUEUE}";
 
     Task content = new Task();
     // TODO: Add code here to assign values to desired fields of the 'content' object
@@ -314,10 +314,10 @@ public class TaskqueueExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'lease' method:
 
     // * The project under which the queue lies.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The taskqueue to lease a task from.
-    String taskqueue = "";
+    String taskqueue = "{MY-TASKQUEUE}";
 
     // * The number of tasks to lease.
     int numTasks = 0;
@@ -384,10 +384,10 @@ public class TaskqueueExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * The project under which the queue lies.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
     // * The id of the taskqueue to list tasks from.
-    String taskqueue = "";
+    String taskqueue = "{MY-TASKQUEUE}";
 
     Taskqueue.Tasks.List request = taskqueueService.tasks().list(project, taskqueue);
     Tasks2 response = request.execute();
@@ -448,13 +448,13 @@ public class TaskqueueExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
     // * The project under which the queue lies.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
 
-    String taskqueue = "";
+    String taskqueue = "{MY-TASKQUEUE}";
 
 
-    String task = "";
+    String task = "{MY-TASK}";
 
     // * The new lease in seconds.
     int newLeaseSeconds = 0;
@@ -521,13 +521,13 @@ public class TaskqueueExample {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * The project under which the queue lies.
-    String project = "";
+    String project = "{MY-PROJECT}";
 
 
-    String taskqueue = "";
+    String taskqueue = "{MY-TASKQUEUE}";
 
 
-    String task = "";
+    String task = "{MY-TASK}";
 
     // * The new lease in seconds.
     int newLeaseSeconds = 0;

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_translate.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_translate.v2.json.baseline
@@ -177,7 +177,7 @@ public class TranslateExample {
     List<String> q = new ArrayList<String>();
 
     // * The target language into which the text should be translated
-    String target = "";
+    String target = "{MY-TARGET}";
 
     Translate.Translations.List request = translateService.translations().list(q, target);
     TranslationsListResponse response = request.execute();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_adexchangebuyer.v1.4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_adexchangebuyer.v1.4.json.baseline
@@ -419,7 +419,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     accountId: 0,
 
     // * The buyer-specific id for this creative.
-    buyerCreativeId: "",
+    buyerCreativeId: "{MY-BUYER-CREATIVE-ID}",
 
     // * The id of the deal id to associate with this creative.
     dealId: '',
@@ -467,7 +467,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     accountId: 0,
 
     // * The buyer-specific id for this creative.
-    buyerCreativeId: "",
+    buyerCreativeId: "{MY-BUYER-CREATIVE-ID}",
 
     // Auth client
     auth: authClient
@@ -599,7 +599,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     accountId: 0,
 
     // * The buyer-specific id for this creative.
-    buyerCreativeId: "",
+    buyerCreativeId: "{MY-BUYER-CREATIVE-ID}",
 
     // * The id of the deal id to disassociate with this creative.
     dealId: '',
@@ -644,7 +644,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * The proposalId to delete deals from.
-    proposalId: "",
+    proposalId: "{MY-PROPOSAL-ID}",
 
     resource: {},
 
@@ -688,7 +688,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * proposalId for which deals need to be added.
-    proposalId: "",
+    proposalId: "{MY-PROPOSAL-ID}",
 
     resource: {},
 
@@ -733,7 +733,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
     // * The proposalId to get deals for. To search across proposals specify order_id = '-' as part of the
     //   URL.
-    proposalId: "",
+    proposalId: "{MY-PROPOSAL-ID}",
 
     // Auth client
     auth: authClient
@@ -775,7 +775,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * The proposalId to edit deals on.
-    proposalId: "",
+    proposalId: "{MY-PROPOSAL-ID}",
 
     resource: {},
 
@@ -819,7 +819,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * The proposalId to add notes for.
-    proposalId: "",
+    proposalId: "{MY-PROPOSAL-ID}",
 
     resource: {},
 
@@ -863,7 +863,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * The proposalId to get notes for.
-    proposalId: "",
+    proposalId: "{MY-PROPOSAL-ID}",
 
     // Auth client
     auth: authClient
@@ -905,7 +905,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'updateproposal' method:
 
     // * The private auction id to be updated.
-    privateAuctionId: "",
+    privateAuctionId: "{MY-PRIVATE-AUCTION-ID}",
 
     resource: {},
 
@@ -952,10 +952,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     accountId: '',
 
     // * The end time of the report in ISO 8601 timestamp format using UTC.
-    endDateTime: "",
+    endDateTime: "{MY-END-DATE-TIME}",
 
     // * The start time of the report in ISO 8601 timestamp format using UTC.
-    startDateTime: "",
+    startDateTime: "{MY-START-DATE-TIME}",
 
     // Auth client
     auth: authClient
@@ -1267,7 +1267,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * The id for the product to get the head revision for.
-    productId: "",
+    productId: "{MY-PRODUCT-ID}",
 
     // Auth client
     auth: authClient
@@ -1348,7 +1348,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Id of the proposal to retrieve.
-    proposalId: "",
+    proposalId: "{MY-PROPOSAL-ID}",
 
     // Auth client
     auth: authClient
@@ -1431,7 +1431,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
     // * The proposal id to update.
-    proposalId: "",
+    proposalId: "{MY-PROPOSAL-ID}",
 
     // * The last known revision number to update. If the head revision in the marketplace database has
     //   since changed, an error will be thrown. The caller should then fetch the latest proposal at head
@@ -1439,7 +1439,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     revisionNumber: '',
 
     // * The proposed action to take on the proposal.
-    updateAction: "",
+    updateAction: "{MY-UPDATE-ACTION}",
 
     resource: {},
 
@@ -1522,7 +1522,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'setupcomplete' method:
 
     // * The proposal id for which the setup is complete
-    proposalId: "",
+    proposalId: "{MY-PROPOSAL-ID}",
 
     // Auth client
     auth: authClient
@@ -1564,7 +1564,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * The proposal id to update.
-    proposalId: "",
+    proposalId: "{MY-PROPOSAL-ID}",
 
     // * The last known revision number to update. If the head revision in the marketplace database has
     //   since changed, an error will be thrown. The caller should then fetch the latest proposal at head
@@ -1572,7 +1572,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     revisionNumber: '',
 
     // * The proposed action to take on the proposal.
-    updateAction: "",
+    updateAction: "{MY-UPDATE-ACTION}",
 
     resource: {},
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_appengine.v1beta5.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_appengine.v1beta5.json.baseline
@@ -27,7 +27,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Part of `name`. Name of the application to get. For example: "apps/myapp".
-    appsId: "",
+    appsId: "{MY-APPS-ID}",
 
     // Auth client
     auth: authClient
@@ -69,10 +69,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Part of `name`. The name of the operation resource.
-    appsId: "",
+    appsId: "{MY-APPS-ID}",
 
     // * Part of `name`. See documentation of `appsId`.
-    operationsId: "",
+    operationsId: "{MY-OPERATIONS-ID}",
 
     // Auth client
     auth: authClient
@@ -114,7 +114,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Part of `name`. The name of the operation collection.
-    appsId: "",
+    appsId: "{MY-APPS-ID}",
 
     // Auth client
     auth: authClient
@@ -163,10 +163,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Part of `name`. Name of the resource requested. For example: "apps/myapp/services/default".
-    appsId: "",
+    appsId: "{MY-APPS-ID}",
 
     // * Part of `name`. See documentation of `appsId`.
-    servicesId: "",
+    servicesId: "{MY-SERVICES-ID}",
 
     // Auth client
     auth: authClient
@@ -208,10 +208,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Part of `name`. Name of the resource requested. For example: "apps/myapp/services/default".
-    appsId: "",
+    appsId: "{MY-APPS-ID}",
 
     // * Part of `name`. See documentation of `appsId`.
-    servicesId: "",
+    servicesId: "{MY-SERVICES-ID}",
 
     // Auth client
     auth: authClient
@@ -253,7 +253,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Part of `name`. Name of the resource requested. For example: "apps/myapp".
-    appsId: "",
+    appsId: "{MY-APPS-ID}",
 
     // Auth client
     auth: authClient
@@ -302,10 +302,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
     // * Part of `name`. Name of the resource to update. For example: "apps/myapp/services/default".
-    appsId: "",
+    appsId: "{MY-APPS-ID}",
 
     // * Part of `name`. See documentation of `appsId`.
-    servicesId: "",
+    servicesId: "{MY-SERVICES-ID}",
 
     resource: {},
 
@@ -349,10 +349,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'create' method:
 
     // * Part of `name`. Name of the resource to update. For example: "apps/myapp/services/default".
-    appsId: "",
+    appsId: "{MY-APPS-ID}",
 
     // * Part of `name`. See documentation of `appsId`.
-    servicesId: "",
+    servicesId: "{MY-SERVICES-ID}",
 
     resource: {},
 
@@ -397,13 +397,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
     // * Part of `name`. Name of the resource requested. For example:
     //   "apps/myapp/services/default/versions/v1".
-    appsId: "",
+    appsId: "{MY-APPS-ID}",
 
     // * Part of `name`. See documentation of `appsId`.
-    servicesId: "",
+    servicesId: "{MY-SERVICES-ID}",
 
     // * Part of `name`. See documentation of `appsId`.
-    versionsId: "",
+    versionsId: "{MY-VERSIONS-ID}",
 
     // Auth client
     auth: authClient
@@ -446,13 +446,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
     // * Part of `name`. Name of the resource requested. For example:
     //   "apps/myapp/services/default/versions/v1".
-    appsId: "",
+    appsId: "{MY-APPS-ID}",
 
     // * Part of `name`. See documentation of `appsId`.
-    servicesId: "",
+    servicesId: "{MY-SERVICES-ID}",
 
     // * Part of `name`. See documentation of `appsId`.
-    versionsId: "",
+    versionsId: "{MY-VERSIONS-ID}",
 
     // Auth client
     auth: authClient
@@ -495,13 +495,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
     // * Part of `name`. Name of the resource requested. For example:
     //   "apps/myapp/services/default/versions/v1".
-    appsId: "",
+    appsId: "{MY-APPS-ID}",
 
     // * Part of `name`. See documentation of `appsId`.
-    servicesId: "",
+    servicesId: "{MY-SERVICES-ID}",
 
     // * Part of `name`. See documentation of `appsId`.
-    versionsId: "",
+    versionsId: "{MY-VERSIONS-ID}",
 
     // Auth client
     auth: authClient
@@ -550,10 +550,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Part of `name`. Name of the resource requested. For example: "apps/myapp/services/default".
-    appsId: "",
+    appsId: "{MY-APPS-ID}",
 
     // * Part of `name`. See documentation of `appsId`.
-    servicesId: "",
+    servicesId: "{MY-SERVICES-ID}",
 
     // Auth client
     auth: authClient
@@ -603,13 +603,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
     // * Part of `name`. Name of the resource to update. For example:
     //   "apps/myapp/services/default/versions/1".
-    appsId: "",
+    appsId: "{MY-APPS-ID}",
 
     // * Part of `name`. See documentation of `appsId`.
-    servicesId: "",
+    servicesId: "{MY-SERVICES-ID}",
 
     // * Part of `name`. See documentation of `appsId`.
-    versionsId: "",
+    versionsId: "{MY-VERSIONS-ID}",
 
     resource: {},
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_autoscaler.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_autoscaler.v1beta2.json.baseline
@@ -27,13 +27,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID of Autoscaler resource.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Zone name of Autoscaler resource.
-    zone: "",
+    zone: "{MY-ZONE}",
 
     // * Name of the Autoscaler resource.
-    autoscaler: "",
+    autoscaler: "{MY-AUTOSCALER}",
 
     // Auth client
     auth: authClient
@@ -75,13 +75,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID of Autoscaler resource.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Zone name of Autoscaler resource.
-    zone: "",
+    zone: "{MY-ZONE}",
 
     // * Name of the Autoscaler resource.
-    autoscaler: "",
+    autoscaler: "{MY-AUTOSCALER}",
 
     // Auth client
     auth: authClient
@@ -123,10 +123,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID of Autoscaler resource.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Zone name of Autoscaler resource.
-    zone: "",
+    zone: "{MY-ZONE}",
 
     resource: {},
 
@@ -170,10 +170,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID of Autoscaler resource.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Zone name of Autoscaler resource.
-    zone: "",
+    zone: "{MY-ZONE}",
 
     // Auth client
     auth: authClient
@@ -222,13 +222,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
     // * Project ID of Autoscaler resource.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Zone name of Autoscaler resource.
-    zone: "",
+    zone: "{MY-ZONE}",
 
     // * Name of the Autoscaler resource.
-    autoscaler: "",
+    autoscaler: "{MY-AUTOSCALER}",
 
     resource: {},
 
@@ -272,13 +272,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * Project ID of Autoscaler resource.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Zone name of Autoscaler resource.
-    zone: "",
+    zone: "{MY-ZONE}",
 
     // * Name of the Autoscaler resource.
-    autoscaler: "",
+    autoscaler: "{MY-AUTOSCALER}",
 
     resource: {},
 
@@ -325,10 +325,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     project: "{MY-PROJECT}",
 
 
-    zone: "",
+    zone: "{MY-ZONE}"  // eg. "us-central1-f",
 
 
-    operation: "",
+    operation: "{MY-OPERATION}",
 
     // Auth client
     auth: authClient
@@ -373,10 +373,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     project: "{MY-PROJECT}",
 
 
-    zone: "",
+    zone: "{MY-ZONE}"  // eg. "us-central1-f",
 
 
-    operation: "",
+    operation: "{MY-OPERATION}",
 
     // Auth client
     auth: authClient
@@ -421,7 +421,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     project: "{MY-PROJECT}",
 
 
-    zone: "",
+    zone: "{MY-ZONE}"  // eg. "us-central1-f",
 
     // Auth client
     auth: authClient
@@ -470,7 +470,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_autoscaler.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_autoscaler.v1beta2.json.baseline
@@ -322,7 +322,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 
-    project: "",
+    project: "{MY-PROJECT}",
 
 
     zone: "",
@@ -370,7 +370,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 
-    project: "",
+    project: "{MY-PROJECT}",
 
 
     zone: "",
@@ -418,7 +418,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 
-    project: "",
+    project: "{MY-PROJECT}",
 
 
     zone: "",

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_bigquery.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_bigquery.v2.json.baseline
@@ -27,10 +27,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID of the dataset being deleted
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // * Dataset ID of dataset being deleted
-    datasetId: "",
+    datasetId: "{MY-DATASET-ID}",
 
     // Auth client
     auth: authClient
@@ -72,10 +72,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID of the requested dataset
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // * Dataset ID of the requested dataset
-    datasetId: "",
+    datasetId: "{MY-DATASET-ID}",
 
     // Auth client
     auth: authClient
@@ -117,7 +117,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID of the new dataset
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     resource: {},
 
@@ -161,7 +161,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID of the datasets to be listed
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // Auth client
     auth: authClient
@@ -210,10 +210,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
     // * Project ID of the dataset being updated
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // * Dataset ID of the dataset being updated
-    datasetId: "",
+    datasetId: "{MY-DATASET-ID}",
 
     resource: {},
 
@@ -257,10 +257,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * Project ID of the dataset being updated
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // * Dataset ID of the dataset being updated
-    datasetId: "",
+    datasetId: "{MY-DATASET-ID}",
 
     resource: {},
 
@@ -304,10 +304,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'cancel' method:
 
     // * [Required] Project ID of the job to cancel
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // * [Required] Job ID of the job to cancel
-    jobId: "",
+    jobId: "{MY-JOB-ID}",
 
     // Auth client
     auth: authClient
@@ -349,10 +349,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * [Required] Project ID of the requested job
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // * [Required] Job ID of the requested job
-    jobId: "",
+    jobId: "{MY-JOB-ID}",
 
     // Auth client
     auth: authClient
@@ -394,10 +394,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'getQueryResults' method:
 
     // * [Required] Project ID of the query job
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // * [Required] Job ID of the query job
-    jobId: "",
+    jobId: "{MY-JOB-ID}",
 
     // Auth client
     auth: authClient
@@ -439,7 +439,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID of the project that will be billed for the job
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     resource: {},
 
@@ -488,7 +488,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID of the jobs to list
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // Auth client
     auth: authClient
@@ -537,7 +537,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'query' method:
 
     // * Project ID of the project billed for the query
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     resource: {},
 
@@ -627,13 +627,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insertAll' method:
 
     // * Project ID of the destination table.
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // * Dataset ID of the destination table.
-    datasetId: "",
+    datasetId: "{MY-DATASET-ID}",
 
     // * Table ID of the destination table.
-    tableId: "",
+    tableId: "{MY-TABLE-ID}",
 
     resource: {},
 
@@ -677,13 +677,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID of the table to read
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // * Dataset ID of the table to read
-    datasetId: "",
+    datasetId: "{MY-DATASET-ID}",
 
     // * Table ID of the table to read
-    tableId: "",
+    tableId: "{MY-TABLE-ID}",
 
     // Auth client
     auth: authClient
@@ -725,13 +725,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID of the table to delete
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // * Dataset ID of the table to delete
-    datasetId: "",
+    datasetId: "{MY-DATASET-ID}",
 
     // * Table ID of the table to delete
-    tableId: "",
+    tableId: "{MY-TABLE-ID}",
 
     // Auth client
     auth: authClient
@@ -773,13 +773,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID of the requested table
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // * Dataset ID of the requested table
-    datasetId: "",
+    datasetId: "{MY-DATASET-ID}",
 
     // * Table ID of the requested table
-    tableId: "",
+    tableId: "{MY-TABLE-ID}",
 
     // Auth client
     auth: authClient
@@ -821,10 +821,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID of the new table
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // * Dataset ID of the new table
-    datasetId: "",
+    datasetId: "{MY-DATASET-ID}",
 
     resource: {},
 
@@ -868,10 +868,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID of the tables to list
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // * Dataset ID of the tables to list
-    datasetId: "",
+    datasetId: "{MY-DATASET-ID}",
 
     // Auth client
     auth: authClient
@@ -920,13 +920,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
     // * Project ID of the table to update
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // * Dataset ID of the table to update
-    datasetId: "",
+    datasetId: "{MY-DATASET-ID}",
 
     // * Table ID of the table to update
-    tableId: "",
+    tableId: "{MY-TABLE-ID}",
 
     resource: {},
 
@@ -970,13 +970,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * Project ID of the table to update
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // * Dataset ID of the table to update
-    datasetId: "",
+    datasetId: "{MY-DATASET-ID}",
 
     // * Table ID of the table to update
-    tableId: "",
+    tableId: "{MY-TABLE-ID}",
 
     resource: {},
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_clouddebugger.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_clouddebugger.v2.json.baseline
@@ -27,7 +27,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Identifies the debuggee.
-    debuggeeId: "",
+    debuggeeId: "{MY-DEBUGGEE-ID}",
 
     // Auth client
     auth: authClient
@@ -69,10 +69,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * Identifies the debuggee being debugged.
-    debuggeeId: "",
+    debuggeeId: "{MY-DEBUGGEE-ID}",
 
     // * Breakpoint identifier, unique in the scope of the debuggee.
-    id: "",
+    id: "{MY-ID}",
 
     resource: {},
 
@@ -157,10 +157,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * ID of the debuggee whose breakpoint to delete.
-    debuggeeId: "",
+    debuggeeId: "{MY-DEBUGGEE-ID}",
 
     // * ID of the breakpoint to delete.
-    breakpointId: "",
+    breakpointId: "{MY-BREAKPOINT-ID}",
 
     // Auth client
     auth: authClient
@@ -202,10 +202,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * ID of the debuggee whose breakpoint to get.
-    debuggeeId: "",
+    debuggeeId: "{MY-DEBUGGEE-ID}",
 
     // * ID of the breakpoint to get.
-    breakpointId: "",
+    breakpointId: "{MY-BREAKPOINT-ID}",
 
     // Auth client
     auth: authClient
@@ -247,7 +247,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * ID of the debuggee whose breakpoints to list.
-    debuggeeId: "",
+    debuggeeId: "{MY-DEBUGGEE-ID}",
 
     // Auth client
     auth: authClient
@@ -289,7 +289,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'set' method:
 
     // * ID of the debuggee where the breakpoint is to be set.
-    debuggeeId: "",
+    debuggeeId: "{MY-DEBUGGEE-ID}",
 
     resource: {},
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_cloudmonitoring.v2beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_cloudmonitoring.v2beta2.json.baseline
@@ -27,7 +27,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'create' method:
 
     // * The project id. The value can be the numeric project ID or string-based project name.
-    project: "",
+    project: "{MY-PROJECT}",
 
     resource: {},
 
@@ -71,10 +71,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * The project ID to which the metric belongs.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the metric.
-    metric: "",
+    metric: "{MY-METRIC}",
 
     // Auth client
     auth: authClient
@@ -116,7 +116,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * The project id. The value can be the numeric project ID or string-based project name.
-    project: "",
+    project: "{MY-PROJECT}",
 
     resource: {},
 
@@ -168,14 +168,14 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
     // * The project ID to which this time series belongs. The value can be the numeric project ID or
     //   string-based project name.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Metric names are protocol-free URLs as listed in the Supported Metrics page. For example,
     //   compute.googleapis.com/instance/disk/read_ops_count.
-    metric: "",
+    metric: "{MY-METRIC}",
 
     // * End of the time interval (inclusive), which is expressed as an RFC 3339 timestamp.
-    youngest: "",
+    youngest: "{MY-YOUNGEST}",
 
     resource: {},
 
@@ -226,7 +226,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'write' method:
 
     // * The project ID. The value can be the numeric project ID or string-based project name.
-    project: "",
+    project: "{MY-PROJECT}",
 
     resource: {},
 
@@ -271,14 +271,14 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
     // * The project ID to which this time series belongs. The value can be the numeric project ID or
     //   string-based project name.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Metric names are protocol-free URLs as listed in the Supported Metrics page. For example,
     //   compute.googleapis.com/instance/disk/read_ops_count.
-    metric: "",
+    metric: "{MY-METRIC}",
 
     // * End of the time interval (inclusive), which is expressed as an RFC 3339 timestamp.
-    youngest: "",
+    youngest: "{MY-YOUNGEST}",
 
     resource: {},
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_cloudresourcemanager.v1beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_cloudresourcemanager.v1beta1.json.baseline
@@ -27,7 +27,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * The id of the Organization resource to fetch.
-    organizationId: "",
+    organizationId: "{MY-ORGANIZATION-ID}",
 
     // Auth client
     auth: authClient
@@ -71,7 +71,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // * REQUIRED: The resource for which the policy is being requested. `resource` is usually specified as
     //   a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified
     //   in this value is resource specific and is specified in the `getIamPolicy` documentation.
-    resource_: "",
+    resource_: "{MY-RESOURCE}",
 
     resource: {},
 
@@ -163,7 +163,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // * REQUIRED: The resource for which the policy is being specified. `resource` is usually specified as
     //   a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified
     //   in this value is resource specific and is specified in the `setIamPolicy` documentation.
-    resource_: "",
+    resource_: "{MY-RESOURCE}",
 
     resource: {},
 
@@ -210,7 +210,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     //   specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the
     //   path specified in this value is resource specific and is specified in the `testIamPermissions`
     //   documentation.
-    resource_: "",
+    resource_: "{MY-RESOURCE}",
 
     resource: {},
 
@@ -255,7 +255,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
     // * An immutable id for the Organization that is assigned on creation. This should be omitted when
     //   creating a new Organization. This field is read-only.
-    organizationId: "",
+    organizationId: "{MY-ORGANIZATION-ID}",
 
     resource: {},
 
@@ -340,7 +340,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * The Project ID (for example, `foo-bar-123`). Required.
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // Auth client
     auth: authClient
@@ -382,7 +382,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * The Project ID (for example, `my-project-123`). Required.
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // Auth client
     auth: authClient
@@ -426,7 +426,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // * REQUIRED: The resource for which the policy is being requested. `resource` is usually specified as
     //   a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified
     //   in this value is resource specific and is specified in the `getIamPolicy` documentation.
-    resource_: "",
+    resource_: "{MY-RESOURCE}",
 
     resource: {},
 
@@ -518,7 +518,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // * REQUIRED: The resource for which the policy is being specified. `resource` is usually specified as
     //   a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified
     //   in this value is resource specific and is specified in the `setIamPolicy` documentation.
-    resource_: "",
+    resource_: "{MY-RESOURCE}",
 
     resource: {},
 
@@ -565,7 +565,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     //   specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the
     //   path specified in this value is resource specific and is specified in the `testIamPermissions`
     //   documentation.
-    resource_: "",
+    resource_: "{MY-RESOURCE}",
 
     resource: {},
 
@@ -609,7 +609,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'undelete' method:
 
     // * The project ID (for example, `foo-bar-123`). Required.
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     resource: {},
 
@@ -653,7 +653,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * The project ID (for example, `my-project-123`). Required.
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     resource: {},
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_cloudtrace.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_cloudtrace.v1.json.baseline
@@ -27,7 +27,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'patchTraces' method:
 
     // * ID of the Cloud project where the trace data is stored.
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     resource: {},
 
@@ -71,10 +71,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * ID of the Cloud project where the trace data is stored.
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // * ID of the trace to return.
-    traceId: "",
+    traceId: "{MY-TRACE-ID}",
 
     // Auth client
     auth: authClient
@@ -116,7 +116,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * ID of the Cloud project where the trace data is stored.
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // Auth client
     auth: authClient

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_clouduseraccounts.beta.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_clouduseraccounts.beta.json.baseline
@@ -27,10 +27,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the Operations resource to delete.
-    operation: "",
+    operation: "{MY-OPERATION}",
 
     // Auth client
     auth: authClient
@@ -72,10 +72,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the Operations resource to return.
-    operation: "",
+    operation: "{MY-OPERATION}",
 
     // Auth client
     auth: authClient
@@ -117,7 +117,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient
@@ -166,10 +166,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'addMember' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the group for this request.
-    groupName: "",
+    groupName: "{MY-GROUP-NAME}",
 
     resource: {},
 
@@ -213,10 +213,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the Group resource to delete.
-    groupName: "",
+    groupName: "{MY-GROUP-NAME}",
 
     // Auth client
     auth: authClient
@@ -258,10 +258,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the Group resource to return.
-    groupName: "",
+    groupName: "{MY-GROUP-NAME}",
 
     // Auth client
     auth: authClient
@@ -303,7 +303,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     resource: {},
 
@@ -347,7 +347,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient
@@ -396,10 +396,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'removeMember' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the group for this request.
-    groupName: "",
+    groupName: "{MY-GROUP-NAME}",
 
     resource: {},
 
@@ -443,16 +443,16 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'getAuthorizedKeysView' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the zone for this request.
-    zone: "",
+    zone: "{MY-ZONE}"  // eg. "us-central1-f",
 
     // * The user account for which you want to get a list of authorized public keys.
-    user: "",
+    user: "{MY-USER}",
 
     // * The fully-qualified URL of the virtual machine requesting the view.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     // Auth client
     auth: authClient
@@ -494,13 +494,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'getLinuxAccountViews' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the zone for this request.
-    zone: "",
+    zone: "{MY-ZONE}"  // eg. "us-central1-f",
 
     // * The fully-qualified URL of the virtual machine requesting the views.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     // Auth client
     auth: authClient
@@ -542,10 +542,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'addPublicKey' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the user for this request.
-    user: "",
+    user: "{MY-USER}",
 
     resource: {},
 
@@ -589,10 +589,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the user resource to delete.
-    user: "",
+    user: "{MY-USER}",
 
     // Auth client
     auth: authClient
@@ -634,10 +634,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the user resource to return.
-    user: "",
+    user: "{MY-USER}",
 
     // Auth client
     auth: authClient
@@ -679,7 +679,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     resource: {},
 
@@ -723,7 +723,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient
@@ -772,14 +772,14 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'removePublicKey' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the user for this request.
-    user: "",
+    user: "{MY-USER}",
 
     // * The fingerprint of the public key to delete. Public keys are identified by their fingerprint,
     //   which is defined by RFC4716 to be the MD5 digest of the public key.
-    fingerprint: "",
+    fingerprint: "{MY-FINGERPRINT}",
 
     // Auth client
     auth: authClient

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_compute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_compute.v1.json.baseline
@@ -27,7 +27,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient
@@ -76,13 +76,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the region for this request.
-    region: "",
+    region: "{MY-REGION}",
 
     // * Name of the address resource to delete.
-    address: "",
+    address: "{MY-ADDRESS}",
 
     // Auth client
     auth: authClient
@@ -124,13 +124,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the region for this request.
-    region: "",
+    region: "{MY-REGION}",
 
     // * Name of the address resource to return.
-    address: "",
+    address: "{MY-ADDRESS}",
 
     // Auth client
     auth: authClient
@@ -172,10 +172,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the region for this request.
-    region: "",
+    region: "{MY-REGION}",
 
     resource: {},
 
@@ -219,10 +219,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the region for this request.
-    region: "",
+    region: "{MY-REGION}",
 
     // Auth client
     auth: authClient
@@ -271,7 +271,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient
@@ -320,13 +320,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the zone for this request.
-    zone: "",
+    zone: "{MY-ZONE}"  // eg. "us-central1-f",
 
     // * Name of the autoscaler to delete.
-    autoscaler: "",
+    autoscaler: "{MY-AUTOSCALER}",
 
     // Auth client
     auth: authClient
@@ -368,13 +368,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the zone for this request.
-    zone: "",
+    zone: "{MY-ZONE}"  // eg. "us-central1-f",
 
     // * Name of the autoscaler to return.
-    autoscaler: "",
+    autoscaler: "{MY-AUTOSCALER}",
 
     // Auth client
     auth: authClient
@@ -416,10 +416,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the zone for this request.
-    zone: "",
+    zone: "{MY-ZONE}"  // eg. "us-central1-f",
 
     resource: {},
 
@@ -463,10 +463,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the zone for this request.
-    zone: "",
+    zone: "{MY-ZONE}"  // eg. "us-central1-f",
 
     // Auth client
     auth: authClient
@@ -515,13 +515,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the zone for this request.
-    zone: "",
+    zone: "{MY-ZONE}"  // eg. "us-central1-f",
 
     // * Name of the autoscaler to update.
-    autoscaler: "",
+    autoscaler: "{MY-AUTOSCALER}",
 
     resource: {},
 
@@ -565,10 +565,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the zone for this request.
-    zone: "",
+    zone: "{MY-ZONE}"  // eg. "us-central1-f",
 
     resource: {},
 
@@ -612,10 +612,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the BackendService resource to delete.
-    backendService: "",
+    backendService: "{MY-BACKEND-SERVICE}",
 
     // Auth client
     auth: authClient
@@ -657,10 +657,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the BackendService resource to return.
-    backendService: "",
+    backendService: "{MY-BACKEND-SERVICE}",
 
     // Auth client
     auth: authClient
@@ -702,10 +702,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'getHealth' method:
 
 
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the BackendService resource to which the queried instance belongs.
-    backendService: "",
+    backendService: "{MY-BACKEND-SERVICE}",
 
     resource: {},
 
@@ -749,7 +749,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     resource: {},
 
@@ -793,7 +793,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient
@@ -842,10 +842,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the BackendService resource to update.
-    backendService: "",
+    backendService: "{MY-BACKEND-SERVICE}",
 
     resource: {},
 
@@ -889,10 +889,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the BackendService resource to update.
-    backendService: "",
+    backendService: "{MY-BACKEND-SERVICE}",
 
     resource: {},
 
@@ -936,7 +936,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient
@@ -985,13 +985,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone for this request.
-    zone: "",
+    zone: "{MY-ZONE}"  // eg. "us-central1-f",
 
     // * Name of the disk type to return.
-    diskType: "",
+    diskType: "{MY-DISK-TYPE}",
 
     // Auth client
     auth: authClient
@@ -1033,10 +1033,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone for this request.
-    zone: "",
+    zone: "{MY-ZONE}"  // eg. "us-central1-f",
 
     // Auth client
     auth: authClient
@@ -1085,7 +1085,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient
@@ -1134,13 +1134,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'createSnapshot' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone for this request.
-    zone: "",
+    zone: "{MY-ZONE}"  // eg. "us-central1-f",
 
     // * Name of the persistent disk to snapshot.
-    disk: "",
+    disk: "{MY-DISK}",
 
     resource: {},
 
@@ -1184,13 +1184,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone for this request.
-    zone: "",
+    zone: "{MY-ZONE}"  // eg. "us-central1-f",
 
     // * Name of the persistent disk to delete.
-    disk: "",
+    disk: "{MY-DISK}",
 
     // Auth client
     auth: authClient
@@ -1232,13 +1232,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone for this request.
-    zone: "",
+    zone: "{MY-ZONE}"  // eg. "us-central1-f",
 
     // * Name of the persistent disk to return.
-    disk: "",
+    disk: "{MY-DISK}",
 
     // Auth client
     auth: authClient
@@ -1280,10 +1280,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone for this request.
-    zone: "",
+    zone: "{MY-ZONE}"  // eg. "us-central1-f",
 
     resource: {},
 
@@ -1327,10 +1327,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone for this request.
-    zone: "",
+    zone: "{MY-ZONE}"  // eg. "us-central1-f",
 
     // Auth client
     auth: authClient
@@ -1379,10 +1379,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the firewall rule to delete.
-    firewall: "",
+    firewall: "{MY-FIREWALL}",
 
     // Auth client
     auth: authClient
@@ -1424,10 +1424,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the firewall rule to return.
-    firewall: "",
+    firewall: "{MY-FIREWALL}",
 
     // Auth client
     auth: authClient
@@ -1469,7 +1469,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     resource: {},
 
@@ -1513,7 +1513,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient
@@ -1562,10 +1562,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the firewall rule to update.
-    firewall: "",
+    firewall: "{MY-FIREWALL}",
 
     resource: {},
 
@@ -1609,10 +1609,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the firewall rule to update.
-    firewall: "",
+    firewall: "{MY-FIREWALL}",
 
     resource: {},
 
@@ -1656,7 +1656,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient
@@ -1705,13 +1705,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the region scoping this request.
-    region: "",
+    region: "{MY-REGION}",
 
     // * Name of the ForwardingRule resource to delete.
-    forwardingRule: "",
+    forwardingRule: "{MY-FORWARDING-RULE}",
 
     // Auth client
     auth: authClient
@@ -1753,13 +1753,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the region scoping this request.
-    region: "",
+    region: "{MY-REGION}",
 
     // * Name of the ForwardingRule resource to return.
-    forwardingRule: "",
+    forwardingRule: "{MY-FORWARDING-RULE}",
 
     // Auth client
     auth: authClient
@@ -1801,10 +1801,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the region scoping this request.
-    region: "",
+    region: "{MY-REGION}",
 
     resource: {},
 
@@ -1848,10 +1848,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the region scoping this request.
-    region: "",
+    region: "{MY-REGION}",
 
     // Auth client
     auth: authClient
@@ -1900,13 +1900,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'setTarget' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the region scoping this request.
-    region: "",
+    region: "{MY-REGION}",
 
     // * Name of the ForwardingRule resource in which target is to be set.
-    forwardingRule: "",
+    forwardingRule: "{MY-FORWARDING-RULE}",
 
     resource: {},
 
@@ -1950,10 +1950,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the address resource to delete.
-    address: "",
+    address: "{MY-ADDRESS}",
 
     // Auth client
     auth: authClient
@@ -1995,10 +1995,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the address resource to return.
-    address: "",
+    address: "{MY-ADDRESS}",
 
     // Auth client
     auth: authClient
@@ -2040,7 +2040,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     resource: {},
 
@@ -2084,7 +2084,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient
@@ -2133,10 +2133,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the ForwardingRule resource to delete.
-    forwardingRule: "",
+    forwardingRule: "{MY-FORWARDING-RULE}",
 
     // Auth client
     auth: authClient
@@ -2178,10 +2178,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the ForwardingRule resource to return.
-    forwardingRule: "",
+    forwardingRule: "{MY-FORWARDING-RULE}",
 
     // Auth client
     auth: authClient
@@ -2223,7 +2223,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     resource: {},
 
@@ -2267,7 +2267,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient
@@ -2316,10 +2316,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'setTarget' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the ForwardingRule resource in which target is to be set.
-    forwardingRule: "",
+    forwardingRule: "{MY-FORWARDING-RULE}",
 
     resource: {},
 
@@ -2363,7 +2363,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient
@@ -2412,10 +2412,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the Operations resource to delete.
-    operation: "",
+    operation: "{MY-OPERATION}",
 
     // Auth client
     auth: authClient
@@ -2457,10 +2457,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the Operations resource to return.
-    operation: "",
+    operation: "{MY-OPERATION}",
 
     // Auth client
     auth: authClient
@@ -2502,7 +2502,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient
@@ -2551,10 +2551,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the HttpHealthCheck resource to delete.
-    httpHealthCheck: "",
+    httpHealthCheck: "{MY-HTTP-HEALTH-CHECK}",
 
     // Auth client
     auth: authClient
@@ -2596,10 +2596,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the HttpHealthCheck resource to return.
-    httpHealthCheck: "",
+    httpHealthCheck: "{MY-HTTP-HEALTH-CHECK}",
 
     // Auth client
     auth: authClient
@@ -2641,7 +2641,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     resource: {},
 
@@ -2685,7 +2685,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient
@@ -2734,10 +2734,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the HttpHealthCheck resource to update.
-    httpHealthCheck: "",
+    httpHealthCheck: "{MY-HTTP-HEALTH-CHECK}",
 
     resource: {},
 
@@ -2781,10 +2781,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the HttpHealthCheck resource to update.
-    httpHealthCheck: "",
+    httpHealthCheck: "{MY-HTTP-HEALTH-CHECK}",
 
     resource: {},
 
@@ -2828,10 +2828,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the HttpsHealthCheck resource to delete.
-    httpsHealthCheck: "",
+    httpsHealthCheck: "{MY-HTTPS-HEALTH-CHECK}",
 
     // Auth client
     auth: authClient
@@ -2873,10 +2873,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the HttpsHealthCheck resource to return.
-    httpsHealthCheck: "",
+    httpsHealthCheck: "{MY-HTTPS-HEALTH-CHECK}",
 
     // Auth client
     auth: authClient
@@ -2918,7 +2918,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     resource: {},
 
@@ -2962,7 +2962,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient
@@ -3011,10 +3011,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the HttpsHealthCheck resource to update.
-    httpsHealthCheck: "",
+    httpsHealthCheck: "{MY-HTTPS-HEALTH-CHECK}",
 
     resource: {},
 
@@ -3058,10 +3058,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the HttpsHealthCheck resource to update.
-    httpsHealthCheck: "",
+    httpsHealthCheck: "{MY-HTTPS-HEALTH-CHECK}",
 
     resource: {},
 
@@ -3105,10 +3105,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the image resource to delete.
-    image: "",
+    image: "{MY-IMAGE}",
 
     // Auth client
     auth: authClient
@@ -3150,10 +3150,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'deprecate' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Image name.
-    image: "",
+    image: "{MY-IMAGE}",
 
     resource: {},
 
@@ -3197,10 +3197,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the image resource to return.
-    image: "",
+    image: "{MY-IMAGE}",
 
     // Auth client
     auth: authClient
@@ -3242,7 +3242,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     resource: {},
 
@@ -3286,7 +3286,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient
@@ -3335,13 +3335,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'abandonInstances' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone where the managed instance group is located.
-    zone: "",
+    zone: "{MY-ZONE}",
 
     // * The name of the managed instance group.
-    instanceGroupManager: "",
+    instanceGroupManager: "{MY-INSTANCE-GROUP-MANAGER}",
 
     resource: {},
 
@@ -3385,7 +3385,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient
@@ -3434,13 +3434,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone where the managed instance group is located.
-    zone: "",
+    zone: "{MY-ZONE}",
 
     // * The name of the managed instance group to delete.
-    instanceGroupManager: "",
+    instanceGroupManager: "{MY-INSTANCE-GROUP-MANAGER}",
 
     // Auth client
     auth: authClient
@@ -3482,13 +3482,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'deleteInstances' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone where the managed instance group is located.
-    zone: "",
+    zone: "{MY-ZONE}",
 
     // * The name of the managed instance group.
-    instanceGroupManager: "",
+    instanceGroupManager: "{MY-INSTANCE-GROUP-MANAGER}",
 
     resource: {},
 
@@ -3532,13 +3532,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone where the managed instance group is located.
-    zone: "",
+    zone: "{MY-ZONE}",
 
     // * The name of the managed instance group.
-    instanceGroupManager: "",
+    instanceGroupManager: "{MY-INSTANCE-GROUP-MANAGER}",
 
     // Auth client
     auth: authClient
@@ -3580,10 +3580,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone where you want to create the managed instance group.
-    zone: "",
+    zone: "{MY-ZONE}",
 
     resource: {},
 
@@ -3627,10 +3627,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone where the managed instance group is located.
-    zone: "",
+    zone: "{MY-ZONE}",
 
     // Auth client
     auth: authClient
@@ -3679,13 +3679,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'listManagedInstances' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone where the managed instance group is located.
-    zone: "",
+    zone: "{MY-ZONE}",
 
     // * The name of the managed instance group.
-    instanceGroupManager: "",
+    instanceGroupManager: "{MY-INSTANCE-GROUP-MANAGER}",
 
     // Auth client
     auth: authClient
@@ -3727,13 +3727,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'recreateInstances' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone where the managed instance group is located.
-    zone: "",
+    zone: "{MY-ZONE}",
 
     // * The name of the managed instance group.
-    instanceGroupManager: "",
+    instanceGroupManager: "{MY-INSTANCE-GROUP-MANAGER}",
 
     resource: {},
 
@@ -3777,13 +3777,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'resize' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone where the managed instance group is located.
-    zone: "",
+    zone: "{MY-ZONE}",
 
     // * The name of the managed instance group.
-    instanceGroupManager: "",
+    instanceGroupManager: "{MY-INSTANCE-GROUP-MANAGER}",
 
     // * The number of running instances that the managed instance group should maintain at any given time.
     //   The group automatically adds or removes instances to maintain the number of instances specified by
@@ -3830,13 +3830,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'setInstanceTemplate' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone where the managed instance group is located.
-    zone: "",
+    zone: "{MY-ZONE}",
 
     // * The name of the managed instance group.
-    instanceGroupManager: "",
+    instanceGroupManager: "{MY-INSTANCE-GROUP-MANAGER}",
 
     resource: {},
 
@@ -3880,13 +3880,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'setTargetPools' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone where the managed instance group is located.
-    zone: "",
+    zone: "{MY-ZONE}",
 
     // * The name of the managed instance group.
-    instanceGroupManager: "",
+    instanceGroupManager: "{MY-INSTANCE-GROUP-MANAGER}",
 
     resource: {},
 
@@ -3930,13 +3930,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'addInstances' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone where the instance group is located.
-    zone: "",
+    zone: "{MY-ZONE}",
 
     // * The name of the instance group where you are adding instances.
-    instanceGroup: "",
+    instanceGroup: "{MY-INSTANCE-GROUP}",
 
     resource: {},
 
@@ -3980,7 +3980,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient
@@ -4029,13 +4029,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone where the instance group is located.
-    zone: "",
+    zone: "{MY-ZONE}",
 
     // * The name of the instance group to delete.
-    instanceGroup: "",
+    instanceGroup: "{MY-INSTANCE-GROUP}",
 
     // Auth client
     auth: authClient
@@ -4077,13 +4077,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone where the instance group is located.
-    zone: "",
+    zone: "{MY-ZONE}",
 
     // * The name of the instance group.
-    instanceGroup: "",
+    instanceGroup: "{MY-INSTANCE-GROUP}",
 
     // Auth client
     auth: authClient
@@ -4125,10 +4125,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone where you want to create the instance group.
-    zone: "",
+    zone: "{MY-ZONE}",
 
     resource: {},
 
@@ -4172,10 +4172,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone where the instance group is located.
-    zone: "",
+    zone: "{MY-ZONE}",
 
     // Auth client
     auth: authClient
@@ -4224,13 +4224,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'listInstances' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone where the instance group is located.
-    zone: "",
+    zone: "{MY-ZONE}",
 
     // * The name of the instance group from which you want to generate a list of included instances.
-    instanceGroup: "",
+    instanceGroup: "{MY-INSTANCE-GROUP}",
 
     resource: {},
 
@@ -4281,13 +4281,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'removeInstances' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone where the instance group is located.
-    zone: "",
+    zone: "{MY-ZONE}",
 
     // * The name of the instance group where the specified instances will be removed.
-    instanceGroup: "",
+    instanceGroup: "{MY-INSTANCE-GROUP}",
 
     resource: {},
 
@@ -4331,13 +4331,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'setNamedPorts' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone where the instance group is located.
-    zone: "",
+    zone: "{MY-ZONE}",
 
     // * The name of the instance group where the named ports are updated.
-    instanceGroup: "",
+    instanceGroup: "{MY-INSTANCE-GROUP}",
 
     resource: {},
 
@@ -4381,10 +4381,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the instance template to delete.
-    instanceTemplate: "",
+    instanceTemplate: "{MY-INSTANCE-TEMPLATE}",
 
     // Auth client
     auth: authClient
@@ -4426,10 +4426,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the instance template.
-    instanceTemplate: "",
+    instanceTemplate: "{MY-INSTANCE-TEMPLATE}",
 
     // Auth client
     auth: authClient
@@ -4471,7 +4471,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     resource: {},
 
@@ -4515,7 +4515,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient
@@ -4564,16 +4564,16 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'addAccessConfig' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone for this request.
-    zone: "",
+    zone: "{MY-ZONE}"  // eg. "us-central1-f",
 
     // * The instance name for this request.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     // * The name of the network interface to add to this instance.
-    networkInterface: "",
+    networkInterface: "{MY-NETWORK-INTERFACE}",
 
     resource: {},
 
@@ -4617,7 +4617,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient
@@ -4666,13 +4666,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'attachDisk' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone for this request.
-    zone: "",
+    zone: "{MY-ZONE}"  // eg. "us-central1-f",
 
     // * The instance name for this request.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     resource: {},
 
@@ -4716,13 +4716,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone for this request.
-    zone: "",
+    zone: "{MY-ZONE}"  // eg. "us-central1-f",
 
     // * Name of the instance resource to delete.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     // Auth client
     auth: authClient
@@ -4764,19 +4764,19 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'deleteAccessConfig' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone for this request.
-    zone: "",
+    zone: "{MY-ZONE}"  // eg. "us-central1-f",
 
     // * The instance name for this request.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     // * The name of the access config to delete.
-    accessConfig: "",
+    accessConfig: "{MY-ACCESS-CONFIG}",
 
     // * The name of the network interface.
-    networkInterface: "",
+    networkInterface: "{MY-NETWORK-INTERFACE}",
 
     // Auth client
     auth: authClient
@@ -4818,16 +4818,16 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'detachDisk' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone for this request.
-    zone: "",
+    zone: "{MY-ZONE}"  // eg. "us-central1-f",
 
     // * Instance name.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     // * Disk device name to detach.
-    deviceName: "",
+    deviceName: "{MY-DEVICE-NAME}",
 
     // Auth client
     auth: authClient
@@ -4869,13 +4869,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone for this request.
-    zone: "",
+    zone: "{MY-ZONE}"  // eg. "us-central1-f",
 
     // * Name of the instance resource to return.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     // Auth client
     auth: authClient
@@ -4917,13 +4917,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'getSerialPortOutput' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone for this request.
-    zone: "",
+    zone: "{MY-ZONE}"  // eg. "us-central1-f",
 
     // * Name of the instance scoping this request.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     // Auth client
     auth: authClient
@@ -4965,10 +4965,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone for this request.
-    zone: "",
+    zone: "{MY-ZONE}"  // eg. "us-central1-f",
 
     resource: {},
 
@@ -5012,10 +5012,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone for this request.
-    zone: "",
+    zone: "{MY-ZONE}"  // eg. "us-central1-f",
 
     // Auth client
     auth: authClient
@@ -5064,13 +5064,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'reset' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone for this request.
-    zone: "",
+    zone: "{MY-ZONE}"  // eg. "us-central1-f",
 
     // * Name of the instance scoping this request.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     // Auth client
     auth: authClient
@@ -5112,19 +5112,19 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'setDiskAutoDelete' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone for this request.
-    zone: "",
+    zone: "{MY-ZONE}"  // eg. "us-central1-f",
 
     // * The instance name.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     // * Whether to auto-delete the disk when the instance is deleted.
     autoDelete: false,
 
     // * The device name of the disk to modify.
-    deviceName: "",
+    deviceName: "{MY-DEVICE-NAME}",
 
     // Auth client
     auth: authClient
@@ -5166,13 +5166,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'setMachineType' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone for this request.
-    zone: "",
+    zone: "{MY-ZONE}"  // eg. "us-central1-f",
 
     // * Name of the instance scoping this request.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     resource: {},
 
@@ -5216,13 +5216,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'setMetadata' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone for this request.
-    zone: "",
+    zone: "{MY-ZONE}"  // eg. "us-central1-f",
 
     // * Name of the instance scoping this request.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     resource: {},
 
@@ -5266,13 +5266,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'setScheduling' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone for this request.
-    zone: "",
+    zone: "{MY-ZONE}"  // eg. "us-central1-f",
 
     // * Instance name.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     resource: {},
 
@@ -5316,13 +5316,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'setTags' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone for this request.
-    zone: "",
+    zone: "{MY-ZONE}"  // eg. "us-central1-f",
 
     // * Name of the instance scoping this request.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     resource: {},
 
@@ -5366,13 +5366,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'start' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone for this request.
-    zone: "",
+    zone: "{MY-ZONE}"  // eg. "us-central1-f",
 
     // * Name of the instance resource to start.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     // Auth client
     auth: authClient
@@ -5414,13 +5414,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'stop' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone for this request.
-    zone: "",
+    zone: "{MY-ZONE}"  // eg. "us-central1-f",
 
     // * Name of the instance resource to stop.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     // Auth client
     auth: authClient
@@ -5462,10 +5462,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the License resource to return.
-    license: "",
+    license: "{MY-LICENSE}",
 
     // Auth client
     auth: authClient
@@ -5507,7 +5507,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient
@@ -5556,13 +5556,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone for this request.
-    zone: "",
+    zone: "{MY-ZONE}"  // eg. "us-central1-f",
 
     // * Name of the machine type to return.
-    machineType: "",
+    machineType: "{MY-MACHINE-TYPE}",
 
     // Auth client
     auth: authClient
@@ -5604,10 +5604,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone for this request.
-    zone: "",
+    zone: "{MY-ZONE}"  // eg. "us-central1-f",
 
     // Auth client
     auth: authClient
@@ -5656,10 +5656,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the network to delete.
-    network: "",
+    network: "{MY-NETWORK}",
 
     // Auth client
     auth: authClient
@@ -5701,10 +5701,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the network to return.
-    network: "",
+    network: "{MY-NETWORK}",
 
     // Auth client
     auth: authClient
@@ -5746,7 +5746,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     resource: {},
 
@@ -5790,7 +5790,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient
@@ -5839,7 +5839,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient
@@ -5881,7 +5881,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'moveDisk' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     resource: {},
 
@@ -5925,7 +5925,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'moveInstance' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     resource: {},
 
@@ -5969,7 +5969,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'setCommonInstanceMetadata' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     resource: {},
 
@@ -6013,7 +6013,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'setUsageExportBucket' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     resource: {},
 
@@ -6057,13 +6057,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the region for this request.
-    region: "",
+    region: "{MY-REGION}",
 
     // * Name of the Operations resource to delete.
-    operation: "",
+    operation: "{MY-OPERATION}",
 
     // Auth client
     auth: authClient
@@ -6105,13 +6105,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the region for this request.
-    region: "",
+    region: "{MY-REGION}",
 
     // * Name of the Operations resource to return.
-    operation: "",
+    operation: "{MY-OPERATION}",
 
     // Auth client
     auth: authClient
@@ -6153,10 +6153,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the region for this request.
-    region: "",
+    region: "{MY-REGION}",
 
     // Auth client
     auth: authClient
@@ -6205,10 +6205,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the region resource to return.
-    region: "",
+    region: "{MY-REGION}",
 
     // Auth client
     auth: authClient
@@ -6250,7 +6250,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient
@@ -6299,10 +6299,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the Route resource to delete.
-    route: "",
+    route: "{MY-ROUTE}",
 
     // Auth client
     auth: authClient
@@ -6344,10 +6344,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the Route resource to return.
-    route: "",
+    route: "{MY-ROUTE}",
 
     // Auth client
     auth: authClient
@@ -6389,7 +6389,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     resource: {},
 
@@ -6433,7 +6433,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient
@@ -6482,10 +6482,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the Snapshot resource to delete.
-    snapshot: "",
+    snapshot: "{MY-SNAPSHOT}",
 
     // Auth client
     auth: authClient
@@ -6527,10 +6527,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the Snapshot resource to return.
-    snapshot: "",
+    snapshot: "{MY-SNAPSHOT}",
 
     // Auth client
     auth: authClient
@@ -6572,7 +6572,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient
@@ -6621,10 +6621,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the SslCertificate resource to delete.
-    sslCertificate: "",
+    sslCertificate: "{MY-SSL-CERTIFICATE}",
 
     // Auth client
     auth: authClient
@@ -6666,10 +6666,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the SslCertificate resource to return.
-    sslCertificate: "",
+    sslCertificate: "{MY-SSL-CERTIFICATE}",
 
     // Auth client
     auth: authClient
@@ -6711,7 +6711,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     resource: {},
 
@@ -6755,7 +6755,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient
@@ -6804,7 +6804,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient
@@ -6853,13 +6853,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the region scoping this request.
-    region: "",
+    region: "{MY-REGION}",
 
     // * Name of the Subnetwork resource to delete.
-    subnetwork: "",
+    subnetwork: "{MY-SUBNETWORK}",
 
     // Auth client
     auth: authClient
@@ -6901,13 +6901,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the region scoping this request.
-    region: "",
+    region: "{MY-REGION}",
 
     // * Name of the Subnetwork resource to return.
-    subnetwork: "",
+    subnetwork: "{MY-SUBNETWORK}",
 
     // Auth client
     auth: authClient
@@ -6949,10 +6949,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the region scoping this request.
-    region: "",
+    region: "{MY-REGION}",
 
     resource: {},
 
@@ -6996,10 +6996,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the region scoping this request.
-    region: "",
+    region: "{MY-REGION}",
 
     // Auth client
     auth: authClient
@@ -7048,10 +7048,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the TargetHttpProxy resource to delete.
-    targetHttpProxy: "",
+    targetHttpProxy: "{MY-TARGET-HTTP-PROXY}",
 
     // Auth client
     auth: authClient
@@ -7093,10 +7093,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the TargetHttpProxy resource to return.
-    targetHttpProxy: "",
+    targetHttpProxy: "{MY-TARGET-HTTP-PROXY}",
 
     // Auth client
     auth: authClient
@@ -7138,7 +7138,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     resource: {},
 
@@ -7182,7 +7182,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient
@@ -7231,10 +7231,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'setUrlMap' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the TargetHttpProxy to set a URL map for.
-    targetHttpProxy: "",
+    targetHttpProxy: "{MY-TARGET-HTTP-PROXY}",
 
     resource: {},
 
@@ -7278,10 +7278,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the TargetHttpsProxy resource to delete.
-    targetHttpsProxy: "",
+    targetHttpsProxy: "{MY-TARGET-HTTPS-PROXY}",
 
     // Auth client
     auth: authClient
@@ -7323,10 +7323,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the TargetHttpsProxy resource to return.
-    targetHttpsProxy: "",
+    targetHttpsProxy: "{MY-TARGET-HTTPS-PROXY}",
 
     // Auth client
     auth: authClient
@@ -7368,7 +7368,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     resource: {},
 
@@ -7412,7 +7412,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient
@@ -7461,10 +7461,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'setSslCertificates' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the TargetHttpsProxy resource to set an SslCertificates resource for.
-    targetHttpsProxy: "",
+    targetHttpsProxy: "{MY-TARGET-HTTPS-PROXY}",
 
     resource: {},
 
@@ -7508,10 +7508,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'setUrlMap' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the TargetHttpsProxy resource whose URL map is to be set.
-    targetHttpsProxy: "",
+    targetHttpsProxy: "{MY-TARGET-HTTPS-PROXY}",
 
     resource: {},
 
@@ -7555,7 +7555,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient
@@ -7604,13 +7604,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the zone scoping this request.
-    zone: "",
+    zone: "{MY-ZONE}"  // eg. "us-central1-f",
 
     // * Name of the TargetInstance resource to delete.
-    targetInstance: "",
+    targetInstance: "{MY-TARGET-INSTANCE}",
 
     // Auth client
     auth: authClient
@@ -7652,13 +7652,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the zone scoping this request.
-    zone: "",
+    zone: "{MY-ZONE}"  // eg. "us-central1-f",
 
     // * Name of the TargetInstance resource to return.
-    targetInstance: "",
+    targetInstance: "{MY-TARGET-INSTANCE}",
 
     // Auth client
     auth: authClient
@@ -7700,10 +7700,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the zone scoping this request.
-    zone: "",
+    zone: "{MY-ZONE}"  // eg. "us-central1-f",
 
     resource: {},
 
@@ -7747,10 +7747,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the zone scoping this request.
-    zone: "",
+    zone: "{MY-ZONE}"  // eg. "us-central1-f",
 
     // Auth client
     auth: authClient
@@ -7799,13 +7799,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'addHealthCheck' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the region scoping this request.
-    region: "",
+    region: "{MY-REGION}",
 
     // * Name of the target pool to add a health check to.
-    targetPool: "",
+    targetPool: "{MY-TARGET-POOL}",
 
     resource: {},
 
@@ -7849,13 +7849,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'addInstance' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the region scoping this request.
-    region: "",
+    region: "{MY-REGION}",
 
     // * Name of the TargetPool resource to add instances to.
-    targetPool: "",
+    targetPool: "{MY-TARGET-POOL}",
 
     resource: {},
 
@@ -7899,7 +7899,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient
@@ -7948,13 +7948,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the region scoping this request.
-    region: "",
+    region: "{MY-REGION}",
 
     // * Name of the TargetPool resource to delete.
-    targetPool: "",
+    targetPool: "{MY-TARGET-POOL}",
 
     // Auth client
     auth: authClient
@@ -7996,13 +7996,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the region scoping this request.
-    region: "",
+    region: "{MY-REGION}",
 
     // * Name of the TargetPool resource to return.
-    targetPool: "",
+    targetPool: "{MY-TARGET-POOL}",
 
     // Auth client
     auth: authClient
@@ -8044,13 +8044,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'getHealth' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the region scoping this request.
-    region: "",
+    region: "{MY-REGION}",
 
     // * Name of the TargetPool resource to which the queried instance belongs.
-    targetPool: "",
+    targetPool: "{MY-TARGET-POOL}",
 
     resource: {},
 
@@ -8094,10 +8094,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the region scoping this request.
-    region: "",
+    region: "{MY-REGION}",
 
     resource: {},
 
@@ -8141,10 +8141,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the region scoping this request.
-    region: "",
+    region: "{MY-REGION}",
 
     // Auth client
     auth: authClient
@@ -8193,13 +8193,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'removeHealthCheck' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the region for this request.
-    region: "",
+    region: "{MY-REGION}",
 
     // * Name of the target pool to remove health checks from.
-    targetPool: "",
+    targetPool: "{MY-TARGET-POOL}",
 
     resource: {},
 
@@ -8243,13 +8243,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'removeInstance' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the region scoping this request.
-    region: "",
+    region: "{MY-REGION}",
 
     // * Name of the TargetPool resource to remove instances from.
-    targetPool: "",
+    targetPool: "{MY-TARGET-POOL}",
 
     resource: {},
 
@@ -8293,13 +8293,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'setBackup' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the region scoping this request.
-    region: "",
+    region: "{MY-REGION}",
 
     // * Name of the TargetPool resource to set a backup pool for.
-    targetPool: "",
+    targetPool: "{MY-TARGET-POOL}",
 
     resource: {},
 
@@ -8343,7 +8343,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient
@@ -8392,13 +8392,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the region for this request.
-    region: "",
+    region: "{MY-REGION}",
 
     // * Name of the target VPN gateway to delete.
-    targetVpnGateway: "",
+    targetVpnGateway: "{MY-TARGET-VPN-GATEWAY}",
 
     // Auth client
     auth: authClient
@@ -8440,13 +8440,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the region for this request.
-    region: "",
+    region: "{MY-REGION}",
 
     // * Name of the target VPN gateway to return.
-    targetVpnGateway: "",
+    targetVpnGateway: "{MY-TARGET-VPN-GATEWAY}",
 
     // Auth client
     auth: authClient
@@ -8488,10 +8488,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the region for this request.
-    region: "",
+    region: "{MY-REGION}",
 
     resource: {},
 
@@ -8535,10 +8535,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the region for this request.
-    region: "",
+    region: "{MY-REGION}",
 
     // Auth client
     auth: authClient
@@ -8587,10 +8587,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the UrlMap resource to delete.
-    urlMap: "",
+    urlMap: "{MY-URL-MAP}",
 
     // Auth client
     auth: authClient
@@ -8632,10 +8632,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the UrlMap resource to return.
-    urlMap: "",
+    urlMap: "{MY-URL-MAP}",
 
     // Auth client
     auth: authClient
@@ -8677,7 +8677,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     resource: {},
 
@@ -8721,7 +8721,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient
@@ -8770,10 +8770,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the UrlMap resource to update.
-    urlMap: "",
+    urlMap: "{MY-URL-MAP}",
 
     resource: {},
 
@@ -8817,10 +8817,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the UrlMap resource to update.
-    urlMap: "",
+    urlMap: "{MY-URL-MAP}",
 
     resource: {},
 
@@ -8864,10 +8864,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'validate' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the UrlMap resource to be validated as.
-    urlMap: "",
+    urlMap: "{MY-URL-MAP}",
 
     resource: {},
 
@@ -8911,7 +8911,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient
@@ -8960,13 +8960,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the region for this request.
-    region: "",
+    region: "{MY-REGION}",
 
     // * Name of the VpnTunnel resource to delete.
-    vpnTunnel: "",
+    vpnTunnel: "{MY-VPN-TUNNEL}",
 
     // Auth client
     auth: authClient
@@ -9008,13 +9008,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the region for this request.
-    region: "",
+    region: "{MY-REGION}",
 
     // * Name of the VpnTunnel resource to return.
-    vpnTunnel: "",
+    vpnTunnel: "{MY-VPN-TUNNEL}",
 
     // Auth client
     auth: authClient
@@ -9056,10 +9056,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the region for this request.
-    region: "",
+    region: "{MY-REGION}",
 
     resource: {},
 
@@ -9103,10 +9103,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the region for this request.
-    region: "",
+    region: "{MY-REGION}",
 
     // Auth client
     auth: authClient
@@ -9155,13 +9155,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the zone for this request.
-    zone: "",
+    zone: "{MY-ZONE}"  // eg. "us-central1-f",
 
     // * Name of the Operations resource to delete.
-    operation: "",
+    operation: "{MY-OPERATION}",
 
     // Auth client
     auth: authClient
@@ -9203,13 +9203,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the zone for this request.
-    zone: "",
+    zone: "{MY-ZONE}"  // eg. "us-central1-f",
 
     // * Name of the Operations resource to return.
-    operation: "",
+    operation: "{MY-OPERATION}",
 
     // Auth client
     auth: authClient
@@ -9251,10 +9251,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the zone for request.
-    zone: "",
+    zone: "{MY-ZONE}"  // eg. "us-central1-f",
 
     // Auth client
     auth: authClient
@@ -9303,10 +9303,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the zone resource to return.
-    zone: "",
+    zone: "{MY-ZONE}"  // eg. "us-central1-f",
 
     // Auth client
     auth: authClient
@@ -9348,7 +9348,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_container.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_container.v1.json.baseline
@@ -28,11 +28,11 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
     // * The Google Developers Console [project ID or project number]
     //   (https://developers.google.com/console/help/new/#projectnumber).
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // * The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
     //   resides.
-    zone: "",
+    zone: "{MY-ZONE}",
 
     resource: {},
 
@@ -77,14 +77,14 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
     // * The Google Developers Console [project ID or project number]
     //   (https://developers.google.com/console/help/new/#projectnumber).
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // * The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
     //   resides.
-    zone: "",
+    zone: "{MY-ZONE}",
 
     // * The name of the cluster to delete.
-    clusterId: "",
+    clusterId: "{MY-CLUSTER-ID}",
 
     // Auth client
     auth: authClient
@@ -127,14 +127,14 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
     // * The Google Developers Console [project ID or project number]
     //   (https://developers.google.com/console/help/new/#projectnumber).
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // * The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
     //   resides.
-    zone: "",
+    zone: "{MY-ZONE}",
 
     // * The name of the cluster to retrieve.
-    clusterId: "",
+    clusterId: "{MY-CLUSTER-ID}",
 
     // Auth client
     auth: authClient
@@ -177,11 +177,11 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
     // * The Google Developers Console [project ID or project number]
     //   (https://developers.google.com/console/help/new/#projectnumber).
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // * The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
     //   resides, or "-" for all zones.
-    zone: "",
+    zone: "{MY-ZONE}",
 
     // Auth client
     auth: authClient
@@ -224,14 +224,14 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
     // * The Google Developers Console [project ID or project number]
     //   (https://developers.google.com/console/help/new/#projectnumber).
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // * The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
     //   resides.
-    zone: "",
+    zone: "{MY-ZONE}",
 
     // * The name of the cluster to upgrade.
-    clusterId: "",
+    clusterId: "{MY-CLUSTER-ID}",
 
     resource: {},
 
@@ -276,11 +276,11 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
     // * The Google Developers Console [project ID or project number]
     //   (https://developers.google.com/console/help/new/#projectnumber).
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // * The name of the Google Compute Engine [zone](/compute/docs/zones#available) to return operations
     //   for, or "-" for all zones.
-    zone: "",
+    zone: "{MY-ZONE}",
 
     // Auth client
     auth: authClient
@@ -323,14 +323,14 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
     // * The Google Developers Console [project ID or project number]
     //   (https://developers.google.com/console/help/new/#projectnumber).
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // * The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
     //   resides.
-    zone: "",
+    zone: "{MY-ZONE}",
 
     // * The server-assigned `name` of the operation.
-    operationId: "",
+    operationId: "{MY-OPERATION-ID}",
 
     // Auth client
     auth: authClient
@@ -373,11 +373,11 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
     // * The Google Developers Console [project ID or project number]
     //   (https://developers.google.com/console/help/new/#projectnumber).
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // * The name of the Google Compute Engine [zone](/compute/docs/zones#available) to return operations
     //   for, or "-" for all zones.
-    zone: "",
+    zone: "{MY-ZONE}",
 
     // Auth client
     auth: authClient

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_dataflow.v1b3.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_dataflow.v1b3.json.baseline
@@ -27,7 +27,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'create' method:
 
     // * The project which owns the job.
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     resource: {},
 
@@ -71,10 +71,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * The project which owns the job.
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // * Identifies a single job.
-    jobId: "",
+    jobId: "{MY-JOB-ID}",
 
     // Auth client
     auth: authClient
@@ -116,10 +116,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'getMetrics' method:
 
     // * A project id.
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // * The job to get messages for.
-    jobId: "",
+    jobId: "{MY-JOB-ID}",
 
     // Auth client
     auth: authClient
@@ -161,7 +161,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * The project which owns the jobs.
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // Auth client
     auth: authClient
@@ -210,10 +210,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * A project id.
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // * The job to get messages about.
-    jobId: "",
+    jobId: "{MY-JOB-ID}",
 
     // Auth client
     auth: authClient
@@ -262,10 +262,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * The project which owns the job.
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // * Identifies a single job.
-    jobId: "",
+    jobId: "{MY-JOB-ID}",
 
     resource: {},
 
@@ -309,10 +309,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'lease' method:
 
     // * Identifies the project this worker belongs to.
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // * Identifies the workflow job this worker belongs to.
-    jobId: "",
+    jobId: "{MY-JOB-ID}",
 
     resource: {},
 
@@ -356,10 +356,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'reportStatus' method:
 
     // * The project which owns the WorkItem's job.
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // * The job which the WorkItem is part of.
-    jobId: "",
+    jobId: "{MY-JOB-ID}",
 
     resource: {},
 
@@ -403,7 +403,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'workerMessages' method:
 
     // * The project to send the WorkerMessages to.
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     resource: {},
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_dataproc.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_dataproc.v1.json.baseline
@@ -27,10 +27,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'create' method:
 
     // * [Required] The ID of the Google Cloud Platform project that the cluster belongs to.
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // * [Required] The Cloud Dataproc region in which to handle the request.
-    region: "",
+    region: "{MY-REGION}",
 
     resource: {},
 
@@ -74,13 +74,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * [Required] The ID of the Google Cloud Platform project that the cluster belongs to.
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // * [Required] The Cloud Dataproc region in which to handle the request.
-    region: "",
+    region: "{MY-REGION}",
 
     // * [Required] The cluster name.
-    clusterName: "",
+    clusterName: "{MY-CLUSTER-NAME}",
 
     // Auth client
     auth: authClient
@@ -122,13 +122,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'diagnose' method:
 
     // * [Required] The ID of the Google Cloud Platform project that the cluster belongs to.
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // * [Required] The Cloud Dataproc region in which to handle the request.
-    region: "",
+    region: "{MY-REGION}",
 
     // * [Required] The cluster name.
-    clusterName: "",
+    clusterName: "{MY-CLUSTER-NAME}",
 
     resource: {},
 
@@ -172,13 +172,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * [Required] The ID of the Google Cloud Platform project that the cluster belongs to.
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // * [Required] The Cloud Dataproc region in which to handle the request.
-    region: "",
+    region: "{MY-REGION}",
 
     // * [Required] The cluster name.
-    clusterName: "",
+    clusterName: "{MY-CLUSTER-NAME}",
 
     // Auth client
     auth: authClient
@@ -220,10 +220,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * [Required] The ID of the Google Cloud Platform project that the cluster belongs to.
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // * [Required] The Cloud Dataproc region in which to handle the request.
-    region: "",
+    region: "{MY-REGION}",
 
     // Auth client
     auth: authClient
@@ -272,13 +272,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
     // * [Required] The ID of the Google Cloud Platform project the cluster belongs to.
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // * [Required] The Cloud Dataproc region in which to handle the request.
-    region: "",
+    region: "{MY-REGION}",
 
     // * [Required] The cluster name.
-    clusterName: "",
+    clusterName: "{MY-CLUSTER-NAME}",
 
     resource: {},
 
@@ -322,13 +322,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'cancel' method:
 
     // * [Required] The ID of the Google Cloud Platform project that the job belongs to.
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // * [Required] The Cloud Dataproc region in which to handle the request.
-    region: "",
+    region: "{MY-REGION}",
 
     // * [Required] The job ID.
-    jobId: "",
+    jobId: "{MY-JOB-ID}",
 
     resource: {},
 
@@ -372,13 +372,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * [Required] The ID of the Google Cloud Platform project that the job belongs to.
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // * [Required] The Cloud Dataproc region in which to handle the request.
-    region: "",
+    region: "{MY-REGION}",
 
     // * [Required] The job ID.
-    jobId: "",
+    jobId: "{MY-JOB-ID}",
 
     // Auth client
     auth: authClient
@@ -420,13 +420,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * [Required] The ID of the Google Cloud Platform project that the job belongs to.
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // * [Required] The Cloud Dataproc region in which to handle the request.
-    region: "",
+    region: "{MY-REGION}",
 
     // * [Required] The job ID.
-    jobId: "",
+    jobId: "{MY-JOB-ID}",
 
     // Auth client
     auth: authClient
@@ -468,10 +468,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * [Required] The ID of the Google Cloud Platform project that the job belongs to.
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // * [Required] The Cloud Dataproc region in which to handle the request.
-    region: "",
+    region: "{MY-REGION}",
 
     // Auth client
     auth: authClient
@@ -520,10 +520,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'submit' method:
 
     // * [Required] The ID of the Google Cloud Platform project that the job belongs to.
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // * [Required] The Cloud Dataproc region in which to handle the request.
-    region: "",
+    region: "{MY-REGION}",
 
     resource: {},
 
@@ -693,7 +693,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * The name of the operation collection.
-    name: "",
+    name: "{MY-NAME}",
 
     // Auth client
     auth: authClient

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_datastore.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_datastore.v1beta2.json.baseline
@@ -27,7 +27,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'allocateIds' method:
 
     // * Identifies the dataset.
-    datasetId: "",
+    datasetId: "{MY-DATASET-ID}",
 
     resource: {},
 
@@ -71,7 +71,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'beginTransaction' method:
 
     // * Identifies the dataset.
-    datasetId: "",
+    datasetId: "{MY-DATASET-ID}",
 
     resource: {},
 
@@ -115,7 +115,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'commit' method:
 
     // * Identifies the dataset.
-    datasetId: "",
+    datasetId: "{MY-DATASET-ID}",
 
     resource: {},
 
@@ -159,7 +159,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'lookup' method:
 
     // * Identifies the dataset.
-    datasetId: "",
+    datasetId: "{MY-DATASET-ID}",
 
     resource: {},
 
@@ -203,7 +203,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'rollback' method:
 
     // * Identifies the dataset.
-    datasetId: "",
+    datasetId: "{MY-DATASET-ID}",
 
     resource: {},
 
@@ -247,7 +247,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'runQuery' method:
 
     // * Identifies the dataset.
-    datasetId: "",
+    datasetId: "{MY-DATASET-ID}",
 
     resource: {},
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_deploymentmanager.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_deploymentmanager.v2.json.baseline
@@ -27,10 +27,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'cancelPreview' method:
 
     // * The project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the deployment for this request.
-    deployment: "",
+    deployment: "{MY-DEPLOYMENT}",
 
     resource: {},
 
@@ -74,10 +74,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * The project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the deployment for this request.
-    deployment: "",
+    deployment: "{MY-DEPLOYMENT}",
 
     // Auth client
     auth: authClient
@@ -119,10 +119,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * The project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the deployment for this request.
-    deployment: "",
+    deployment: "{MY-DEPLOYMENT}",
 
     // Auth client
     auth: authClient
@@ -164,7 +164,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * The project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     resource: {},
 
@@ -208,7 +208,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * The project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient
@@ -257,10 +257,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
     // * The project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the deployment for this request.
-    deployment: "",
+    deployment: "{MY-DEPLOYMENT}",
 
     resource: {},
 
@@ -304,10 +304,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'stop' method:
 
     // * The project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the deployment for this request.
-    deployment: "",
+    deployment: "{MY-DEPLOYMENT}",
 
     resource: {},
 
@@ -351,10 +351,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * The project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the deployment for this request.
-    deployment: "",
+    deployment: "{MY-DEPLOYMENT}",
 
     resource: {},
 
@@ -398,13 +398,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * The project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the deployment for this request.
-    deployment: "",
+    deployment: "{MY-DEPLOYMENT}",
 
     // * The name of the manifest for this request.
-    manifest: "",
+    manifest: "{MY-MANIFEST}",
 
     // Auth client
     auth: authClient
@@ -446,10 +446,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * The project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the deployment for this request.
-    deployment: "",
+    deployment: "{MY-DEPLOYMENT}",
 
     // Auth client
     auth: authClient
@@ -498,10 +498,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * The project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the operation for this request.
-    operation: "",
+    operation: "{MY-OPERATION}",
 
     // Auth client
     auth: authClient
@@ -543,7 +543,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * The project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient
@@ -592,13 +592,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * The project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the deployment for this request.
-    deployment: "",
+    deployment: "{MY-DEPLOYMENT}",
 
     // * The name of the resource for this request.
-    resource_: "",
+    resource_: "{MY-RESOURCE}",
 
     // Auth client
     auth: authClient
@@ -640,10 +640,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * The project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the deployment for this request.
-    deployment: "",
+    deployment: "{MY-DEPLOYMENT}",
 
     // Auth client
     auth: authClient
@@ -692,7 +692,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * The project ID for this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_dns.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_dns.v1.json.baseline
@@ -27,10 +27,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'create' method:
 
     // * Identifies the project addressed by this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-    managedZone: "",
+    managedZone: "{MY-MANAGED-ZONE}",
 
     resource: {},
 
@@ -74,13 +74,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Identifies the project addressed by this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-    managedZone: "",
+    managedZone: "{MY-MANAGED-ZONE}",
 
     // * The identifier of the requested change, from a previous ResourceRecordSetsChangeResponse.
-    changeId: "",
+    changeId: "{MY-CHANGE-ID}",
 
     // Auth client
     auth: authClient
@@ -122,10 +122,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Identifies the project addressed by this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-    managedZone: "",
+    managedZone: "{MY-MANAGED-ZONE}",
 
     // Auth client
     auth: authClient
@@ -174,7 +174,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'create' method:
 
     // * Identifies the project addressed by this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     resource: {},
 
@@ -218,10 +218,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Identifies the project addressed by this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-    managedZone: "",
+    managedZone: "{MY-MANAGED-ZONE}",
 
     // Auth client
     auth: authClient
@@ -263,10 +263,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Identifies the project addressed by this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-    managedZone: "",
+    managedZone: "{MY-MANAGED-ZONE}",
 
     // Auth client
     auth: authClient
@@ -308,7 +308,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Identifies the project addressed by this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient
@@ -357,7 +357,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Identifies the project addressed by this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient
@@ -399,10 +399,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Identifies the project addressed by this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-    managedZone: "",
+    managedZone: "{MY-MANAGED-ZONE}",
 
     // Auth client
     auth: authClient

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_prediction.v1.6.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_prediction.v1.6.json.baseline
@@ -27,10 +27,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'predict' method:
 
     // * The project associated with the model.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of a hosted model.
-    hostedModelName: "",
+    hostedModelName: "{MY-HOSTED-MODEL-NAME}",
 
     resource: {},
 
@@ -74,10 +74,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'analyze' method:
 
     // * The project associated with the model.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The unique name for the predictive model.
-    id: "",
+    id: "{MY-ID}",
 
     // Auth client
     auth: authClient
@@ -119,10 +119,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * The project associated with the model.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The unique name for the predictive model.
-    id: "",
+    id: "{MY-ID}",
 
     // Auth client
     auth: authClient
@@ -164,10 +164,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * The project associated with the model.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The unique name for the predictive model.
-    id: "",
+    id: "{MY-ID}",
 
     // Auth client
     auth: authClient
@@ -209,7 +209,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * The project associated with the model.
-    project: "",
+    project: "{MY-PROJECT}",
 
     resource: {},
 
@@ -253,7 +253,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * The project associated with the model.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient
@@ -302,10 +302,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'predict' method:
 
     // * The project associated with the model.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The unique name for the predictive model.
-    id: "",
+    id: "{MY-ID}",
 
     resource: {},
 
@@ -349,10 +349,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * The project associated with the model.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The unique name for the predictive model.
-    id: "",
+    id: "{MY-ID}",
 
     resource: {},
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_replicapoolupdater.v1beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_replicapoolupdater.v1beta1.json.baseline
@@ -27,13 +27,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'cancel' method:
 
     // * The Google Developers Console project name.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone in which the update's target resides.
-    zone: "",
+    zone: "{MY-ZONE}",
 
     // * The name of the update.
-    rollingUpdate: "",
+    rollingUpdate: "{MY-ROLLING-UPDATE}",
 
     // Auth client
     auth: authClient
@@ -75,13 +75,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * The Google Developers Console project name.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone in which the update's target resides.
-    zone: "",
+    zone: "{MY-ZONE}",
 
     // * The name of the update.
-    rollingUpdate: "",
+    rollingUpdate: "{MY-ROLLING-UPDATE}",
 
     // Auth client
     auth: authClient
@@ -123,10 +123,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * The Google Developers Console project name.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone in which the update's target resides.
-    zone: "",
+    zone: "{MY-ZONE}",
 
     resource: {},
 
@@ -170,10 +170,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * The Google Developers Console project name.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone in which the update's target resides.
-    zone: "",
+    zone: "{MY-ZONE}",
 
     // Auth client
     auth: authClient
@@ -222,13 +222,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'listInstanceUpdates' method:
 
     // * The Google Developers Console project name.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone in which the update's target resides.
-    zone: "",
+    zone: "{MY-ZONE}",
 
     // * The name of the update.
-    rollingUpdate: "",
+    rollingUpdate: "{MY-ROLLING-UPDATE}",
 
     // Auth client
     auth: authClient
@@ -277,13 +277,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'pause' method:
 
     // * The Google Developers Console project name.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone in which the update's target resides.
-    zone: "",
+    zone: "{MY-ZONE}",
 
     // * The name of the update.
-    rollingUpdate: "",
+    rollingUpdate: "{MY-ROLLING-UPDATE}",
 
     // Auth client
     auth: authClient
@@ -325,13 +325,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'resume' method:
 
     // * The Google Developers Console project name.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone in which the update's target resides.
-    zone: "",
+    zone: "{MY-ZONE}",
 
     // * The name of the update.
-    rollingUpdate: "",
+    rollingUpdate: "{MY-ROLLING-UPDATE}",
 
     // Auth client
     auth: authClient
@@ -373,13 +373,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'rollback' method:
 
     // * The Google Developers Console project name.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The name of the zone in which the update's target resides.
-    zone: "",
+    zone: "{MY-ZONE}",
 
     // * The name of the update.
-    rollingUpdate: "",
+    rollingUpdate: "{MY-ROLLING-UPDATE}",
 
     // Auth client
     auth: authClient
@@ -421,13 +421,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Name of the project scoping this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the zone scoping this request.
-    zone: "",
+    zone: "{MY-ZONE}",
 
     // * Name of the operation resource to return.
-    operation: "",
+    operation: "{MY-OPERATION}",
 
     // Auth client
     auth: authClient
@@ -469,10 +469,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Name of the project scoping this request.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Name of the zone scoping this request.
-    zone: "",
+    zone: "{MY-ZONE}",
 
     // Auth client
     auth: authClient

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_sqladmin.v1beta4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_sqladmin.v1beta4.json.baseline
@@ -27,10 +27,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID of the project that contains the instance.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Cloud SQL instance ID. This does not include the project ID.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     // * The ID of the Backup Run to delete. To find a Backup Run ID, use the list method.
     id: '',
@@ -75,10 +75,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID of the project that contains the instance.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Cloud SQL instance ID. This does not include the project ID.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     // * The ID of this Backup Run.
     id: '',
@@ -123,10 +123,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID of the project that contains the instance.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Cloud SQL instance ID. This does not include the project ID.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     // Auth client
     auth: authClient
@@ -175,13 +175,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID of the project that contains the instance.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Database instance ID. This does not include the project ID.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     // * Name of the database to be deleted in the instance.
-    database: "",
+    database: "{MY-DATABASE}",
 
     // Auth client
     auth: authClient
@@ -223,13 +223,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID of the project that contains the instance.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Database instance ID. This does not include the project ID.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     // * Name of the database in the instance.
-    database: "",
+    database: "{MY-DATABASE}",
 
     // Auth client
     auth: authClient
@@ -271,10 +271,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID of the project that contains the instance.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Database instance ID. This does not include the project ID.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     resource: {},
 
@@ -318,10 +318,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID of the project for which to list Cloud SQL instances.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Cloud SQL instance ID. This does not include the project ID.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     // Auth client
     auth: authClient
@@ -363,13 +363,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
     // * Project ID of the project that contains the instance.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Database instance ID. This does not include the project ID.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     // * Name of the database to be updated in the instance.
-    database: "",
+    database: "{MY-DATABASE}",
 
     resource: {},
 
@@ -413,13 +413,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * Project ID of the project that contains the instance.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Database instance ID. This does not include the project ID.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     // * Name of the database to be updated in the instance.
-    database: "",
+    database: "{MY-DATABASE}",
 
     resource: {},
 
@@ -502,10 +502,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'clone' method:
 
     // * Project ID of the source as well as the clone Cloud SQL instance.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The ID of the Cloud SQL instance to be cloned (source). This does not include the project ID.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     resource: {},
 
@@ -549,10 +549,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID of the project that contains the instance to be deleted.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Cloud SQL instance ID. This does not include the project ID.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     // Auth client
     auth: authClient
@@ -594,10 +594,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'export' method:
 
     // * Project ID of the project that contains the instance to be exported.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Cloud SQL instance ID. This does not include the project ID.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     resource: {},
 
@@ -641,10 +641,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'failover' method:
 
     // * ID of the project that contains the read replica.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Cloud SQL instance ID. This does not include the project ID.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     resource: {},
 
@@ -688,10 +688,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID of the project that contains the instance.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Database instance ID. This does not include the project ID.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     // Auth client
     auth: authClient
@@ -733,10 +733,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'import' method:
 
     // * Project ID of the project that contains the instance.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Cloud SQL instance ID. This does not include the project ID.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     resource: {},
 
@@ -780,7 +780,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID of the project to which the newly created Cloud SQL instances should belong.
-    project: "",
+    project: "{MY-PROJECT}",
 
     resource: {},
 
@@ -824,7 +824,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID of the project for which to list Cloud SQL instances.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient
@@ -873,10 +873,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
     // * Project ID of the project that contains the instance.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Cloud SQL instance ID. This does not include the project ID.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     resource: {},
 
@@ -920,10 +920,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'promoteReplica' method:
 
     // * ID of the project that contains the read replica.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Cloud SQL read replica instance name.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     // Auth client
     auth: authClient
@@ -965,10 +965,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'resetSslConfig' method:
 
     // * Project ID of the project that contains the instance.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Cloud SQL instance ID. This does not include the project ID.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     // Auth client
     auth: authClient
@@ -1010,10 +1010,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'restart' method:
 
     // * Project ID of the project that contains the instance to be restarted.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Cloud SQL instance ID. This does not include the project ID.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     // Auth client
     auth: authClient
@@ -1055,10 +1055,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'restoreBackup' method:
 
     // * Project ID of the project that contains the instance.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Cloud SQL instance ID. This does not include the project ID.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     resource: {},
 
@@ -1102,10 +1102,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'startReplica' method:
 
     // * ID of the project that contains the read replica.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Cloud SQL read replica instance name.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     // Auth client
     auth: authClient
@@ -1147,10 +1147,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'stopReplica' method:
 
     // * ID of the project that contains the read replica.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Cloud SQL read replica instance name.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     // Auth client
     auth: authClient
@@ -1192,10 +1192,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * Project ID of the project that contains the instance.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Cloud SQL instance ID. This does not include the project ID.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     resource: {},
 
@@ -1239,10 +1239,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID of the project that contains the instance.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Instance operation ID.
-    operation: "",
+    operation: "{MY-OPERATION}",
 
     // Auth client
     auth: authClient
@@ -1284,10 +1284,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID of the project that contains the instance.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Cloud SQL instance ID. This does not include the project ID.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     // Auth client
     auth: authClient
@@ -1336,10 +1336,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'createEphemeral' method:
 
     // * Project ID of the Cloud SQL project.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Cloud SQL instance ID. This does not include the project ID.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     resource: {},
 
@@ -1383,13 +1383,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID of the project that contains the instance to be deleted.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Cloud SQL instance ID. This does not include the project ID.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     // * Sha1 FingerPrint.
-    sha1Fingerprint: "",
+    sha1Fingerprint: "{MY-SHA1-FINGERPRINT}",
 
     // Auth client
     auth: authClient
@@ -1431,13 +1431,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Project ID of the project that contains the instance.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Cloud SQL instance ID. This does not include the project ID.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     // * Sha1 FingerPrint.
-    sha1Fingerprint: "",
+    sha1Fingerprint: "{MY-SHA1-FINGERPRINT}",
 
     // Auth client
     auth: authClient
@@ -1479,10 +1479,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID of the project to which the newly created Cloud SQL instances should belong.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Cloud SQL instance ID. This does not include the project ID.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     resource: {},
 
@@ -1526,10 +1526,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID of the project for which to list Cloud SQL instances.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Cloud SQL instance ID. This does not include the project ID.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     // Auth client
     auth: authClient
@@ -1571,7 +1571,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID of the project for which to list tiers.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient
@@ -1613,16 +1613,16 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Project ID of the project that contains the instance.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Database instance ID. This does not include the project ID.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     // * Host of the user in the instance.
-    host: "",
+    host: "{MY-HOST}",
 
     // * Name of the user in the instance.
-    name: "",
+    name: "{MY-NAME}",
 
     // Auth client
     auth: authClient
@@ -1664,10 +1664,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Project ID of the project that contains the instance.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Database instance ID. This does not include the project ID.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     resource: {},
 
@@ -1711,10 +1711,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Project ID of the project that contains the instance.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Database instance ID. This does not include the project ID.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     // Auth client
     auth: authClient
@@ -1756,16 +1756,16 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * Project ID of the project that contains the instance.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * Database instance ID. This does not include the project ID.
-    instance: "",
+    instance: "{MY-INSTANCE}",
 
     // * Host of the user in the instance.
-    host: "",
+    host: "{MY-HOST}",
 
     // * Name of the user in the instance.
-    name: "",
+    name: "{MY-NAME}",
 
     resource: {},
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_storage.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_storage.v1.json.baseline
@@ -27,11 +27,11 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Name of a bucket.
-    bucket: "",
+    bucket: "{MY-BUCKET}",
 
     // * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
     //   group-emailAddress, allUsers, or allAuthenticatedUsers.
-    entity: "",
+    entity: "{MY-ENTITY}",
 
     // Auth client
     auth: authClient
@@ -73,11 +73,11 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Name of a bucket.
-    bucket: "",
+    bucket: "{MY-BUCKET}",
 
     // * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
     //   group-emailAddress, allUsers, or allAuthenticatedUsers.
-    entity: "",
+    entity: "{MY-ENTITY}",
 
     // Auth client
     auth: authClient
@@ -119,7 +119,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Name of a bucket.
-    bucket: "",
+    bucket: "{MY-BUCKET}",
 
     resource: {},
 
@@ -163,7 +163,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Name of a bucket.
-    bucket: "",
+    bucket: "{MY-BUCKET}",
 
     // Auth client
     auth: authClient
@@ -205,11 +205,11 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
     // * Name of a bucket.
-    bucket: "",
+    bucket: "{MY-BUCKET}",
 
     // * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
     //   group-emailAddress, allUsers, or allAuthenticatedUsers.
-    entity: "",
+    entity: "{MY-ENTITY}",
 
     resource: {},
 
@@ -253,11 +253,11 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * Name of a bucket.
-    bucket: "",
+    bucket: "{MY-BUCKET}",
 
     // * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
     //   group-emailAddress, allUsers, or allAuthenticatedUsers.
-    entity: "",
+    entity: "{MY-ENTITY}",
 
     resource: {},
 
@@ -301,7 +301,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Name of a bucket.
-    bucket: "",
+    bucket: "{MY-BUCKET}",
 
     // Auth client
     auth: authClient
@@ -343,7 +343,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Name of a bucket.
-    bucket: "",
+    bucket: "{MY-BUCKET}",
 
     // Auth client
     auth: authClient
@@ -385,7 +385,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * A valid API project identifier.
-    project: "",
+    project: "{MY-PROJECT}",
 
     resource: {},
 
@@ -429,7 +429,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * A valid API project identifier.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // Auth client
     auth: authClient
@@ -478,7 +478,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
     // * Name of a bucket.
-    bucket: "",
+    bucket: "{MY-BUCKET}",
 
     resource: {},
 
@@ -522,7 +522,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * Name of a bucket.
-    bucket: "",
+    bucket: "{MY-BUCKET}",
 
     resource: {},
 
@@ -607,11 +607,11 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Name of a bucket.
-    bucket: "",
+    bucket: "{MY-BUCKET}",
 
     // * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
     //   group-emailAddress, allUsers, or allAuthenticatedUsers.
-    entity: "",
+    entity: "{MY-ENTITY}",
 
     // Auth client
     auth: authClient
@@ -653,11 +653,11 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Name of a bucket.
-    bucket: "",
+    bucket: "{MY-BUCKET}",
 
     // * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
     //   group-emailAddress, allUsers, or allAuthenticatedUsers.
-    entity: "",
+    entity: "{MY-ENTITY}",
 
     // Auth client
     auth: authClient
@@ -699,7 +699,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Name of a bucket.
-    bucket: "",
+    bucket: "{MY-BUCKET}",
 
     resource: {},
 
@@ -743,7 +743,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Name of a bucket.
-    bucket: "",
+    bucket: "{MY-BUCKET}",
 
     // Auth client
     auth: authClient
@@ -785,11 +785,11 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
     // * Name of a bucket.
-    bucket: "",
+    bucket: "{MY-BUCKET}",
 
     // * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
     //   group-emailAddress, allUsers, or allAuthenticatedUsers.
-    entity: "",
+    entity: "{MY-ENTITY}",
 
     resource: {},
 
@@ -833,11 +833,11 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * Name of a bucket.
-    bucket: "",
+    bucket: "{MY-BUCKET}",
 
     // * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
     //   group-emailAddress, allUsers, or allAuthenticatedUsers.
-    entity: "",
+    entity: "{MY-ENTITY}",
 
     resource: {},
 
@@ -881,15 +881,15 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Name of a bucket.
-    bucket: "",
+    bucket: "{MY-BUCKET}",
 
     // * Name of the object. For information about how to URL encode object names to be path safe, see
     //   Encoding URI Path Parts.
-    object: "",
+    object: "{MY-OBJECT}",
 
     // * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
     //   group-emailAddress, allUsers, or allAuthenticatedUsers.
-    entity: "",
+    entity: "{MY-ENTITY}",
 
     // Auth client
     auth: authClient
@@ -931,15 +931,15 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Name of a bucket.
-    bucket: "",
+    bucket: "{MY-BUCKET}",
 
     // * Name of the object. For information about how to URL encode object names to be path safe, see
     //   Encoding URI Path Parts.
-    object: "",
+    object: "{MY-OBJECT}",
 
     // * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
     //   group-emailAddress, allUsers, or allAuthenticatedUsers.
-    entity: "",
+    entity: "{MY-ENTITY}",
 
     // Auth client
     auth: authClient
@@ -981,11 +981,11 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * Name of a bucket.
-    bucket: "",
+    bucket: "{MY-BUCKET}",
 
     // * Name of the object. For information about how to URL encode object names to be path safe, see
     //   Encoding URI Path Parts.
-    object: "",
+    object: "{MY-OBJECT}",
 
     resource: {},
 
@@ -1029,11 +1029,11 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Name of a bucket.
-    bucket: "",
+    bucket: "{MY-BUCKET}",
 
     // * Name of the object. For information about how to URL encode object names to be path safe, see
     //   Encoding URI Path Parts.
-    object: "",
+    object: "{MY-OBJECT}",
 
     // Auth client
     auth: authClient
@@ -1075,15 +1075,15 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
     // * Name of a bucket.
-    bucket: "",
+    bucket: "{MY-BUCKET}",
 
     // * Name of the object. For information about how to URL encode object names to be path safe, see
     //   Encoding URI Path Parts.
-    object: "",
+    object: "{MY-OBJECT}",
 
     // * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
     //   group-emailAddress, allUsers, or allAuthenticatedUsers.
-    entity: "",
+    entity: "{MY-ENTITY}",
 
     resource: {},
 
@@ -1127,15 +1127,15 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * Name of a bucket.
-    bucket: "",
+    bucket: "{MY-BUCKET}",
 
     // * Name of the object. For information about how to URL encode object names to be path safe, see
     //   Encoding URI Path Parts.
-    object: "",
+    object: "{MY-OBJECT}",
 
     // * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
     //   group-emailAddress, allUsers, or allAuthenticatedUsers.
-    entity: "",
+    entity: "{MY-ENTITY}",
 
     resource: {},
 
@@ -1179,11 +1179,11 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'compose' method:
 
     // * Name of the bucket in which to store the new object.
-    destinationBucket: "",
+    destinationBucket: "{MY-DESTINATION-BUCKET}",
 
     // * Name of the new object. For information about how to URL encode object names to be path safe, see
     //   Encoding URI Path Parts.
-    destinationObject: "",
+    destinationObject: "{MY-DESTINATION-OBJECT}",
 
     resource: {},
 
@@ -1227,20 +1227,20 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'copy' method:
 
     // * Name of the bucket in which to find the source object.
-    sourceBucket: "",
+    sourceBucket: "{MY-SOURCE-BUCKET}",
 
     // * Name of the source object. For information about how to URL encode object names to be path safe,
     //   see Encoding URI Path Parts.
-    sourceObject: "",
+    sourceObject: "{MY-SOURCE-OBJECT}",
 
     // * Name of the bucket in which to store the new object. Overrides the provided object metadata's
     //   bucket value, if any.For information about how to URL encode object names to be path safe, see
     //   Encoding URI Path Parts.
-    destinationBucket: "",
+    destinationBucket: "{MY-DESTINATION-BUCKET}",
 
     // * Name of the new object. Required when the object metadata is not otherwise provided. Overrides the
     //   object metadata's name value, if any.
-    destinationObject: "",
+    destinationObject: "{MY-DESTINATION-OBJECT}",
 
     resource: {},
 
@@ -1284,11 +1284,11 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * Name of the bucket in which the object resides.
-    bucket: "",
+    bucket: "{MY-BUCKET}",
 
     // * Name of the object. For information about how to URL encode object names to be path safe, see
     //   Encoding URI Path Parts.
-    object: "",
+    object: "{MY-OBJECT}",
 
     // Auth client
     auth: authClient
@@ -1330,11 +1330,11 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * Name of the bucket in which the object resides.
-    bucket: "",
+    bucket: "{MY-BUCKET}",
 
     // * Name of the object. For information about how to URL encode object names to be path safe, see
     //   Encoding URI Path Parts.
-    object: "",
+    object: "{MY-OBJECT}",
 
     // Auth client
     auth: authClient
@@ -1377,7 +1377,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
     // * Name of the bucket in which to store the new object. Overrides the provided object metadata's
     //   bucket value, if any.
-    bucket: "",
+    bucket: "{MY-BUCKET}",
 
     resource: {},
 
@@ -1426,7 +1426,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * Name of the bucket in which to look for objects.
-    bucket: "",
+    bucket: "{MY-BUCKET}",
 
     // Auth client
     auth: authClient
@@ -1475,11 +1475,11 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
     // * Name of the bucket in which the object resides.
-    bucket: "",
+    bucket: "{MY-BUCKET}",
 
     // * Name of the object. For information about how to URL encode object names to be path safe, see
     //   Encoding URI Path Parts.
-    object: "",
+    object: "{MY-OBJECT}",
 
     resource: {},
 
@@ -1523,20 +1523,20 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'rewrite' method:
 
     // * Name of the bucket in which to find the source object.
-    sourceBucket: "",
+    sourceBucket: "{MY-SOURCE-BUCKET}",
 
     // * Name of the source object. For information about how to URL encode object names to be path safe,
     //   see Encoding URI Path Parts.
-    sourceObject: "",
+    sourceObject: "{MY-SOURCE-OBJECT}",
 
     // * Name of the bucket in which to store the new object. Overrides the provided object metadata's
     //   bucket value, if any.
-    destinationBucket: "",
+    destinationBucket: "{MY-DESTINATION-BUCKET}",
 
     // * Name of the new object. Required when the object metadata is not otherwise provided. Overrides the
     //   object metadata's name value, if any. For information about how to URL encode object names to be
     //   path safe, see Encoding URI Path Parts.
-    destinationObject: "",
+    destinationObject: "{MY-DESTINATION-OBJECT}",
 
     resource: {},
 
@@ -1580,11 +1580,11 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * Name of the bucket in which the object resides.
-    bucket: "",
+    bucket: "{MY-BUCKET}",
 
     // * Name of the object. For information about how to URL encode object names to be path safe, see
     //   Encoding URI Path Parts.
-    object: "",
+    object: "{MY-OBJECT}",
 
     resource: {},
 
@@ -1628,7 +1628,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'watchAll' method:
 
     // * Name of the bucket in which to look for objects.
-    bucket: "",
+    bucket: "{MY-BUCKET}",
 
     resource: {},
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_storagetransfer.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_storagetransfer.v1.json.baseline
@@ -67,7 +67,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
     // * The ID of the Google Developers Console project that the Google service account is associated
     //   with. Required.
-    projectId: "",
+    projectId: "{MY-PROJECT-ID}",
 
     // Auth client
     auth: authClient
@@ -150,7 +150,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * The job to get. Required.
-    jobName: "",
+    jobName: "{MY-JOB-NAME}",
 
     // Auth client
     auth: authClient
@@ -238,7 +238,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
     // * The name of job to update. Required.
-    jobName: "",
+    jobName: "{MY-JOB-NAME}",
 
     resource: {},
 
@@ -282,7 +282,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'cancel' method:
 
     // * The name of the operation resource to be cancelled.
-    name: "",
+    name: "{MY-NAME}",
 
     // Auth client
     auth: authClient
@@ -324,7 +324,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * The name of the operation resource to be deleted.
-    name: "",
+    name: "{MY-NAME}",
 
     // Auth client
     auth: authClient
@@ -366,7 +366,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * The name of the operation resource.
-    name: "",
+    name: "{MY-NAME}",
 
     // Auth client
     auth: authClient
@@ -408,7 +408,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * The value `transferOperations`.
-    name: "",
+    name: "{MY-NAME}",
 
     // Auth client
     auth: authClient
@@ -457,7 +457,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'pause' method:
 
     // * The name of the transfer operation. Required.
-    name: "",
+    name: "{MY-NAME}",
 
     resource: {},
 
@@ -501,7 +501,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'resume' method:
 
     // * The name of the transfer operation. Required.
-    name: "",
+    name: "{MY-NAME}",
 
     resource: {},
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_taskqueue.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_taskqueue.v1beta2.json.baseline
@@ -27,10 +27,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * The project under which the queue lies.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The id of the taskqueue to get the properties of.
-    taskqueue: "",
+    taskqueue: "{MY-TASKQUEUE}",
 
     // Auth client
     auth: authClient
@@ -72,13 +72,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
     // * The project under which the queue lies.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The taskqueue to delete a task from.
-    taskqueue: "",
+    taskqueue: "{MY-TASKQUEUE}",
 
     // * The id of the task to delete.
-    task: "",
+    task: "{MY-TASK}",
 
     // Auth client
     auth: authClient
@@ -120,13 +120,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
     // * The project under which the queue lies.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The taskqueue in which the task belongs.
-    taskqueue: "",
+    taskqueue: "{MY-TASKQUEUE}",
 
     // * The task to get properties of.
-    task: "",
+    task: "{MY-TASK}",
 
     // Auth client
     auth: authClient
@@ -168,10 +168,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
     // * The project under which the queue lies
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The taskqueue to insert the task into
-    taskqueue: "",
+    taskqueue: "{MY-TASKQUEUE}",
 
     resource: {},
 
@@ -215,10 +215,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'lease' method:
 
     // * The project under which the queue lies.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The taskqueue to lease a task from.
-    taskqueue: "",
+    taskqueue: "{MY-TASKQUEUE}",
 
     // * The number of tasks to lease.
     numTasks: 0,
@@ -266,10 +266,10 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
     // * The project under which the queue lies.
-    project: "",
+    project: "{MY-PROJECT}",
 
     // * The id of the taskqueue to list tasks from.
-    taskqueue: "",
+    taskqueue: "{MY-TASKQUEUE}",
 
     // Auth client
     auth: authClient
@@ -311,13 +311,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
     // * The project under which the queue lies.
-    project: "",
+    project: "{MY-PROJECT}",
 
 
-    taskqueue: "",
+    taskqueue: "{MY-TASKQUEUE}",
 
 
-    task: "",
+    task: "{MY-TASK}",
 
     // * The new lease in seconds.
     newLeaseSeconds: 0,
@@ -364,13 +364,13 @@ google.auth.getApplicationDefault(function(err, authClient) {
     // TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
     // * The project under which the queue lies.
-    project: "",
+    project: "{MY-PROJECT}",
 
 
-    taskqueue: "",
+    taskqueue: "{MY-TASKQUEUE}",
 
 
-    task: "",
+    task: "{MY-TASK}",
 
     // * The new lease in seconds.
     newLeaseSeconds: 0,

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_translate.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_translate.v2.json.baseline
@@ -111,7 +111,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
     q: "",
 
     // * The target language into which the text should be translated
-    target: "",
+    target: "{MY-TARGET}",
 
     // Auth client
     auth: authClient

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_adexchangebuyer.v1.4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_adexchangebuyer.v1.4.json.baseline
@@ -331,7 +331,7 @@ $service = new Google_Service_Adexchangebuyer($client);
 $accountId = 0;
 
 // * The buyer-specific id for this creative.
-$buyerCreativeId = '';
+$buyerCreativeId = '{MY-BUYER-CREATIVE-ID}';
 
 // * The id of the deal id to associate with this creative.
 $dealId = '0';
@@ -369,7 +369,7 @@ $service = new Google_Service_Adexchangebuyer($client);
 $accountId = 0;
 
 // * The buyer-specific id for this creative.
-$buyerCreativeId = '';
+$buyerCreativeId = '{MY-BUYER-CREATIVE-ID}';
 
 $response = $service->creatives->get($accountId, $buyerCreativeId);
 
@@ -470,7 +470,7 @@ $service = new Google_Service_Adexchangebuyer($client);
 $accountId = 0;
 
 // * The buyer-specific id for this creative.
-$buyerCreativeId = '';
+$buyerCreativeId = '{MY-BUYER-CREATIVE-ID}';
 
 // * The id of the deal id to disassociate with this creative.
 $dealId = '0';
@@ -505,7 +505,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Adexchangebuyer($client);
 
 // * The proposalId to delete deals from.
-$proposalId = '';
+$proposalId = '{MY-PROPOSAL-ID}';
 
 $postBody = new Google_Service_Adexchangebuyer_DeleteOrderDealsRequest($client);
 
@@ -539,7 +539,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Adexchangebuyer($client);
 
 // * proposalId for which deals need to be added.
-$proposalId = '';
+$proposalId = '{MY-PROPOSAL-ID}';
 
 $postBody = new Google_Service_Adexchangebuyer_AddOrderDealsRequest($client);
 
@@ -574,7 +574,7 @@ $service = new Google_Service_Adexchangebuyer($client);
 
 // * The proposalId to get deals for. To search across proposals specify order_id = '-' as part of the
 //   URL.
-$proposalId = '';
+$proposalId = '{MY-PROPOSAL-ID}';
 
 $response = $service->marketplacedeals->listMarketplacedeals($proposalId);
 
@@ -606,7 +606,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Adexchangebuyer($client);
 
 // * The proposalId to edit deals on.
-$proposalId = '';
+$proposalId = '{MY-PROPOSAL-ID}';
 
 $postBody = new Google_Service_Adexchangebuyer_EditAllOrderDealsRequest($client);
 
@@ -640,7 +640,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Adexchangebuyer($client);
 
 // * The proposalId to add notes for.
-$proposalId = '';
+$proposalId = '{MY-PROPOSAL-ID}';
 
 $postBody = new Google_Service_Adexchangebuyer_AddOrderNotesRequest($client);
 
@@ -674,7 +674,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Adexchangebuyer($client);
 
 // * The proposalId to get notes for.
-$proposalId = '';
+$proposalId = '{MY-PROPOSAL-ID}';
 
 $response = $service->marketplacenotes->listMarketplacenotes($proposalId);
 
@@ -706,7 +706,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Adexchangebuyer($client);
 
 // * The private auction id to be updated.
-$privateAuctionId = '';
+$privateAuctionId = '{MY-PRIVATE-AUCTION-ID}';
 
 $postBody = new Google_Service_Adexchangebuyer_UpdatePrivateAuctionProposalRequest($client);
 
@@ -743,10 +743,10 @@ $service = new Google_Service_Adexchangebuyer($client);
 $accountId = '0';
 
 // * The end time of the report in ISO 8601 timestamp format using UTC.
-$endDateTime = '';
+$endDateTime = '{MY-END-DATE-TIME}';
 
 // * The start time of the report in ISO 8601 timestamp format using UTC.
-$startDateTime = '';
+$startDateTime = '{MY-START-DATE-TIME}';
 
 $response = $service->performanceReport->listPerformanceReport($accountId, $endDateTime, $startDateTime);
 
@@ -988,7 +988,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Adexchangebuyer($client);
 
 // * The id for the product to get the head revision for.
-$productId = '';
+$productId = '{MY-PRODUCT-ID}';
 
 $response = $service->products->get($productId);
 
@@ -1050,7 +1050,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Adexchangebuyer($client);
 
 // * Id of the proposal to retrieve.
-$proposalId = '';
+$proposalId = '{MY-PROPOSAL-ID}';
 
 $response = $service->proposals->get($proposalId);
 
@@ -1114,7 +1114,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Adexchangebuyer($client);
 
 // * The proposal id to update.
-$proposalId = '';
+$proposalId = '{MY-PROPOSAL-ID}';
 
 // * The last known revision number to update. If the head revision in the marketplace database has
 //   since changed, an error will be thrown. The caller should then fetch the latest proposal at head
@@ -1122,7 +1122,7 @@ $proposalId = '';
 $revisionNumber = '0';
 
 // * The proposed action to take on the proposal.
-$updateAction = '';
+$updateAction = '{MY-UPDATE-ACTION}';
 
 $postBody = new Google_Service_Adexchangebuyer_Proposal($client);
 
@@ -1186,7 +1186,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Adexchangebuyer($client);
 
 // * The proposal id for which the setup is complete
-$proposalId = '';
+$proposalId = '{MY-PROPOSAL-ID}';
 
 $response = $service->proposals->setupcomplete($proposalId);
 
@@ -1218,7 +1218,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Adexchangebuyer($client);
 
 // * The proposal id to update.
-$proposalId = '';
+$proposalId = '{MY-PROPOSAL-ID}';
 
 // * The last known revision number to update. If the head revision in the marketplace database has
 //   since changed, an error will be thrown. The caller should then fetch the latest proposal at head
@@ -1226,7 +1226,7 @@ $proposalId = '';
 $revisionNumber = '0';
 
 // * The proposed action to take on the proposal.
-$updateAction = '';
+$updateAction = '{MY-UPDATE-ACTION}';
 
 $postBody = new Google_Service_Adexchangebuyer_Proposal($client);
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_appengine.v1beta5.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_appengine.v1beta5.json.baseline
@@ -27,7 +27,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Appengine($client);
 
 // * Part of `name`. Name of the application to get. For example: "apps/myapp".
-$appsId = '';
+$appsId = '{MY-APPS-ID}';
 
 $response = $service->apps->get($appsId);
 
@@ -59,10 +59,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Appengine($client);
 
 // * Part of `name`. The name of the operation resource.
-$appsId = '';
+$appsId = '{MY-APPS-ID}';
 
 // * Part of `name`. See documentation of `appsId`.
-$operationsId = '';
+$operationsId = '{MY-OPERATIONS-ID}';
 
 $response = $service->apps_operations->get($appsId, $operationsId);
 
@@ -94,7 +94,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Appengine($client);
 
 // * Part of `name`. The name of the operation collection.
-$appsId = '';
+$appsId = '{MY-APPS-ID}';
 
 $response = $service->apps_operations->listAppsOperations($appsId);
 
@@ -130,10 +130,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Appengine($client);
 
 // * Part of `name`. Name of the resource requested. For example: "apps/myapp/services/default".
-$appsId = '';
+$appsId = '{MY-APPS-ID}';
 
 // * Part of `name`. See documentation of `appsId`.
-$servicesId = '';
+$servicesId = '{MY-SERVICES-ID}';
 
 $response = $service->apps_services->delete($appsId, $servicesId);
 
@@ -165,10 +165,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Appengine($client);
 
 // * Part of `name`. Name of the resource requested. For example: "apps/myapp/services/default".
-$appsId = '';
+$appsId = '{MY-APPS-ID}';
 
 // * Part of `name`. See documentation of `appsId`.
-$servicesId = '';
+$servicesId = '{MY-SERVICES-ID}';
 
 $response = $service->apps_services->get($appsId, $servicesId);
 
@@ -200,7 +200,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Appengine($client);
 
 // * Part of `name`. Name of the resource requested. For example: "apps/myapp".
-$appsId = '';
+$appsId = '{MY-APPS-ID}';
 
 $response = $service->apps_services->listAppsServices($appsId);
 
@@ -236,10 +236,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Appengine($client);
 
 // * Part of `name`. Name of the resource to update. For example: "apps/myapp/services/default".
-$appsId = '';
+$appsId = '{MY-APPS-ID}';
 
 // * Part of `name`. See documentation of `appsId`.
-$servicesId = '';
+$servicesId = '{MY-SERVICES-ID}';
 
 $postBody = new Google_Service_Appengine_Service($client);
 
@@ -273,10 +273,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Appengine($client);
 
 // * Part of `name`. Name of the resource to update. For example: "apps/myapp/services/default".
-$appsId = '';
+$appsId = '{MY-APPS-ID}';
 
 // * Part of `name`. See documentation of `appsId`.
-$servicesId = '';
+$servicesId = '{MY-SERVICES-ID}';
 
 $postBody = new Google_Service_Appengine_Version($client);
 
@@ -311,13 +311,13 @@ $service = new Google_Service_Appengine($client);
 
 // * Part of `name`. Name of the resource requested. For example:
 //   "apps/myapp/services/default/versions/v1".
-$appsId = '';
+$appsId = '{MY-APPS-ID}';
 
 // * Part of `name`. See documentation of `appsId`.
-$servicesId = '';
+$servicesId = '{MY-SERVICES-ID}';
 
 // * Part of `name`. See documentation of `appsId`.
-$versionsId = '';
+$versionsId = '{MY-VERSIONS-ID}';
 
 $response = $service->apps_services_versions->delete($appsId, $servicesId, $versionsId);
 
@@ -350,13 +350,13 @@ $service = new Google_Service_Appengine($client);
 
 // * Part of `name`. Name of the resource requested. For example:
 //   "apps/myapp/services/default/versions/v1".
-$appsId = '';
+$appsId = '{MY-APPS-ID}';
 
 // * Part of `name`. See documentation of `appsId`.
-$servicesId = '';
+$servicesId = '{MY-SERVICES-ID}';
 
 // * Part of `name`. See documentation of `appsId`.
-$versionsId = '';
+$versionsId = '{MY-VERSIONS-ID}';
 
 $response = $service->apps_services_versions->get($appsId, $servicesId, $versionsId);
 
@@ -389,13 +389,13 @@ $service = new Google_Service_Appengine($client);
 
 // * Part of `name`. Name of the resource requested. For example:
 //   "apps/myapp/services/default/versions/v1".
-$appsId = '';
+$appsId = '{MY-APPS-ID}';
 
 // * Part of `name`. See documentation of `appsId`.
-$servicesId = '';
+$servicesId = '{MY-SERVICES-ID}';
 
 // * Part of `name`. See documentation of `appsId`.
-$versionsId = '';
+$versionsId = '{MY-VERSIONS-ID}';
 
 $response = $service->apps_services_versions_instances->listAppsServicesVersionsInstances($appsId, $servicesId, $versionsId);
 
@@ -431,10 +431,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Appengine($client);
 
 // * Part of `name`. Name of the resource requested. For example: "apps/myapp/services/default".
-$appsId = '';
+$appsId = '{MY-APPS-ID}';
 
 // * Part of `name`. See documentation of `appsId`.
-$servicesId = '';
+$servicesId = '{MY-SERVICES-ID}';
 
 $response = $service->apps_services_versions->listAppsServicesVersions($appsId, $servicesId);
 
@@ -471,13 +471,13 @@ $service = new Google_Service_Appengine($client);
 
 // * Part of `name`. Name of the resource to update. For example:
 //   "apps/myapp/services/default/versions/1".
-$appsId = '';
+$appsId = '{MY-APPS-ID}';
 
 // * Part of `name`. See documentation of `appsId`.
-$servicesId = '';
+$servicesId = '{MY-SERVICES-ID}';
 
 // * Part of `name`. See documentation of `appsId`.
-$versionsId = '';
+$versionsId = '{MY-VERSIONS-ID}';
 
 $postBody = new Google_Service_Appengine_Version($client);
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_autoscaler.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_autoscaler.v1beta2.json.baseline
@@ -27,13 +27,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Autoscaler($client);
 
 // * Project ID of Autoscaler resource.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Zone name of Autoscaler resource.
-$zone = '';
+$zone = '{MY-ZONE}';
 
 // * Name of the Autoscaler resource.
-$autoscaler = '';
+$autoscaler = '{MY-AUTOSCALER}';
 
 $response = $service->autoscalers->delete($project, $zone, $autoscaler);
 
@@ -65,13 +65,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Autoscaler($client);
 
 // * Project ID of Autoscaler resource.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Zone name of Autoscaler resource.
-$zone = '';
+$zone = '{MY-ZONE}';
 
 // * Name of the Autoscaler resource.
-$autoscaler = '';
+$autoscaler = '{MY-AUTOSCALER}';
 
 $response = $service->autoscalers->get($project, $zone, $autoscaler);
 
@@ -103,10 +103,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Autoscaler($client);
 
 // * Project ID of Autoscaler resource.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Zone name of Autoscaler resource.
-$zone = '';
+$zone = '{MY-ZONE}';
 
 $postBody = new Google_Service_Autoscaler_Autoscaler($client);
 
@@ -140,10 +140,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Autoscaler($client);
 
 // * Project ID of Autoscaler resource.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Zone name of Autoscaler resource.
-$zone = '';
+$zone = '{MY-ZONE}';
 
 $response = $service->autoscalers->listAutoscalers($project, $zone);
 
@@ -179,13 +179,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Autoscaler($client);
 
 // * Project ID of Autoscaler resource.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Zone name of Autoscaler resource.
-$zone = '';
+$zone = '{MY-ZONE}';
 
 // * Name of the Autoscaler resource.
-$autoscaler = '';
+$autoscaler = '{MY-AUTOSCALER}';
 
 $postBody = new Google_Service_Autoscaler_Autoscaler($client);
 
@@ -219,13 +219,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Autoscaler($client);
 
 // * Project ID of Autoscaler resource.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Zone name of Autoscaler resource.
-$zone = '';
+$zone = '{MY-ZONE}';
 
 // * Name of the Autoscaler resource.
-$autoscaler = '';
+$autoscaler = '{MY-AUTOSCALER}';
 
 $postBody = new Google_Service_Autoscaler_Autoscaler($client);
 
@@ -259,13 +259,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Autoscaler($client);
 
 
-$project = '';
+$project = '{MY-PROJECT}';
 
 
-$zone = '';
+$zone = '{MY-ZONE}'  // eg. 'us-central1-f';
 
 
-$operation = '';
+$operation = '{MY-OPERATION}';
 
 $response = $service->zoneOperations->delete($project, $zone, $operation);
 
@@ -297,13 +297,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Autoscaler($client);
 
 
-$project = '';
+$project = '{MY-PROJECT}';
 
 
-$zone = '';
+$zone = '{MY-ZONE}'  // eg. 'us-central1-f';
 
 
-$operation = '';
+$operation = '{MY-OPERATION}';
 
 $response = $service->zoneOperations->get($project, $zone, $operation);
 
@@ -335,10 +335,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Autoscaler($client);
 
 
-$project = '';
+$project = '{MY-PROJECT}';
 
 
-$zone = '';
+$zone = '{MY-ZONE}'  // eg. 'us-central1-f';
 
 $response = $service->zoneOperations->listZoneOperations($project, $zone);
 
@@ -374,7 +374,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Autoscaler($client);
 
 
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->zones->listZones($project);
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_bigquery.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_bigquery.v2.json.baseline
@@ -27,10 +27,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Bigquery($client);
 
 // * Project ID of the dataset being deleted
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 // * Dataset ID of dataset being deleted
-$datasetId = '';
+$datasetId = '{MY-DATASET-ID}';
 
 $response = $service->datasets->delete($projectId, $datasetId);
 
@@ -62,10 +62,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Bigquery($client);
 
 // * Project ID of the requested dataset
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 // * Dataset ID of the requested dataset
-$datasetId = '';
+$datasetId = '{MY-DATASET-ID}';
 
 $response = $service->datasets->get($projectId, $datasetId);
 
@@ -97,7 +97,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Bigquery($client);
 
 // * Project ID of the new dataset
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 $postBody = new Google_Service_Bigquery_Dataset($client);
 
@@ -131,7 +131,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Bigquery($client);
 
 // * Project ID of the datasets to be listed
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 $response = $service->datasets->listDatasets($projectId);
 
@@ -167,10 +167,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Bigquery($client);
 
 // * Project ID of the dataset being updated
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 // * Dataset ID of the dataset being updated
-$datasetId = '';
+$datasetId = '{MY-DATASET-ID}';
 
 $postBody = new Google_Service_Bigquery_Dataset($client);
 
@@ -204,10 +204,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Bigquery($client);
 
 // * Project ID of the dataset being updated
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 // * Dataset ID of the dataset being updated
-$datasetId = '';
+$datasetId = '{MY-DATASET-ID}';
 
 $postBody = new Google_Service_Bigquery_Dataset($client);
 
@@ -241,10 +241,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Bigquery($client);
 
 // * [Required] Project ID of the job to cancel
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 // * [Required] Job ID of the job to cancel
-$jobId = '';
+$jobId = '{MY-JOB-ID}';
 
 $response = $service->jobs->cancel($projectId, $jobId);
 
@@ -276,10 +276,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Bigquery($client);
 
 // * [Required] Project ID of the requested job
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 // * [Required] Job ID of the requested job
-$jobId = '';
+$jobId = '{MY-JOB-ID}';
 
 $response = $service->jobs->get($projectId, $jobId);
 
@@ -311,10 +311,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Bigquery($client);
 
 // * [Required] Project ID of the query job
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 // * [Required] Job ID of the query job
-$jobId = '';
+$jobId = '{MY-JOB-ID}';
 
 $response = $service->jobs->getQueryResults($projectId, $jobId);
 
@@ -346,7 +346,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Bigquery($client);
 
 // * Project ID of the project that will be billed for the job
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 $postBody = new Google_Service_Bigquery_Job($client);
 
@@ -380,7 +380,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Bigquery($client);
 
 // * Project ID of the jobs to list
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 $response = $service->jobs->listJobs($projectId);
 
@@ -416,7 +416,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Bigquery($client);
 
 // * Project ID of the project billed for the query
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 $postBody = new Google_Service_Bigquery_QueryRequest($client);
 
@@ -484,13 +484,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Bigquery($client);
 
 // * Project ID of the destination table.
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 // * Dataset ID of the destination table.
-$datasetId = '';
+$datasetId = '{MY-DATASET-ID}';
 
 // * Table ID of the destination table.
-$tableId = '';
+$tableId = '{MY-TABLE-ID}';
 
 $postBody = new Google_Service_Bigquery_TableDataInsertAllRequest($client);
 
@@ -524,13 +524,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Bigquery($client);
 
 // * Project ID of the table to read
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 // * Dataset ID of the table to read
-$datasetId = '';
+$datasetId = '{MY-DATASET-ID}';
 
 // * Table ID of the table to read
-$tableId = '';
+$tableId = '{MY-TABLE-ID}';
 
 $response = $service->tabledata->listTabledata($projectId, $datasetId, $tableId);
 
@@ -562,13 +562,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Bigquery($client);
 
 // * Project ID of the table to delete
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 // * Dataset ID of the table to delete
-$datasetId = '';
+$datasetId = '{MY-DATASET-ID}';
 
 // * Table ID of the table to delete
-$tableId = '';
+$tableId = '{MY-TABLE-ID}';
 
 $response = $service->tables->delete($projectId, $datasetId, $tableId);
 
@@ -600,13 +600,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Bigquery($client);
 
 // * Project ID of the requested table
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 // * Dataset ID of the requested table
-$datasetId = '';
+$datasetId = '{MY-DATASET-ID}';
 
 // * Table ID of the requested table
-$tableId = '';
+$tableId = '{MY-TABLE-ID}';
 
 $response = $service->tables->get($projectId, $datasetId, $tableId);
 
@@ -638,10 +638,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Bigquery($client);
 
 // * Project ID of the new table
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 // * Dataset ID of the new table
-$datasetId = '';
+$datasetId = '{MY-DATASET-ID}';
 
 $postBody = new Google_Service_Bigquery_Table($client);
 
@@ -675,10 +675,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Bigquery($client);
 
 // * Project ID of the tables to list
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 // * Dataset ID of the tables to list
-$datasetId = '';
+$datasetId = '{MY-DATASET-ID}';
 
 $response = $service->tables->listTables($projectId, $datasetId);
 
@@ -714,13 +714,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Bigquery($client);
 
 // * Project ID of the table to update
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 // * Dataset ID of the table to update
-$datasetId = '';
+$datasetId = '{MY-DATASET-ID}';
 
 // * Table ID of the table to update
-$tableId = '';
+$tableId = '{MY-TABLE-ID}';
 
 $postBody = new Google_Service_Bigquery_Table($client);
 
@@ -754,13 +754,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Bigquery($client);
 
 // * Project ID of the table to update
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 // * Dataset ID of the table to update
-$datasetId = '';
+$datasetId = '{MY-DATASET-ID}';
 
 // * Table ID of the table to update
-$tableId = '';
+$tableId = '{MY-TABLE-ID}';
 
 $postBody = new Google_Service_Bigquery_Table($client);
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_clouddebugger.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_clouddebugger.v2.json.baseline
@@ -27,7 +27,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudDebugger($client);
 
 // * Identifies the debuggee.
-$debuggeeId = '';
+$debuggeeId = '{MY-DEBUGGEE-ID}';
 
 $response = $service->controller_debuggees_breakpoints->listControllerDebuggeesBreakpoints($debuggeeId);
 
@@ -59,10 +59,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudDebugger($client);
 
 // * Identifies the debuggee being debugged.
-$debuggeeId = '';
+$debuggeeId = '{MY-DEBUGGEE-ID}';
 
 // * Breakpoint identifier, unique in the scope of the debuggee.
-$id = '';
+$id = '{MY-ID}';
 
 $postBody = new Google_Service_CloudDebugger_UpdateActiveBreakpointRequest($client);
 
@@ -128,10 +128,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudDebugger($client);
 
 // * ID of the debuggee whose breakpoint to delete.
-$debuggeeId = '';
+$debuggeeId = '{MY-DEBUGGEE-ID}';
 
 // * ID of the breakpoint to delete.
-$breakpointId = '';
+$breakpointId = '{MY-BREAKPOINT-ID}';
 
 $response = $service->debugger_debuggees_breakpoints->delete($debuggeeId, $breakpointId);
 
@@ -163,10 +163,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudDebugger($client);
 
 // * ID of the debuggee whose breakpoint to get.
-$debuggeeId = '';
+$debuggeeId = '{MY-DEBUGGEE-ID}';
 
 // * ID of the breakpoint to get.
-$breakpointId = '';
+$breakpointId = '{MY-BREAKPOINT-ID}';
 
 $response = $service->debugger_debuggees_breakpoints->get($debuggeeId, $breakpointId);
 
@@ -198,7 +198,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudDebugger($client);
 
 // * ID of the debuggee whose breakpoints to list.
-$debuggeeId = '';
+$debuggeeId = '{MY-DEBUGGEE-ID}';
 
 $response = $service->debugger_debuggees_breakpoints->listDebuggerDebuggeesBreakpoints($debuggeeId);
 
@@ -230,7 +230,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudDebugger($client);
 
 // * ID of the debuggee where the breakpoint is to be set.
-$debuggeeId = '';
+$debuggeeId = '{MY-DEBUGGEE-ID}';
 
 $postBody = new Google_Service_CloudDebugger_Breakpoint($client);
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_cloudmonitoring.v2beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_cloudmonitoring.v2beta2.json.baseline
@@ -27,7 +27,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudMonitoring($client);
 
 // * The project id. The value can be the numeric project ID or string-based project name.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $postBody = new Google_Service_CloudMonitoring_MetricDescriptor($client);
 
@@ -61,10 +61,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudMonitoring($client);
 
 // * The project ID to which the metric belongs.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the metric.
-$metric = '';
+$metric = '{MY-METRIC}';
 
 $response = $service->metricDescriptors->delete($project, $metric);
 
@@ -96,7 +96,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudMonitoring($client);
 
 // * The project id. The value can be the numeric project ID or string-based project name.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $postBody = new Google_Service_CloudMonitoring_ListMetricDescriptorsRequest($client);
 
@@ -135,14 +135,14 @@ $service = new Google_Service_CloudMonitoring($client);
 
 // * The project ID to which this time series belongs. The value can be the numeric project ID or
 //   string-based project name.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Metric names are protocol-free URLs as listed in the Supported Metrics page. For example,
 //   compute.googleapis.com/instance/disk/read_ops_count.
-$metric = '';
+$metric = '{MY-METRIC}';
 
 // * End of the time interval (inclusive), which is expressed as an RFC 3339 timestamp.
-$youngest = '';
+$youngest = '{MY-YOUNGEST}';
 
 $postBody = new Google_Service_CloudMonitoring_ListTimeseriesRequest($client);
 
@@ -180,7 +180,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudMonitoring($client);
 
 // * The project ID. The value can be the numeric project ID or string-based project name.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $postBody = new Google_Service_CloudMonitoring_WriteTimeseriesRequest($client);
 
@@ -215,14 +215,14 @@ $service = new Google_Service_CloudMonitoring($client);
 
 // * The project ID to which this time series belongs. The value can be the numeric project ID or
 //   string-based project name.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Metric names are protocol-free URLs as listed in the Supported Metrics page. For example,
 //   compute.googleapis.com/instance/disk/read_ops_count.
-$metric = '';
+$metric = '{MY-METRIC}';
 
 // * End of the time interval (inclusive), which is expressed as an RFC 3339 timestamp.
-$youngest = '';
+$youngest = '{MY-YOUNGEST}';
 
 $postBody = new Google_Service_CloudMonitoring_ListTimeseriesDescriptorsRequest($client);
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_cloudresourcemanager.v1beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_cloudresourcemanager.v1beta1.json.baseline
@@ -27,7 +27,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudResourceManager($client);
 
 // * The id of the Organization resource to fetch.
-$organizationId = '';
+$organizationId = '{MY-ORGANIZATION-ID}';
 
 $response = $service->organizations->get($organizationId);
 
@@ -61,7 +61,7 @@ $service = new Google_Service_CloudResourceManager($client);
 // * REQUIRED: The resource for which the policy is being requested. `resource` is usually specified as
 //   a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified
 //   in this value is resource specific and is specified in the `getIamPolicy` documentation.
-$resource = '';
+$resource = '{MY-RESOURCE}';
 
 $postBody = new Google_Service_CloudResourceManager_GetIamPolicyRequest($client);
 
@@ -131,7 +131,7 @@ $service = new Google_Service_CloudResourceManager($client);
 // * REQUIRED: The resource for which the policy is being specified. `resource` is usually specified as
 //   a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified
 //   in this value is resource specific and is specified in the `setIamPolicy` documentation.
-$resource = '';
+$resource = '{MY-RESOURCE}';
 
 $postBody = new Google_Service_CloudResourceManager_SetIamPolicyRequest($client);
 
@@ -168,7 +168,7 @@ $service = new Google_Service_CloudResourceManager($client);
 //   specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the
 //   path specified in this value is resource specific and is specified in the `testIamPermissions`
 //   documentation.
-$resource = '';
+$resource = '{MY-RESOURCE}';
 
 $postBody = new Google_Service_CloudResourceManager_TestIamPermissionsRequest($client);
 
@@ -203,7 +203,7 @@ $service = new Google_Service_CloudResourceManager($client);
 
 // * An immutable id for the Organization that is assigned on creation. This should be omitted when
 //   creating a new Organization. This field is read-only.
-$organizationId = '';
+$organizationId = '{MY-ORGANIZATION-ID}';
 
 $postBody = new Google_Service_CloudResourceManager_Organization($client);
 
@@ -269,7 +269,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudResourceManager($client);
 
 // * The Project ID (for example, `foo-bar-123`). Required.
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 $response = $service->projects->delete($projectId);
 
@@ -301,7 +301,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudResourceManager($client);
 
 // * The Project ID (for example, `my-project-123`). Required.
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 $response = $service->projects->get($projectId);
 
@@ -335,7 +335,7 @@ $service = new Google_Service_CloudResourceManager($client);
 // * REQUIRED: The resource for which the policy is being requested. `resource` is usually specified as
 //   a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified
 //   in this value is resource specific and is specified in the `getIamPolicy` documentation.
-$resource = '';
+$resource = '{MY-RESOURCE}';
 
 $postBody = new Google_Service_CloudResourceManager_GetIamPolicyRequest($client);
 
@@ -405,7 +405,7 @@ $service = new Google_Service_CloudResourceManager($client);
 // * REQUIRED: The resource for which the policy is being specified. `resource` is usually specified as
 //   a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified
 //   in this value is resource specific and is specified in the `setIamPolicy` documentation.
-$resource = '';
+$resource = '{MY-RESOURCE}';
 
 $postBody = new Google_Service_CloudResourceManager_SetIamPolicyRequest($client);
 
@@ -442,7 +442,7 @@ $service = new Google_Service_CloudResourceManager($client);
 //   specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the
 //   path specified in this value is resource specific and is specified in the `testIamPermissions`
 //   documentation.
-$resource = '';
+$resource = '{MY-RESOURCE}';
 
 $postBody = new Google_Service_CloudResourceManager_TestIamPermissionsRequest($client);
 
@@ -476,7 +476,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudResourceManager($client);
 
 // * The project ID (for example, `foo-bar-123`). Required.
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 $postBody = new Google_Service_CloudResourceManager_UndeleteProjectRequest($client);
 
@@ -510,7 +510,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudResourceManager($client);
 
 // * The project ID (for example, `my-project-123`). Required.
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 $postBody = new Google_Service_CloudResourceManager_Project($client);
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_cloudtrace.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_cloudtrace.v1.json.baseline
@@ -27,7 +27,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudTrace($client);
 
 // * ID of the Cloud project where the trace data is stored.
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 $postBody = new Google_Service_CloudTrace_Traces($client);
 
@@ -61,10 +61,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudTrace($client);
 
 // * ID of the Cloud project where the trace data is stored.
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 // * ID of the trace to return.
-$traceId = '';
+$traceId = '{MY-TRACE-ID}';
 
 $response = $service->projects_traces->get($projectId, $traceId);
 
@@ -96,7 +96,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudTrace($client);
 
 // * ID of the Cloud project where the trace data is stored.
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 $response = $service->projects_traces->listProjectsTraces($projectId);
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_clouduseraccounts.beta.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_clouduseraccounts.beta.json.baseline
@@ -27,10 +27,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudUserAccounts($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the Operations resource to delete.
-$operation = '';
+$operation = '{MY-OPERATION}';
 
 $response = $service->globalAccountsOperations->delete($project, $operation);
 
@@ -62,10 +62,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudUserAccounts($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the Operations resource to return.
-$operation = '';
+$operation = '{MY-OPERATION}';
 
 $response = $service->globalAccountsOperations->get($project, $operation);
 
@@ -97,7 +97,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudUserAccounts($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->globalAccountsOperations->listGlobalAccountsOperations($project);
 
@@ -133,10 +133,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudUserAccounts($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the group for this request.
-$groupName = '';
+$groupName = '{MY-GROUP-NAME}';
 
 $postBody = new Google_Service_CloudUserAccounts_GroupsAddMemberRequest($client);
 
@@ -170,10 +170,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudUserAccounts($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the Group resource to delete.
-$groupName = '';
+$groupName = '{MY-GROUP-NAME}';
 
 $response = $service->groups->delete($project, $groupName);
 
@@ -205,10 +205,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudUserAccounts($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the Group resource to return.
-$groupName = '';
+$groupName = '{MY-GROUP-NAME}';
 
 $response = $service->groups->get($project, $groupName);
 
@@ -240,7 +240,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudUserAccounts($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $postBody = new Google_Service_CloudUserAccounts_Group($client);
 
@@ -274,7 +274,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudUserAccounts($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->groups->listGroups($project);
 
@@ -310,10 +310,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudUserAccounts($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the group for this request.
-$groupName = '';
+$groupName = '{MY-GROUP-NAME}';
 
 $postBody = new Google_Service_CloudUserAccounts_GroupsRemoveMemberRequest($client);
 
@@ -347,16 +347,16 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudUserAccounts($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the zone for this request.
-$zone = '';
+$zone = '{MY-ZONE}'  // eg. 'us-central1-f';
 
 // * The user account for which you want to get a list of authorized public keys.
-$user = '';
+$user = '{MY-USER}';
 
 // * The fully-qualified URL of the virtual machine requesting the view.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 $response = $service->linux->getAuthorizedKeysView($project, $zone, $user, $instance);
 
@@ -388,13 +388,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudUserAccounts($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the zone for this request.
-$zone = '';
+$zone = '{MY-ZONE}'  // eg. 'us-central1-f';
 
 // * The fully-qualified URL of the virtual machine requesting the views.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 $response = $service->linux->getLinuxAccountViews($project, $zone, $instance);
 
@@ -426,10 +426,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudUserAccounts($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the user for this request.
-$user = '';
+$user = '{MY-USER}';
 
 $postBody = new Google_Service_CloudUserAccounts_PublicKey($client);
 
@@ -463,10 +463,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudUserAccounts($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the user resource to delete.
-$user = '';
+$user = '{MY-USER}';
 
 $response = $service->users->delete($project, $user);
 
@@ -498,10 +498,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudUserAccounts($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the user resource to return.
-$user = '';
+$user = '{MY-USER}';
 
 $response = $service->users->get($project, $user);
 
@@ -533,7 +533,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudUserAccounts($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $postBody = new Google_Service_CloudUserAccounts_User($client);
 
@@ -567,7 +567,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudUserAccounts($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->users->listUsers($project);
 
@@ -603,14 +603,14 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudUserAccounts($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the user for this request.
-$user = '';
+$user = '{MY-USER}';
 
 // * The fingerprint of the public key to delete. Public keys are identified by their fingerprint,
 //   which is defined by RFC4716 to be the MD5 digest of the public key.
-$fingerprint = '';
+$fingerprint = '{MY-FINGERPRINT}';
 
 $response = $service->users->removePublicKey($project, $user, $fingerprint);
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_compute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_compute.v1.json.baseline
@@ -27,7 +27,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->addresses->aggregatedList($project);
 
@@ -63,13 +63,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the region for this request.
-$region = '';
+$region = '{MY-REGION}';
 
 // * Name of the address resource to delete.
-$address = '';
+$address = '{MY-ADDRESS}';
 
 $response = $service->addresses->delete($project, $region, $address);
 
@@ -101,13 +101,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the region for this request.
-$region = '';
+$region = '{MY-REGION}';
 
 // * Name of the address resource to return.
-$address = '';
+$address = '{MY-ADDRESS}';
 
 $response = $service->addresses->get($project, $region, $address);
 
@@ -139,10 +139,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the region for this request.
-$region = '';
+$region = '{MY-REGION}';
 
 $postBody = new Google_Service_Compute_Address($client);
 
@@ -176,10 +176,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the region for this request.
-$region = '';
+$region = '{MY-REGION}';
 
 $response = $service->addresses->listAddresses($project, $region);
 
@@ -215,7 +215,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->autoscalers->aggregatedList($project);
 
@@ -251,13 +251,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the zone for this request.
-$zone = '';
+$zone = '{MY-ZONE}'  // eg. 'us-central1-f';
 
 // * Name of the autoscaler to delete.
-$autoscaler = '';
+$autoscaler = '{MY-AUTOSCALER}';
 
 $response = $service->autoscalers->delete($project, $zone, $autoscaler);
 
@@ -289,13 +289,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the zone for this request.
-$zone = '';
+$zone = '{MY-ZONE}'  // eg. 'us-central1-f';
 
 // * Name of the autoscaler to return.
-$autoscaler = '';
+$autoscaler = '{MY-AUTOSCALER}';
 
 $response = $service->autoscalers->get($project, $zone, $autoscaler);
 
@@ -327,10 +327,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the zone for this request.
-$zone = '';
+$zone = '{MY-ZONE}'  // eg. 'us-central1-f';
 
 $postBody = new Google_Service_Compute_Autoscaler($client);
 
@@ -364,10 +364,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the zone for this request.
-$zone = '';
+$zone = '{MY-ZONE}'  // eg. 'us-central1-f';
 
 $response = $service->autoscalers->listAutoscalers($project, $zone);
 
@@ -403,13 +403,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the zone for this request.
-$zone = '';
+$zone = '{MY-ZONE}'  // eg. 'us-central1-f';
 
 // * Name of the autoscaler to update.
-$autoscaler = '';
+$autoscaler = '{MY-AUTOSCALER}';
 
 $postBody = new Google_Service_Compute_Autoscaler($client);
 
@@ -443,10 +443,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the zone for this request.
-$zone = '';
+$zone = '{MY-ZONE}'  // eg. 'us-central1-f';
 
 $postBody = new Google_Service_Compute_Autoscaler($client);
 
@@ -480,10 +480,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the BackendService resource to delete.
-$backendService = '';
+$backendService = '{MY-BACKEND-SERVICE}';
 
 $response = $service->backendServices->delete($project, $backendService);
 
@@ -515,10 +515,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the BackendService resource to return.
-$backendService = '';
+$backendService = '{MY-BACKEND-SERVICE}';
 
 $response = $service->backendServices->get($project, $backendService);
 
@@ -550,10 +550,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the BackendService resource to which the queried instance belongs.
-$backendService = '';
+$backendService = '{MY-BACKEND-SERVICE}';
 
 $postBody = new Google_Service_Compute_ResourceGroupReference($client);
 
@@ -587,7 +587,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $postBody = new Google_Service_Compute_BackendService($client);
 
@@ -621,7 +621,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->backendServices->listBackendServices($project);
 
@@ -657,10 +657,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the BackendService resource to update.
-$backendService = '';
+$backendService = '{MY-BACKEND-SERVICE}';
 
 $postBody = new Google_Service_Compute_BackendService($client);
 
@@ -694,10 +694,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the BackendService resource to update.
-$backendService = '';
+$backendService = '{MY-BACKEND-SERVICE}';
 
 $postBody = new Google_Service_Compute_BackendService($client);
 
@@ -731,7 +731,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->diskTypes->aggregatedList($project);
 
@@ -767,13 +767,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone for this request.
-$zone = '';
+$zone = '{MY-ZONE}'  // eg. 'us-central1-f';
 
 // * Name of the disk type to return.
-$diskType = '';
+$diskType = '{MY-DISK-TYPE}';
 
 $response = $service->diskTypes->get($project, $zone, $diskType);
 
@@ -805,10 +805,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone for this request.
-$zone = '';
+$zone = '{MY-ZONE}'  // eg. 'us-central1-f';
 
 $response = $service->diskTypes->listDiskTypes($project, $zone);
 
@@ -844,7 +844,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->disks->aggregatedList($project);
 
@@ -880,13 +880,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone for this request.
-$zone = '';
+$zone = '{MY-ZONE}'  // eg. 'us-central1-f';
 
 // * Name of the persistent disk to snapshot.
-$disk = '';
+$disk = '{MY-DISK}';
 
 $postBody = new Google_Service_Compute_Snapshot($client);
 
@@ -920,13 +920,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone for this request.
-$zone = '';
+$zone = '{MY-ZONE}'  // eg. 'us-central1-f';
 
 // * Name of the persistent disk to delete.
-$disk = '';
+$disk = '{MY-DISK}';
 
 $response = $service->disks->delete($project, $zone, $disk);
 
@@ -958,13 +958,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone for this request.
-$zone = '';
+$zone = '{MY-ZONE}'  // eg. 'us-central1-f';
 
 // * Name of the persistent disk to return.
-$disk = '';
+$disk = '{MY-DISK}';
 
 $response = $service->disks->get($project, $zone, $disk);
 
@@ -996,10 +996,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone for this request.
-$zone = '';
+$zone = '{MY-ZONE}'  // eg. 'us-central1-f';
 
 $postBody = new Google_Service_Compute_Disk($client);
 
@@ -1033,10 +1033,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone for this request.
-$zone = '';
+$zone = '{MY-ZONE}'  // eg. 'us-central1-f';
 
 $response = $service->disks->listDisks($project, $zone);
 
@@ -1072,10 +1072,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the firewall rule to delete.
-$firewall = '';
+$firewall = '{MY-FIREWALL}';
 
 $response = $service->firewalls->delete($project, $firewall);
 
@@ -1107,10 +1107,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the firewall rule to return.
-$firewall = '';
+$firewall = '{MY-FIREWALL}';
 
 $response = $service->firewalls->get($project, $firewall);
 
@@ -1142,7 +1142,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $postBody = new Google_Service_Compute_Firewall($client);
 
@@ -1176,7 +1176,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->firewalls->listFirewalls($project);
 
@@ -1212,10 +1212,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the firewall rule to update.
-$firewall = '';
+$firewall = '{MY-FIREWALL}';
 
 $postBody = new Google_Service_Compute_Firewall($client);
 
@@ -1249,10 +1249,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the firewall rule to update.
-$firewall = '';
+$firewall = '{MY-FIREWALL}';
 
 $postBody = new Google_Service_Compute_Firewall($client);
 
@@ -1286,7 +1286,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->forwardingRules->aggregatedList($project);
 
@@ -1322,13 +1322,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the region scoping this request.
-$region = '';
+$region = '{MY-REGION}';
 
 // * Name of the ForwardingRule resource to delete.
-$forwardingRule = '';
+$forwardingRule = '{MY-FORWARDING-RULE}';
 
 $response = $service->forwardingRules->delete($project, $region, $forwardingRule);
 
@@ -1360,13 +1360,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the region scoping this request.
-$region = '';
+$region = '{MY-REGION}';
 
 // * Name of the ForwardingRule resource to return.
-$forwardingRule = '';
+$forwardingRule = '{MY-FORWARDING-RULE}';
 
 $response = $service->forwardingRules->get($project, $region, $forwardingRule);
 
@@ -1398,10 +1398,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the region scoping this request.
-$region = '';
+$region = '{MY-REGION}';
 
 $postBody = new Google_Service_Compute_ForwardingRule($client);
 
@@ -1435,10 +1435,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the region scoping this request.
-$region = '';
+$region = '{MY-REGION}';
 
 $response = $service->forwardingRules->listForwardingRules($project, $region);
 
@@ -1474,13 +1474,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the region scoping this request.
-$region = '';
+$region = '{MY-REGION}';
 
 // * Name of the ForwardingRule resource in which target is to be set.
-$forwardingRule = '';
+$forwardingRule = '{MY-FORWARDING-RULE}';
 
 $postBody = new Google_Service_Compute_TargetReference($client);
 
@@ -1514,10 +1514,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the address resource to delete.
-$address = '';
+$address = '{MY-ADDRESS}';
 
 $response = $service->globalAddresses->delete($project, $address);
 
@@ -1549,10 +1549,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the address resource to return.
-$address = '';
+$address = '{MY-ADDRESS}';
 
 $response = $service->globalAddresses->get($project, $address);
 
@@ -1584,7 +1584,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $postBody = new Google_Service_Compute_Address($client);
 
@@ -1618,7 +1618,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->globalAddresses->listGlobalAddresses($project);
 
@@ -1654,10 +1654,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the ForwardingRule resource to delete.
-$forwardingRule = '';
+$forwardingRule = '{MY-FORWARDING-RULE}';
 
 $response = $service->globalForwardingRules->delete($project, $forwardingRule);
 
@@ -1689,10 +1689,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the ForwardingRule resource to return.
-$forwardingRule = '';
+$forwardingRule = '{MY-FORWARDING-RULE}';
 
 $response = $service->globalForwardingRules->get($project, $forwardingRule);
 
@@ -1724,7 +1724,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $postBody = new Google_Service_Compute_ForwardingRule($client);
 
@@ -1758,7 +1758,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->globalForwardingRules->listGlobalForwardingRules($project);
 
@@ -1794,10 +1794,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the ForwardingRule resource in which target is to be set.
-$forwardingRule = '';
+$forwardingRule = '{MY-FORWARDING-RULE}';
 
 $postBody = new Google_Service_Compute_TargetReference($client);
 
@@ -1831,7 +1831,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->globalOperations->aggregatedList($project);
 
@@ -1867,10 +1867,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the Operations resource to delete.
-$operation = '';
+$operation = '{MY-OPERATION}';
 
 $response = $service->globalOperations->delete($project, $operation);
 
@@ -1902,10 +1902,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the Operations resource to return.
-$operation = '';
+$operation = '{MY-OPERATION}';
 
 $response = $service->globalOperations->get($project, $operation);
 
@@ -1937,7 +1937,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->globalOperations->listGlobalOperations($project);
 
@@ -1973,10 +1973,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the HttpHealthCheck resource to delete.
-$httpHealthCheck = '';
+$httpHealthCheck = '{MY-HTTP-HEALTH-CHECK}';
 
 $response = $service->httpHealthChecks->delete($project, $httpHealthCheck);
 
@@ -2008,10 +2008,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the HttpHealthCheck resource to return.
-$httpHealthCheck = '';
+$httpHealthCheck = '{MY-HTTP-HEALTH-CHECK}';
 
 $response = $service->httpHealthChecks->get($project, $httpHealthCheck);
 
@@ -2043,7 +2043,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $postBody = new Google_Service_Compute_HttpHealthCheck($client);
 
@@ -2077,7 +2077,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->httpHealthChecks->listHttpHealthChecks($project);
 
@@ -2113,10 +2113,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the HttpHealthCheck resource to update.
-$httpHealthCheck = '';
+$httpHealthCheck = '{MY-HTTP-HEALTH-CHECK}';
 
 $postBody = new Google_Service_Compute_HttpHealthCheck($client);
 
@@ -2150,10 +2150,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the HttpHealthCheck resource to update.
-$httpHealthCheck = '';
+$httpHealthCheck = '{MY-HTTP-HEALTH-CHECK}';
 
 $postBody = new Google_Service_Compute_HttpHealthCheck($client);
 
@@ -2187,10 +2187,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the HttpsHealthCheck resource to delete.
-$httpsHealthCheck = '';
+$httpsHealthCheck = '{MY-HTTPS-HEALTH-CHECK}';
 
 $response = $service->httpsHealthChecks->delete($project, $httpsHealthCheck);
 
@@ -2222,10 +2222,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the HttpsHealthCheck resource to return.
-$httpsHealthCheck = '';
+$httpsHealthCheck = '{MY-HTTPS-HEALTH-CHECK}';
 
 $response = $service->httpsHealthChecks->get($project, $httpsHealthCheck);
 
@@ -2257,7 +2257,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $postBody = new Google_Service_Compute_HttpsHealthCheck($client);
 
@@ -2291,7 +2291,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->httpsHealthChecks->listHttpsHealthChecks($project);
 
@@ -2327,10 +2327,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the HttpsHealthCheck resource to update.
-$httpsHealthCheck = '';
+$httpsHealthCheck = '{MY-HTTPS-HEALTH-CHECK}';
 
 $postBody = new Google_Service_Compute_HttpsHealthCheck($client);
 
@@ -2364,10 +2364,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the HttpsHealthCheck resource to update.
-$httpsHealthCheck = '';
+$httpsHealthCheck = '{MY-HTTPS-HEALTH-CHECK}';
 
 $postBody = new Google_Service_Compute_HttpsHealthCheck($client);
 
@@ -2401,10 +2401,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the image resource to delete.
-$image = '';
+$image = '{MY-IMAGE}';
 
 $response = $service->images->delete($project, $image);
 
@@ -2436,10 +2436,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Image name.
-$image = '';
+$image = '{MY-IMAGE}';
 
 $postBody = new Google_Service_Compute_DeprecationStatus($client);
 
@@ -2473,10 +2473,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the image resource to return.
-$image = '';
+$image = '{MY-IMAGE}';
 
 $response = $service->images->get($project, $image);
 
@@ -2508,7 +2508,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $postBody = new Google_Service_Compute_Image($client);
 
@@ -2542,7 +2542,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->images->listImages($project);
 
@@ -2578,13 +2578,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone where the managed instance group is located.
-$zone = '';
+$zone = '{MY-ZONE}';
 
 // * The name of the managed instance group.
-$instanceGroupManager = '';
+$instanceGroupManager = '{MY-INSTANCE-GROUP-MANAGER}';
 
 $postBody = new Google_Service_Compute_InstanceGroupManagersAbandonInstancesRequest($client);
 
@@ -2618,7 +2618,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->instanceGroupManagers->aggregatedList($project);
 
@@ -2654,13 +2654,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone where the managed instance group is located.
-$zone = '';
+$zone = '{MY-ZONE}';
 
 // * The name of the managed instance group to delete.
-$instanceGroupManager = '';
+$instanceGroupManager = '{MY-INSTANCE-GROUP-MANAGER}';
 
 $response = $service->instanceGroupManagers->delete($project, $zone, $instanceGroupManager);
 
@@ -2692,13 +2692,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone where the managed instance group is located.
-$zone = '';
+$zone = '{MY-ZONE}';
 
 // * The name of the managed instance group.
-$instanceGroupManager = '';
+$instanceGroupManager = '{MY-INSTANCE-GROUP-MANAGER}';
 
 $postBody = new Google_Service_Compute_InstanceGroupManagersDeleteInstancesRequest($client);
 
@@ -2732,13 +2732,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone where the managed instance group is located.
-$zone = '';
+$zone = '{MY-ZONE}';
 
 // * The name of the managed instance group.
-$instanceGroupManager = '';
+$instanceGroupManager = '{MY-INSTANCE-GROUP-MANAGER}';
 
 $response = $service->instanceGroupManagers->get($project, $zone, $instanceGroupManager);
 
@@ -2770,10 +2770,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone where you want to create the managed instance group.
-$zone = '';
+$zone = '{MY-ZONE}';
 
 $postBody = new Google_Service_Compute_InstanceGroupManager($client);
 
@@ -2807,10 +2807,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone where the managed instance group is located.
-$zone = '';
+$zone = '{MY-ZONE}';
 
 $response = $service->instanceGroupManagers->listInstanceGroupManagers($project, $zone);
 
@@ -2846,13 +2846,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone where the managed instance group is located.
-$zone = '';
+$zone = '{MY-ZONE}';
 
 // * The name of the managed instance group.
-$instanceGroupManager = '';
+$instanceGroupManager = '{MY-INSTANCE-GROUP-MANAGER}';
 
 $response = $service->instanceGroupManagers->listManagedInstances($project, $zone, $instanceGroupManager);
 
@@ -2884,13 +2884,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone where the managed instance group is located.
-$zone = '';
+$zone = '{MY-ZONE}';
 
 // * The name of the managed instance group.
-$instanceGroupManager = '';
+$instanceGroupManager = '{MY-INSTANCE-GROUP-MANAGER}';
 
 $postBody = new Google_Service_Compute_InstanceGroupManagersRecreateInstancesRequest($client);
 
@@ -2924,13 +2924,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone where the managed instance group is located.
-$zone = '';
+$zone = '{MY-ZONE}';
 
 // * The name of the managed instance group.
-$instanceGroupManager = '';
+$instanceGroupManager = '{MY-INSTANCE-GROUP-MANAGER}';
 
 // * The number of running instances that the managed instance group should maintain at any given time.
 //   The group automatically adds or removes instances to maintain the number of instances specified by
@@ -2967,13 +2967,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone where the managed instance group is located.
-$zone = '';
+$zone = '{MY-ZONE}';
 
 // * The name of the managed instance group.
-$instanceGroupManager = '';
+$instanceGroupManager = '{MY-INSTANCE-GROUP-MANAGER}';
 
 $postBody = new Google_Service_Compute_InstanceGroupManagersSetInstanceTemplateRequest($client);
 
@@ -3007,13 +3007,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone where the managed instance group is located.
-$zone = '';
+$zone = '{MY-ZONE}';
 
 // * The name of the managed instance group.
-$instanceGroupManager = '';
+$instanceGroupManager = '{MY-INSTANCE-GROUP-MANAGER}';
 
 $postBody = new Google_Service_Compute_InstanceGroupManagersSetTargetPoolsRequest($client);
 
@@ -3047,13 +3047,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone where the instance group is located.
-$zone = '';
+$zone = '{MY-ZONE}';
 
 // * The name of the instance group where you are adding instances.
-$instanceGroup = '';
+$instanceGroup = '{MY-INSTANCE-GROUP}';
 
 $postBody = new Google_Service_Compute_InstanceGroupsAddInstancesRequest($client);
 
@@ -3087,7 +3087,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->instanceGroups->aggregatedList($project);
 
@@ -3123,13 +3123,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone where the instance group is located.
-$zone = '';
+$zone = '{MY-ZONE}';
 
 // * The name of the instance group to delete.
-$instanceGroup = '';
+$instanceGroup = '{MY-INSTANCE-GROUP}';
 
 $response = $service->instanceGroups->delete($project, $zone, $instanceGroup);
 
@@ -3161,13 +3161,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone where the instance group is located.
-$zone = '';
+$zone = '{MY-ZONE}';
 
 // * The name of the instance group.
-$instanceGroup = '';
+$instanceGroup = '{MY-INSTANCE-GROUP}';
 
 $response = $service->instanceGroups->get($project, $zone, $instanceGroup);
 
@@ -3199,10 +3199,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone where you want to create the instance group.
-$zone = '';
+$zone = '{MY-ZONE}';
 
 $postBody = new Google_Service_Compute_InstanceGroup($client);
 
@@ -3236,10 +3236,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone where the instance group is located.
-$zone = '';
+$zone = '{MY-ZONE}';
 
 $response = $service->instanceGroups->listInstanceGroups($project, $zone);
 
@@ -3275,13 +3275,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone where the instance group is located.
-$zone = '';
+$zone = '{MY-ZONE}';
 
 // * The name of the instance group from which you want to generate a list of included instances.
-$instanceGroup = '';
+$instanceGroup = '{MY-INSTANCE-GROUP}';
 
 $postBody = new Google_Service_Compute_InstanceGroupsListInstancesRequest($client);
 
@@ -3319,13 +3319,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone where the instance group is located.
-$zone = '';
+$zone = '{MY-ZONE}';
 
 // * The name of the instance group where the specified instances will be removed.
-$instanceGroup = '';
+$instanceGroup = '{MY-INSTANCE-GROUP}';
 
 $postBody = new Google_Service_Compute_InstanceGroupsRemoveInstancesRequest($client);
 
@@ -3359,13 +3359,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone where the instance group is located.
-$zone = '';
+$zone = '{MY-ZONE}';
 
 // * The name of the instance group where the named ports are updated.
-$instanceGroup = '';
+$instanceGroup = '{MY-INSTANCE-GROUP}';
 
 $postBody = new Google_Service_Compute_InstanceGroupsSetNamedPortsRequest($client);
 
@@ -3399,10 +3399,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the instance template to delete.
-$instanceTemplate = '';
+$instanceTemplate = '{MY-INSTANCE-TEMPLATE}';
 
 $response = $service->instanceTemplates->delete($project, $instanceTemplate);
 
@@ -3434,10 +3434,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the instance template.
-$instanceTemplate = '';
+$instanceTemplate = '{MY-INSTANCE-TEMPLATE}';
 
 $response = $service->instanceTemplates->get($project, $instanceTemplate);
 
@@ -3469,7 +3469,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $postBody = new Google_Service_Compute_InstanceTemplate($client);
 
@@ -3503,7 +3503,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->instanceTemplates->listInstanceTemplates($project);
 
@@ -3539,16 +3539,16 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone for this request.
-$zone = '';
+$zone = '{MY-ZONE}'  // eg. 'us-central1-f';
 
 // * The instance name for this request.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 // * The name of the network interface to add to this instance.
-$networkInterface = '';
+$networkInterface = '{MY-NETWORK-INTERFACE}';
 
 $postBody = new Google_Service_Compute_AccessConfig($client);
 
@@ -3582,7 +3582,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->instances->aggregatedList($project);
 
@@ -3618,13 +3618,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone for this request.
-$zone = '';
+$zone = '{MY-ZONE}'  // eg. 'us-central1-f';
 
 // * The instance name for this request.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 $postBody = new Google_Service_Compute_AttachedDisk($client);
 
@@ -3658,13 +3658,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone for this request.
-$zone = '';
+$zone = '{MY-ZONE}'  // eg. 'us-central1-f';
 
 // * Name of the instance resource to delete.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 $response = $service->instances->delete($project, $zone, $instance);
 
@@ -3696,19 +3696,19 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone for this request.
-$zone = '';
+$zone = '{MY-ZONE}'  // eg. 'us-central1-f';
 
 // * The instance name for this request.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 // * The name of the access config to delete.
-$accessConfig = '';
+$accessConfig = '{MY-ACCESS-CONFIG}';
 
 // * The name of the network interface.
-$networkInterface = '';
+$networkInterface = '{MY-NETWORK-INTERFACE}';
 
 $response = $service->instances->deleteAccessConfig($project, $zone, $instance, $accessConfig, $networkInterface);
 
@@ -3740,16 +3740,16 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone for this request.
-$zone = '';
+$zone = '{MY-ZONE}'  // eg. 'us-central1-f';
 
 // * Instance name.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 // * Disk device name to detach.
-$deviceName = '';
+$deviceName = '{MY-DEVICE-NAME}';
 
 $response = $service->instances->detachDisk($project, $zone, $instance, $deviceName);
 
@@ -3781,13 +3781,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone for this request.
-$zone = '';
+$zone = '{MY-ZONE}'  // eg. 'us-central1-f';
 
 // * Name of the instance resource to return.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 $response = $service->instances->get($project, $zone, $instance);
 
@@ -3819,13 +3819,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone for this request.
-$zone = '';
+$zone = '{MY-ZONE}'  // eg. 'us-central1-f';
 
 // * Name of the instance scoping this request.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 $response = $service->instances->getSerialPortOutput($project, $zone, $instance);
 
@@ -3857,10 +3857,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone for this request.
-$zone = '';
+$zone = '{MY-ZONE}'  // eg. 'us-central1-f';
 
 $postBody = new Google_Service_Compute_Instance($client);
 
@@ -3894,10 +3894,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone for this request.
-$zone = '';
+$zone = '{MY-ZONE}'  // eg. 'us-central1-f';
 
 $response = $service->instances->listInstances($project, $zone);
 
@@ -3933,13 +3933,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone for this request.
-$zone = '';
+$zone = '{MY-ZONE}'  // eg. 'us-central1-f';
 
 // * Name of the instance scoping this request.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 $response = $service->instances->reset($project, $zone, $instance);
 
@@ -3971,19 +3971,19 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone for this request.
-$zone = '';
+$zone = '{MY-ZONE}'  // eg. 'us-central1-f';
 
 // * The instance name.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 // * Whether to auto-delete the disk when the instance is deleted.
 $autoDelete = false;
 
 // * The device name of the disk to modify.
-$deviceName = '';
+$deviceName = '{MY-DEVICE-NAME}';
 
 $response = $service->instances->setDiskAutoDelete($project, $zone, $instance, $autoDelete, $deviceName);
 
@@ -4015,13 +4015,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone for this request.
-$zone = '';
+$zone = '{MY-ZONE}'  // eg. 'us-central1-f';
 
 // * Name of the instance scoping this request.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 $postBody = new Google_Service_Compute_InstancesSetMachineTypeRequest($client);
 
@@ -4055,13 +4055,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone for this request.
-$zone = '';
+$zone = '{MY-ZONE}'  // eg. 'us-central1-f';
 
 // * Name of the instance scoping this request.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 $postBody = new Google_Service_Compute_Metadata($client);
 
@@ -4095,13 +4095,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone for this request.
-$zone = '';
+$zone = '{MY-ZONE}'  // eg. 'us-central1-f';
 
 // * Instance name.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 $postBody = new Google_Service_Compute_Scheduling($client);
 
@@ -4135,13 +4135,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone for this request.
-$zone = '';
+$zone = '{MY-ZONE}'  // eg. 'us-central1-f';
 
 // * Name of the instance scoping this request.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 $postBody = new Google_Service_Compute_Tags($client);
 
@@ -4175,13 +4175,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone for this request.
-$zone = '';
+$zone = '{MY-ZONE}'  // eg. 'us-central1-f';
 
 // * Name of the instance resource to start.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 $response = $service->instances->start($project, $zone, $instance);
 
@@ -4213,13 +4213,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone for this request.
-$zone = '';
+$zone = '{MY-ZONE}'  // eg. 'us-central1-f';
 
 // * Name of the instance resource to stop.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 $response = $service->instances->stop($project, $zone, $instance);
 
@@ -4251,10 +4251,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the License resource to return.
-$license = '';
+$license = '{MY-LICENSE}';
 
 $response = $service->licenses->get($project, $license);
 
@@ -4286,7 +4286,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->machineTypes->aggregatedList($project);
 
@@ -4322,13 +4322,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone for this request.
-$zone = '';
+$zone = '{MY-ZONE}'  // eg. 'us-central1-f';
 
 // * Name of the machine type to return.
-$machineType = '';
+$machineType = '{MY-MACHINE-TYPE}';
 
 $response = $service->machineTypes->get($project, $zone, $machineType);
 
@@ -4360,10 +4360,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone for this request.
-$zone = '';
+$zone = '{MY-ZONE}'  // eg. 'us-central1-f';
 
 $response = $service->machineTypes->listMachineTypes($project, $zone);
 
@@ -4399,10 +4399,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the network to delete.
-$network = '';
+$network = '{MY-NETWORK}';
 
 $response = $service->networks->delete($project, $network);
 
@@ -4434,10 +4434,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the network to return.
-$network = '';
+$network = '{MY-NETWORK}';
 
 $response = $service->networks->get($project, $network);
 
@@ -4469,7 +4469,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $postBody = new Google_Service_Compute_Network($client);
 
@@ -4503,7 +4503,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->networks->listNetworks($project);
 
@@ -4539,7 +4539,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->projects->get($project);
 
@@ -4571,7 +4571,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $postBody = new Google_Service_Compute_DiskMoveRequest($client);
 
@@ -4605,7 +4605,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $postBody = new Google_Service_Compute_InstanceMoveRequest($client);
 
@@ -4639,7 +4639,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $postBody = new Google_Service_Compute_Metadata($client);
 
@@ -4673,7 +4673,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $postBody = new Google_Service_Compute_UsageExportLocation($client);
 
@@ -4707,13 +4707,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the region for this request.
-$region = '';
+$region = '{MY-REGION}';
 
 // * Name of the Operations resource to delete.
-$operation = '';
+$operation = '{MY-OPERATION}';
 
 $response = $service->regionOperations->delete($project, $region, $operation);
 
@@ -4745,13 +4745,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the region for this request.
-$region = '';
+$region = '{MY-REGION}';
 
 // * Name of the Operations resource to return.
-$operation = '';
+$operation = '{MY-OPERATION}';
 
 $response = $service->regionOperations->get($project, $region, $operation);
 
@@ -4783,10 +4783,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the region for this request.
-$region = '';
+$region = '{MY-REGION}';
 
 $response = $service->regionOperations->listRegionOperations($project, $region);
 
@@ -4822,10 +4822,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the region resource to return.
-$region = '';
+$region = '{MY-REGION}';
 
 $response = $service->regions->get($project, $region);
 
@@ -4857,7 +4857,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->regions->listRegions($project);
 
@@ -4893,10 +4893,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the Route resource to delete.
-$route = '';
+$route = '{MY-ROUTE}';
 
 $response = $service->routes->delete($project, $route);
 
@@ -4928,10 +4928,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the Route resource to return.
-$route = '';
+$route = '{MY-ROUTE}';
 
 $response = $service->routes->get($project, $route);
 
@@ -4963,7 +4963,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $postBody = new Google_Service_Compute_Route($client);
 
@@ -4997,7 +4997,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->routes->listRoutes($project);
 
@@ -5033,10 +5033,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the Snapshot resource to delete.
-$snapshot = '';
+$snapshot = '{MY-SNAPSHOT}';
 
 $response = $service->snapshots->delete($project, $snapshot);
 
@@ -5068,10 +5068,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the Snapshot resource to return.
-$snapshot = '';
+$snapshot = '{MY-SNAPSHOT}';
 
 $response = $service->snapshots->get($project, $snapshot);
 
@@ -5103,7 +5103,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->snapshots->listSnapshots($project);
 
@@ -5139,10 +5139,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the SslCertificate resource to delete.
-$sslCertificate = '';
+$sslCertificate = '{MY-SSL-CERTIFICATE}';
 
 $response = $service->sslCertificates->delete($project, $sslCertificate);
 
@@ -5174,10 +5174,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the SslCertificate resource to return.
-$sslCertificate = '';
+$sslCertificate = '{MY-SSL-CERTIFICATE}';
 
 $response = $service->sslCertificates->get($project, $sslCertificate);
 
@@ -5209,7 +5209,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $postBody = new Google_Service_Compute_SslCertificate($client);
 
@@ -5243,7 +5243,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->sslCertificates->listSslCertificates($project);
 
@@ -5279,7 +5279,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->subnetworks->aggregatedList($project);
 
@@ -5315,13 +5315,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the region scoping this request.
-$region = '';
+$region = '{MY-REGION}';
 
 // * Name of the Subnetwork resource to delete.
-$subnetwork = '';
+$subnetwork = '{MY-SUBNETWORK}';
 
 $response = $service->subnetworks->delete($project, $region, $subnetwork);
 
@@ -5353,13 +5353,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the region scoping this request.
-$region = '';
+$region = '{MY-REGION}';
 
 // * Name of the Subnetwork resource to return.
-$subnetwork = '';
+$subnetwork = '{MY-SUBNETWORK}';
 
 $response = $service->subnetworks->get($project, $region, $subnetwork);
 
@@ -5391,10 +5391,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the region scoping this request.
-$region = '';
+$region = '{MY-REGION}';
 
 $postBody = new Google_Service_Compute_Subnetwork($client);
 
@@ -5428,10 +5428,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the region scoping this request.
-$region = '';
+$region = '{MY-REGION}';
 
 $response = $service->subnetworks->listSubnetworks($project, $region);
 
@@ -5467,10 +5467,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the TargetHttpProxy resource to delete.
-$targetHttpProxy = '';
+$targetHttpProxy = '{MY-TARGET-HTTP-PROXY}';
 
 $response = $service->targetHttpProxies->delete($project, $targetHttpProxy);
 
@@ -5502,10 +5502,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the TargetHttpProxy resource to return.
-$targetHttpProxy = '';
+$targetHttpProxy = '{MY-TARGET-HTTP-PROXY}';
 
 $response = $service->targetHttpProxies->get($project, $targetHttpProxy);
 
@@ -5537,7 +5537,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $postBody = new Google_Service_Compute_TargetHttpProxy($client);
 
@@ -5571,7 +5571,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->targetHttpProxies->listTargetHttpProxies($project);
 
@@ -5607,10 +5607,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the TargetHttpProxy to set a URL map for.
-$targetHttpProxy = '';
+$targetHttpProxy = '{MY-TARGET-HTTP-PROXY}';
 
 $postBody = new Google_Service_Compute_UrlMapReference($client);
 
@@ -5644,10 +5644,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the TargetHttpsProxy resource to delete.
-$targetHttpsProxy = '';
+$targetHttpsProxy = '{MY-TARGET-HTTPS-PROXY}';
 
 $response = $service->targetHttpsProxies->delete($project, $targetHttpsProxy);
 
@@ -5679,10 +5679,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the TargetHttpsProxy resource to return.
-$targetHttpsProxy = '';
+$targetHttpsProxy = '{MY-TARGET-HTTPS-PROXY}';
 
 $response = $service->targetHttpsProxies->get($project, $targetHttpsProxy);
 
@@ -5714,7 +5714,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $postBody = new Google_Service_Compute_TargetHttpsProxy($client);
 
@@ -5748,7 +5748,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->targetHttpsProxies->listTargetHttpsProxies($project);
 
@@ -5784,10 +5784,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the TargetHttpsProxy resource to set an SslCertificates resource for.
-$targetHttpsProxy = '';
+$targetHttpsProxy = '{MY-TARGET-HTTPS-PROXY}';
 
 $postBody = new Google_Service_Compute_TargetHttpsProxiesSetSslCertificatesRequest($client);
 
@@ -5821,10 +5821,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the TargetHttpsProxy resource whose URL map is to be set.
-$targetHttpsProxy = '';
+$targetHttpsProxy = '{MY-TARGET-HTTPS-PROXY}';
 
 $postBody = new Google_Service_Compute_UrlMapReference($client);
 
@@ -5858,7 +5858,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->targetInstances->aggregatedList($project);
 
@@ -5894,13 +5894,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the zone scoping this request.
-$zone = '';
+$zone = '{MY-ZONE}'  // eg. 'us-central1-f';
 
 // * Name of the TargetInstance resource to delete.
-$targetInstance = '';
+$targetInstance = '{MY-TARGET-INSTANCE}';
 
 $response = $service->targetInstances->delete($project, $zone, $targetInstance);
 
@@ -5932,13 +5932,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the zone scoping this request.
-$zone = '';
+$zone = '{MY-ZONE}'  // eg. 'us-central1-f';
 
 // * Name of the TargetInstance resource to return.
-$targetInstance = '';
+$targetInstance = '{MY-TARGET-INSTANCE}';
 
 $response = $service->targetInstances->get($project, $zone, $targetInstance);
 
@@ -5970,10 +5970,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the zone scoping this request.
-$zone = '';
+$zone = '{MY-ZONE}'  // eg. 'us-central1-f';
 
 $postBody = new Google_Service_Compute_TargetInstance($client);
 
@@ -6007,10 +6007,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the zone scoping this request.
-$zone = '';
+$zone = '{MY-ZONE}'  // eg. 'us-central1-f';
 
 $response = $service->targetInstances->listTargetInstances($project, $zone);
 
@@ -6046,13 +6046,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the region scoping this request.
-$region = '';
+$region = '{MY-REGION}';
 
 // * Name of the target pool to add a health check to.
-$targetPool = '';
+$targetPool = '{MY-TARGET-POOL}';
 
 $postBody = new Google_Service_Compute_TargetPoolsAddHealthCheckRequest($client);
 
@@ -6086,13 +6086,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the region scoping this request.
-$region = '';
+$region = '{MY-REGION}';
 
 // * Name of the TargetPool resource to add instances to.
-$targetPool = '';
+$targetPool = '{MY-TARGET-POOL}';
 
 $postBody = new Google_Service_Compute_TargetPoolsAddInstanceRequest($client);
 
@@ -6126,7 +6126,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->targetPools->aggregatedList($project);
 
@@ -6162,13 +6162,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the region scoping this request.
-$region = '';
+$region = '{MY-REGION}';
 
 // * Name of the TargetPool resource to delete.
-$targetPool = '';
+$targetPool = '{MY-TARGET-POOL}';
 
 $response = $service->targetPools->delete($project, $region, $targetPool);
 
@@ -6200,13 +6200,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the region scoping this request.
-$region = '';
+$region = '{MY-REGION}';
 
 // * Name of the TargetPool resource to return.
-$targetPool = '';
+$targetPool = '{MY-TARGET-POOL}';
 
 $response = $service->targetPools->get($project, $region, $targetPool);
 
@@ -6238,13 +6238,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the region scoping this request.
-$region = '';
+$region = '{MY-REGION}';
 
 // * Name of the TargetPool resource to which the queried instance belongs.
-$targetPool = '';
+$targetPool = '{MY-TARGET-POOL}';
 
 $postBody = new Google_Service_Compute_InstanceReference($client);
 
@@ -6278,10 +6278,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the region scoping this request.
-$region = '';
+$region = '{MY-REGION}';
 
 $postBody = new Google_Service_Compute_TargetPool($client);
 
@@ -6315,10 +6315,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the region scoping this request.
-$region = '';
+$region = '{MY-REGION}';
 
 $response = $service->targetPools->listTargetPools($project, $region);
 
@@ -6354,13 +6354,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the region for this request.
-$region = '';
+$region = '{MY-REGION}';
 
 // * Name of the target pool to remove health checks from.
-$targetPool = '';
+$targetPool = '{MY-TARGET-POOL}';
 
 $postBody = new Google_Service_Compute_TargetPoolsRemoveHealthCheckRequest($client);
 
@@ -6394,13 +6394,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the region scoping this request.
-$region = '';
+$region = '{MY-REGION}';
 
 // * Name of the TargetPool resource to remove instances from.
-$targetPool = '';
+$targetPool = '{MY-TARGET-POOL}';
 
 $postBody = new Google_Service_Compute_TargetPoolsRemoveInstanceRequest($client);
 
@@ -6434,13 +6434,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the region scoping this request.
-$region = '';
+$region = '{MY-REGION}';
 
 // * Name of the TargetPool resource to set a backup pool for.
-$targetPool = '';
+$targetPool = '{MY-TARGET-POOL}';
 
 $postBody = new Google_Service_Compute_TargetReference($client);
 
@@ -6474,7 +6474,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->targetVpnGateways->aggregatedList($project);
 
@@ -6510,13 +6510,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the region for this request.
-$region = '';
+$region = '{MY-REGION}';
 
 // * Name of the target VPN gateway to delete.
-$targetVpnGateway = '';
+$targetVpnGateway = '{MY-TARGET-VPN-GATEWAY}';
 
 $response = $service->targetVpnGateways->delete($project, $region, $targetVpnGateway);
 
@@ -6548,13 +6548,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the region for this request.
-$region = '';
+$region = '{MY-REGION}';
 
 // * Name of the target VPN gateway to return.
-$targetVpnGateway = '';
+$targetVpnGateway = '{MY-TARGET-VPN-GATEWAY}';
 
 $response = $service->targetVpnGateways->get($project, $region, $targetVpnGateway);
 
@@ -6586,10 +6586,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the region for this request.
-$region = '';
+$region = '{MY-REGION}';
 
 $postBody = new Google_Service_Compute_TargetVpnGateway($client);
 
@@ -6623,10 +6623,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the region for this request.
-$region = '';
+$region = '{MY-REGION}';
 
 $response = $service->targetVpnGateways->listTargetVpnGateways($project, $region);
 
@@ -6662,10 +6662,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the UrlMap resource to delete.
-$urlMap = '';
+$urlMap = '{MY-URL-MAP}';
 
 $response = $service->urlMaps->delete($project, $urlMap);
 
@@ -6697,10 +6697,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the UrlMap resource to return.
-$urlMap = '';
+$urlMap = '{MY-URL-MAP}';
 
 $response = $service->urlMaps->get($project, $urlMap);
 
@@ -6732,7 +6732,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $postBody = new Google_Service_Compute_UrlMap($client);
 
@@ -6766,7 +6766,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->urlMaps->listUrlMaps($project);
 
@@ -6802,10 +6802,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the UrlMap resource to update.
-$urlMap = '';
+$urlMap = '{MY-URL-MAP}';
 
 $postBody = new Google_Service_Compute_UrlMap($client);
 
@@ -6839,10 +6839,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the UrlMap resource to update.
-$urlMap = '';
+$urlMap = '{MY-URL-MAP}';
 
 $postBody = new Google_Service_Compute_UrlMap($client);
 
@@ -6876,10 +6876,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the UrlMap resource to be validated as.
-$urlMap = '';
+$urlMap = '{MY-URL-MAP}';
 
 $postBody = new Google_Service_Compute_UrlMapsValidateRequest($client);
 
@@ -6913,7 +6913,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->vpnTunnels->aggregatedList($project);
 
@@ -6949,13 +6949,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the region for this request.
-$region = '';
+$region = '{MY-REGION}';
 
 // * Name of the VpnTunnel resource to delete.
-$vpnTunnel = '';
+$vpnTunnel = '{MY-VPN-TUNNEL}';
 
 $response = $service->vpnTunnels->delete($project, $region, $vpnTunnel);
 
@@ -6987,13 +6987,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the region for this request.
-$region = '';
+$region = '{MY-REGION}';
 
 // * Name of the VpnTunnel resource to return.
-$vpnTunnel = '';
+$vpnTunnel = '{MY-VPN-TUNNEL}';
 
 $response = $service->vpnTunnels->get($project, $region, $vpnTunnel);
 
@@ -7025,10 +7025,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the region for this request.
-$region = '';
+$region = '{MY-REGION}';
 
 $postBody = new Google_Service_Compute_VpnTunnel($client);
 
@@ -7062,10 +7062,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the region for this request.
-$region = '';
+$region = '{MY-REGION}';
 
 $response = $service->vpnTunnels->listVpnTunnels($project, $region);
 
@@ -7101,13 +7101,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the zone for this request.
-$zone = '';
+$zone = '{MY-ZONE}'  // eg. 'us-central1-f';
 
 // * Name of the Operations resource to delete.
-$operation = '';
+$operation = '{MY-OPERATION}';
 
 $response = $service->zoneOperations->delete($project, $zone, $operation);
 
@@ -7139,13 +7139,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the zone for this request.
-$zone = '';
+$zone = '{MY-ZONE}'  // eg. 'us-central1-f';
 
 // * Name of the Operations resource to return.
-$operation = '';
+$operation = '{MY-OPERATION}';
 
 $response = $service->zoneOperations->get($project, $zone, $operation);
 
@@ -7177,10 +7177,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the zone for request.
-$zone = '';
+$zone = '{MY-ZONE}'  // eg. 'us-central1-f';
 
 $response = $service->zoneOperations->listZoneOperations($project, $zone);
 
@@ -7216,10 +7216,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the zone resource to return.
-$zone = '';
+$zone = '{MY-ZONE}'  // eg. 'us-central1-f';
 
 $response = $service->zones->get($project, $zone);
 
@@ -7251,7 +7251,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 // * Project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->zones->listZones($project);
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_container.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_container.v1.json.baseline
@@ -28,11 +28,11 @@ $service = new Google_Service_Container($client);
 
 // * The Google Developers Console [project ID or project number]
 //   (https://developers.google.com/console/help/new/#projectnumber).
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 // * The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
 //   resides.
-$zone = '';
+$zone = '{MY-ZONE}';
 
 $postBody = new Google_Service_Container_CreateClusterRequest($client);
 
@@ -67,14 +67,14 @@ $service = new Google_Service_Container($client);
 
 // * The Google Developers Console [project ID or project number]
 //   (https://developers.google.com/console/help/new/#projectnumber).
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 // * The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
 //   resides.
-$zone = '';
+$zone = '{MY-ZONE}';
 
 // * The name of the cluster to delete.
-$clusterId = '';
+$clusterId = '{MY-CLUSTER-ID}';
 
 $response = $service->projects_zones_clusters->delete($projectId, $zone, $clusterId);
 
@@ -107,14 +107,14 @@ $service = new Google_Service_Container($client);
 
 // * The Google Developers Console [project ID or project number]
 //   (https://developers.google.com/console/help/new/#projectnumber).
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 // * The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
 //   resides.
-$zone = '';
+$zone = '{MY-ZONE}';
 
 // * The name of the cluster to retrieve.
-$clusterId = '';
+$clusterId = '{MY-CLUSTER-ID}';
 
 $response = $service->projects_zones_clusters->get($projectId, $zone, $clusterId);
 
@@ -147,11 +147,11 @@ $service = new Google_Service_Container($client);
 
 // * The Google Developers Console [project ID or project number]
 //   (https://developers.google.com/console/help/new/#projectnumber).
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 // * The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
 //   resides, or "-" for all zones.
-$zone = '';
+$zone = '{MY-ZONE}';
 
 $response = $service->projects_zones_clusters->listProjectsZonesClusters($projectId, $zone);
 
@@ -184,14 +184,14 @@ $service = new Google_Service_Container($client);
 
 // * The Google Developers Console [project ID or project number]
 //   (https://developers.google.com/console/help/new/#projectnumber).
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 // * The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
 //   resides.
-$zone = '';
+$zone = '{MY-ZONE}';
 
 // * The name of the cluster to upgrade.
-$clusterId = '';
+$clusterId = '{MY-CLUSTER-ID}';
 
 $postBody = new Google_Service_Container_UpdateClusterRequest($client);
 
@@ -226,11 +226,11 @@ $service = new Google_Service_Container($client);
 
 // * The Google Developers Console [project ID or project number]
 //   (https://developers.google.com/console/help/new/#projectnumber).
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 // * The name of the Google Compute Engine [zone](/compute/docs/zones#available) to return operations
 //   for, or "-" for all zones.
-$zone = '';
+$zone = '{MY-ZONE}';
 
 $response = $service->projects_zones->getServerconfig($projectId, $zone);
 
@@ -263,14 +263,14 @@ $service = new Google_Service_Container($client);
 
 // * The Google Developers Console [project ID or project number]
 //   (https://developers.google.com/console/help/new/#projectnumber).
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 // * The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
 //   resides.
-$zone = '';
+$zone = '{MY-ZONE}';
 
 // * The server-assigned `name` of the operation.
-$operationId = '';
+$operationId = '{MY-OPERATION-ID}';
 
 $response = $service->projects_zones_operations->get($projectId, $zone, $operationId);
 
@@ -303,11 +303,11 @@ $service = new Google_Service_Container($client);
 
 // * The Google Developers Console [project ID or project number]
 //   (https://developers.google.com/console/help/new/#projectnumber).
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 // * The name of the Google Compute Engine [zone](/compute/docs/zones#available) to return operations
 //   for, or "-" for all zones.
-$zone = '';
+$zone = '{MY-ZONE}';
 
 $response = $service->projects_zones_operations->listProjectsZonesOperations($projectId, $zone);
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_dataflow.v1b3.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_dataflow.v1b3.json.baseline
@@ -27,7 +27,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Dataflow($client);
 
 // * The project which owns the job.
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 $postBody = new Google_Service_Dataflow_Job($client);
 
@@ -61,10 +61,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Dataflow($client);
 
 // * The project which owns the job.
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 // * Identifies a single job.
-$jobId = '';
+$jobId = '{MY-JOB-ID}';
 
 $response = $service->projects_jobs->get($projectId, $jobId);
 
@@ -96,10 +96,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Dataflow($client);
 
 // * A project id.
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 // * The job to get messages for.
-$jobId = '';
+$jobId = '{MY-JOB-ID}';
 
 $response = $service->projects_jobs->getMetrics($projectId, $jobId);
 
@@ -131,7 +131,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Dataflow($client);
 
 // * The project which owns the jobs.
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 $response = $service->projects_jobs->listProjectsJobs($projectId);
 
@@ -167,10 +167,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Dataflow($client);
 
 // * A project id.
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 // * The job to get messages about.
-$jobId = '';
+$jobId = '{MY-JOB-ID}';
 
 $response = $service->projects_jobs_messages->listProjectsJobsMessages($projectId, $jobId);
 
@@ -206,10 +206,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Dataflow($client);
 
 // * The project which owns the job.
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 // * Identifies a single job.
-$jobId = '';
+$jobId = '{MY-JOB-ID}';
 
 $postBody = new Google_Service_Dataflow_Job($client);
 
@@ -243,10 +243,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Dataflow($client);
 
 // * Identifies the project this worker belongs to.
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 // * Identifies the workflow job this worker belongs to.
-$jobId = '';
+$jobId = '{MY-JOB-ID}';
 
 $postBody = new Google_Service_Dataflow_LeaseWorkItemRequest($client);
 
@@ -280,10 +280,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Dataflow($client);
 
 // * The project which owns the WorkItem's job.
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 // * The job which the WorkItem is part of.
-$jobId = '';
+$jobId = '{MY-JOB-ID}';
 
 $postBody = new Google_Service_Dataflow_ReportWorkItemStatusRequest($client);
 
@@ -317,7 +317,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Dataflow($client);
 
 // * The project to send the WorkerMessages to.
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 $postBody = new Google_Service_Dataflow_SendWorkerMessagesRequest($client);
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_dataproc.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_dataproc.v1.json.baseline
@@ -27,10 +27,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Dataproc($client);
 
 // * [Required] The ID of the Google Cloud Platform project that the cluster belongs to.
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 // * [Required] The Cloud Dataproc region in which to handle the request.
-$region = '';
+$region = '{MY-REGION}';
 
 $postBody = new Google_Service_Dataproc_Cluster($client);
 
@@ -64,13 +64,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Dataproc($client);
 
 // * [Required] The ID of the Google Cloud Platform project that the cluster belongs to.
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 // * [Required] The Cloud Dataproc region in which to handle the request.
-$region = '';
+$region = '{MY-REGION}';
 
 // * [Required] The cluster name.
-$clusterName = '';
+$clusterName = '{MY-CLUSTER-NAME}';
 
 $response = $service->projects_regions_clusters->delete($projectId, $region, $clusterName);
 
@@ -102,13 +102,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Dataproc($client);
 
 // * [Required] The ID of the Google Cloud Platform project that the cluster belongs to.
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 // * [Required] The Cloud Dataproc region in which to handle the request.
-$region = '';
+$region = '{MY-REGION}';
 
 // * [Required] The cluster name.
-$clusterName = '';
+$clusterName = '{MY-CLUSTER-NAME}';
 
 $postBody = new Google_Service_Dataproc_DiagnoseClusterRequest($client);
 
@@ -142,13 +142,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Dataproc($client);
 
 // * [Required] The ID of the Google Cloud Platform project that the cluster belongs to.
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 // * [Required] The Cloud Dataproc region in which to handle the request.
-$region = '';
+$region = '{MY-REGION}';
 
 // * [Required] The cluster name.
-$clusterName = '';
+$clusterName = '{MY-CLUSTER-NAME}';
 
 $response = $service->projects_regions_clusters->get($projectId, $region, $clusterName);
 
@@ -180,10 +180,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Dataproc($client);
 
 // * [Required] The ID of the Google Cloud Platform project that the cluster belongs to.
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 // * [Required] The Cloud Dataproc region in which to handle the request.
-$region = '';
+$region = '{MY-REGION}';
 
 $response = $service->projects_regions_clusters->listProjectsRegionsClusters($projectId, $region);
 
@@ -219,13 +219,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Dataproc($client);
 
 // * [Required] The ID of the Google Cloud Platform project the cluster belongs to.
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 // * [Required] The Cloud Dataproc region in which to handle the request.
-$region = '';
+$region = '{MY-REGION}';
 
 // * [Required] The cluster name.
-$clusterName = '';
+$clusterName = '{MY-CLUSTER-NAME}';
 
 $postBody = new Google_Service_Dataproc_Cluster($client);
 
@@ -259,13 +259,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Dataproc($client);
 
 // * [Required] The ID of the Google Cloud Platform project that the job belongs to.
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 // * [Required] The Cloud Dataproc region in which to handle the request.
-$region = '';
+$region = '{MY-REGION}';
 
 // * [Required] The job ID.
-$jobId = '';
+$jobId = '{MY-JOB-ID}';
 
 $postBody = new Google_Service_Dataproc_CancelJobRequest($client);
 
@@ -299,13 +299,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Dataproc($client);
 
 // * [Required] The ID of the Google Cloud Platform project that the job belongs to.
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 // * [Required] The Cloud Dataproc region in which to handle the request.
-$region = '';
+$region = '{MY-REGION}';
 
 // * [Required] The job ID.
-$jobId = '';
+$jobId = '{MY-JOB-ID}';
 
 $response = $service->projects_regions_jobs->delete($projectId, $region, $jobId);
 
@@ -337,13 +337,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Dataproc($client);
 
 // * [Required] The ID of the Google Cloud Platform project that the job belongs to.
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 // * [Required] The Cloud Dataproc region in which to handle the request.
-$region = '';
+$region = '{MY-REGION}';
 
 // * [Required] The job ID.
-$jobId = '';
+$jobId = '{MY-JOB-ID}';
 
 $response = $service->projects_regions_jobs->get($projectId, $region, $jobId);
 
@@ -375,10 +375,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Dataproc($client);
 
 // * [Required] The ID of the Google Cloud Platform project that the job belongs to.
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 // * [Required] The Cloud Dataproc region in which to handle the request.
-$region = '';
+$region = '{MY-REGION}';
 
 $response = $service->projects_regions_jobs->listProjectsRegionsJobs($projectId, $region);
 
@@ -414,10 +414,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Dataproc($client);
 
 // * [Required] The ID of the Google Cloud Platform project that the job belongs to.
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 // * [Required] The Cloud Dataproc region in which to handle the request.
-$region = '';
+$region = '{MY-REGION}';
 
 $postBody = new Google_Service_Dataproc_SubmitJobRequest($client);
 
@@ -547,7 +547,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Dataproc($client);
 
 // * The name of the operation collection.
-$name = '';
+$name = '{MY-NAME}';
 
 $response = $service->projects_regions_operations->listProjectsRegionsOperations($name);
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_datastore.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_datastore.v1beta2.json.baseline
@@ -27,7 +27,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Datastore($client);
 
 // * Identifies the dataset.
-$datasetId = '';
+$datasetId = '{MY-DATASET-ID}';
 
 $postBody = new Google_Service_Datastore_AllocateIdsRequest($client);
 
@@ -61,7 +61,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Datastore($client);
 
 // * Identifies the dataset.
-$datasetId = '';
+$datasetId = '{MY-DATASET-ID}';
 
 $postBody = new Google_Service_Datastore_BeginTransactionRequest($client);
 
@@ -95,7 +95,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Datastore($client);
 
 // * Identifies the dataset.
-$datasetId = '';
+$datasetId = '{MY-DATASET-ID}';
 
 $postBody = new Google_Service_Datastore_CommitRequest($client);
 
@@ -129,7 +129,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Datastore($client);
 
 // * Identifies the dataset.
-$datasetId = '';
+$datasetId = '{MY-DATASET-ID}';
 
 $postBody = new Google_Service_Datastore_LookupRequest($client);
 
@@ -163,7 +163,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Datastore($client);
 
 // * Identifies the dataset.
-$datasetId = '';
+$datasetId = '{MY-DATASET-ID}';
 
 $postBody = new Google_Service_Datastore_RollbackRequest($client);
 
@@ -197,7 +197,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Datastore($client);
 
 // * Identifies the dataset.
-$datasetId = '';
+$datasetId = '{MY-DATASET-ID}';
 
 $postBody = new Google_Service_Datastore_RunQueryRequest($client);
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_deploymentmanager.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_deploymentmanager.v2.json.baseline
@@ -27,10 +27,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_DeploymentManager($client);
 
 // * The project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the deployment for this request.
-$deployment = '';
+$deployment = '{MY-DEPLOYMENT}';
 
 $postBody = new Google_Service_DeploymentManager_DeploymentsCancelPreviewRequest($client);
 
@@ -64,10 +64,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_DeploymentManager($client);
 
 // * The project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the deployment for this request.
-$deployment = '';
+$deployment = '{MY-DEPLOYMENT}';
 
 $response = $service->deployments->delete($project, $deployment);
 
@@ -99,10 +99,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_DeploymentManager($client);
 
 // * The project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the deployment for this request.
-$deployment = '';
+$deployment = '{MY-DEPLOYMENT}';
 
 $response = $service->deployments->get($project, $deployment);
 
@@ -134,7 +134,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_DeploymentManager($client);
 
 // * The project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $postBody = new Google_Service_DeploymentManager_Deployment($client);
 
@@ -168,7 +168,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_DeploymentManager($client);
 
 // * The project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->deployments->listDeployments($project);
 
@@ -204,10 +204,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_DeploymentManager($client);
 
 // * The project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the deployment for this request.
-$deployment = '';
+$deployment = '{MY-DEPLOYMENT}';
 
 $postBody = new Google_Service_DeploymentManager_Deployment($client);
 
@@ -241,10 +241,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_DeploymentManager($client);
 
 // * The project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the deployment for this request.
-$deployment = '';
+$deployment = '{MY-DEPLOYMENT}';
 
 $postBody = new Google_Service_DeploymentManager_DeploymentsStopRequest($client);
 
@@ -278,10 +278,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_DeploymentManager($client);
 
 // * The project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the deployment for this request.
-$deployment = '';
+$deployment = '{MY-DEPLOYMENT}';
 
 $postBody = new Google_Service_DeploymentManager_Deployment($client);
 
@@ -315,13 +315,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_DeploymentManager($client);
 
 // * The project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the deployment for this request.
-$deployment = '';
+$deployment = '{MY-DEPLOYMENT}';
 
 // * The name of the manifest for this request.
-$manifest = '';
+$manifest = '{MY-MANIFEST}';
 
 $response = $service->manifests->get($project, $deployment, $manifest);
 
@@ -353,10 +353,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_DeploymentManager($client);
 
 // * The project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the deployment for this request.
-$deployment = '';
+$deployment = '{MY-DEPLOYMENT}';
 
 $response = $service->manifests->listManifests($project, $deployment);
 
@@ -392,10 +392,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_DeploymentManager($client);
 
 // * The project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the operation for this request.
-$operation = '';
+$operation = '{MY-OPERATION}';
 
 $response = $service->operations->get($project, $operation);
 
@@ -427,7 +427,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_DeploymentManager($client);
 
 // * The project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->operations->listOperations($project);
 
@@ -463,13 +463,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_DeploymentManager($client);
 
 // * The project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the deployment for this request.
-$deployment = '';
+$deployment = '{MY-DEPLOYMENT}';
 
 // * The name of the resource for this request.
-$resource = '';
+$resource = '{MY-RESOURCE}';
 
 $response = $service->resources->get($project, $deployment, $resource);
 
@@ -501,10 +501,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_DeploymentManager($client);
 
 // * The project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the deployment for this request.
-$deployment = '';
+$deployment = '{MY-DEPLOYMENT}';
 
 $response = $service->resources->listResources($project, $deployment);
 
@@ -540,7 +540,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_DeploymentManager($client);
 
 // * The project ID for this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->types->listTypes($project);
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_dns.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_dns.v1.json.baseline
@@ -27,10 +27,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Dns($client);
 
 // * Identifies the project addressed by this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-$managedZone = '';
+$managedZone = '{MY-MANAGED-ZONE}';
 
 $postBody = new Google_Service_Dns_Change($client);
 
@@ -64,13 +64,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Dns($client);
 
 // * Identifies the project addressed by this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-$managedZone = '';
+$managedZone = '{MY-MANAGED-ZONE}';
 
 // * The identifier of the requested change, from a previous ResourceRecordSetsChangeResponse.
-$changeId = '';
+$changeId = '{MY-CHANGE-ID}';
 
 $response = $service->changes->get($project, $managedZone, $changeId);
 
@@ -102,10 +102,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Dns($client);
 
 // * Identifies the project addressed by this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-$managedZone = '';
+$managedZone = '{MY-MANAGED-ZONE}';
 
 $response = $service->changes->listChanges($project, $managedZone);
 
@@ -141,7 +141,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Dns($client);
 
 // * Identifies the project addressed by this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $postBody = new Google_Service_Dns_ManagedZone($client);
 
@@ -175,10 +175,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Dns($client);
 
 // * Identifies the project addressed by this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-$managedZone = '';
+$managedZone = '{MY-MANAGED-ZONE}';
 
 $response = $service->managedZones->delete($project, $managedZone);
 
@@ -210,10 +210,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Dns($client);
 
 // * Identifies the project addressed by this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-$managedZone = '';
+$managedZone = '{MY-MANAGED-ZONE}';
 
 $response = $service->managedZones->get($project, $managedZone);
 
@@ -245,7 +245,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Dns($client);
 
 // * Identifies the project addressed by this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->managedZones->listManagedZones($project);
 
@@ -281,7 +281,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Dns($client);
 
 // * Identifies the project addressed by this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->projects->get($project);
 
@@ -313,10 +313,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Dns($client);
 
 // * Identifies the project addressed by this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-$managedZone = '';
+$managedZone = '{MY-MANAGED-ZONE}';
 
 $response = $service->resourceRecordSets->listResourceRecordSets($project, $managedZone);
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_prediction.v1.6.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_prediction.v1.6.json.baseline
@@ -27,10 +27,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Prediction($client);
 
 // * The project associated with the model.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of a hosted model.
-$hostedModelName = '';
+$hostedModelName = '{MY-HOSTED-MODEL-NAME}';
 
 $postBody = new Google_Service_Prediction_Input($client);
 
@@ -64,10 +64,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Prediction($client);
 
 // * The project associated with the model.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The unique name for the predictive model.
-$id = '';
+$id = '{MY-ID}';
 
 $response = $service->trainedmodels->analyze($project, $id);
 
@@ -99,10 +99,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Prediction($client);
 
 // * The project associated with the model.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The unique name for the predictive model.
-$id = '';
+$id = '{MY-ID}';
 
 $response = $service->trainedmodels->delete($project, $id);
 
@@ -134,10 +134,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Prediction($client);
 
 // * The project associated with the model.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The unique name for the predictive model.
-$id = '';
+$id = '{MY-ID}';
 
 $response = $service->trainedmodels->get($project, $id);
 
@@ -169,7 +169,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Prediction($client);
 
 // * The project associated with the model.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $postBody = new Google_Service_Prediction_Insert($client);
 
@@ -203,7 +203,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Prediction($client);
 
 // * The project associated with the model.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->trainedmodels->listTrainedmodels($project);
 
@@ -239,10 +239,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Prediction($client);
 
 // * The project associated with the model.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The unique name for the predictive model.
-$id = '';
+$id = '{MY-ID}';
 
 $postBody = new Google_Service_Prediction_Input($client);
 
@@ -276,10 +276,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Prediction($client);
 
 // * The project associated with the model.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The unique name for the predictive model.
-$id = '';
+$id = '{MY-ID}';
 
 $postBody = new Google_Service_Prediction_Update($client);
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_replicapoolupdater.v1beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_replicapoolupdater.v1beta1.json.baseline
@@ -27,13 +27,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Replicapoolupdater($client);
 
 // * The Google Developers Console project name.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone in which the update's target resides.
-$zone = '';
+$zone = '{MY-ZONE}';
 
 // * The name of the update.
-$rollingUpdate = '';
+$rollingUpdate = '{MY-ROLLING-UPDATE}';
 
 $response = $service->rollingUpdates->cancel($project, $zone, $rollingUpdate);
 
@@ -65,13 +65,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Replicapoolupdater($client);
 
 // * The Google Developers Console project name.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone in which the update's target resides.
-$zone = '';
+$zone = '{MY-ZONE}';
 
 // * The name of the update.
-$rollingUpdate = '';
+$rollingUpdate = '{MY-ROLLING-UPDATE}';
 
 $response = $service->rollingUpdates->get($project, $zone, $rollingUpdate);
 
@@ -103,10 +103,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Replicapoolupdater($client);
 
 // * The Google Developers Console project name.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone in which the update's target resides.
-$zone = '';
+$zone = '{MY-ZONE}';
 
 $postBody = new Google_Service_Replicapoolupdater_RollingUpdate($client);
 
@@ -140,10 +140,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Replicapoolupdater($client);
 
 // * The Google Developers Console project name.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone in which the update's target resides.
-$zone = '';
+$zone = '{MY-ZONE}';
 
 $response = $service->rollingUpdates->listRollingUpdates($project, $zone);
 
@@ -179,13 +179,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Replicapoolupdater($client);
 
 // * The Google Developers Console project name.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone in which the update's target resides.
-$zone = '';
+$zone = '{MY-ZONE}';
 
 // * The name of the update.
-$rollingUpdate = '';
+$rollingUpdate = '{MY-ROLLING-UPDATE}';
 
 $response = $service->rollingUpdates->listInstanceUpdates($project, $zone, $rollingUpdate);
 
@@ -221,13 +221,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Replicapoolupdater($client);
 
 // * The Google Developers Console project name.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone in which the update's target resides.
-$zone = '';
+$zone = '{MY-ZONE}';
 
 // * The name of the update.
-$rollingUpdate = '';
+$rollingUpdate = '{MY-ROLLING-UPDATE}';
 
 $response = $service->rollingUpdates->pause($project, $zone, $rollingUpdate);
 
@@ -259,13 +259,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Replicapoolupdater($client);
 
 // * The Google Developers Console project name.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone in which the update's target resides.
-$zone = '';
+$zone = '{MY-ZONE}';
 
 // * The name of the update.
-$rollingUpdate = '';
+$rollingUpdate = '{MY-ROLLING-UPDATE}';
 
 $response = $service->rollingUpdates->resume($project, $zone, $rollingUpdate);
 
@@ -297,13 +297,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Replicapoolupdater($client);
 
 // * The Google Developers Console project name.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The name of the zone in which the update's target resides.
-$zone = '';
+$zone = '{MY-ZONE}';
 
 // * The name of the update.
-$rollingUpdate = '';
+$rollingUpdate = '{MY-ROLLING-UPDATE}';
 
 $response = $service->rollingUpdates->rollback($project, $zone, $rollingUpdate);
 
@@ -335,13 +335,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Replicapoolupdater($client);
 
 // * Name of the project scoping this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the zone scoping this request.
-$zone = '';
+$zone = '{MY-ZONE}';
 
 // * Name of the operation resource to return.
-$operation = '';
+$operation = '{MY-OPERATION}';
 
 $response = $service->zoneOperations->get($project, $zone, $operation);
 
@@ -373,10 +373,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Replicapoolupdater($client);
 
 // * Name of the project scoping this request.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Name of the zone scoping this request.
-$zone = '';
+$zone = '{MY-ZONE}';
 
 $response = $service->zoneOperations->listZoneOperations($project, $zone);
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_sqladmin.v1beta4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_sqladmin.v1beta4.json.baseline
@@ -27,10 +27,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_SQLAdmin($client);
 
 // * Project ID of the project that contains the instance.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Cloud SQL instance ID. This does not include the project ID.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 // * The ID of the Backup Run to delete. To find a Backup Run ID, use the list method.
 $id = '0';
@@ -65,10 +65,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_SQLAdmin($client);
 
 // * Project ID of the project that contains the instance.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Cloud SQL instance ID. This does not include the project ID.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 // * The ID of this Backup Run.
 $id = '0';
@@ -103,10 +103,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_SQLAdmin($client);
 
 // * Project ID of the project that contains the instance.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Cloud SQL instance ID. This does not include the project ID.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 $response = $service->backupRuns->listBackupRuns($project, $instance);
 
@@ -142,13 +142,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_SQLAdmin($client);
 
 // * Project ID of the project that contains the instance.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Database instance ID. This does not include the project ID.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 // * Name of the database to be deleted in the instance.
-$database = '';
+$database = '{MY-DATABASE}';
 
 $response = $service->databases->delete($project, $instance, $database);
 
@@ -180,13 +180,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_SQLAdmin($client);
 
 // * Project ID of the project that contains the instance.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Database instance ID. This does not include the project ID.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 // * Name of the database in the instance.
-$database = '';
+$database = '{MY-DATABASE}';
 
 $response = $service->databases->get($project, $instance, $database);
 
@@ -218,10 +218,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_SQLAdmin($client);
 
 // * Project ID of the project that contains the instance.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Database instance ID. This does not include the project ID.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 $postBody = new Google_Service_SQLAdmin_Database($client);
 
@@ -255,10 +255,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_SQLAdmin($client);
 
 // * Project ID of the project for which to list Cloud SQL instances.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Cloud SQL instance ID. This does not include the project ID.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 $response = $service->databases->listDatabases($project, $instance);
 
@@ -290,13 +290,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_SQLAdmin($client);
 
 // * Project ID of the project that contains the instance.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Database instance ID. This does not include the project ID.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 // * Name of the database to be updated in the instance.
-$database = '';
+$database = '{MY-DATABASE}';
 
 $postBody = new Google_Service_SQLAdmin_Database($client);
 
@@ -330,13 +330,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_SQLAdmin($client);
 
 // * Project ID of the project that contains the instance.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Database instance ID. This does not include the project ID.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 // * Name of the database to be updated in the instance.
-$database = '';
+$database = '{MY-DATABASE}';
 
 $postBody = new Google_Service_SQLAdmin_Database($client);
 
@@ -400,10 +400,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_SQLAdmin($client);
 
 // * Project ID of the source as well as the clone Cloud SQL instance.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The ID of the Cloud SQL instance to be cloned (source). This does not include the project ID.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 $postBody = new Google_Service_SQLAdmin_InstancesCloneRequest($client);
 
@@ -437,10 +437,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_SQLAdmin($client);
 
 // * Project ID of the project that contains the instance to be deleted.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Cloud SQL instance ID. This does not include the project ID.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 $response = $service->instances->delete($project, $instance);
 
@@ -472,10 +472,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_SQLAdmin($client);
 
 // * Project ID of the project that contains the instance to be exported.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Cloud SQL instance ID. This does not include the project ID.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 $postBody = new Google_Service_SQLAdmin_InstancesExportRequest($client);
 
@@ -509,10 +509,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_SQLAdmin($client);
 
 // * ID of the project that contains the read replica.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Cloud SQL instance ID. This does not include the project ID.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 $postBody = new Google_Service_SQLAdmin_InstancesFailoverRequest($client);
 
@@ -546,10 +546,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_SQLAdmin($client);
 
 // * Project ID of the project that contains the instance.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Database instance ID. This does not include the project ID.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 $response = $service->instances->get($project, $instance);
 
@@ -581,10 +581,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_SQLAdmin($client);
 
 // * Project ID of the project that contains the instance.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Cloud SQL instance ID. This does not include the project ID.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 $postBody = new Google_Service_SQLAdmin_InstancesImportRequest($client);
 
@@ -618,7 +618,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_SQLAdmin($client);
 
 // * Project ID of the project to which the newly created Cloud SQL instances should belong.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $postBody = new Google_Service_SQLAdmin_DatabaseInstance($client);
 
@@ -652,7 +652,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_SQLAdmin($client);
 
 // * Project ID of the project for which to list Cloud SQL instances.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->instances->listInstances($project);
 
@@ -688,10 +688,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_SQLAdmin($client);
 
 // * Project ID of the project that contains the instance.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Cloud SQL instance ID. This does not include the project ID.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 $postBody = new Google_Service_SQLAdmin_DatabaseInstance($client);
 
@@ -725,10 +725,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_SQLAdmin($client);
 
 // * ID of the project that contains the read replica.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Cloud SQL read replica instance name.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 $response = $service->instances->promoteReplica($project, $instance);
 
@@ -760,10 +760,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_SQLAdmin($client);
 
 // * Project ID of the project that contains the instance.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Cloud SQL instance ID. This does not include the project ID.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 $response = $service->instances->resetSslConfig($project, $instance);
 
@@ -795,10 +795,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_SQLAdmin($client);
 
 // * Project ID of the project that contains the instance to be restarted.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Cloud SQL instance ID. This does not include the project ID.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 $response = $service->instances->restart($project, $instance);
 
@@ -830,10 +830,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_SQLAdmin($client);
 
 // * Project ID of the project that contains the instance.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Cloud SQL instance ID. This does not include the project ID.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 $postBody = new Google_Service_SQLAdmin_InstancesRestoreBackupRequest($client);
 
@@ -867,10 +867,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_SQLAdmin($client);
 
 // * ID of the project that contains the read replica.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Cloud SQL read replica instance name.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 $response = $service->instances->startReplica($project, $instance);
 
@@ -902,10 +902,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_SQLAdmin($client);
 
 // * ID of the project that contains the read replica.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Cloud SQL read replica instance name.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 $response = $service->instances->stopReplica($project, $instance);
 
@@ -937,10 +937,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_SQLAdmin($client);
 
 // * Project ID of the project that contains the instance.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Cloud SQL instance ID. This does not include the project ID.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 $postBody = new Google_Service_SQLAdmin_DatabaseInstance($client);
 
@@ -974,10 +974,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_SQLAdmin($client);
 
 // * Project ID of the project that contains the instance.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Instance operation ID.
-$operation = '';
+$operation = '{MY-OPERATION}';
 
 $response = $service->operations->get($project, $operation);
 
@@ -1009,10 +1009,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_SQLAdmin($client);
 
 // * Project ID of the project that contains the instance.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Cloud SQL instance ID. This does not include the project ID.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 $response = $service->operations->listOperations($project, $instance);
 
@@ -1048,10 +1048,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_SQLAdmin($client);
 
 // * Project ID of the Cloud SQL project.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Cloud SQL instance ID. This does not include the project ID.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 $postBody = new Google_Service_SQLAdmin_SslCertsCreateEphemeralRequest($client);
 
@@ -1085,13 +1085,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_SQLAdmin($client);
 
 // * Project ID of the project that contains the instance to be deleted.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Cloud SQL instance ID. This does not include the project ID.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 // * Sha1 FingerPrint.
-$sha1Fingerprint = '';
+$sha1Fingerprint = '{MY-SHA1-FINGERPRINT}';
 
 $response = $service->sslCerts->delete($project, $instance, $sha1Fingerprint);
 
@@ -1123,13 +1123,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_SQLAdmin($client);
 
 // * Project ID of the project that contains the instance.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Cloud SQL instance ID. This does not include the project ID.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 // * Sha1 FingerPrint.
-$sha1Fingerprint = '';
+$sha1Fingerprint = '{MY-SHA1-FINGERPRINT}';
 
 $response = $service->sslCerts->get($project, $instance, $sha1Fingerprint);
 
@@ -1161,10 +1161,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_SQLAdmin($client);
 
 // * Project ID of the project to which the newly created Cloud SQL instances should belong.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Cloud SQL instance ID. This does not include the project ID.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 $postBody = new Google_Service_SQLAdmin_SslCertsInsertRequest($client);
 
@@ -1198,10 +1198,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_SQLAdmin($client);
 
 // * Project ID of the project for which to list Cloud SQL instances.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Cloud SQL instance ID. This does not include the project ID.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 $response = $service->sslCerts->listSslCerts($project, $instance);
 
@@ -1233,7 +1233,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_SQLAdmin($client);
 
 // * Project ID of the project for which to list tiers.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->tiers->listTiers($project);
 
@@ -1265,16 +1265,16 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_SQLAdmin($client);
 
 // * Project ID of the project that contains the instance.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Database instance ID. This does not include the project ID.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 // * Host of the user in the instance.
-$host = '';
+$host = '{MY-HOST}';
 
 // * Name of the user in the instance.
-$name = '';
+$name = '{MY-NAME}';
 
 $response = $service->users->delete($project, $instance, $host, $name);
 
@@ -1306,10 +1306,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_SQLAdmin($client);
 
 // * Project ID of the project that contains the instance.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Database instance ID. This does not include the project ID.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 $postBody = new Google_Service_SQLAdmin_User($client);
 
@@ -1343,10 +1343,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_SQLAdmin($client);
 
 // * Project ID of the project that contains the instance.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Database instance ID. This does not include the project ID.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 $response = $service->users->listUsers($project, $instance);
 
@@ -1378,16 +1378,16 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_SQLAdmin($client);
 
 // * Project ID of the project that contains the instance.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * Database instance ID. This does not include the project ID.
-$instance = '';
+$instance = '{MY-INSTANCE}';
 
 // * Host of the user in the instance.
-$host = '';
+$host = '{MY-HOST}';
 
 // * Name of the user in the instance.
-$name = '';
+$name = '{MY-NAME}';
 
 $postBody = new Google_Service_SQLAdmin_User($client);
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_storage.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_storage.v1.json.baseline
@@ -27,11 +27,11 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storage($client);
 
 // * Name of a bucket.
-$bucket = '';
+$bucket = '{MY-BUCKET}';
 
 // * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
 //   group-emailAddress, allUsers, or allAuthenticatedUsers.
-$entity = '';
+$entity = '{MY-ENTITY}';
 
 $response = $service->bucketAccessControls->delete($bucket, $entity);
 
@@ -63,11 +63,11 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storage($client);
 
 // * Name of a bucket.
-$bucket = '';
+$bucket = '{MY-BUCKET}';
 
 // * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
 //   group-emailAddress, allUsers, or allAuthenticatedUsers.
-$entity = '';
+$entity = '{MY-ENTITY}';
 
 $response = $service->bucketAccessControls->get($bucket, $entity);
 
@@ -99,7 +99,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storage($client);
 
 // * Name of a bucket.
-$bucket = '';
+$bucket = '{MY-BUCKET}';
 
 $postBody = new Google_Service_Storage_BucketAccessControl($client);
 
@@ -133,7 +133,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storage($client);
 
 // * Name of a bucket.
-$bucket = '';
+$bucket = '{MY-BUCKET}';
 
 $response = $service->bucketAccessControls->listBucketAccessControls($bucket);
 
@@ -165,11 +165,11 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storage($client);
 
 // * Name of a bucket.
-$bucket = '';
+$bucket = '{MY-BUCKET}';
 
 // * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
 //   group-emailAddress, allUsers, or allAuthenticatedUsers.
-$entity = '';
+$entity = '{MY-ENTITY}';
 
 $postBody = new Google_Service_Storage_BucketAccessControl($client);
 
@@ -203,11 +203,11 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storage($client);
 
 // * Name of a bucket.
-$bucket = '';
+$bucket = '{MY-BUCKET}';
 
 // * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
 //   group-emailAddress, allUsers, or allAuthenticatedUsers.
-$entity = '';
+$entity = '{MY-ENTITY}';
 
 $postBody = new Google_Service_Storage_BucketAccessControl($client);
 
@@ -241,7 +241,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storage($client);
 
 // * Name of a bucket.
-$bucket = '';
+$bucket = '{MY-BUCKET}';
 
 $response = $service->buckets->delete($bucket);
 
@@ -273,7 +273,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storage($client);
 
 // * Name of a bucket.
-$bucket = '';
+$bucket = '{MY-BUCKET}';
 
 $response = $service->buckets->get($bucket);
 
@@ -305,7 +305,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storage($client);
 
 // * A valid API project identifier.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $postBody = new Google_Service_Storage_Bucket($client);
 
@@ -339,7 +339,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storage($client);
 
 // * A valid API project identifier.
-$project = '';
+$project = '{MY-PROJECT}';
 
 $response = $service->buckets->listBuckets($project);
 
@@ -375,7 +375,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storage($client);
 
 // * Name of a bucket.
-$bucket = '';
+$bucket = '{MY-BUCKET}';
 
 $postBody = new Google_Service_Storage_Bucket($client);
 
@@ -409,7 +409,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storage($client);
 
 // * Name of a bucket.
-$bucket = '';
+$bucket = '{MY-BUCKET}';
 
 $postBody = new Google_Service_Storage_Bucket($client);
 
@@ -475,11 +475,11 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storage($client);
 
 // * Name of a bucket.
-$bucket = '';
+$bucket = '{MY-BUCKET}';
 
 // * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
 //   group-emailAddress, allUsers, or allAuthenticatedUsers.
-$entity = '';
+$entity = '{MY-ENTITY}';
 
 $response = $service->defaultObjectAccessControls->delete($bucket, $entity);
 
@@ -511,11 +511,11 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storage($client);
 
 // * Name of a bucket.
-$bucket = '';
+$bucket = '{MY-BUCKET}';
 
 // * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
 //   group-emailAddress, allUsers, or allAuthenticatedUsers.
-$entity = '';
+$entity = '{MY-ENTITY}';
 
 $response = $service->defaultObjectAccessControls->get($bucket, $entity);
 
@@ -547,7 +547,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storage($client);
 
 // * Name of a bucket.
-$bucket = '';
+$bucket = '{MY-BUCKET}';
 
 $postBody = new Google_Service_Storage_ObjectAccessControl($client);
 
@@ -581,7 +581,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storage($client);
 
 // * Name of a bucket.
-$bucket = '';
+$bucket = '{MY-BUCKET}';
 
 $response = $service->defaultObjectAccessControls->listDefaultObjectAccessControls($bucket);
 
@@ -613,11 +613,11 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storage($client);
 
 // * Name of a bucket.
-$bucket = '';
+$bucket = '{MY-BUCKET}';
 
 // * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
 //   group-emailAddress, allUsers, or allAuthenticatedUsers.
-$entity = '';
+$entity = '{MY-ENTITY}';
 
 $postBody = new Google_Service_Storage_ObjectAccessControl($client);
 
@@ -651,11 +651,11 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storage($client);
 
 // * Name of a bucket.
-$bucket = '';
+$bucket = '{MY-BUCKET}';
 
 // * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
 //   group-emailAddress, allUsers, or allAuthenticatedUsers.
-$entity = '';
+$entity = '{MY-ENTITY}';
 
 $postBody = new Google_Service_Storage_ObjectAccessControl($client);
 
@@ -689,15 +689,15 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storage($client);
 
 // * Name of a bucket.
-$bucket = '';
+$bucket = '{MY-BUCKET}';
 
 // * Name of the object. For information about how to URL encode object names to be path safe, see
 //   Encoding URI Path Parts.
-$object = '';
+$object = '{MY-OBJECT}';
 
 // * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
 //   group-emailAddress, allUsers, or allAuthenticatedUsers.
-$entity = '';
+$entity = '{MY-ENTITY}';
 
 $response = $service->objectAccessControls->delete($bucket, $object, $entity);
 
@@ -729,15 +729,15 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storage($client);
 
 // * Name of a bucket.
-$bucket = '';
+$bucket = '{MY-BUCKET}';
 
 // * Name of the object. For information about how to URL encode object names to be path safe, see
 //   Encoding URI Path Parts.
-$object = '';
+$object = '{MY-OBJECT}';
 
 // * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
 //   group-emailAddress, allUsers, or allAuthenticatedUsers.
-$entity = '';
+$entity = '{MY-ENTITY}';
 
 $response = $service->objectAccessControls->get($bucket, $object, $entity);
 
@@ -769,11 +769,11 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storage($client);
 
 // * Name of a bucket.
-$bucket = '';
+$bucket = '{MY-BUCKET}';
 
 // * Name of the object. For information about how to URL encode object names to be path safe, see
 //   Encoding URI Path Parts.
-$object = '';
+$object = '{MY-OBJECT}';
 
 $postBody = new Google_Service_Storage_ObjectAccessControl($client);
 
@@ -807,11 +807,11 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storage($client);
 
 // * Name of a bucket.
-$bucket = '';
+$bucket = '{MY-BUCKET}';
 
 // * Name of the object. For information about how to URL encode object names to be path safe, see
 //   Encoding URI Path Parts.
-$object = '';
+$object = '{MY-OBJECT}';
 
 $response = $service->objectAccessControls->listObjectAccessControls($bucket, $object);
 
@@ -843,15 +843,15 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storage($client);
 
 // * Name of a bucket.
-$bucket = '';
+$bucket = '{MY-BUCKET}';
 
 // * Name of the object. For information about how to URL encode object names to be path safe, see
 //   Encoding URI Path Parts.
-$object = '';
+$object = '{MY-OBJECT}';
 
 // * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
 //   group-emailAddress, allUsers, or allAuthenticatedUsers.
-$entity = '';
+$entity = '{MY-ENTITY}';
 
 $postBody = new Google_Service_Storage_ObjectAccessControl($client);
 
@@ -885,15 +885,15 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storage($client);
 
 // * Name of a bucket.
-$bucket = '';
+$bucket = '{MY-BUCKET}';
 
 // * Name of the object. For information about how to URL encode object names to be path safe, see
 //   Encoding URI Path Parts.
-$object = '';
+$object = '{MY-OBJECT}';
 
 // * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
 //   group-emailAddress, allUsers, or allAuthenticatedUsers.
-$entity = '';
+$entity = '{MY-ENTITY}';
 
 $postBody = new Google_Service_Storage_ObjectAccessControl($client);
 
@@ -927,11 +927,11 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storage($client);
 
 // * Name of the bucket in which to store the new object.
-$destinationBucket = '';
+$destinationBucket = '{MY-DESTINATION-BUCKET}';
 
 // * Name of the new object. For information about how to URL encode object names to be path safe, see
 //   Encoding URI Path Parts.
-$destinationObject = '';
+$destinationObject = '{MY-DESTINATION-OBJECT}';
 
 $postBody = new Google_Service_Storage_ComposeRequest($client);
 
@@ -965,20 +965,20 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storage($client);
 
 // * Name of the bucket in which to find the source object.
-$sourceBucket = '';
+$sourceBucket = '{MY-SOURCE-BUCKET}';
 
 // * Name of the source object. For information about how to URL encode object names to be path safe,
 //   see Encoding URI Path Parts.
-$sourceObject = '';
+$sourceObject = '{MY-SOURCE-OBJECT}';
 
 // * Name of the bucket in which to store the new object. Overrides the provided object metadata's
 //   bucket value, if any.For information about how to URL encode object names to be path safe, see
 //   Encoding URI Path Parts.
-$destinationBucket = '';
+$destinationBucket = '{MY-DESTINATION-BUCKET}';
 
 // * Name of the new object. Required when the object metadata is not otherwise provided. Overrides the
 //   object metadata's name value, if any.
-$destinationObject = '';
+$destinationObject = '{MY-DESTINATION-OBJECT}';
 
 $postBody = new Google_Service_Storage_StorageObject($client);
 
@@ -1012,11 +1012,11 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storage($client);
 
 // * Name of the bucket in which the object resides.
-$bucket = '';
+$bucket = '{MY-BUCKET}';
 
 // * Name of the object. For information about how to URL encode object names to be path safe, see
 //   Encoding URI Path Parts.
-$object = '';
+$object = '{MY-OBJECT}';
 
 $response = $service->objects->delete($bucket, $object);
 
@@ -1048,11 +1048,11 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storage($client);
 
 // * Name of the bucket in which the object resides.
-$bucket = '';
+$bucket = '{MY-BUCKET}';
 
 // * Name of the object. For information about how to URL encode object names to be path safe, see
 //   Encoding URI Path Parts.
-$object = '';
+$object = '{MY-OBJECT}';
 
 $response = $service->objects->get($bucket, $object);
 
@@ -1085,7 +1085,7 @@ $service = new Google_Service_Storage($client);
 
 // * Name of the bucket in which to store the new object. Overrides the provided object metadata's
 //   bucket value, if any.
-$bucket = '';
+$bucket = '{MY-BUCKET}';
 
 $postBody = new Google_Service_Storage_StorageObject($client);
 
@@ -1119,7 +1119,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storage($client);
 
 // * Name of the bucket in which to look for objects.
-$bucket = '';
+$bucket = '{MY-BUCKET}';
 
 $response = $service->objects->listObjects($bucket);
 
@@ -1155,11 +1155,11 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storage($client);
 
 // * Name of the bucket in which the object resides.
-$bucket = '';
+$bucket = '{MY-BUCKET}';
 
 // * Name of the object. For information about how to URL encode object names to be path safe, see
 //   Encoding URI Path Parts.
-$object = '';
+$object = '{MY-OBJECT}';
 
 $postBody = new Google_Service_Storage_StorageObject($client);
 
@@ -1193,20 +1193,20 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storage($client);
 
 // * Name of the bucket in which to find the source object.
-$sourceBucket = '';
+$sourceBucket = '{MY-SOURCE-BUCKET}';
 
 // * Name of the source object. For information about how to URL encode object names to be path safe,
 //   see Encoding URI Path Parts.
-$sourceObject = '';
+$sourceObject = '{MY-SOURCE-OBJECT}';
 
 // * Name of the bucket in which to store the new object. Overrides the provided object metadata's
 //   bucket value, if any.
-$destinationBucket = '';
+$destinationBucket = '{MY-DESTINATION-BUCKET}';
 
 // * Name of the new object. Required when the object metadata is not otherwise provided. Overrides the
 //   object metadata's name value, if any. For information about how to URL encode object names to be
 //   path safe, see Encoding URI Path Parts.
-$destinationObject = '';
+$destinationObject = '{MY-DESTINATION-OBJECT}';
 
 $postBody = new Google_Service_Storage_StorageObject($client);
 
@@ -1240,11 +1240,11 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storage($client);
 
 // * Name of the bucket in which the object resides.
-$bucket = '';
+$bucket = '{MY-BUCKET}';
 
 // * Name of the object. For information about how to URL encode object names to be path safe, see
 //   Encoding URI Path Parts.
-$object = '';
+$object = '{MY-OBJECT}';
 
 $postBody = new Google_Service_Storage_StorageObject($client);
 
@@ -1278,7 +1278,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storage($client);
 
 // * Name of the bucket in which to look for objects.
-$bucket = '';
+$bucket = '{MY-BUCKET}';
 
 $postBody = new Google_Service_Storage_Channel($client);
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_storagetransfer.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_storagetransfer.v1.json.baseline
@@ -58,7 +58,7 @@ $service = new Google_Service_Storagetransfer($client);
 
 // * The ID of the Google Developers Console project that the Google service account is associated
 //   with. Required.
-$projectId = '';
+$projectId = '{MY-PROJECT-ID}';
 
 $response = $service->googleServiceAccounts->get($projectId);
 
@@ -122,7 +122,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storagetransfer($client);
 
 // * The job to get. Required.
-$jobName = '';
+$jobName = '{MY-JOB-NAME}';
 
 $response = $service->transferJobs->get($jobName);
 
@@ -188,7 +188,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storagetransfer($client);
 
 // * The name of job to update. Required.
-$jobName = '';
+$jobName = '{MY-JOB-NAME}';
 
 $postBody = new Google_Service_Storagetransfer_UpdateTransferJobRequest($client);
 
@@ -222,7 +222,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storagetransfer($client);
 
 // * The name of the operation resource to be cancelled.
-$name = '';
+$name = '{MY-NAME}';
 
 $response = $service->transferOperations->cancel($name);
 
@@ -254,7 +254,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storagetransfer($client);
 
 // * The name of the operation resource to be deleted.
-$name = '';
+$name = '{MY-NAME}';
 
 $response = $service->transferOperations->delete($name);
 
@@ -286,7 +286,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storagetransfer($client);
 
 // * The name of the operation resource.
-$name = '';
+$name = '{MY-NAME}';
 
 $response = $service->transferOperations->get($name);
 
@@ -318,7 +318,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storagetransfer($client);
 
 // * The value `transferOperations`.
-$name = '';
+$name = '{MY-NAME}';
 
 $response = $service->transferOperations->listTransferOperations($name);
 
@@ -354,7 +354,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storagetransfer($client);
 
 // * The name of the transfer operation. Required.
-$name = '';
+$name = '{MY-NAME}';
 
 $postBody = new Google_Service_Storagetransfer_PauseTransferOperationRequest($client);
 
@@ -388,7 +388,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storagetransfer($client);
 
 // * The name of the transfer operation. Required.
-$name = '';
+$name = '{MY-NAME}';
 
 $postBody = new Google_Service_Storagetransfer_ResumeTransferOperationRequest($client);
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_taskqueue.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_taskqueue.v1beta2.json.baseline
@@ -27,10 +27,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Taskqueue($client);
 
 // * The project under which the queue lies.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The id of the taskqueue to get the properties of.
-$taskqueue = '';
+$taskqueue = '{MY-TASKQUEUE}';
 
 $response = $service->taskqueues->get($project, $taskqueue);
 
@@ -62,13 +62,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Taskqueue($client);
 
 // * The project under which the queue lies.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The taskqueue to delete a task from.
-$taskqueue = '';
+$taskqueue = '{MY-TASKQUEUE}';
 
 // * The id of the task to delete.
-$task = '';
+$task = '{MY-TASK}';
 
 $response = $service->tasks->delete($project, $taskqueue, $task);
 
@@ -100,13 +100,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Taskqueue($client);
 
 // * The project under which the queue lies.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The taskqueue in which the task belongs.
-$taskqueue = '';
+$taskqueue = '{MY-TASKQUEUE}';
 
 // * The task to get properties of.
-$task = '';
+$task = '{MY-TASK}';
 
 $response = $service->tasks->get($project, $taskqueue, $task);
 
@@ -138,10 +138,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Taskqueue($client);
 
 // * The project under which the queue lies
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The taskqueue to insert the task into
-$taskqueue = '';
+$taskqueue = '{MY-TASKQUEUE}';
 
 $postBody = new Google_Service_Taskqueue_Task($client);
 
@@ -175,10 +175,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Taskqueue($client);
 
 // * The project under which the queue lies.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The taskqueue to lease a task from.
-$taskqueue = '';
+$taskqueue = '{MY-TASKQUEUE}';
 
 // * The number of tasks to lease.
 $numTasks = 0;
@@ -216,10 +216,10 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Taskqueue($client);
 
 // * The project under which the queue lies.
-$project = '';
+$project = '{MY-PROJECT}';
 
 // * The id of the taskqueue to list tasks from.
-$taskqueue = '';
+$taskqueue = '{MY-TASKQUEUE}';
 
 $response = $service->tasks->listTasks($project, $taskqueue);
 
@@ -251,13 +251,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Taskqueue($client);
 
 // * The project under which the queue lies.
-$project = '';
+$project = '{MY-PROJECT}';
 
 
-$taskqueue = '';
+$taskqueue = '{MY-TASKQUEUE}';
 
 
-$task = '';
+$task = '{MY-TASK}';
 
 // * The new lease in seconds.
 $newLeaseSeconds = 0;
@@ -294,13 +294,13 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Taskqueue($client);
 
 // * The project under which the queue lies.
-$project = '';
+$project = '{MY-PROJECT}';
 
 
-$taskqueue = '';
+$taskqueue = '{MY-TASKQUEUE}';
 
 
-$task = '';
+$task = '{MY-TASK}';
 
 // * The new lease in seconds.
 $newLeaseSeconds = 0;

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_translate.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_translate.v2.json.baseline
@@ -92,7 +92,7 @@ $service = new Google_Service_Translate($client);
 $q = [];
 
 // * The target language into which the text should be translated
-$target = '';
+$target = '{MY-TARGET}';
 
 $response = $service->translations->listTranslations($q, $target);
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_adexchangebuyer.v1.4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_adexchangebuyer.v1.4.json.baseline
@@ -410,7 +410,7 @@ service = discovery.build('adexchangebuyer', 'v1.4', credentials=credentials)
 accountId = 0
 
 # * The buyer-specific id for this creative.
-buyerCreativeId = ''
+buyerCreativeId = '{MY-BUYER-CREATIVE-ID}'
 
 # * The id of the deal id to associate with this creative.
 dealId = str(0L)
@@ -572,7 +572,7 @@ service = discovery.build('adexchangebuyer', 'v1.4', credentials=credentials)
 accountId = 0
 
 # * The buyer-specific id for this creative.
-buyerCreativeId = ''
+buyerCreativeId = '{MY-BUYER-CREATIVE-ID}'
 
 # * The id of the deal id to disassociate with this creative.
 dealId = str(0L)
@@ -701,7 +701,7 @@ service = discovery.build('adexchangebuyer', 'v1.4', credentials=credentials)
 
 # * The proposalId to get deals for. To search across proposals specify order_id = '-' as part of the
 #   URL.
-proposalId = ''
+proposalId = '{MY-PROPOSAL-ID}'
 
 request = service.marketplacedeals().list(proposalId=proposalId)
 response = request.execute()
@@ -911,7 +911,7 @@ service = discovery.build('adexchangebuyer', 'v1.4', credentials=credentials)
 accountId = str(0L)
 
 # * The end time of the report in ISO 8601 timestamp format using UTC.
-endDateTime = ''
+endDateTime = '{MY-END-DATE-TIME}'
 
 # * The start time of the report in ISO 8601 timestamp format using UTC.
 startDateTime = '{MY-START-DATE-TIME}'
@@ -1369,7 +1369,7 @@ service = discovery.build('adexchangebuyer', 'v1.4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
 # * The proposal id to update.
-proposalId = ''
+proposalId = '{MY-PROPOSAL-ID}'
 
 # * The last known revision number to update. If the head revision in the marketplace database has
 #   since changed, an error will be thrown. The caller should then fetch the latest proposal at head
@@ -1492,7 +1492,7 @@ service = discovery.build('adexchangebuyer', 'v1.4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
 # * The proposal id to update.
-proposalId = ''
+proposalId = '{MY-PROPOSAL-ID}'
 
 # * The last known revision number to update. If the head revision in the marketplace database has
 #   since changed, an error will be thrown. The caller should then fetch the latest proposal at head

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_adexchangebuyer.v1.4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_adexchangebuyer.v1.4.json.baseline
@@ -453,7 +453,7 @@ service = discovery.build('adexchangebuyer', 'v1.4', credentials=credentials)
 accountId = 0
 
 # * The buyer-specific id for this creative.
-buyerCreativeId = ''
+buyerCreativeId = '{MY-BUYER-CREATIVE-ID}'
 
 request = service.creatives().get(accountId=accountId, buyerCreativeId=buyerCreativeId)
 response = request.execute()
@@ -612,7 +612,7 @@ service = discovery.build('adexchangebuyer', 'v1.4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * The proposalId to delete deals from.
-proposalId = ''
+proposalId = '{MY-PROPOSAL-ID}'
 
 delete_order_deals_request_body = {
 # TODO: Add desired entries of the 'delete_order_deals_request_body' dict
@@ -656,7 +656,7 @@ service = discovery.build('adexchangebuyer', 'v1.4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
 # * proposalId for which deals need to be added.
-proposalId = ''
+proposalId = '{MY-PROPOSAL-ID}'
 
 add_order_deals_request_body = {
 # TODO: Add desired entries of the 'add_order_deals_request_body' dict
@@ -741,7 +741,7 @@ service = discovery.build('adexchangebuyer', 'v1.4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
 # * The proposalId to edit deals on.
-proposalId = ''
+proposalId = '{MY-PROPOSAL-ID}'
 
 edit_all_order_deals_request_body = {
 # TODO: Add desired entries of the 'edit_all_order_deals_request_body' dict
@@ -785,7 +785,7 @@ service = discovery.build('adexchangebuyer', 'v1.4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
 # * The proposalId to add notes for.
-proposalId = ''
+proposalId = '{MY-PROPOSAL-ID}'
 
 add_order_notes_request_body = {
 # TODO: Add desired entries of the 'add_order_notes_request_body' dict
@@ -829,7 +829,7 @@ service = discovery.build('adexchangebuyer', 'v1.4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * The proposalId to get notes for.
-proposalId = ''
+proposalId = '{MY-PROPOSAL-ID}'
 
 request = service.marketplacenotes().list(proposalId=proposalId)
 response = request.execute()
@@ -867,7 +867,7 @@ service = discovery.build('adexchangebuyer', 'v1.4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'updateproposal' method:
 
 # * The private auction id to be updated.
-privateAuctionId = ''
+privateAuctionId = '{MY-PRIVATE-AUCTION-ID}'
 
 update_private_auction_proposal_request_body = {
 # TODO: Add desired entries of the 'update_private_auction_proposal_request_body' dict
@@ -914,7 +914,7 @@ accountId = str(0L)
 endDateTime = ''
 
 # * The start time of the report in ISO 8601 timestamp format using UTC.
-startDateTime = ''
+startDateTime = '{MY-START-DATE-TIME}'
 
 request = service.performanceReport().list(accountId=accountId, endDateTime=endDateTime, startDateTime=startDateTime)
 response = request.execute()
@@ -1213,7 +1213,7 @@ service = discovery.build('adexchangebuyer', 'v1.4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * The id for the product to get the head revision for.
-productId = ''
+productId = '{MY-PRODUCT-ID}'
 
 request = service.products().get(productId=productId)
 response = request.execute()
@@ -1289,7 +1289,7 @@ service = discovery.build('adexchangebuyer', 'v1.4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Id of the proposal to retrieve.
-proposalId = ''
+proposalId = '{MY-PROPOSAL-ID}'
 
 request = service.proposals().get(proposalId=proposalId)
 response = request.execute()
@@ -1377,7 +1377,7 @@ proposalId = ''
 revisionNumber = str(0L)
 
 # * The proposed action to take on the proposal.
-updateAction = ''
+updateAction = '{MY-UPDATE-ACTION}'
 
 proposal_body = {
 # TODO: Add desired entries of the 'proposal_body' dict to be changed
@@ -1455,7 +1455,7 @@ service = discovery.build('adexchangebuyer', 'v1.4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'setupcomplete' method:
 
 # * The proposal id for which the setup is complete
-proposalId = ''
+proposalId = '{MY-PROPOSAL-ID}'
 
 request = service.proposals().setupcomplete(proposalId=proposalId)
 request.execute()
@@ -1500,7 +1500,7 @@ proposalId = ''
 revisionNumber = str(0L)
 
 # * The proposed action to take on the proposal.
-updateAction = ''
+updateAction = '{MY-UPDATE-ACTION}'
 
 proposal_body = {
 # TODO: Add desired entries of the 'proposal_body' dict

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_appengine.v1beta5.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_appengine.v1beta5.json.baseline
@@ -32,7 +32,7 @@ service = discovery.build('appengine', 'v1beta5', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Part of `name`. Name of the application to get. For example: "apps/myapp".
-appsId = ''
+appsId = '{MY-APPS-ID}'
 
 request = service.apps().get(appsId=appsId)
 response = request.execute()
@@ -75,7 +75,7 @@ service = discovery.build('appengine', 'v1beta5', credentials=credentials)
 appsId = ''
 
 # * Part of `name`. See documentation of `appsId`.
-operationsId = ''
+operationsId = '{MY-OPERATIONS-ID}'
 
 request = service.apps().operations().get(appsId=appsId, operationsId=operationsId)
 response = request.execute()
@@ -113,7 +113,7 @@ service = discovery.build('appengine', 'v1beta5', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Part of `name`. The name of the operation collection.
-appsId = ''
+appsId = '{MY-APPS-ID}'
 
 operations = service.apps().operations()
 request = operations.list(appsId=appsId)
@@ -160,7 +160,7 @@ service = discovery.build('appengine', 'v1beta5', credentials=credentials)
 appsId = ''
 
 # * Part of `name`. See documentation of `appsId`.
-servicesId = ''
+servicesId = '{MY-SERVICES-ID}'
 
 request = service.apps().services().delete(appsId=appsId, servicesId=servicesId)
 response = request.execute()
@@ -203,7 +203,7 @@ service = discovery.build('appengine', 'v1beta5', credentials=credentials)
 appsId = ''
 
 # * Part of `name`. See documentation of `appsId`.
-servicesId = ''
+servicesId = '{MY-SERVICES-ID}'
 
 request = service.apps().services().get(appsId=appsId, servicesId=servicesId)
 response = request.execute()
@@ -241,7 +241,7 @@ service = discovery.build('appengine', 'v1beta5', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Part of `name`. Name of the resource requested. For example: "apps/myapp".
-appsId = ''
+appsId = '{MY-APPS-ID}'
 
 services = service.apps().services()
 request = services.list(appsId=appsId)
@@ -288,7 +288,7 @@ service = discovery.build('appengine', 'v1beta5', credentials=credentials)
 appsId = ''
 
 # * Part of `name`. See documentation of `appsId`.
-servicesId = ''
+servicesId = '{MY-SERVICES-ID}'
 
 service_body = {
 # TODO: Add desired entries of the 'service_body' dict to be changed
@@ -335,7 +335,7 @@ service = discovery.build('appengine', 'v1beta5', credentials=credentials)
 appsId = ''
 
 # * Part of `name`. See documentation of `appsId`.
-servicesId = ''
+servicesId = '{MY-SERVICES-ID}'
 
 version_body = {
 # TODO: Add desired entries of the 'version_body' dict
@@ -386,7 +386,7 @@ appsId = ''
 servicesId = ''
 
 # * Part of `name`. See documentation of `appsId`.
-versionsId = ''
+versionsId = '{MY-VERSIONS-ID}'
 
 request = service.apps().services().versions().delete(appsId=appsId, servicesId=servicesId, versionsId=versionsId)
 response = request.execute()
@@ -433,7 +433,7 @@ appsId = ''
 servicesId = ''
 
 # * Part of `name`. See documentation of `appsId`.
-versionsId = ''
+versionsId = '{MY-VERSIONS-ID}'
 
 request = service.apps().services().versions().get(appsId=appsId, servicesId=servicesId, versionsId=versionsId)
 response = request.execute()
@@ -478,7 +478,7 @@ appsId = ''
 servicesId = ''
 
 # * Part of `name`. See documentation of `appsId`.
-versionsId = ''
+versionsId = '{MY-VERSIONS-ID}'
 
 instances = service.apps().services().versions().instances()
 request = instances.list(appsId=appsId, servicesId=servicesId, versionsId=versionsId)
@@ -523,7 +523,7 @@ service = discovery.build('appengine', 'v1beta5', credentials=credentials)
 appsId = ''
 
 # * Part of `name`. See documentation of `appsId`.
-servicesId = ''
+servicesId = '{MY-SERVICES-ID}'
 
 versions = service.apps().services().versions()
 request = versions.list(appsId=appsId, servicesId=servicesId)
@@ -574,7 +574,7 @@ appsId = ''
 servicesId = ''
 
 # * Part of `name`. See documentation of `appsId`.
-versionsId = ''
+versionsId = '{MY-VERSIONS-ID}'
 
 version_body = {
 # TODO: Add desired entries of the 'version_body' dict to be changed

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_appengine.v1beta5.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_appengine.v1beta5.json.baseline
@@ -72,7 +72,7 @@ service = discovery.build('appengine', 'v1beta5', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Part of `name`. The name of the operation resource.
-appsId = ''
+appsId = '{MY-APPS-ID}'
 
 # * Part of `name`. See documentation of `appsId`.
 operationsId = '{MY-OPERATIONS-ID}'
@@ -157,7 +157,7 @@ service = discovery.build('appengine', 'v1beta5', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Part of `name`. Name of the resource requested. For example: "apps/myapp/services/default".
-appsId = ''
+appsId = '{MY-APPS-ID}'
 
 # * Part of `name`. See documentation of `appsId`.
 servicesId = '{MY-SERVICES-ID}'
@@ -200,7 +200,7 @@ service = discovery.build('appengine', 'v1beta5', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Part of `name`. Name of the resource requested. For example: "apps/myapp/services/default".
-appsId = ''
+appsId = '{MY-APPS-ID}'
 
 # * Part of `name`. See documentation of `appsId`.
 servicesId = '{MY-SERVICES-ID}'
@@ -285,7 +285,7 @@ service = discovery.build('appengine', 'v1beta5', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
 # * Part of `name`. Name of the resource to update. For example: "apps/myapp/services/default".
-appsId = ''
+appsId = '{MY-APPS-ID}'
 
 # * Part of `name`. See documentation of `appsId`.
 servicesId = '{MY-SERVICES-ID}'
@@ -332,7 +332,7 @@ service = discovery.build('appengine', 'v1beta5', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'create' method:
 
 # * Part of `name`. Name of the resource to update. For example: "apps/myapp/services/default".
-appsId = ''
+appsId = '{MY-APPS-ID}'
 
 # * Part of `name`. See documentation of `appsId`.
 servicesId = '{MY-SERVICES-ID}'
@@ -380,10 +380,10 @@ service = discovery.build('appengine', 'v1beta5', credentials=credentials)
 
 # * Part of `name`. Name of the resource requested. For example:
 #   "apps/myapp/services/default/versions/v1".
-appsId = ''
+appsId = '{MY-APPS-ID}'
 
 # * Part of `name`. See documentation of `appsId`.
-servicesId = ''
+servicesId = '{MY-SERVICES-ID}'
 
 # * Part of `name`. See documentation of `appsId`.
 versionsId = '{MY-VERSIONS-ID}'
@@ -427,10 +427,10 @@ service = discovery.build('appengine', 'v1beta5', credentials=credentials)
 
 # * Part of `name`. Name of the resource requested. For example:
 #   "apps/myapp/services/default/versions/v1".
-appsId = ''
+appsId = '{MY-APPS-ID}'
 
 # * Part of `name`. See documentation of `appsId`.
-servicesId = ''
+servicesId = '{MY-SERVICES-ID}'
 
 # * Part of `name`. See documentation of `appsId`.
 versionsId = '{MY-VERSIONS-ID}'
@@ -472,10 +472,10 @@ service = discovery.build('appengine', 'v1beta5', credentials=credentials)
 
 # * Part of `name`. Name of the resource requested. For example:
 #   "apps/myapp/services/default/versions/v1".
-appsId = ''
+appsId = '{MY-APPS-ID}'
 
 # * Part of `name`. See documentation of `appsId`.
-servicesId = ''
+servicesId = '{MY-SERVICES-ID}'
 
 # * Part of `name`. See documentation of `appsId`.
 versionsId = '{MY-VERSIONS-ID}'
@@ -520,7 +520,7 @@ service = discovery.build('appengine', 'v1beta5', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Part of `name`. Name of the resource requested. For example: "apps/myapp/services/default".
-appsId = ''
+appsId = '{MY-APPS-ID}'
 
 # * Part of `name`. See documentation of `appsId`.
 servicesId = '{MY-SERVICES-ID}'
@@ -568,10 +568,10 @@ service = discovery.build('appengine', 'v1beta5', credentials=credentials)
 
 # * Part of `name`. Name of the resource to update. For example:
 #   "apps/myapp/services/default/versions/1".
-appsId = ''
+appsId = '{MY-APPS-ID}'
 
 # * Part of `name`. See documentation of `appsId`.
-servicesId = ''
+servicesId = '{MY-SERVICES-ID}'
 
 # * Part of `name`. See documentation of `appsId`.
 versionsId = '{MY-VERSIONS-ID}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_autoscaler.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_autoscaler.v1beta2.json.baseline
@@ -38,7 +38,7 @@ project = ''
 zone = ''
 
 # * Name of the Autoscaler resource.
-autoscaler = ''
+autoscaler = '{MY-AUTOSCALER}'
 
 request = service.autoscalers().delete(project=project, zone=zone, autoscaler=autoscaler)
 response = request.execute()
@@ -84,7 +84,7 @@ project = ''
 zone = ''
 
 # * Name of the Autoscaler resource.
-autoscaler = ''
+autoscaler = '{MY-AUTOSCALER}'
 
 request = service.autoscalers().get(project=project, zone=zone, autoscaler=autoscaler)
 response = request.execute()
@@ -127,7 +127,7 @@ service = discovery.build('autoscaler', 'v1beta2', credentials=credentials)
 project = ''
 
 # * Zone name of Autoscaler resource.
-zone = ''
+zone = '{MY-ZONE}'
 
 autoscaler_body = {
 # TODO: Add desired entries of the 'autoscaler_body' dict
@@ -172,7 +172,7 @@ service = discovery.build('autoscaler', 'v1beta2', credentials=credentials)
 project = ''
 
 # * Zone name of Autoscaler resource.
-zone = ''
+zone = '{MY-ZONE}'
 
 autoscalers = service.autoscalers()
 request = autoscalers.list(project=project, zone=zone)
@@ -222,7 +222,7 @@ project = ''
 zone = ''
 
 # * Name of the Autoscaler resource.
-autoscaler = ''
+autoscaler = '{MY-AUTOSCALER}'
 
 autoscaler_body = {
 # TODO: Add desired entries of the 'autoscaler_body' dict to be changed
@@ -272,7 +272,7 @@ project = ''
 zone = ''
 
 # * Name of the Autoscaler resource.
-autoscaler = ''
+autoscaler = '{MY-AUTOSCALER}'
 
 autoscaler_body = {
 # TODO: Add desired entries of the 'autoscaler_body' dict

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_autoscaler.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_autoscaler.v1beta2.json.baseline
@@ -32,10 +32,10 @@ service = discovery.build('autoscaler', 'v1beta2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Project ID of Autoscaler resource.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Zone name of Autoscaler resource.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * Name of the Autoscaler resource.
 autoscaler = '{MY-AUTOSCALER}'
@@ -78,10 +78,10 @@ service = discovery.build('autoscaler', 'v1beta2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID of Autoscaler resource.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Zone name of Autoscaler resource.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * Name of the Autoscaler resource.
 autoscaler = '{MY-AUTOSCALER}'
@@ -124,7 +124,7 @@ service = discovery.build('autoscaler', 'v1beta2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
 # * Project ID of Autoscaler resource.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Zone name of Autoscaler resource.
 zone = '{MY-ZONE}'
@@ -169,7 +169,7 @@ service = discovery.build('autoscaler', 'v1beta2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID of Autoscaler resource.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Zone name of Autoscaler resource.
 zone = '{MY-ZONE}'
@@ -216,10 +216,10 @@ service = discovery.build('autoscaler', 'v1beta2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
 # * Project ID of Autoscaler resource.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Zone name of Autoscaler resource.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * Name of the Autoscaler resource.
 autoscaler = '{MY-AUTOSCALER}'
@@ -266,10 +266,10 @@ service = discovery.build('autoscaler', 'v1beta2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
 # * Project ID of Autoscaler resource.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Zone name of Autoscaler resource.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * Name of the Autoscaler resource.
 autoscaler = '{MY-AUTOSCALER}'
@@ -314,13 +314,13 @@ service = discovery.build('autoscaler', 'v1beta2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 
-project = ''
+project = '{MY-PROJECT}'
 
 
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 
-operation = ''
+operation = '{MY-OPERATION}'
 
 request = service.zoneOperations().delete(project=project, zone=zone, operation=operation)
 request.execute()
@@ -357,13 +357,13 @@ service = discovery.build('autoscaler', 'v1beta2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 
-project = ''
+project = '{MY-PROJECT}'
 
 
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 
-operation = ''
+operation = '{MY-OPERATION}'
 
 request = service.zoneOperations().get(project=project, zone=zone, operation=operation)
 response = request.execute()
@@ -401,10 +401,10 @@ service = discovery.build('autoscaler', 'v1beta2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 
-project = ''
+project = '{MY-PROJECT}'
 
 
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 zoneOperations = service.zoneOperations()
 request = zoneOperations.list(project=project, zone=zone)
@@ -446,7 +446,7 @@ service = discovery.build('autoscaler', 'v1beta2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 
-project = ''
+project = '{MY-PROJECT}'
 
 zones = service.zones()
 request = zones.list(project=project)

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_bigquery.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_bigquery.v2.json.baseline
@@ -33,7 +33,7 @@ service = discovery.build('bigquery', 'v2', credentials=credentials)
 projectId = ''
 
 # * Dataset ID of dataset being deleted
-datasetId = ''
+datasetId = '{MY-DATASET-ID}'
 
 request = service.datasets().delete(projectId=projectId, datasetId=datasetId)
 request.execute()
@@ -73,7 +73,7 @@ service = discovery.build('bigquery', 'v2', credentials=credentials)
 projectId = ''
 
 # * Dataset ID of the requested dataset
-datasetId = ''
+datasetId = '{MY-DATASET-ID}'
 
 request = service.datasets().get(projectId=projectId, datasetId=datasetId)
 response = request.execute()
@@ -113,7 +113,7 @@ service = discovery.build('bigquery', 'v2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
 # * Project ID of the new dataset
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 dataset_body = {
 # TODO: Add desired entries of the 'dataset_body' dict
@@ -155,7 +155,7 @@ service = discovery.build('bigquery', 'v2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID of the datasets to be listed
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 datasets = service.datasets()
 request = datasets.list(projectId=projectId)
@@ -202,7 +202,7 @@ service = discovery.build('bigquery', 'v2', credentials=credentials)
 projectId = ''
 
 # * Dataset ID of the dataset being updated
-datasetId = ''
+datasetId = '{MY-DATASET-ID}'
 
 dataset_body = {
 # TODO: Add desired entries of the 'dataset_body' dict to be changed
@@ -249,7 +249,7 @@ service = discovery.build('bigquery', 'v2', credentials=credentials)
 projectId = ''
 
 # * Dataset ID of the dataset being updated
-datasetId = ''
+datasetId = '{MY-DATASET-ID}'
 
 dataset_body = {
 # TODO: Add desired entries of the 'dataset_body' dict
@@ -296,7 +296,7 @@ service = discovery.build('bigquery', 'v2', credentials=credentials)
 projectId = ''
 
 # * [Required] Job ID of the job to cancel
-jobId = ''
+jobId = '{MY-JOB-ID}'
 
 request = service.jobs().cancel(projectId=projectId, jobId=jobId)
 response = request.execute()
@@ -339,7 +339,7 @@ service = discovery.build('bigquery', 'v2', credentials=credentials)
 projectId = ''
 
 # * [Required] Job ID of the requested job
-jobId = ''
+jobId = '{MY-JOB-ID}'
 
 request = service.jobs().get(projectId=projectId, jobId=jobId)
 response = request.execute()
@@ -382,7 +382,7 @@ service = discovery.build('bigquery', 'v2', credentials=credentials)
 projectId = ''
 
 # * [Required] Job ID of the query job
-jobId = ''
+jobId = '{MY-JOB-ID}'
 
 request = service.jobs().getQueryResults(projectId=projectId, jobId=jobId)
 response = request.execute()
@@ -422,7 +422,7 @@ service = discovery.build('bigquery', 'v2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
 # * Project ID of the project that will be billed for the job
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 job_body = {
 # TODO: Add desired entries of the 'job_body' dict
@@ -464,7 +464,7 @@ service = discovery.build('bigquery', 'v2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID of the jobs to list
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 jobs = service.jobs()
 request = jobs.list(projectId=projectId)
@@ -508,7 +508,7 @@ service = discovery.build('bigquery', 'v2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'query' method:
 
 # * Project ID of the project billed for the query
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 query_request_body = {
 # TODO: Add desired entries of the 'query_request_body' dict
@@ -596,7 +596,7 @@ projectId = ''
 datasetId = ''
 
 # * Table ID of the destination table.
-tableId = ''
+tableId = '{MY-TABLE-ID}'
 
 table_data_insert_all_request_body = {
 # TODO: Add desired entries of the 'table_data_insert_all_request_body' dict
@@ -646,7 +646,7 @@ projectId = ''
 datasetId = ''
 
 # * Table ID of the table to read
-tableId = ''
+tableId = '{MY-TABLE-ID}'
 
 request = service.tabledata().list(projectId=projectId, datasetId=datasetId, tableId=tableId)
 response = request.execute()
@@ -690,7 +690,7 @@ projectId = ''
 datasetId = ''
 
 # * Table ID of the table to delete
-tableId = ''
+tableId = '{MY-TABLE-ID}'
 
 request = service.tables().delete(projectId=projectId, datasetId=datasetId, tableId=tableId)
 request.execute()
@@ -733,7 +733,7 @@ projectId = ''
 datasetId = ''
 
 # * Table ID of the requested table
-tableId = ''
+tableId = '{MY-TABLE-ID}'
 
 request = service.tables().get(projectId=projectId, datasetId=datasetId, tableId=tableId)
 response = request.execute()
@@ -776,7 +776,7 @@ service = discovery.build('bigquery', 'v2', credentials=credentials)
 projectId = ''
 
 # * Dataset ID of the new table
-datasetId = ''
+datasetId = '{MY-DATASET-ID}'
 
 table_body = {
 # TODO: Add desired entries of the 'table_body' dict
@@ -821,7 +821,7 @@ service = discovery.build('bigquery', 'v2', credentials=credentials)
 projectId = ''
 
 # * Dataset ID of the tables to list
-datasetId = ''
+datasetId = '{MY-DATASET-ID}'
 
 tables = service.tables()
 request = tables.list(projectId=projectId, datasetId=datasetId)
@@ -871,7 +871,7 @@ projectId = ''
 datasetId = ''
 
 # * Table ID of the table to update
-tableId = ''
+tableId = '{MY-TABLE-ID}'
 
 table_body = {
 # TODO: Add desired entries of the 'table_body' dict to be changed
@@ -921,7 +921,7 @@ projectId = ''
 datasetId = ''
 
 # * Table ID of the table to update
-tableId = ''
+tableId = '{MY-TABLE-ID}'
 
 table_body = {
 # TODO: Add desired entries of the 'table_body' dict

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_bigquery.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_bigquery.v2.json.baseline
@@ -30,7 +30,7 @@ service = discovery.build('bigquery', 'v2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Project ID of the dataset being deleted
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 # * Dataset ID of dataset being deleted
 datasetId = '{MY-DATASET-ID}'
@@ -70,7 +70,7 @@ service = discovery.build('bigquery', 'v2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID of the requested dataset
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 # * Dataset ID of the requested dataset
 datasetId = '{MY-DATASET-ID}'
@@ -199,7 +199,7 @@ service = discovery.build('bigquery', 'v2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
 # * Project ID of the dataset being updated
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 # * Dataset ID of the dataset being updated
 datasetId = '{MY-DATASET-ID}'
@@ -246,7 +246,7 @@ service = discovery.build('bigquery', 'v2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
 # * Project ID of the dataset being updated
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 # * Dataset ID of the dataset being updated
 datasetId = '{MY-DATASET-ID}'
@@ -293,7 +293,7 @@ service = discovery.build('bigquery', 'v2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'cancel' method:
 
 # * [Required] Project ID of the job to cancel
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 # * [Required] Job ID of the job to cancel
 jobId = '{MY-JOB-ID}'
@@ -336,7 +336,7 @@ service = discovery.build('bigquery', 'v2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * [Required] Project ID of the requested job
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 # * [Required] Job ID of the requested job
 jobId = '{MY-JOB-ID}'
@@ -379,7 +379,7 @@ service = discovery.build('bigquery', 'v2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'getQueryResults' method:
 
 # * [Required] Project ID of the query job
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 # * [Required] Job ID of the query job
 jobId = '{MY-JOB-ID}'
@@ -590,10 +590,10 @@ service = discovery.build('bigquery', 'v2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'insertAll' method:
 
 # * Project ID of the destination table.
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 # * Dataset ID of the destination table.
-datasetId = ''
+datasetId = '{MY-DATASET-ID}'
 
 # * Table ID of the destination table.
 tableId = '{MY-TABLE-ID}'
@@ -640,10 +640,10 @@ service = discovery.build('bigquery', 'v2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID of the table to read
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 # * Dataset ID of the table to read
-datasetId = ''
+datasetId = '{MY-DATASET-ID}'
 
 # * Table ID of the table to read
 tableId = '{MY-TABLE-ID}'
@@ -684,10 +684,10 @@ service = discovery.build('bigquery', 'v2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Project ID of the table to delete
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 # * Dataset ID of the table to delete
-datasetId = ''
+datasetId = '{MY-DATASET-ID}'
 
 # * Table ID of the table to delete
 tableId = '{MY-TABLE-ID}'
@@ -727,10 +727,10 @@ service = discovery.build('bigquery', 'v2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID of the requested table
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 # * Dataset ID of the requested table
-datasetId = ''
+datasetId = '{MY-DATASET-ID}'
 
 # * Table ID of the requested table
 tableId = '{MY-TABLE-ID}'
@@ -773,7 +773,7 @@ service = discovery.build('bigquery', 'v2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
 # * Project ID of the new table
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 # * Dataset ID of the new table
 datasetId = '{MY-DATASET-ID}'
@@ -818,7 +818,7 @@ service = discovery.build('bigquery', 'v2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID of the tables to list
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 # * Dataset ID of the tables to list
 datasetId = '{MY-DATASET-ID}'
@@ -865,10 +865,10 @@ service = discovery.build('bigquery', 'v2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
 # * Project ID of the table to update
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 # * Dataset ID of the table to update
-datasetId = ''
+datasetId = '{MY-DATASET-ID}'
 
 # * Table ID of the table to update
 tableId = '{MY-TABLE-ID}'
@@ -915,10 +915,10 @@ service = discovery.build('bigquery', 'v2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
 # * Project ID of the table to update
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 # * Dataset ID of the table to update
-datasetId = ''
+datasetId = '{MY-DATASET-ID}'
 
 # * Table ID of the table to update
 tableId = '{MY-TABLE-ID}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_clouddebugger.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_clouddebugger.v2.json.baseline
@@ -32,7 +32,7 @@ service = discovery.build('clouddebugger', 'v2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Identifies the debuggee.
-debuggeeId = ''
+debuggeeId = '{MY-DEBUGGEE-ID}'
 
 request = service.controller().debuggees().breakpoints().list(debuggeeId=debuggeeId)
 response = request.execute()
@@ -75,7 +75,7 @@ service = discovery.build('clouddebugger', 'v2', credentials=credentials)
 debuggeeId = ''
 
 # * Breakpoint identifier, unique in the scope of the debuggee.
-id = ''
+id = '{MY-ID}'
 
 update_active_breakpoint_request_body = {
 # TODO: Add desired entries of the 'update_active_breakpoint_request_body' dict
@@ -160,7 +160,7 @@ service = discovery.build('clouddebugger', 'v2', credentials=credentials)
 debuggeeId = ''
 
 # * ID of the breakpoint to delete.
-breakpointId = ''
+breakpointId = '{MY-BREAKPOINT-ID}'
 
 request = service.debugger().debuggees().breakpoints().delete(debuggeeId=debuggeeId, breakpointId=breakpointId)
 request.execute()
@@ -200,7 +200,7 @@ service = discovery.build('clouddebugger', 'v2', credentials=credentials)
 debuggeeId = ''
 
 # * ID of the breakpoint to get.
-breakpointId = ''
+breakpointId = '{MY-BREAKPOINT-ID}'
 
 request = service.debugger().debuggees().breakpoints().get(debuggeeId=debuggeeId, breakpointId=breakpointId)
 response = request.execute()
@@ -240,7 +240,7 @@ service = discovery.build('clouddebugger', 'v2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * ID of the debuggee whose breakpoints to list.
-debuggeeId = ''
+debuggeeId = '{MY-DEBUGGEE-ID}'
 
 request = service.debugger().debuggees().breakpoints().list(debuggeeId=debuggeeId)
 response = request.execute()
@@ -280,7 +280,7 @@ service = discovery.build('clouddebugger', 'v2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'set' method:
 
 # * ID of the debuggee where the breakpoint is to be set.
-debuggeeId = ''
+debuggeeId = '{MY-DEBUGGEE-ID}'
 
 breakpoint_body = {
 # TODO: Add desired entries of the 'breakpoint_body' dict

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_clouddebugger.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_clouddebugger.v2.json.baseline
@@ -72,7 +72,7 @@ service = discovery.build('clouddebugger', 'v2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
 # * Identifies the debuggee being debugged.
-debuggeeId = ''
+debuggeeId = '{MY-DEBUGGEE-ID}'
 
 # * Breakpoint identifier, unique in the scope of the debuggee.
 id = '{MY-ID}'
@@ -157,7 +157,7 @@ service = discovery.build('clouddebugger', 'v2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * ID of the debuggee whose breakpoint to delete.
-debuggeeId = ''
+debuggeeId = '{MY-DEBUGGEE-ID}'
 
 # * ID of the breakpoint to delete.
 breakpointId = '{MY-BREAKPOINT-ID}'
@@ -197,7 +197,7 @@ service = discovery.build('clouddebugger', 'v2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * ID of the debuggee whose breakpoint to get.
-debuggeeId = ''
+debuggeeId = '{MY-DEBUGGEE-ID}'
 
 # * ID of the breakpoint to get.
 breakpointId = '{MY-BREAKPOINT-ID}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_cloudmonitoring.v2beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_cloudmonitoring.v2beta2.json.baseline
@@ -76,7 +76,7 @@ service = discovery.build('cloudmonitoring', 'v2beta2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * The project ID to which the metric belongs.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the metric.
 metric = '{MY-METRIC}'
@@ -160,11 +160,11 @@ service = discovery.build('cloudmonitoring', 'v2beta2', credentials=credentials)
 
 # * The project ID to which this time series belongs. The value can be the numeric project ID or
 #   string-based project name.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Metric names are protocol-free URLs as listed in the Supported Metrics page. For example,
 #   compute.googleapis.com/instance/disk/read_ops_count.
-metric = ''
+metric = '{MY-METRIC}'
 
 # * End of the time interval (inclusive), which is expressed as an RFC 3339 timestamp.
 youngest = '{MY-YOUNGEST}'
@@ -254,11 +254,11 @@ service = discovery.build('cloudmonitoring', 'v2beta2', credentials=credentials)
 
 # * The project ID to which this time series belongs. The value can be the numeric project ID or
 #   string-based project name.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Metric names are protocol-free URLs as listed in the Supported Metrics page. For example,
 #   compute.googleapis.com/instance/disk/read_ops_count.
-metric = ''
+metric = '{MY-METRIC}'
 
 # * End of the time interval (inclusive), which is expressed as an RFC 3339 timestamp.
 youngest = '{MY-YOUNGEST}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_cloudmonitoring.v2beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_cloudmonitoring.v2beta2.json.baseline
@@ -32,7 +32,7 @@ service = discovery.build('cloudmonitoring', 'v2beta2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'create' method:
 
 # * The project id. The value can be the numeric project ID or string-based project name.
-project = ''
+project = '{MY-PROJECT}'
 
 metric_descriptor_body = {
 # TODO: Add desired entries of the 'metric_descriptor_body' dict
@@ -79,7 +79,7 @@ service = discovery.build('cloudmonitoring', 'v2beta2', credentials=credentials)
 project = ''
 
 # * Name of the metric.
-metric = ''
+metric = '{MY-METRIC}'
 
 request = service.metricDescriptors().delete(project=project, metric=metric)
 response = request.execute()
@@ -117,7 +117,7 @@ service = discovery.build('cloudmonitoring', 'v2beta2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * The project id. The value can be the numeric project ID or string-based project name.
-project = ''
+project = '{MY-PROJECT}'
 
 metricDescriptors = service.metricDescriptors()
 request = metricDescriptors.list(project=project)
@@ -167,7 +167,7 @@ project = ''
 metric = ''
 
 # * End of the time interval (inclusive), which is expressed as an RFC 3339 timestamp.
-youngest = ''
+youngest = '{MY-YOUNGEST}'
 
 timeseries = service.timeseries()
 request = timeseries.list(project=project, metric=metric, youngest=youngest)
@@ -211,7 +211,7 @@ service = discovery.build('cloudmonitoring', 'v2beta2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'write' method:
 
 # * The project ID. The value can be the numeric project ID or string-based project name.
-project = ''
+project = '{MY-PROJECT}'
 
 write_timeseries_request_body = {
 # TODO: Add desired entries of the 'write_timeseries_request_body' dict
@@ -261,7 +261,7 @@ project = ''
 metric = ''
 
 # * End of the time interval (inclusive), which is expressed as an RFC 3339 timestamp.
-youngest = ''
+youngest = '{MY-YOUNGEST}'
 
 timeseriesDescriptors = service.timeseriesDescriptors()
 request = timeseriesDescriptors.list(project=project, metric=metric, youngest=youngest)

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_cloudresourcemanager.v1beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_cloudresourcemanager.v1beta1.json.baseline
@@ -32,7 +32,7 @@ service = discovery.build('cloudresourcemanager', 'v1beta1', credentials=credent
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * The id of the Organization resource to fetch.
-organizationId = ''
+organizationId = '{MY-ORGANIZATION-ID}'
 
 request = service.organizations().get(organizationId=organizationId)
 response = request.execute()
@@ -332,7 +332,7 @@ service = discovery.build('cloudresourcemanager', 'v1beta1', credentials=credent
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * The Project ID (for example, `foo-bar-123`). Required.
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 request = service.projects().delete(projectId=projectId)
 request.execute()
@@ -369,7 +369,7 @@ service = discovery.build('cloudresourcemanager', 'v1beta1', credentials=credent
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * The Project ID (for example, `my-project-123`). Required.
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 request = service.projects().get(projectId=projectId)
 response = request.execute()
@@ -584,7 +584,7 @@ service = discovery.build('cloudresourcemanager', 'v1beta1', credentials=credent
 # TODO: Change placeholders below to appropriate parameter values for the 'undelete' method:
 
 # * The project ID (for example, `foo-bar-123`). Required.
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 undelete_project_request_body = {
 # TODO: Add desired entries of the 'undelete_project_request_body' dict
@@ -625,7 +625,7 @@ service = discovery.build('cloudresourcemanager', 'v1beta1', credentials=credent
 # TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
 # * The project ID (for example, `my-project-123`). Required.
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 project_body = {
 # TODO: Add desired entries of the 'project_body' dict

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_cloudresourcemanager.v1beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_cloudresourcemanager.v1beta1.json.baseline
@@ -74,7 +74,7 @@ service = discovery.build('cloudresourcemanager', 'v1beta1', credentials=credent
 # * REQUIRED: The resource for which the policy is being requested. `resource` is usually specified as
 #   a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified
 #   in this value is resource specific and is specified in the `getIamPolicy` documentation.
-resource = ''
+resource = '{MY-RESOURCE}'
 
 get_iam_policy_request_body = {
 # TODO: Add desired entries of the 'get_iam_policy_request_body' dict
@@ -158,7 +158,7 @@ service = discovery.build('cloudresourcemanager', 'v1beta1', credentials=credent
 # * REQUIRED: The resource for which the policy is being specified. `resource` is usually specified as
 #   a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified
 #   in this value is resource specific and is specified in the `setIamPolicy` documentation.
-resource = ''
+resource = '{MY-RESOURCE}'
 
 set_iam_policy_request_body = {
 # TODO: Add desired entries of the 'set_iam_policy_request_body' dict
@@ -205,7 +205,7 @@ service = discovery.build('cloudresourcemanager', 'v1beta1', credentials=credent
 #   specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the
 #   path specified in this value is resource specific and is specified in the `testIamPermissions`
 #   documentation.
-resource = ''
+resource = '{MY-RESOURCE}'
 
 test_iam_permissions_request_body = {
 # TODO: Add desired entries of the 'test_iam_permissions_request_body' dict
@@ -250,7 +250,7 @@ service = discovery.build('cloudresourcemanager', 'v1beta1', credentials=credent
 
 # * An immutable id for the Organization that is assigned on creation. This should be omitted when
 #   creating a new Organization. This field is read-only.
-organizationId = ''
+organizationId = '{MY-ORGANIZATION-ID}'
 
 organization_body = {
 # TODO: Add desired entries of the 'organization_body' dict
@@ -411,7 +411,7 @@ service = discovery.build('cloudresourcemanager', 'v1beta1', credentials=credent
 # * REQUIRED: The resource for which the policy is being requested. `resource` is usually specified as
 #   a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified
 #   in this value is resource specific and is specified in the `getIamPolicy` documentation.
-resource = ''
+resource = '{MY-RESOURCE}'
 
 get_iam_policy_request_body = {
 # TODO: Add desired entries of the 'get_iam_policy_request_body' dict
@@ -495,7 +495,7 @@ service = discovery.build('cloudresourcemanager', 'v1beta1', credentials=credent
 # * REQUIRED: The resource for which the policy is being specified. `resource` is usually specified as
 #   a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified
 #   in this value is resource specific and is specified in the `setIamPolicy` documentation.
-resource = ''
+resource = '{MY-RESOURCE}'
 
 set_iam_policy_request_body = {
 # TODO: Add desired entries of the 'set_iam_policy_request_body' dict
@@ -542,7 +542,7 @@ service = discovery.build('cloudresourcemanager', 'v1beta1', credentials=credent
 #   specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the
 #   path specified in this value is resource specific and is specified in the `testIamPermissions`
 #   documentation.
-resource = ''
+resource = '{MY-RESOURCE}'
 
 test_iam_permissions_request_body = {
 # TODO: Add desired entries of the 'test_iam_permissions_request_body' dict

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_cloudtrace.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_cloudtrace.v1.json.baseline
@@ -30,7 +30,7 @@ service = discovery.build('cloudtrace', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'patchTraces' method:
 
 # * ID of the Cloud project where the trace data is stored.
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 traces_body = {
 # TODO: Add desired entries of the 'traces_body' dict to be changed
@@ -74,7 +74,7 @@ service = discovery.build('cloudtrace', 'v1', credentials=credentials)
 projectId = ''
 
 # * ID of the trace to return.
-traceId = ''
+traceId = '{MY-TRACE-ID}'
 
 request = service.projects().traces().get(projectId=projectId, traceId=traceId)
 response = request.execute()
@@ -112,7 +112,7 @@ service = discovery.build('cloudtrace', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * ID of the Cloud project where the trace data is stored.
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 traces = service.projects().traces()
 request = traces.list(projectId=projectId)

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_cloudtrace.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_cloudtrace.v1.json.baseline
@@ -71,7 +71,7 @@ service = discovery.build('cloudtrace', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * ID of the Cloud project where the trace data is stored.
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 # * ID of the trace to return.
 traceId = '{MY-TRACE-ID}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_clouduseraccounts.beta.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_clouduseraccounts.beta.json.baseline
@@ -30,7 +30,7 @@ service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the Operations resource to delete.
 operation = '{MY-OPERATION}'
@@ -70,7 +70,7 @@ service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the Operations resource to return.
 operation = '{MY-OPERATION}'
@@ -155,7 +155,7 @@ service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'addMember' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the group for this request.
 groupName = '{MY-GROUP-NAME}'
@@ -202,7 +202,7 @@ service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the Group resource to delete.
 groupName = '{MY-GROUP-NAME}'
@@ -245,7 +245,7 @@ service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the Group resource to return.
 groupName = '{MY-GROUP-NAME}'
@@ -374,7 +374,7 @@ service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'removeMember' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the group for this request.
 groupName = '{MY-GROUP-NAME}'
@@ -421,13 +421,13 @@ service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'getAuthorizedKeysView' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * The user account for which you want to get a list of authorized public keys.
-user = ''
+user = '{MY-USER}'
 
 # * The fully-qualified URL of the virtual machine requesting the view.
 instance = '{MY-INSTANCE}'
@@ -470,10 +470,10 @@ service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'getLinuxAccountViews' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * The fully-qualified URL of the virtual machine requesting the views.
 instance = '{MY-INSTANCE}'
@@ -516,7 +516,7 @@ service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'addPublicKey' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the user for this request.
 user = '{MY-USER}'
@@ -563,7 +563,7 @@ service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the user resource to delete.
 user = '{MY-USER}'
@@ -606,7 +606,7 @@ service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the user resource to return.
 user = '{MY-USER}'
@@ -735,14 +735,14 @@ service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'removePublicKey' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the user for this request.
-user = ''
+user = '{MY-USER}'
 
 # * The fingerprint of the public key to delete. Public keys are identified by their fingerprint,
 #   which is defined by RFC4716 to be the MD5 digest of the public key.
-fingerprint = ''
+fingerprint = '{MY-FINGERPRINT}'
 
 request = service.users().removePublicKey(project=project, user=user, fingerprint=fingerprint)
 response = request.execute()

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_clouduseraccounts.beta.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_clouduseraccounts.beta.json.baseline
@@ -33,7 +33,7 @@ service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
 project = ''
 
 # * Name of the Operations resource to delete.
-operation = ''
+operation = '{MY-OPERATION}'
 
 request = service.globalAccountsOperations().delete(project=project, operation=operation)
 request.execute()
@@ -73,7 +73,7 @@ service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
 project = ''
 
 # * Name of the Operations resource to return.
-operation = ''
+operation = '{MY-OPERATION}'
 
 request = service.globalAccountsOperations().get(project=project, operation=operation)
 response = request.execute()
@@ -111,7 +111,7 @@ service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 globalAccountsOperations = service.globalAccountsOperations()
 request = globalAccountsOperations.list(project=project)
@@ -158,7 +158,7 @@ service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
 project = ''
 
 # * Name of the group for this request.
-groupName = ''
+groupName = '{MY-GROUP-NAME}'
 
 groups_add_member_request_body = {
 # TODO: Add desired entries of the 'groups_add_member_request_body' dict
@@ -205,7 +205,7 @@ service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
 project = ''
 
 # * Name of the Group resource to delete.
-groupName = ''
+groupName = '{MY-GROUP-NAME}'
 
 request = service.groups().delete(project=project, groupName=groupName)
 response = request.execute()
@@ -248,7 +248,7 @@ service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
 project = ''
 
 # * Name of the Group resource to return.
-groupName = ''
+groupName = '{MY-GROUP-NAME}'
 
 request = service.groups().get(project=project, groupName=groupName)
 response = request.execute()
@@ -288,7 +288,7 @@ service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 group_body = {
 # TODO: Add desired entries of the 'group_body' dict
@@ -330,7 +330,7 @@ service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 groups = service.groups()
 request = groups.list(project=project)
@@ -377,7 +377,7 @@ service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
 project = ''
 
 # * Name of the group for this request.
-groupName = ''
+groupName = '{MY-GROUP-NAME}'
 
 groups_remove_member_request_body = {
 # TODO: Add desired entries of the 'groups_remove_member_request_body' dict
@@ -430,7 +430,7 @@ zone = ''
 user = ''
 
 # * The fully-qualified URL of the virtual machine requesting the view.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 request = service.linux().getAuthorizedKeysView(project=project, zone=zone, user=user, instance=instance)
 response = request.execute()
@@ -476,7 +476,7 @@ project = ''
 zone = ''
 
 # * The fully-qualified URL of the virtual machine requesting the views.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 request = service.linux().getLinuxAccountViews(project=project, zone=zone, instance=instance)
 response = request.execute()
@@ -519,7 +519,7 @@ service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
 project = ''
 
 # * Name of the user for this request.
-user = ''
+user = '{MY-USER}'
 
 public_key_body = {
 # TODO: Add desired entries of the 'public_key_body' dict
@@ -566,7 +566,7 @@ service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
 project = ''
 
 # * Name of the user resource to delete.
-user = ''
+user = '{MY-USER}'
 
 request = service.users().delete(project=project, user=user)
 response = request.execute()
@@ -609,7 +609,7 @@ service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
 project = ''
 
 # * Name of the user resource to return.
-user = ''
+user = '{MY-USER}'
 
 request = service.users().get(project=project, user=user)
 response = request.execute()
@@ -649,7 +649,7 @@ service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 user_body = {
 # TODO: Add desired entries of the 'user_body' dict
@@ -691,7 +691,7 @@ service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 users = service.users()
 request = users.list(project=project)

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_compute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_compute.v1.json.baseline
@@ -74,10 +74,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region for this request.
-region = ''
+region = '{MY-REGION}'
 
 # * Name of the address resource to delete.
 address = '{MY-ADDRESS}'
@@ -120,10 +120,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region for this request.
-region = ''
+region = '{MY-REGION}'
 
 # * Name of the address resource to return.
 address = '{MY-ADDRESS}'
@@ -166,7 +166,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region for this request.
 region = '{MY-REGION}'
@@ -211,7 +211,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region for this request.
 region = '{MY-REGION}'
@@ -300,10 +300,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * Name of the autoscaler to delete.
 autoscaler = '{MY-AUTOSCALER}'
@@ -346,10 +346,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * Name of the autoscaler to return.
 autoscaler = '{MY-AUTOSCALER}'
@@ -392,7 +392,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the zone for this request.
 zone = '{MY-ZONE}'  # eg. 'us-central1-f'
@@ -437,7 +437,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the zone for this request.
 zone = '{MY-ZONE}'  # eg. 'us-central1-f'
@@ -484,10 +484,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * Name of the autoscaler to update.
 autoscaler = '{MY-AUTOSCALER}'
@@ -534,7 +534,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the zone for this request.
 zone = '{MY-ZONE}'  # eg. 'us-central1-f'
@@ -581,7 +581,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the BackendService resource to delete.
 backendService = '{MY-BACKEND-SERVICE}'
@@ -624,7 +624,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the BackendService resource to return.
 backendService = '{MY-BACKEND-SERVICE}'
@@ -667,7 +667,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'getHealth' method:
 
 
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the BackendService resource to which the queried instance belongs.
 backendService = '{MY-BACKEND-SERVICE}'
@@ -800,7 +800,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the BackendService resource to update.
 backendService = '{MY-BACKEND-SERVICE}'
@@ -847,7 +847,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the BackendService resource to update.
 backendService = '{MY-BACKEND-SERVICE}'
@@ -936,10 +936,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * Name of the disk type to return.
 diskType = '{MY-DISK-TYPE}'
@@ -980,7 +980,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
 zone = '{MY-ZONE}'  # eg. 'us-central1-f'
@@ -1069,10 +1069,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'createSnapshot' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * Name of the persistent disk to snapshot.
 disk = '{MY-DISK}'
@@ -1119,10 +1119,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * Name of the persistent disk to delete.
 disk = '{MY-DISK}'
@@ -1165,10 +1165,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * Name of the persistent disk to return.
 disk = '{MY-DISK}'
@@ -1211,7 +1211,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
 zone = '{MY-ZONE}'  # eg. 'us-central1-f'
@@ -1256,7 +1256,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
 zone = '{MY-ZONE}'  # eg. 'us-central1-f'
@@ -1303,7 +1303,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the firewall rule to delete.
 firewall = '{MY-FIREWALL}'
@@ -1346,7 +1346,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the firewall rule to return.
 firewall = '{MY-FIREWALL}'
@@ -1475,7 +1475,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the firewall rule to update.
 firewall = '{MY-FIREWALL}'
@@ -1522,7 +1522,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the firewall rule to update.
 firewall = '{MY-FIREWALL}'
@@ -1611,10 +1611,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region scoping this request.
-region = ''
+region = '{MY-REGION}'
 
 # * Name of the ForwardingRule resource to delete.
 forwardingRule = '{MY-FORWARDING-RULE}'
@@ -1657,10 +1657,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region scoping this request.
-region = ''
+region = '{MY-REGION}'
 
 # * Name of the ForwardingRule resource to return.
 forwardingRule = '{MY-FORWARDING-RULE}'
@@ -1703,7 +1703,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region scoping this request.
 region = '{MY-REGION}'
@@ -1748,7 +1748,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region scoping this request.
 region = '{MY-REGION}'
@@ -1795,10 +1795,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'setTarget' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region scoping this request.
-region = ''
+region = '{MY-REGION}'
 
 # * Name of the ForwardingRule resource in which target is to be set.
 forwardingRule = '{MY-FORWARDING-RULE}'
@@ -1845,7 +1845,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the address resource to delete.
 address = '{MY-ADDRESS}'
@@ -1888,7 +1888,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the address resource to return.
 address = '{MY-ADDRESS}'
@@ -2017,7 +2017,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the ForwardingRule resource to delete.
 forwardingRule = '{MY-FORWARDING-RULE}'
@@ -2060,7 +2060,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the ForwardingRule resource to return.
 forwardingRule = '{MY-FORWARDING-RULE}'
@@ -2189,7 +2189,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'setTarget' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the ForwardingRule resource in which target is to be set.
 forwardingRule = '{MY-FORWARDING-RULE}'
@@ -2276,7 +2276,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the Operations resource to delete.
 operation = '{MY-OPERATION}'
@@ -2316,7 +2316,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the Operations resource to return.
 operation = '{MY-OPERATION}'
@@ -2401,7 +2401,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the HttpHealthCheck resource to delete.
 httpHealthCheck = '{MY-HTTP-HEALTH-CHECK}'
@@ -2444,7 +2444,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the HttpHealthCheck resource to return.
 httpHealthCheck = '{MY-HTTP-HEALTH-CHECK}'
@@ -2573,7 +2573,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the HttpHealthCheck resource to update.
 httpHealthCheck = '{MY-HTTP-HEALTH-CHECK}'
@@ -2620,7 +2620,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the HttpHealthCheck resource to update.
 httpHealthCheck = '{MY-HTTP-HEALTH-CHECK}'
@@ -2667,7 +2667,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the HttpsHealthCheck resource to delete.
 httpsHealthCheck = '{MY-HTTPS-HEALTH-CHECK}'
@@ -2710,7 +2710,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the HttpsHealthCheck resource to return.
 httpsHealthCheck = '{MY-HTTPS-HEALTH-CHECK}'
@@ -2839,7 +2839,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the HttpsHealthCheck resource to update.
 httpsHealthCheck = '{MY-HTTPS-HEALTH-CHECK}'
@@ -2886,7 +2886,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the HttpsHealthCheck resource to update.
 httpsHealthCheck = '{MY-HTTPS-HEALTH-CHECK}'
@@ -2933,7 +2933,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the image resource to delete.
 image = '{MY-IMAGE}'
@@ -2976,7 +2976,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'deprecate' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Image name.
 image = '{MY-IMAGE}'
@@ -3023,7 +3023,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the image resource to return.
 image = '{MY-IMAGE}'
@@ -3152,10 +3152,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'abandonInstances' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone where the managed instance group is located.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the managed instance group.
 instanceGroupManager = '{MY-INSTANCE-GROUP-MANAGER}'
@@ -3244,10 +3244,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone where the managed instance group is located.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the managed instance group to delete.
 instanceGroupManager = '{MY-INSTANCE-GROUP-MANAGER}'
@@ -3290,10 +3290,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'deleteInstances' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone where the managed instance group is located.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the managed instance group.
 instanceGroupManager = '{MY-INSTANCE-GROUP-MANAGER}'
@@ -3340,10 +3340,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone where the managed instance group is located.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the managed instance group.
 instanceGroupManager = '{MY-INSTANCE-GROUP-MANAGER}'
@@ -3386,7 +3386,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone where you want to create the managed instance group.
 zone = '{MY-ZONE}'
@@ -3431,7 +3431,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone where the managed instance group is located.
 zone = '{MY-ZONE}'
@@ -3478,10 +3478,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'listManagedInstances' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone where the managed instance group is located.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the managed instance group.
 instanceGroupManager = '{MY-INSTANCE-GROUP-MANAGER}'
@@ -3524,10 +3524,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'recreateInstances' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone where the managed instance group is located.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the managed instance group.
 instanceGroupManager = '{MY-INSTANCE-GROUP-MANAGER}'
@@ -3574,13 +3574,13 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'resize' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone where the managed instance group is located.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the managed instance group.
-instanceGroupManager = ''
+instanceGroupManager = '{MY-INSTANCE-GROUP-MANAGER}'
 
 # * The number of running instances that the managed instance group should maintain at any given time.
 #   The group automatically adds or removes instances to maintain the number of instances specified by
@@ -3625,10 +3625,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'setInstanceTemplate' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone where the managed instance group is located.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the managed instance group.
 instanceGroupManager = '{MY-INSTANCE-GROUP-MANAGER}'
@@ -3675,10 +3675,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'setTargetPools' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone where the managed instance group is located.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the managed instance group.
 instanceGroupManager = '{MY-INSTANCE-GROUP-MANAGER}'
@@ -3725,10 +3725,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'addInstances' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone where the instance group is located.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the instance group where you are adding instances.
 instanceGroup = '{MY-INSTANCE-GROUP}'
@@ -3817,10 +3817,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone where the instance group is located.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the instance group to delete.
 instanceGroup = '{MY-INSTANCE-GROUP}'
@@ -3863,10 +3863,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone where the instance group is located.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the instance group.
 instanceGroup = '{MY-INSTANCE-GROUP}'
@@ -3909,7 +3909,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone where you want to create the instance group.
 zone = '{MY-ZONE}'
@@ -3954,7 +3954,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone where the instance group is located.
 zone = '{MY-ZONE}'
@@ -3999,10 +3999,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'listInstances' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone where the instance group is located.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the instance group from which you want to generate a list of included instances.
 instanceGroup = '{MY-INSTANCE-GROUP}'
@@ -4053,10 +4053,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'removeInstances' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone where the instance group is located.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the instance group where the specified instances will be removed.
 instanceGroup = '{MY-INSTANCE-GROUP}'
@@ -4103,10 +4103,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'setNamedPorts' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone where the instance group is located.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the instance group where the named ports are updated.
 instanceGroup = '{MY-INSTANCE-GROUP}'
@@ -4153,7 +4153,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the instance template to delete.
 instanceTemplate = '{MY-INSTANCE-TEMPLATE}'
@@ -4196,7 +4196,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the instance template.
 instanceTemplate = '{MY-INSTANCE-TEMPLATE}'
@@ -4325,13 +4325,13 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'addAccessConfig' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * The instance name for this request.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # * The name of the network interface to add to this instance.
 networkInterface = '{MY-NETWORK-INTERFACE}'
@@ -4420,10 +4420,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'attachDisk' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * The instance name for this request.
 instance = '{MY-INSTANCE}'
@@ -4470,10 +4470,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * Name of the instance resource to delete.
 instance = '{MY-INSTANCE}'
@@ -4516,16 +4516,16 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'deleteAccessConfig' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * The instance name for this request.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # * The name of the access config to delete.
-accessConfig = ''
+accessConfig = '{MY-ACCESS-CONFIG}'
 
 # * The name of the network interface.
 networkInterface = '{MY-NETWORK-INTERFACE}'
@@ -4568,13 +4568,13 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'detachDisk' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * Instance name.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # * Disk device name to detach.
 deviceName = '{MY-DEVICE-NAME}'
@@ -4617,10 +4617,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * Name of the instance resource to return.
 instance = '{MY-INSTANCE}'
@@ -4663,10 +4663,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'getSerialPortOutput' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * Name of the instance scoping this request.
 instance = '{MY-INSTANCE}'
@@ -4709,7 +4709,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
 zone = '{MY-ZONE}'  # eg. 'us-central1-f'
@@ -4754,7 +4754,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
 zone = '{MY-ZONE}'  # eg. 'us-central1-f'
@@ -4801,10 +4801,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'reset' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * Name of the instance scoping this request.
 instance = '{MY-INSTANCE}'
@@ -4847,13 +4847,13 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'setDiskAutoDelete' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * The instance name.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # * Whether to auto-delete the disk when the instance is deleted.
 autoDelete = False
@@ -4899,10 +4899,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'setMachineType' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * Name of the instance scoping this request.
 instance = '{MY-INSTANCE}'
@@ -4949,10 +4949,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'setMetadata' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * Name of the instance scoping this request.
 instance = '{MY-INSTANCE}'
@@ -4999,10 +4999,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'setScheduling' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * Instance name.
 instance = '{MY-INSTANCE}'
@@ -5049,10 +5049,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'setTags' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * Name of the instance scoping this request.
 instance = '{MY-INSTANCE}'
@@ -5099,10 +5099,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'start' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * Name of the instance resource to start.
 instance = '{MY-INSTANCE}'
@@ -5145,10 +5145,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'stop' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * Name of the instance resource to stop.
 instance = '{MY-INSTANCE}'
@@ -5191,7 +5191,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the License resource to return.
 license = '{MY-LICENSE}'
@@ -5276,10 +5276,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * Name of the machine type to return.
 machineType = '{MY-MACHINE-TYPE}'
@@ -5320,7 +5320,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
 zone = '{MY-ZONE}'  # eg. 'us-central1-f'
@@ -5367,7 +5367,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the network to delete.
 network = '{MY-NETWORK}'
@@ -5410,7 +5410,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the network to return.
 network = '{MY-NETWORK}'
@@ -5753,10 +5753,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region for this request.
-region = ''
+region = '{MY-REGION}'
 
 # * Name of the Operations resource to delete.
 operation = '{MY-OPERATION}'
@@ -5796,10 +5796,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region for this request.
-region = ''
+region = '{MY-REGION}'
 
 # * Name of the Operations resource to return.
 operation = '{MY-OPERATION}'
@@ -5840,7 +5840,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region for this request.
 region = '{MY-REGION}'
@@ -5887,7 +5887,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region resource to return.
 region = '{MY-REGION}'
@@ -5972,7 +5972,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the Route resource to delete.
 route = '{MY-ROUTE}'
@@ -6015,7 +6015,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the Route resource to return.
 route = '{MY-ROUTE}'
@@ -6144,7 +6144,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the Snapshot resource to delete.
 snapshot = '{MY-SNAPSHOT}'
@@ -6187,7 +6187,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the Snapshot resource to return.
 snapshot = '{MY-SNAPSHOT}'
@@ -6272,7 +6272,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the SslCertificate resource to delete.
 sslCertificate = '{MY-SSL-CERTIFICATE}'
@@ -6315,7 +6315,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the SslCertificate resource to return.
 sslCertificate = '{MY-SSL-CERTIFICATE}'
@@ -6486,10 +6486,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region scoping this request.
-region = ''
+region = '{MY-REGION}'
 
 # * Name of the Subnetwork resource to delete.
 subnetwork = '{MY-SUBNETWORK}'
@@ -6532,10 +6532,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region scoping this request.
-region = ''
+region = '{MY-REGION}'
 
 # * Name of the Subnetwork resource to return.
 subnetwork = '{MY-SUBNETWORK}'
@@ -6578,7 +6578,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region scoping this request.
 region = '{MY-REGION}'
@@ -6623,7 +6623,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region scoping this request.
 region = '{MY-REGION}'
@@ -6670,7 +6670,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the TargetHttpProxy resource to delete.
 targetHttpProxy = '{MY-TARGET-HTTP-PROXY}'
@@ -6713,7 +6713,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the TargetHttpProxy resource to return.
 targetHttpProxy = '{MY-TARGET-HTTP-PROXY}'
@@ -6842,7 +6842,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'setUrlMap' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the TargetHttpProxy to set a URL map for.
 targetHttpProxy = '{MY-TARGET-HTTP-PROXY}'
@@ -6889,7 +6889,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the TargetHttpsProxy resource to delete.
 targetHttpsProxy = '{MY-TARGET-HTTPS-PROXY}'
@@ -6932,7 +6932,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the TargetHttpsProxy resource to return.
 targetHttpsProxy = '{MY-TARGET-HTTPS-PROXY}'
@@ -7061,7 +7061,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'setSslCertificates' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the TargetHttpsProxy resource to set an SslCertificates resource for.
 targetHttpsProxy = '{MY-TARGET-HTTPS-PROXY}'
@@ -7108,7 +7108,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'setUrlMap' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the TargetHttpsProxy resource whose URL map is to be set.
 targetHttpsProxy = '{MY-TARGET-HTTPS-PROXY}'
@@ -7197,10 +7197,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the zone scoping this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * Name of the TargetInstance resource to delete.
 targetInstance = '{MY-TARGET-INSTANCE}'
@@ -7243,10 +7243,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the zone scoping this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * Name of the TargetInstance resource to return.
 targetInstance = '{MY-TARGET-INSTANCE}'
@@ -7289,7 +7289,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the zone scoping this request.
 zone = '{MY-ZONE}'  # eg. 'us-central1-f'
@@ -7334,7 +7334,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the zone scoping this request.
 zone = '{MY-ZONE}'  # eg. 'us-central1-f'
@@ -7381,10 +7381,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'addHealthCheck' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region scoping this request.
-region = ''
+region = '{MY-REGION}'
 
 # * Name of the target pool to add a health check to.
 targetPool = '{MY-TARGET-POOL}'
@@ -7431,10 +7431,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'addInstance' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region scoping this request.
-region = ''
+region = '{MY-REGION}'
 
 # * Name of the TargetPool resource to add instances to.
 targetPool = '{MY-TARGET-POOL}'
@@ -7523,10 +7523,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region scoping this request.
-region = ''
+region = '{MY-REGION}'
 
 # * Name of the TargetPool resource to delete.
 targetPool = '{MY-TARGET-POOL}'
@@ -7569,10 +7569,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region scoping this request.
-region = ''
+region = '{MY-REGION}'
 
 # * Name of the TargetPool resource to return.
 targetPool = '{MY-TARGET-POOL}'
@@ -7615,10 +7615,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'getHealth' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region scoping this request.
-region = ''
+region = '{MY-REGION}'
 
 # * Name of the TargetPool resource to which the queried instance belongs.
 targetPool = '{MY-TARGET-POOL}'
@@ -7665,7 +7665,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region scoping this request.
 region = '{MY-REGION}'
@@ -7710,7 +7710,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region scoping this request.
 region = '{MY-REGION}'
@@ -7757,10 +7757,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'removeHealthCheck' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region for this request.
-region = ''
+region = '{MY-REGION}'
 
 # * Name of the target pool to remove health checks from.
 targetPool = '{MY-TARGET-POOL}'
@@ -7807,10 +7807,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'removeInstance' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region scoping this request.
-region = ''
+region = '{MY-REGION}'
 
 # * Name of the TargetPool resource to remove instances from.
 targetPool = '{MY-TARGET-POOL}'
@@ -7857,10 +7857,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'setBackup' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region scoping this request.
-region = ''
+region = '{MY-REGION}'
 
 # * Name of the TargetPool resource to set a backup pool for.
 targetPool = '{MY-TARGET-POOL}'
@@ -7949,10 +7949,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region for this request.
-region = ''
+region = '{MY-REGION}'
 
 # * Name of the target VPN gateway to delete.
 targetVpnGateway = '{MY-TARGET-VPN-GATEWAY}'
@@ -7995,10 +7995,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region for this request.
-region = ''
+region = '{MY-REGION}'
 
 # * Name of the target VPN gateway to return.
 targetVpnGateway = '{MY-TARGET-VPN-GATEWAY}'
@@ -8041,7 +8041,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region for this request.
 region = '{MY-REGION}'
@@ -8086,7 +8086,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region for this request.
 region = '{MY-REGION}'
@@ -8133,7 +8133,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the UrlMap resource to delete.
 urlMap = '{MY-URL-MAP}'
@@ -8176,7 +8176,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the UrlMap resource to return.
 urlMap = '{MY-URL-MAP}'
@@ -8305,7 +8305,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the UrlMap resource to update.
 urlMap = '{MY-URL-MAP}'
@@ -8352,7 +8352,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the UrlMap resource to update.
 urlMap = '{MY-URL-MAP}'
@@ -8399,7 +8399,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'validate' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the UrlMap resource to be validated as.
 urlMap = '{MY-URL-MAP}'
@@ -8488,10 +8488,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region for this request.
-region = ''
+region = '{MY-REGION}'
 
 # * Name of the VpnTunnel resource to delete.
 vpnTunnel = '{MY-VPN-TUNNEL}'
@@ -8534,10 +8534,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region for this request.
-region = ''
+region = '{MY-REGION}'
 
 # * Name of the VpnTunnel resource to return.
 vpnTunnel = '{MY-VPN-TUNNEL}'
@@ -8580,7 +8580,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region for this request.
 region = '{MY-REGION}'
@@ -8625,7 +8625,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region for this request.
 region = '{MY-REGION}'
@@ -8670,10 +8670,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * Name of the Operations resource to delete.
 operation = '{MY-OPERATION}'
@@ -8713,10 +8713,10 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * Name of the Operations resource to return.
 operation = '{MY-OPERATION}'
@@ -8757,7 +8757,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the zone for request.
 zone = '{MY-ZONE}'  # eg. 'us-central1-f'
@@ -8804,7 +8804,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the zone resource to return.
 zone = '{MY-ZONE}'  # eg. 'us-central1-f'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_compute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_compute.v1.json.baseline
@@ -30,7 +30,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 addresses = service.addresses()
 request = addresses.aggregatedList(project=project)
@@ -80,7 +80,7 @@ project = ''
 region = ''
 
 # * Name of the address resource to delete.
-address = ''
+address = '{MY-ADDRESS}'
 
 request = service.addresses().delete(project=project, region=region, address=address)
 response = request.execute()
@@ -126,7 +126,7 @@ project = ''
 region = ''
 
 # * Name of the address resource to return.
-address = ''
+address = '{MY-ADDRESS}'
 
 request = service.addresses().get(project=project, region=region, address=address)
 response = request.execute()
@@ -169,7 +169,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the region for this request.
-region = ''
+region = '{MY-REGION}'
 
 address_body = {
 # TODO: Add desired entries of the 'address_body' dict
@@ -214,7 +214,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the region for this request.
-region = ''
+region = '{MY-REGION}'
 
 addresses = service.addresses()
 request = addresses.list(project=project, region=region)
@@ -256,7 +256,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 autoscalers = service.autoscalers()
 request = autoscalers.aggregatedList(project=project)
@@ -306,7 +306,7 @@ project = ''
 zone = ''
 
 # * Name of the autoscaler to delete.
-autoscaler = ''
+autoscaler = '{MY-AUTOSCALER}'
 
 request = service.autoscalers().delete(project=project, zone=zone, autoscaler=autoscaler)
 response = request.execute()
@@ -352,7 +352,7 @@ project = ''
 zone = ''
 
 # * Name of the autoscaler to return.
-autoscaler = ''
+autoscaler = '{MY-AUTOSCALER}'
 
 request = service.autoscalers().get(project=project, zone=zone, autoscaler=autoscaler)
 response = request.execute()
@@ -395,7 +395,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the zone for this request.
-zone = ''
+zone = 'us-central1-f'
 
 autoscaler_body = {
 # TODO: Add desired entries of the 'autoscaler_body' dict
@@ -440,7 +440,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the zone for this request.
-zone = ''
+zone = 'us-central1-f'
 
 autoscalers = service.autoscalers()
 request = autoscalers.list(project=project, zone=zone)
@@ -490,7 +490,7 @@ project = ''
 zone = ''
 
 # * Name of the autoscaler to update.
-autoscaler = ''
+autoscaler = '{MY-AUTOSCALER}'
 
 autoscaler_body = {
 # TODO: Add desired entries of the 'autoscaler_body' dict to be changed
@@ -537,7 +537,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the zone for this request.
-zone = ''
+zone = 'us-central1-f'
 
 autoscaler_body = {
 # TODO: Add desired entries of the 'autoscaler_body' dict
@@ -584,7 +584,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the BackendService resource to delete.
-backendService = ''
+backendService = '{MY-BACKEND-SERVICE}'
 
 request = service.backendServices().delete(project=project, backendService=backendService)
 response = request.execute()
@@ -627,7 +627,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the BackendService resource to return.
-backendService = ''
+backendService = '{MY-BACKEND-SERVICE}'
 
 request = service.backendServices().get(project=project, backendService=backendService)
 response = request.execute()
@@ -670,7 +670,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the BackendService resource to which the queried instance belongs.
-backendService = ''
+backendService = '{MY-BACKEND-SERVICE}'
 
 resource_group_reference_body = {
 # TODO: Add desired entries of the 'resource_group_reference_body' dict
@@ -714,7 +714,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 backend_service_body = {
 # TODO: Add desired entries of the 'backend_service_body' dict
@@ -756,7 +756,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 backendServices = service.backendServices()
 request = backendServices.list(project=project)
@@ -803,7 +803,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the BackendService resource to update.
-backendService = ''
+backendService = '{MY-BACKEND-SERVICE}'
 
 backend_service_body = {
 # TODO: Add desired entries of the 'backend_service_body' dict to be changed
@@ -850,7 +850,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the BackendService resource to update.
-backendService = ''
+backendService = '{MY-BACKEND-SERVICE}'
 
 backend_service_body = {
 # TODO: Add desired entries of the 'backend_service_body' dict
@@ -892,7 +892,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 diskTypes = service.diskTypes()
 request = diskTypes.aggregatedList(project=project)
@@ -942,7 +942,7 @@ project = ''
 zone = ''
 
 # * Name of the disk type to return.
-diskType = ''
+diskType = '{MY-DISK-TYPE}'
 
 request = service.diskTypes().get(project=project, zone=zone, diskType=diskType)
 response = request.execute()
@@ -983,7 +983,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * The name of the zone for this request.
-zone = ''
+zone = 'us-central1-f'
 
 diskTypes = service.diskTypes()
 request = diskTypes.list(project=project, zone=zone)
@@ -1025,7 +1025,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 disks = service.disks()
 request = disks.aggregatedList(project=project)
@@ -1075,7 +1075,7 @@ project = ''
 zone = ''
 
 # * Name of the persistent disk to snapshot.
-disk = ''
+disk = '{MY-DISK}'
 
 snapshot_body = {
 # TODO: Add desired entries of the 'snapshot_body' dict
@@ -1125,7 +1125,7 @@ project = ''
 zone = ''
 
 # * Name of the persistent disk to delete.
-disk = ''
+disk = '{MY-DISK}'
 
 request = service.disks().delete(project=project, zone=zone, disk=disk)
 response = request.execute()
@@ -1171,7 +1171,7 @@ project = ''
 zone = ''
 
 # * Name of the persistent disk to return.
-disk = ''
+disk = '{MY-DISK}'
 
 request = service.disks().get(project=project, zone=zone, disk=disk)
 response = request.execute()
@@ -1214,7 +1214,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * The name of the zone for this request.
-zone = ''
+zone = 'us-central1-f'
 
 disk_body = {
 # TODO: Add desired entries of the 'disk_body' dict
@@ -1259,7 +1259,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * The name of the zone for this request.
-zone = ''
+zone = 'us-central1-f'
 
 disks = service.disks()
 request = disks.list(project=project, zone=zone)
@@ -1306,7 +1306,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the firewall rule to delete.
-firewall = ''
+firewall = '{MY-FIREWALL}'
 
 request = service.firewalls().delete(project=project, firewall=firewall)
 response = request.execute()
@@ -1349,7 +1349,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the firewall rule to return.
-firewall = ''
+firewall = '{MY-FIREWALL}'
 
 request = service.firewalls().get(project=project, firewall=firewall)
 response = request.execute()
@@ -1389,7 +1389,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 firewall_body = {
 # TODO: Add desired entries of the 'firewall_body' dict
@@ -1431,7 +1431,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 firewalls = service.firewalls()
 request = firewalls.list(project=project)
@@ -1478,7 +1478,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the firewall rule to update.
-firewall = ''
+firewall = '{MY-FIREWALL}'
 
 firewall_body = {
 # TODO: Add desired entries of the 'firewall_body' dict to be changed
@@ -1525,7 +1525,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the firewall rule to update.
-firewall = ''
+firewall = '{MY-FIREWALL}'
 
 firewall_body = {
 # TODO: Add desired entries of the 'firewall_body' dict
@@ -1567,7 +1567,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 forwardingRules = service.forwardingRules()
 request = forwardingRules.aggregatedList(project=project)
@@ -1617,7 +1617,7 @@ project = ''
 region = ''
 
 # * Name of the ForwardingRule resource to delete.
-forwardingRule = ''
+forwardingRule = '{MY-FORWARDING-RULE}'
 
 request = service.forwardingRules().delete(project=project, region=region, forwardingRule=forwardingRule)
 response = request.execute()
@@ -1663,7 +1663,7 @@ project = ''
 region = ''
 
 # * Name of the ForwardingRule resource to return.
-forwardingRule = ''
+forwardingRule = '{MY-FORWARDING-RULE}'
 
 request = service.forwardingRules().get(project=project, region=region, forwardingRule=forwardingRule)
 response = request.execute()
@@ -1706,7 +1706,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the region scoping this request.
-region = ''
+region = '{MY-REGION}'
 
 forwarding_rule_body = {
 # TODO: Add desired entries of the 'forwarding_rule_body' dict
@@ -1751,7 +1751,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the region scoping this request.
-region = ''
+region = '{MY-REGION}'
 
 forwardingRules = service.forwardingRules()
 request = forwardingRules.list(project=project, region=region)
@@ -1801,7 +1801,7 @@ project = ''
 region = ''
 
 # * Name of the ForwardingRule resource in which target is to be set.
-forwardingRule = ''
+forwardingRule = '{MY-FORWARDING-RULE}'
 
 target_reference_body = {
 # TODO: Add desired entries of the 'target_reference_body' dict
@@ -1848,7 +1848,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the address resource to delete.
-address = ''
+address = '{MY-ADDRESS}'
 
 request = service.globalAddresses().delete(project=project, address=address)
 response = request.execute()
@@ -1891,7 +1891,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the address resource to return.
-address = ''
+address = '{MY-ADDRESS}'
 
 request = service.globalAddresses().get(project=project, address=address)
 response = request.execute()
@@ -1931,7 +1931,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 address_body = {
 # TODO: Add desired entries of the 'address_body' dict
@@ -1973,7 +1973,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 globalAddresses = service.globalAddresses()
 request = globalAddresses.list(project=project)
@@ -2020,7 +2020,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the ForwardingRule resource to delete.
-forwardingRule = ''
+forwardingRule = '{MY-FORWARDING-RULE}'
 
 request = service.globalForwardingRules().delete(project=project, forwardingRule=forwardingRule)
 response = request.execute()
@@ -2063,7 +2063,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the ForwardingRule resource to return.
-forwardingRule = ''
+forwardingRule = '{MY-FORWARDING-RULE}'
 
 request = service.globalForwardingRules().get(project=project, forwardingRule=forwardingRule)
 response = request.execute()
@@ -2103,7 +2103,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 forwarding_rule_body = {
 # TODO: Add desired entries of the 'forwarding_rule_body' dict
@@ -2145,7 +2145,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 globalForwardingRules = service.globalForwardingRules()
 request = globalForwardingRules.list(project=project)
@@ -2192,7 +2192,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the ForwardingRule resource in which target is to be set.
-forwardingRule = ''
+forwardingRule = '{MY-FORWARDING-RULE}'
 
 target_reference_body = {
 # TODO: Add desired entries of the 'target_reference_body' dict
@@ -2234,7 +2234,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 globalOperations = service.globalOperations()
 request = globalOperations.aggregatedList(project=project)
@@ -2279,7 +2279,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the Operations resource to delete.
-operation = ''
+operation = '{MY-OPERATION}'
 
 request = service.globalOperations().delete(project=project, operation=operation)
 request.execute()
@@ -2319,7 +2319,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the Operations resource to return.
-operation = ''
+operation = '{MY-OPERATION}'
 
 request = service.globalOperations().get(project=project, operation=operation)
 response = request.execute()
@@ -2357,7 +2357,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 globalOperations = service.globalOperations()
 request = globalOperations.list(project=project)
@@ -2404,7 +2404,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the HttpHealthCheck resource to delete.
-httpHealthCheck = ''
+httpHealthCheck = '{MY-HTTP-HEALTH-CHECK}'
 
 request = service.httpHealthChecks().delete(project=project, httpHealthCheck=httpHealthCheck)
 response = request.execute()
@@ -2447,7 +2447,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the HttpHealthCheck resource to return.
-httpHealthCheck = ''
+httpHealthCheck = '{MY-HTTP-HEALTH-CHECK}'
 
 request = service.httpHealthChecks().get(project=project, httpHealthCheck=httpHealthCheck)
 response = request.execute()
@@ -2487,7 +2487,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 http_health_check_body = {
 # TODO: Add desired entries of the 'http_health_check_body' dict
@@ -2529,7 +2529,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 httpHealthChecks = service.httpHealthChecks()
 request = httpHealthChecks.list(project=project)
@@ -2576,7 +2576,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the HttpHealthCheck resource to update.
-httpHealthCheck = ''
+httpHealthCheck = '{MY-HTTP-HEALTH-CHECK}'
 
 http_health_check_body = {
 # TODO: Add desired entries of the 'http_health_check_body' dict to be changed
@@ -2623,7 +2623,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the HttpHealthCheck resource to update.
-httpHealthCheck = ''
+httpHealthCheck = '{MY-HTTP-HEALTH-CHECK}'
 
 http_health_check_body = {
 # TODO: Add desired entries of the 'http_health_check_body' dict
@@ -2670,7 +2670,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the HttpsHealthCheck resource to delete.
-httpsHealthCheck = ''
+httpsHealthCheck = '{MY-HTTPS-HEALTH-CHECK}'
 
 request = service.httpsHealthChecks().delete(project=project, httpsHealthCheck=httpsHealthCheck)
 response = request.execute()
@@ -2713,7 +2713,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the HttpsHealthCheck resource to return.
-httpsHealthCheck = ''
+httpsHealthCheck = '{MY-HTTPS-HEALTH-CHECK}'
 
 request = service.httpsHealthChecks().get(project=project, httpsHealthCheck=httpsHealthCheck)
 response = request.execute()
@@ -2753,7 +2753,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 https_health_check_body = {
 # TODO: Add desired entries of the 'https_health_check_body' dict
@@ -2795,7 +2795,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 httpsHealthChecks = service.httpsHealthChecks()
 request = httpsHealthChecks.list(project=project)
@@ -2842,7 +2842,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the HttpsHealthCheck resource to update.
-httpsHealthCheck = ''
+httpsHealthCheck = '{MY-HTTPS-HEALTH-CHECK}'
 
 https_health_check_body = {
 # TODO: Add desired entries of the 'https_health_check_body' dict to be changed
@@ -2889,7 +2889,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the HttpsHealthCheck resource to update.
-httpsHealthCheck = ''
+httpsHealthCheck = '{MY-HTTPS-HEALTH-CHECK}'
 
 https_health_check_body = {
 # TODO: Add desired entries of the 'https_health_check_body' dict
@@ -2936,7 +2936,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the image resource to delete.
-image = ''
+image = '{MY-IMAGE}'
 
 request = service.images().delete(project=project, image=image)
 response = request.execute()
@@ -2979,7 +2979,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Image name.
-image = ''
+image = '{MY-IMAGE}'
 
 deprecation_status_body = {
 # TODO: Add desired entries of the 'deprecation_status_body' dict
@@ -3026,7 +3026,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the image resource to return.
-image = ''
+image = '{MY-IMAGE}'
 
 request = service.images().get(project=project, image=image)
 response = request.execute()
@@ -3066,7 +3066,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 image_body = {
 # TODO: Add desired entries of the 'image_body' dict
@@ -3108,7 +3108,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 images = service.images()
 request = images.list(project=project)
@@ -3158,7 +3158,7 @@ project = ''
 zone = ''
 
 # * The name of the managed instance group.
-instanceGroupManager = ''
+instanceGroupManager = '{MY-INSTANCE-GROUP-MANAGER}'
 
 instance_group_managers_abandon_instances_request_body = {
 # TODO: Add desired entries of the 'instance_group_managers_abandon_instances_request_body' dict
@@ -3200,7 +3200,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 instanceGroupManagers = service.instanceGroupManagers()
 request = instanceGroupManagers.aggregatedList(project=project)
@@ -3250,7 +3250,7 @@ project = ''
 zone = ''
 
 # * The name of the managed instance group to delete.
-instanceGroupManager = ''
+instanceGroupManager = '{MY-INSTANCE-GROUP-MANAGER}'
 
 request = service.instanceGroupManagers().delete(project=project, zone=zone, instanceGroupManager=instanceGroupManager)
 response = request.execute()
@@ -3296,7 +3296,7 @@ project = ''
 zone = ''
 
 # * The name of the managed instance group.
-instanceGroupManager = ''
+instanceGroupManager = '{MY-INSTANCE-GROUP-MANAGER}'
 
 instance_group_managers_delete_instances_request_body = {
 # TODO: Add desired entries of the 'instance_group_managers_delete_instances_request_body' dict
@@ -3346,7 +3346,7 @@ project = ''
 zone = ''
 
 # * The name of the managed instance group.
-instanceGroupManager = ''
+instanceGroupManager = '{MY-INSTANCE-GROUP-MANAGER}'
 
 request = service.instanceGroupManagers().get(project=project, zone=zone, instanceGroupManager=instanceGroupManager)
 response = request.execute()
@@ -3389,7 +3389,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * The name of the zone where you want to create the managed instance group.
-zone = ''
+zone = '{MY-ZONE}'
 
 instance_group_manager_body = {
 # TODO: Add desired entries of the 'instance_group_manager_body' dict
@@ -3434,7 +3434,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * The name of the zone where the managed instance group is located.
-zone = ''
+zone = '{MY-ZONE}'
 
 instanceGroupManagers = service.instanceGroupManagers()
 request = instanceGroupManagers.list(project=project, zone=zone)
@@ -3484,7 +3484,7 @@ project = ''
 zone = ''
 
 # * The name of the managed instance group.
-instanceGroupManager = ''
+instanceGroupManager = '{MY-INSTANCE-GROUP-MANAGER}'
 
 request = service.instanceGroupManagers().listManagedInstances(project=project, zone=zone, instanceGroupManager=instanceGroupManager)
 response = request.execute()
@@ -3530,7 +3530,7 @@ project = ''
 zone = ''
 
 # * The name of the managed instance group.
-instanceGroupManager = ''
+instanceGroupManager = '{MY-INSTANCE-GROUP-MANAGER}'
 
 instance_group_managers_recreate_instances_request_body = {
 # TODO: Add desired entries of the 'instance_group_managers_recreate_instances_request_body' dict
@@ -3631,7 +3631,7 @@ project = ''
 zone = ''
 
 # * The name of the managed instance group.
-instanceGroupManager = ''
+instanceGroupManager = '{MY-INSTANCE-GROUP-MANAGER}'
 
 instance_group_managers_set_instance_template_request_body = {
 # TODO: Add desired entries of the 'instance_group_managers_set_instance_template_request_body' dict
@@ -3681,7 +3681,7 @@ project = ''
 zone = ''
 
 # * The name of the managed instance group.
-instanceGroupManager = ''
+instanceGroupManager = '{MY-INSTANCE-GROUP-MANAGER}'
 
 instance_group_managers_set_target_pools_request_body = {
 # TODO: Add desired entries of the 'instance_group_managers_set_target_pools_request_body' dict
@@ -3731,7 +3731,7 @@ project = ''
 zone = ''
 
 # * The name of the instance group where you are adding instances.
-instanceGroup = ''
+instanceGroup = '{MY-INSTANCE-GROUP}'
 
 instance_groups_add_instances_request_body = {
 # TODO: Add desired entries of the 'instance_groups_add_instances_request_body' dict
@@ -3773,7 +3773,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 instanceGroups = service.instanceGroups()
 request = instanceGroups.aggregatedList(project=project)
@@ -3823,7 +3823,7 @@ project = ''
 zone = ''
 
 # * The name of the instance group to delete.
-instanceGroup = ''
+instanceGroup = '{MY-INSTANCE-GROUP}'
 
 request = service.instanceGroups().delete(project=project, zone=zone, instanceGroup=instanceGroup)
 response = request.execute()
@@ -3869,7 +3869,7 @@ project = ''
 zone = ''
 
 # * The name of the instance group.
-instanceGroup = ''
+instanceGroup = '{MY-INSTANCE-GROUP}'
 
 request = service.instanceGroups().get(project=project, zone=zone, instanceGroup=instanceGroup)
 response = request.execute()
@@ -3912,7 +3912,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * The name of the zone where you want to create the instance group.
-zone = ''
+zone = '{MY-ZONE}'
 
 instance_group_body = {
 # TODO: Add desired entries of the 'instance_group_body' dict
@@ -3957,7 +3957,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * The name of the zone where the instance group is located.
-zone = ''
+zone = '{MY-ZONE}'
 
 instanceGroups = service.instanceGroups()
 request = instanceGroups.list(project=project, zone=zone)
@@ -4005,7 +4005,7 @@ project = ''
 zone = ''
 
 # * The name of the instance group from which you want to generate a list of included instances.
-instanceGroup = ''
+instanceGroup = '{MY-INSTANCE-GROUP}'
 
 instance_groups_list_instances_request_body = {
 # TODO: Add desired entries of the 'instance_groups_list_instances_request_body' dict
@@ -4059,7 +4059,7 @@ project = ''
 zone = ''
 
 # * The name of the instance group where the specified instances will be removed.
-instanceGroup = ''
+instanceGroup = '{MY-INSTANCE-GROUP}'
 
 instance_groups_remove_instances_request_body = {
 # TODO: Add desired entries of the 'instance_groups_remove_instances_request_body' dict
@@ -4109,7 +4109,7 @@ project = ''
 zone = ''
 
 # * The name of the instance group where the named ports are updated.
-instanceGroup = ''
+instanceGroup = '{MY-INSTANCE-GROUP}'
 
 instance_groups_set_named_ports_request_body = {
 # TODO: Add desired entries of the 'instance_groups_set_named_ports_request_body' dict
@@ -4156,7 +4156,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * The name of the instance template to delete.
-instanceTemplate = ''
+instanceTemplate = '{MY-INSTANCE-TEMPLATE}'
 
 request = service.instanceTemplates().delete(project=project, instanceTemplate=instanceTemplate)
 response = request.execute()
@@ -4199,7 +4199,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * The name of the instance template.
-instanceTemplate = ''
+instanceTemplate = '{MY-INSTANCE-TEMPLATE}'
 
 request = service.instanceTemplates().get(project=project, instanceTemplate=instanceTemplate)
 response = request.execute()
@@ -4239,7 +4239,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 instance_template_body = {
 # TODO: Add desired entries of the 'instance_template_body' dict
@@ -4281,7 +4281,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 instanceTemplates = service.instanceTemplates()
 request = instanceTemplates.list(project=project)
@@ -4334,7 +4334,7 @@ zone = ''
 instance = ''
 
 # * The name of the network interface to add to this instance.
-networkInterface = ''
+networkInterface = '{MY-NETWORK-INTERFACE}'
 
 access_config_body = {
 # TODO: Add desired entries of the 'access_config_body' dict
@@ -4376,7 +4376,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 instances = service.instances()
 request = instances.aggregatedList(project=project)
@@ -4426,7 +4426,7 @@ project = ''
 zone = ''
 
 # * The instance name for this request.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 attached_disk_body = {
 # TODO: Add desired entries of the 'attached_disk_body' dict
@@ -4476,7 +4476,7 @@ project = ''
 zone = ''
 
 # * Name of the instance resource to delete.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 request = service.instances().delete(project=project, zone=zone, instance=instance)
 response = request.execute()
@@ -4528,7 +4528,7 @@ instance = ''
 accessConfig = ''
 
 # * The name of the network interface.
-networkInterface = ''
+networkInterface = '{MY-NETWORK-INTERFACE}'
 
 request = service.instances().deleteAccessConfig(project=project, zone=zone, instance=instance, accessConfig=accessConfig, networkInterface=networkInterface)
 response = request.execute()
@@ -4577,7 +4577,7 @@ zone = ''
 instance = ''
 
 # * Disk device name to detach.
-deviceName = ''
+deviceName = '{MY-DEVICE-NAME}'
 
 request = service.instances().detachDisk(project=project, zone=zone, instance=instance, deviceName=deviceName)
 response = request.execute()
@@ -4623,7 +4623,7 @@ project = ''
 zone = ''
 
 # * Name of the instance resource to return.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 request = service.instances().get(project=project, zone=zone, instance=instance)
 response = request.execute()
@@ -4669,7 +4669,7 @@ project = ''
 zone = ''
 
 # * Name of the instance scoping this request.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 request = service.instances().getSerialPortOutput(project=project, zone=zone, instance=instance)
 response = request.execute()
@@ -4712,7 +4712,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * The name of the zone for this request.
-zone = ''
+zone = 'us-central1-f'
 
 instance_body = {
 # TODO: Add desired entries of the 'instance_body' dict
@@ -4757,7 +4757,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * The name of the zone for this request.
-zone = ''
+zone = 'us-central1-f'
 
 instances = service.instances()
 request = instances.list(project=project, zone=zone)
@@ -4807,7 +4807,7 @@ project = ''
 zone = ''
 
 # * Name of the instance scoping this request.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 request = service.instances().reset(project=project, zone=zone, instance=instance)
 response = request.execute()
@@ -4859,7 +4859,7 @@ instance = ''
 autoDelete = False
 
 # * The device name of the disk to modify.
-deviceName = ''
+deviceName = '{MY-DEVICE-NAME}'
 
 request = service.instances().setDiskAutoDelete(project=project, zone=zone, instance=instance, autoDelete=autoDelete, deviceName=deviceName)
 response = request.execute()
@@ -4905,7 +4905,7 @@ project = ''
 zone = ''
 
 # * Name of the instance scoping this request.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 instances_set_machine_type_request_body = {
 # TODO: Add desired entries of the 'instances_set_machine_type_request_body' dict
@@ -4955,7 +4955,7 @@ project = ''
 zone = ''
 
 # * Name of the instance scoping this request.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 metadata_body = {
 # TODO: Add desired entries of the 'metadata_body' dict
@@ -5005,7 +5005,7 @@ project = ''
 zone = ''
 
 # * Instance name.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 scheduling_body = {
 # TODO: Add desired entries of the 'scheduling_body' dict
@@ -5055,7 +5055,7 @@ project = ''
 zone = ''
 
 # * Name of the instance scoping this request.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 tags_body = {
 # TODO: Add desired entries of the 'tags_body' dict
@@ -5105,7 +5105,7 @@ project = ''
 zone = ''
 
 # * Name of the instance resource to start.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 request = service.instances().start(project=project, zone=zone, instance=instance)
 response = request.execute()
@@ -5151,7 +5151,7 @@ project = ''
 zone = ''
 
 # * Name of the instance resource to stop.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 request = service.instances().stop(project=project, zone=zone, instance=instance)
 response = request.execute()
@@ -5194,7 +5194,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the License resource to return.
-license = ''
+license = '{MY-LICENSE}'
 
 request = service.licenses().get(project=project, license=license)
 response = request.execute()
@@ -5232,7 +5232,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 machineTypes = service.machineTypes()
 request = machineTypes.aggregatedList(project=project)
@@ -5282,7 +5282,7 @@ project = ''
 zone = ''
 
 # * Name of the machine type to return.
-machineType = ''
+machineType = '{MY-MACHINE-TYPE}'
 
 request = service.machineTypes().get(project=project, zone=zone, machineType=machineType)
 response = request.execute()
@@ -5323,7 +5323,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * The name of the zone for this request.
-zone = ''
+zone = 'us-central1-f'
 
 machineTypes = service.machineTypes()
 request = machineTypes.list(project=project, zone=zone)
@@ -5370,7 +5370,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the network to delete.
-network = ''
+network = '{MY-NETWORK}'
 
 request = service.networks().delete(project=project, network=network)
 response = request.execute()
@@ -5413,7 +5413,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the network to return.
-network = ''
+network = '{MY-NETWORK}'
 
 request = service.networks().get(project=project, network=network)
 response = request.execute()
@@ -5453,7 +5453,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 network_body = {
 # TODO: Add desired entries of the 'network_body' dict
@@ -5495,7 +5495,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 networks = service.networks()
 request = networks.list(project=project)
@@ -5539,7 +5539,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 request = service.projects().get(project=project)
 response = request.execute()
@@ -5579,7 +5579,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'moveDisk' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 disk_move_request_body = {
 # TODO: Add desired entries of the 'disk_move_request_body' dict
@@ -5623,7 +5623,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'moveInstance' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 instance_move_request_body = {
 # TODO: Add desired entries of the 'instance_move_request_body' dict
@@ -5667,7 +5667,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'setCommonInstanceMetadata' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 metadata_body = {
 # TODO: Add desired entries of the 'metadata_body' dict
@@ -5711,7 +5711,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'setUsageExportBucket' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 usage_export_location_body = {
 # TODO: Add desired entries of the 'usage_export_location_body' dict
@@ -5759,7 +5759,7 @@ project = ''
 region = ''
 
 # * Name of the Operations resource to delete.
-operation = ''
+operation = '{MY-OPERATION}'
 
 request = service.regionOperations().delete(project=project, region=region, operation=operation)
 request.execute()
@@ -5802,7 +5802,7 @@ project = ''
 region = ''
 
 # * Name of the Operations resource to return.
-operation = ''
+operation = '{MY-OPERATION}'
 
 request = service.regionOperations().get(project=project, region=region, operation=operation)
 response = request.execute()
@@ -5843,7 +5843,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the region for this request.
-region = ''
+region = '{MY-REGION}'
 
 regionOperations = service.regionOperations()
 request = regionOperations.list(project=project, region=region)
@@ -5890,7 +5890,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the region resource to return.
-region = ''
+region = '{MY-REGION}'
 
 request = service.regions().get(project=project, region=region)
 response = request.execute()
@@ -5928,7 +5928,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 regions = service.regions()
 request = regions.list(project=project)
@@ -5975,7 +5975,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the Route resource to delete.
-route = ''
+route = '{MY-ROUTE}'
 
 request = service.routes().delete(project=project, route=route)
 response = request.execute()
@@ -6018,7 +6018,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the Route resource to return.
-route = ''
+route = '{MY-ROUTE}'
 
 request = service.routes().get(project=project, route=route)
 response = request.execute()
@@ -6058,7 +6058,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 route_body = {
 # TODO: Add desired entries of the 'route_body' dict
@@ -6100,7 +6100,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 routes = service.routes()
 request = routes.list(project=project)
@@ -6147,7 +6147,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the Snapshot resource to delete.
-snapshot = ''
+snapshot = '{MY-SNAPSHOT}'
 
 request = service.snapshots().delete(project=project, snapshot=snapshot)
 response = request.execute()
@@ -6190,7 +6190,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the Snapshot resource to return.
-snapshot = ''
+snapshot = '{MY-SNAPSHOT}'
 
 request = service.snapshots().get(project=project, snapshot=snapshot)
 response = request.execute()
@@ -6228,7 +6228,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 snapshots = service.snapshots()
 request = snapshots.list(project=project)
@@ -6275,7 +6275,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the SslCertificate resource to delete.
-sslCertificate = ''
+sslCertificate = '{MY-SSL-CERTIFICATE}'
 
 request = service.sslCertificates().delete(project=project, sslCertificate=sslCertificate)
 response = request.execute()
@@ -6318,7 +6318,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the SslCertificate resource to return.
-sslCertificate = ''
+sslCertificate = '{MY-SSL-CERTIFICATE}'
 
 request = service.sslCertificates().get(project=project, sslCertificate=sslCertificate)
 response = request.execute()
@@ -6358,7 +6358,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 ssl_certificate_body = {
 # TODO: Add desired entries of the 'ssl_certificate_body' dict
@@ -6400,7 +6400,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 sslCertificates = service.sslCertificates()
 request = sslCertificates.list(project=project)
@@ -6442,7 +6442,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 subnetworks = service.subnetworks()
 request = subnetworks.aggregatedList(project=project)
@@ -6492,7 +6492,7 @@ project = ''
 region = ''
 
 # * Name of the Subnetwork resource to delete.
-subnetwork = ''
+subnetwork = '{MY-SUBNETWORK}'
 
 request = service.subnetworks().delete(project=project, region=region, subnetwork=subnetwork)
 response = request.execute()
@@ -6538,7 +6538,7 @@ project = ''
 region = ''
 
 # * Name of the Subnetwork resource to return.
-subnetwork = ''
+subnetwork = '{MY-SUBNETWORK}'
 
 request = service.subnetworks().get(project=project, region=region, subnetwork=subnetwork)
 response = request.execute()
@@ -6581,7 +6581,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the region scoping this request.
-region = ''
+region = '{MY-REGION}'
 
 subnetwork_body = {
 # TODO: Add desired entries of the 'subnetwork_body' dict
@@ -6626,7 +6626,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the region scoping this request.
-region = ''
+region = '{MY-REGION}'
 
 subnetworks = service.subnetworks()
 request = subnetworks.list(project=project, region=region)
@@ -6673,7 +6673,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the TargetHttpProxy resource to delete.
-targetHttpProxy = ''
+targetHttpProxy = '{MY-TARGET-HTTP-PROXY}'
 
 request = service.targetHttpProxies().delete(project=project, targetHttpProxy=targetHttpProxy)
 response = request.execute()
@@ -6716,7 +6716,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the TargetHttpProxy resource to return.
-targetHttpProxy = ''
+targetHttpProxy = '{MY-TARGET-HTTP-PROXY}'
 
 request = service.targetHttpProxies().get(project=project, targetHttpProxy=targetHttpProxy)
 response = request.execute()
@@ -6756,7 +6756,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 target_http_proxy_body = {
 # TODO: Add desired entries of the 'target_http_proxy_body' dict
@@ -6798,7 +6798,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 targetHttpProxies = service.targetHttpProxies()
 request = targetHttpProxies.list(project=project)
@@ -6845,7 +6845,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the TargetHttpProxy to set a URL map for.
-targetHttpProxy = ''
+targetHttpProxy = '{MY-TARGET-HTTP-PROXY}'
 
 url_map_reference_body = {
 # TODO: Add desired entries of the 'url_map_reference_body' dict
@@ -6892,7 +6892,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the TargetHttpsProxy resource to delete.
-targetHttpsProxy = ''
+targetHttpsProxy = '{MY-TARGET-HTTPS-PROXY}'
 
 request = service.targetHttpsProxies().delete(project=project, targetHttpsProxy=targetHttpsProxy)
 response = request.execute()
@@ -6935,7 +6935,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the TargetHttpsProxy resource to return.
-targetHttpsProxy = ''
+targetHttpsProxy = '{MY-TARGET-HTTPS-PROXY}'
 
 request = service.targetHttpsProxies().get(project=project, targetHttpsProxy=targetHttpsProxy)
 response = request.execute()
@@ -6975,7 +6975,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 target_https_proxy_body = {
 # TODO: Add desired entries of the 'target_https_proxy_body' dict
@@ -7017,7 +7017,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 targetHttpsProxies = service.targetHttpsProxies()
 request = targetHttpsProxies.list(project=project)
@@ -7064,7 +7064,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the TargetHttpsProxy resource to set an SslCertificates resource for.
-targetHttpsProxy = ''
+targetHttpsProxy = '{MY-TARGET-HTTPS-PROXY}'
 
 target_https_proxies_set_ssl_certificates_request_body = {
 # TODO: Add desired entries of the 'target_https_proxies_set_ssl_certificates_request_body' dict
@@ -7111,7 +7111,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the TargetHttpsProxy resource whose URL map is to be set.
-targetHttpsProxy = ''
+targetHttpsProxy = '{MY-TARGET-HTTPS-PROXY}'
 
 url_map_reference_body = {
 # TODO: Add desired entries of the 'url_map_reference_body' dict
@@ -7153,7 +7153,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 targetInstances = service.targetInstances()
 request = targetInstances.aggregatedList(project=project)
@@ -7203,7 +7203,7 @@ project = ''
 zone = ''
 
 # * Name of the TargetInstance resource to delete.
-targetInstance = ''
+targetInstance = '{MY-TARGET-INSTANCE}'
 
 request = service.targetInstances().delete(project=project, zone=zone, targetInstance=targetInstance)
 response = request.execute()
@@ -7249,7 +7249,7 @@ project = ''
 zone = ''
 
 # * Name of the TargetInstance resource to return.
-targetInstance = ''
+targetInstance = '{MY-TARGET-INSTANCE}'
 
 request = service.targetInstances().get(project=project, zone=zone, targetInstance=targetInstance)
 response = request.execute()
@@ -7292,7 +7292,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the zone scoping this request.
-zone = ''
+zone = 'us-central1-f'
 
 target_instance_body = {
 # TODO: Add desired entries of the 'target_instance_body' dict
@@ -7337,7 +7337,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the zone scoping this request.
-zone = ''
+zone = 'us-central1-f'
 
 targetInstances = service.targetInstances()
 request = targetInstances.list(project=project, zone=zone)
@@ -7387,7 +7387,7 @@ project = ''
 region = ''
 
 # * Name of the target pool to add a health check to.
-targetPool = ''
+targetPool = '{MY-TARGET-POOL}'
 
 target_pools_add_health_check_request_body = {
 # TODO: Add desired entries of the 'target_pools_add_health_check_request_body' dict
@@ -7437,7 +7437,7 @@ project = ''
 region = ''
 
 # * Name of the TargetPool resource to add instances to.
-targetPool = ''
+targetPool = '{MY-TARGET-POOL}'
 
 target_pools_add_instance_request_body = {
 # TODO: Add desired entries of the 'target_pools_add_instance_request_body' dict
@@ -7479,7 +7479,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 targetPools = service.targetPools()
 request = targetPools.aggregatedList(project=project)
@@ -7529,7 +7529,7 @@ project = ''
 region = ''
 
 # * Name of the TargetPool resource to delete.
-targetPool = ''
+targetPool = '{MY-TARGET-POOL}'
 
 request = service.targetPools().delete(project=project, region=region, targetPool=targetPool)
 response = request.execute()
@@ -7575,7 +7575,7 @@ project = ''
 region = ''
 
 # * Name of the TargetPool resource to return.
-targetPool = ''
+targetPool = '{MY-TARGET-POOL}'
 
 request = service.targetPools().get(project=project, region=region, targetPool=targetPool)
 response = request.execute()
@@ -7621,7 +7621,7 @@ project = ''
 region = ''
 
 # * Name of the TargetPool resource to which the queried instance belongs.
-targetPool = ''
+targetPool = '{MY-TARGET-POOL}'
 
 instance_reference_body = {
 # TODO: Add desired entries of the 'instance_reference_body' dict
@@ -7668,7 +7668,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the region scoping this request.
-region = ''
+region = '{MY-REGION}'
 
 target_pool_body = {
 # TODO: Add desired entries of the 'target_pool_body' dict
@@ -7713,7 +7713,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the region scoping this request.
-region = ''
+region = '{MY-REGION}'
 
 targetPools = service.targetPools()
 request = targetPools.list(project=project, region=region)
@@ -7763,7 +7763,7 @@ project = ''
 region = ''
 
 # * Name of the target pool to remove health checks from.
-targetPool = ''
+targetPool = '{MY-TARGET-POOL}'
 
 target_pools_remove_health_check_request_body = {
 # TODO: Add desired entries of the 'target_pools_remove_health_check_request_body' dict
@@ -7813,7 +7813,7 @@ project = ''
 region = ''
 
 # * Name of the TargetPool resource to remove instances from.
-targetPool = ''
+targetPool = '{MY-TARGET-POOL}'
 
 target_pools_remove_instance_request_body = {
 # TODO: Add desired entries of the 'target_pools_remove_instance_request_body' dict
@@ -7863,7 +7863,7 @@ project = ''
 region = ''
 
 # * Name of the TargetPool resource to set a backup pool for.
-targetPool = ''
+targetPool = '{MY-TARGET-POOL}'
 
 target_reference_body = {
 # TODO: Add desired entries of the 'target_reference_body' dict
@@ -7905,7 +7905,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 targetVpnGateways = service.targetVpnGateways()
 request = targetVpnGateways.aggregatedList(project=project)
@@ -7955,7 +7955,7 @@ project = ''
 region = ''
 
 # * Name of the target VPN gateway to delete.
-targetVpnGateway = ''
+targetVpnGateway = '{MY-TARGET-VPN-GATEWAY}'
 
 request = service.targetVpnGateways().delete(project=project, region=region, targetVpnGateway=targetVpnGateway)
 response = request.execute()
@@ -8001,7 +8001,7 @@ project = ''
 region = ''
 
 # * Name of the target VPN gateway to return.
-targetVpnGateway = ''
+targetVpnGateway = '{MY-TARGET-VPN-GATEWAY}'
 
 request = service.targetVpnGateways().get(project=project, region=region, targetVpnGateway=targetVpnGateway)
 response = request.execute()
@@ -8044,7 +8044,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the region for this request.
-region = ''
+region = '{MY-REGION}'
 
 target_vpn_gateway_body = {
 # TODO: Add desired entries of the 'target_vpn_gateway_body' dict
@@ -8089,7 +8089,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the region for this request.
-region = ''
+region = '{MY-REGION}'
 
 targetVpnGateways = service.targetVpnGateways()
 request = targetVpnGateways.list(project=project, region=region)
@@ -8136,7 +8136,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the UrlMap resource to delete.
-urlMap = ''
+urlMap = '{MY-URL-MAP}'
 
 request = service.urlMaps().delete(project=project, urlMap=urlMap)
 response = request.execute()
@@ -8179,7 +8179,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the UrlMap resource to return.
-urlMap = ''
+urlMap = '{MY-URL-MAP}'
 
 request = service.urlMaps().get(project=project, urlMap=urlMap)
 response = request.execute()
@@ -8219,7 +8219,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 url_map_body = {
 # TODO: Add desired entries of the 'url_map_body' dict
@@ -8261,7 +8261,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 urlMaps = service.urlMaps()
 request = urlMaps.list(project=project)
@@ -8308,7 +8308,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the UrlMap resource to update.
-urlMap = ''
+urlMap = '{MY-URL-MAP}'
 
 url_map_body = {
 # TODO: Add desired entries of the 'url_map_body' dict to be changed
@@ -8355,7 +8355,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the UrlMap resource to update.
-urlMap = ''
+urlMap = '{MY-URL-MAP}'
 
 url_map_body = {
 # TODO: Add desired entries of the 'url_map_body' dict
@@ -8402,7 +8402,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the UrlMap resource to be validated as.
-urlMap = ''
+urlMap = '{MY-URL-MAP}'
 
 url_maps_validate_request_body = {
 # TODO: Add desired entries of the 'url_maps_validate_request_body' dict
@@ -8444,7 +8444,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'aggregatedList' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 vpnTunnels = service.vpnTunnels()
 request = vpnTunnels.aggregatedList(project=project)
@@ -8494,7 +8494,7 @@ project = ''
 region = ''
 
 # * Name of the VpnTunnel resource to delete.
-vpnTunnel = ''
+vpnTunnel = '{MY-VPN-TUNNEL}'
 
 request = service.vpnTunnels().delete(project=project, region=region, vpnTunnel=vpnTunnel)
 response = request.execute()
@@ -8540,7 +8540,7 @@ project = ''
 region = ''
 
 # * Name of the VpnTunnel resource to return.
-vpnTunnel = ''
+vpnTunnel = '{MY-VPN-TUNNEL}'
 
 request = service.vpnTunnels().get(project=project, region=region, vpnTunnel=vpnTunnel)
 response = request.execute()
@@ -8583,7 +8583,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the region for this request.
-region = ''
+region = '{MY-REGION}'
 
 vpn_tunnel_body = {
 # TODO: Add desired entries of the 'vpn_tunnel_body' dict
@@ -8628,7 +8628,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the region for this request.
-region = ''
+region = '{MY-REGION}'
 
 vpnTunnels = service.vpnTunnels()
 request = vpnTunnels.list(project=project, region=region)
@@ -8676,7 +8676,7 @@ project = ''
 zone = ''
 
 # * Name of the Operations resource to delete.
-operation = ''
+operation = '{MY-OPERATION}'
 
 request = service.zoneOperations().delete(project=project, zone=zone, operation=operation)
 request.execute()
@@ -8719,7 +8719,7 @@ project = ''
 zone = ''
 
 # * Name of the Operations resource to return.
-operation = ''
+operation = '{MY-OPERATION}'
 
 request = service.zoneOperations().get(project=project, zone=zone, operation=operation)
 response = request.execute()
@@ -8760,7 +8760,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the zone for request.
-zone = ''
+zone = 'us-central1-f'
 
 zoneOperations = service.zoneOperations()
 request = zoneOperations.list(project=project, zone=zone)
@@ -8807,7 +8807,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the zone resource to return.
-zone = ''
+zone = 'us-central1-f'
 
 request = service.zones().get(project=project, zone=zone)
 response = request.execute()
@@ -8845,7 +8845,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 zones = service.zones()
 request = zones.list(project=project)

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_compute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_compute.v1.json.baseline
@@ -395,7 +395,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the zone for this request.
-zone = 'us-central1-f'
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 autoscaler_body = {
 # TODO: Add desired entries of the 'autoscaler_body' dict
@@ -440,7 +440,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the zone for this request.
-zone = 'us-central1-f'
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 autoscalers = service.autoscalers()
 request = autoscalers.list(project=project, zone=zone)
@@ -537,7 +537,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the zone for this request.
-zone = 'us-central1-f'
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 autoscaler_body = {
 # TODO: Add desired entries of the 'autoscaler_body' dict
@@ -983,7 +983,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * The name of the zone for this request.
-zone = 'us-central1-f'
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 diskTypes = service.diskTypes()
 request = diskTypes.list(project=project, zone=zone)
@@ -1214,7 +1214,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * The name of the zone for this request.
-zone = 'us-central1-f'
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 disk_body = {
 # TODO: Add desired entries of the 'disk_body' dict
@@ -1259,7 +1259,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * The name of the zone for this request.
-zone = 'us-central1-f'
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 disks = service.disks()
 request = disks.list(project=project, zone=zone)
@@ -4712,7 +4712,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * The name of the zone for this request.
-zone = 'us-central1-f'
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 instance_body = {
 # TODO: Add desired entries of the 'instance_body' dict
@@ -4757,7 +4757,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * The name of the zone for this request.
-zone = 'us-central1-f'
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 instances = service.instances()
 request = instances.list(project=project, zone=zone)
@@ -5323,7 +5323,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * The name of the zone for this request.
-zone = 'us-central1-f'
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 machineTypes = service.machineTypes()
 request = machineTypes.list(project=project, zone=zone)
@@ -7292,7 +7292,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the zone scoping this request.
-zone = 'us-central1-f'
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 target_instance_body = {
 # TODO: Add desired entries of the 'target_instance_body' dict
@@ -7337,7 +7337,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the zone scoping this request.
-zone = 'us-central1-f'
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 targetInstances = service.targetInstances()
 request = targetInstances.list(project=project, zone=zone)
@@ -8760,7 +8760,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the zone for request.
-zone = 'us-central1-f'
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 zoneOperations = service.zoneOperations()
 request = zoneOperations.list(project=project, zone=zone)
@@ -8807,7 +8807,7 @@ service = discovery.build('compute', 'v1', credentials=credentials)
 project = ''
 
 # * Name of the zone resource to return.
-zone = 'us-central1-f'
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 request = service.zones().get(project=project, zone=zone)
 response = request.execute()

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_container.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_container.v1.json.baseline
@@ -33,11 +33,11 @@ service = discovery.build('container', 'v1', credentials=credentials)
 
 # * The Google Developers Console [project ID or project number]
 #   (https://developers.google.com/console/help/new/#projectnumber).
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 # * The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
 #   resides.
-zone = ''
+zone = '{MY-ZONE}'
 
 create_cluster_request_body = {
 # TODO: Add desired entries of the 'create_cluster_request_body' dict
@@ -82,11 +82,11 @@ service = discovery.build('container', 'v1', credentials=credentials)
 
 # * The Google Developers Console [project ID or project number]
 #   (https://developers.google.com/console/help/new/#projectnumber).
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 # * The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
 #   resides.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the cluster to delete.
 clusterId = '{MY-CLUSTER-ID}'
@@ -130,11 +130,11 @@ service = discovery.build('container', 'v1', credentials=credentials)
 
 # * The Google Developers Console [project ID or project number]
 #   (https://developers.google.com/console/help/new/#projectnumber).
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 # * The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
 #   resides.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the cluster to retrieve.
 clusterId = '{MY-CLUSTER-ID}'
@@ -178,11 +178,11 @@ service = discovery.build('container', 'v1', credentials=credentials)
 
 # * The Google Developers Console [project ID or project number]
 #   (https://developers.google.com/console/help/new/#projectnumber).
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 # * The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
 #   resides, or "-" for all zones.
-zone = ''
+zone = '{MY-ZONE}'
 
 request = service.projects().zones().clusters().list(projectId=projectId, zone=zone)
 response = request.execute()
@@ -223,11 +223,11 @@ service = discovery.build('container', 'v1', credentials=credentials)
 
 # * The Google Developers Console [project ID or project number]
 #   (https://developers.google.com/console/help/new/#projectnumber).
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 # * The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
 #   resides.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the cluster to upgrade.
 clusterId = '{MY-CLUSTER-ID}'
@@ -275,11 +275,11 @@ service = discovery.build('container', 'v1', credentials=credentials)
 
 # * The Google Developers Console [project ID or project number]
 #   (https://developers.google.com/console/help/new/#projectnumber).
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 # * The name of the Google Compute Engine [zone](/compute/docs/zones#available) to return operations
 #   for, or "-" for all zones.
-zone = ''
+zone = '{MY-ZONE}'
 
 request = service.projects().zones().getServerconfig(projectId=projectId, zone=zone)
 response = request.execute()
@@ -320,11 +320,11 @@ service = discovery.build('container', 'v1', credentials=credentials)
 
 # * The Google Developers Console [project ID or project number]
 #   (https://developers.google.com/console/help/new/#projectnumber).
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 # * The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
 #   resides.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The server-assigned `name` of the operation.
 operationId = '{MY-OPERATION-ID}'
@@ -368,11 +368,11 @@ service = discovery.build('container', 'v1', credentials=credentials)
 
 # * The Google Developers Console [project ID or project number]
 #   (https://developers.google.com/console/help/new/#projectnumber).
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 # * The name of the Google Compute Engine [zone](/compute/docs/zones#available) to return operations
 #   for, or "-" for all zones.
-zone = ''
+zone = '{MY-ZONE}'
 
 request = service.projects().zones().operations().list(projectId=projectId, zone=zone)
 response = request.execute()

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_container.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_container.v1.json.baseline
@@ -89,7 +89,7 @@ projectId = ''
 zone = ''
 
 # * The name of the cluster to delete.
-clusterId = ''
+clusterId = '{MY-CLUSTER-ID}'
 
 request = service.projects().zones().clusters().delete(projectId=projectId, zone=zone, clusterId=clusterId)
 response = request.execute()
@@ -137,7 +137,7 @@ projectId = ''
 zone = ''
 
 # * The name of the cluster to retrieve.
-clusterId = ''
+clusterId = '{MY-CLUSTER-ID}'
 
 request = service.projects().zones().clusters().get(projectId=projectId, zone=zone, clusterId=clusterId)
 response = request.execute()
@@ -230,7 +230,7 @@ projectId = ''
 zone = ''
 
 # * The name of the cluster to upgrade.
-clusterId = ''
+clusterId = '{MY-CLUSTER-ID}'
 
 update_cluster_request_body = {
 # TODO: Add desired entries of the 'update_cluster_request_body' dict
@@ -327,7 +327,7 @@ projectId = ''
 zone = ''
 
 # * The server-assigned `name` of the operation.
-operationId = ''
+operationId = '{MY-OPERATION-ID}'
 
 request = service.projects().zones().operations().get(projectId=projectId, zone=zone, operationId=operationId)
 response = request.execute()

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_dataflow.v1b3.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_dataflow.v1b3.json.baseline
@@ -32,7 +32,7 @@ service = discovery.build('dataflow', 'v1b3', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'create' method:
 
 # * The project which owns the job.
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 job_body = {
 # TODO: Add desired entries of the 'job_body' dict
@@ -79,7 +79,7 @@ service = discovery.build('dataflow', 'v1b3', credentials=credentials)
 projectId = ''
 
 # * Identifies a single job.
-jobId = ''
+jobId = '{MY-JOB-ID}'
 
 request = service.projects().jobs().get(projectId=projectId, jobId=jobId)
 response = request.execute()
@@ -122,7 +122,7 @@ service = discovery.build('dataflow', 'v1b3', credentials=credentials)
 projectId = ''
 
 # * The job to get messages for.
-jobId = ''
+jobId = '{MY-JOB-ID}'
 
 request = service.projects().jobs().getMetrics(projectId=projectId, jobId=jobId)
 response = request.execute()
@@ -160,7 +160,7 @@ service = discovery.build('dataflow', 'v1b3', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * The project which owns the jobs.
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 jobs = service.projects().jobs()
 request = jobs.list(projectId=projectId)
@@ -205,7 +205,7 @@ service = discovery.build('dataflow', 'v1b3', credentials=credentials)
 projectId = ''
 
 # * The job to get messages about.
-jobId = ''
+jobId = '{MY-JOB-ID}'
 
 messages = service.projects().jobs().messages()
 request = messages.list(projectId=projectId, jobId=jobId)
@@ -252,7 +252,7 @@ service = discovery.build('dataflow', 'v1b3', credentials=credentials)
 projectId = ''
 
 # * Identifies a single job.
-jobId = ''
+jobId = '{MY-JOB-ID}'
 
 job_body = {
 # TODO: Add desired entries of the 'job_body' dict
@@ -299,7 +299,7 @@ service = discovery.build('dataflow', 'v1b3', credentials=credentials)
 projectId = ''
 
 # * Identifies the workflow job this worker belongs to.
-jobId = ''
+jobId = '{MY-JOB-ID}'
 
 lease_work_item_request_body = {
 # TODO: Add desired entries of the 'lease_work_item_request_body' dict
@@ -346,7 +346,7 @@ service = discovery.build('dataflow', 'v1b3', credentials=credentials)
 projectId = ''
 
 # * The job which the WorkItem is part of.
-jobId = ''
+jobId = '{MY-JOB-ID}'
 
 report_work_item_status_request_body = {
 # TODO: Add desired entries of the 'report_work_item_status_request_body' dict
@@ -390,7 +390,7 @@ service = discovery.build('dataflow', 'v1b3', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'workerMessages' method:
 
 # * The project to send the WorkerMessages to.
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 send_worker_messages_request_body = {
 # TODO: Add desired entries of the 'send_worker_messages_request_body' dict

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_dataflow.v1b3.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_dataflow.v1b3.json.baseline
@@ -76,7 +76,7 @@ service = discovery.build('dataflow', 'v1b3', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * The project which owns the job.
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 # * Identifies a single job.
 jobId = '{MY-JOB-ID}'
@@ -119,7 +119,7 @@ service = discovery.build('dataflow', 'v1b3', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'getMetrics' method:
 
 # * A project id.
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 # * The job to get messages for.
 jobId = '{MY-JOB-ID}'
@@ -202,7 +202,7 @@ service = discovery.build('dataflow', 'v1b3', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * A project id.
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 # * The job to get messages about.
 jobId = '{MY-JOB-ID}'
@@ -249,7 +249,7 @@ service = discovery.build('dataflow', 'v1b3', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
 # * The project which owns the job.
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 # * Identifies a single job.
 jobId = '{MY-JOB-ID}'
@@ -296,7 +296,7 @@ service = discovery.build('dataflow', 'v1b3', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'lease' method:
 
 # * Identifies the project this worker belongs to.
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 # * Identifies the workflow job this worker belongs to.
 jobId = '{MY-JOB-ID}'
@@ -343,7 +343,7 @@ service = discovery.build('dataflow', 'v1b3', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'reportStatus' method:
 
 # * The project which owns the WorkItem's job.
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 # * The job which the WorkItem is part of.
 jobId = '{MY-JOB-ID}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_dataproc.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_dataproc.v1.json.baseline
@@ -35,7 +35,7 @@ service = discovery.build('dataproc', 'v1', credentials=credentials)
 projectId = ''
 
 # * [Required] The Cloud Dataproc region in which to handle the request.
-region = ''
+region = '{MY-REGION}'
 
 cluster_body = {
 # TODO: Add desired entries of the 'cluster_body' dict
@@ -85,7 +85,7 @@ projectId = ''
 region = ''
 
 # * [Required] The cluster name.
-clusterName = ''
+clusterName = '{MY-CLUSTER-NAME}'
 
 request = service.projects().regions().clusters().delete(projectId=projectId, region=region, clusterName=clusterName)
 response = request.execute()
@@ -131,7 +131,7 @@ projectId = ''
 region = ''
 
 # * [Required] The cluster name.
-clusterName = ''
+clusterName = '{MY-CLUSTER-NAME}'
 
 diagnose_cluster_request_body = {
 # TODO: Add desired entries of the 'diagnose_cluster_request_body' dict
@@ -181,7 +181,7 @@ projectId = ''
 region = ''
 
 # * [Required] The cluster name.
-clusterName = ''
+clusterName = '{MY-CLUSTER-NAME}'
 
 request = service.projects().regions().clusters().get(projectId=projectId, region=region, clusterName=clusterName)
 response = request.execute()
@@ -222,7 +222,7 @@ service = discovery.build('dataproc', 'v1', credentials=credentials)
 projectId = ''
 
 # * [Required] The Cloud Dataproc region in which to handle the request.
-region = ''
+region = '{MY-REGION}'
 
 clusters = service.projects().regions().clusters()
 request = clusters.list(projectId=projectId, region=region)
@@ -272,7 +272,7 @@ projectId = ''
 region = ''
 
 # * [Required] The cluster name.
-clusterName = ''
+clusterName = '{MY-CLUSTER-NAME}'
 
 cluster_body = {
 # TODO: Add desired entries of the 'cluster_body' dict to be changed
@@ -322,7 +322,7 @@ projectId = ''
 region = ''
 
 # * [Required] The job ID.
-jobId = ''
+jobId = '{MY-JOB-ID}'
 
 cancel_job_request_body = {
 # TODO: Add desired entries of the 'cancel_job_request_body' dict
@@ -370,7 +370,7 @@ projectId = ''
 region = ''
 
 # * [Required] The job ID.
-jobId = ''
+jobId = '{MY-JOB-ID}'
 
 request = service.projects().regions().jobs().delete(projectId=projectId, region=region, jobId=jobId)
 request.execute()
@@ -413,7 +413,7 @@ projectId = ''
 region = ''
 
 # * [Required] The job ID.
-jobId = ''
+jobId = '{MY-JOB-ID}'
 
 request = service.projects().regions().jobs().get(projectId=projectId, region=region, jobId=jobId)
 response = request.execute()
@@ -454,7 +454,7 @@ service = discovery.build('dataproc', 'v1', credentials=credentials)
 projectId = ''
 
 # * [Required] The Cloud Dataproc region in which to handle the request.
-region = ''
+region = '{MY-REGION}'
 
 jobs = service.projects().regions().jobs()
 request = jobs.list(projectId=projectId, region=region)
@@ -501,7 +501,7 @@ service = discovery.build('dataproc', 'v1', credentials=credentials)
 projectId = ''
 
 # * [Required] The Cloud Dataproc region in which to handle the request.
-region = ''
+region = '{MY-REGION}'
 
 submit_job_request_body = {
 # TODO: Add desired entries of the 'submit_job_request_body' dict
@@ -653,7 +653,7 @@ service = discovery.build('dataproc', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * The name of the operation collection.
-name = ''
+name = '{MY-NAME}'
 
 operations = service.projects().regions().operations()
 request = operations.list(name=name)

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_dataproc.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_dataproc.v1.json.baseline
@@ -32,7 +32,7 @@ service = discovery.build('dataproc', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'create' method:
 
 # * [Required] The ID of the Google Cloud Platform project that the cluster belongs to.
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 # * [Required] The Cloud Dataproc region in which to handle the request.
 region = '{MY-REGION}'
@@ -79,10 +79,10 @@ service = discovery.build('dataproc', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * [Required] The ID of the Google Cloud Platform project that the cluster belongs to.
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 # * [Required] The Cloud Dataproc region in which to handle the request.
-region = ''
+region = '{MY-REGION}'
 
 # * [Required] The cluster name.
 clusterName = '{MY-CLUSTER-NAME}'
@@ -125,10 +125,10 @@ service = discovery.build('dataproc', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'diagnose' method:
 
 # * [Required] The ID of the Google Cloud Platform project that the cluster belongs to.
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 # * [Required] The Cloud Dataproc region in which to handle the request.
-region = ''
+region = '{MY-REGION}'
 
 # * [Required] The cluster name.
 clusterName = '{MY-CLUSTER-NAME}'
@@ -175,10 +175,10 @@ service = discovery.build('dataproc', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * [Required] The ID of the Google Cloud Platform project that the cluster belongs to.
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 # * [Required] The Cloud Dataproc region in which to handle the request.
-region = ''
+region = '{MY-REGION}'
 
 # * [Required] The cluster name.
 clusterName = '{MY-CLUSTER-NAME}'
@@ -219,7 +219,7 @@ service = discovery.build('dataproc', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * [Required] The ID of the Google Cloud Platform project that the cluster belongs to.
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 # * [Required] The Cloud Dataproc region in which to handle the request.
 region = '{MY-REGION}'
@@ -266,10 +266,10 @@ service = discovery.build('dataproc', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
 # * [Required] The ID of the Google Cloud Platform project the cluster belongs to.
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 # * [Required] The Cloud Dataproc region in which to handle the request.
-region = ''
+region = '{MY-REGION}'
 
 # * [Required] The cluster name.
 clusterName = '{MY-CLUSTER-NAME}'
@@ -316,10 +316,10 @@ service = discovery.build('dataproc', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'cancel' method:
 
 # * [Required] The ID of the Google Cloud Platform project that the job belongs to.
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 # * [Required] The Cloud Dataproc region in which to handle the request.
-region = ''
+region = '{MY-REGION}'
 
 # * [Required] The job ID.
 jobId = '{MY-JOB-ID}'
@@ -364,10 +364,10 @@ service = discovery.build('dataproc', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * [Required] The ID of the Google Cloud Platform project that the job belongs to.
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 # * [Required] The Cloud Dataproc region in which to handle the request.
-region = ''
+region = '{MY-REGION}'
 
 # * [Required] The job ID.
 jobId = '{MY-JOB-ID}'
@@ -407,10 +407,10 @@ service = discovery.build('dataproc', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * [Required] The ID of the Google Cloud Platform project that the job belongs to.
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 # * [Required] The Cloud Dataproc region in which to handle the request.
-region = ''
+region = '{MY-REGION}'
 
 # * [Required] The job ID.
 jobId = '{MY-JOB-ID}'
@@ -451,7 +451,7 @@ service = discovery.build('dataproc', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * [Required] The ID of the Google Cloud Platform project that the job belongs to.
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 # * [Required] The Cloud Dataproc region in which to handle the request.
 region = '{MY-REGION}'
@@ -498,7 +498,7 @@ service = discovery.build('dataproc', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'submit' method:
 
 # * [Required] The ID of the Google Cloud Platform project that the job belongs to.
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 # * [Required] The Cloud Dataproc region in which to handle the request.
 region = '{MY-REGION}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_datastore.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_datastore.v1beta2.json.baseline
@@ -32,7 +32,7 @@ service = discovery.build('datastore', 'v1beta2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'allocateIds' method:
 
 # * Identifies the dataset.
-datasetId = ''
+datasetId = '{MY-DATASET-ID}'
 
 allocate_ids_request_body = {
 # TODO: Add desired entries of the 'allocate_ids_request_body' dict
@@ -76,7 +76,7 @@ service = discovery.build('datastore', 'v1beta2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'beginTransaction' method:
 
 # * Identifies the dataset.
-datasetId = ''
+datasetId = '{MY-DATASET-ID}'
 
 begin_transaction_request_body = {
 # TODO: Add desired entries of the 'begin_transaction_request_body' dict
@@ -120,7 +120,7 @@ service = discovery.build('datastore', 'v1beta2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'commit' method:
 
 # * Identifies the dataset.
-datasetId = ''
+datasetId = '{MY-DATASET-ID}'
 
 commit_request_body = {
 # TODO: Add desired entries of the 'commit_request_body' dict
@@ -164,7 +164,7 @@ service = discovery.build('datastore', 'v1beta2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'lookup' method:
 
 # * Identifies the dataset.
-datasetId = ''
+datasetId = '{MY-DATASET-ID}'
 
 lookup_request_body = {
 # TODO: Add desired entries of the 'lookup_request_body' dict
@@ -208,7 +208,7 @@ service = discovery.build('datastore', 'v1beta2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'rollback' method:
 
 # * Identifies the dataset.
-datasetId = ''
+datasetId = '{MY-DATASET-ID}'
 
 rollback_request_body = {
 # TODO: Add desired entries of the 'rollback_request_body' dict
@@ -252,7 +252,7 @@ service = discovery.build('datastore', 'v1beta2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'runQuery' method:
 
 # * Identifies the dataset.
-datasetId = ''
+datasetId = '{MY-DATASET-ID}'
 
 run_query_request_body = {
 # TODO: Add desired entries of the 'run_query_request_body' dict

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_deploymentmanager.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_deploymentmanager.v2.json.baseline
@@ -35,7 +35,7 @@ service = discovery.build('deploymentmanager', 'v2', credentials=credentials)
 project = ''
 
 # * The name of the deployment for this request.
-deployment = ''
+deployment = '{MY-DEPLOYMENT}'
 
 deployments_cancel_preview_request_body = {
 # TODO: Add desired entries of the 'deployments_cancel_preview_request_body' dict
@@ -82,7 +82,7 @@ service = discovery.build('deploymentmanager', 'v2', credentials=credentials)
 project = ''
 
 # * The name of the deployment for this request.
-deployment = ''
+deployment = '{MY-DEPLOYMENT}'
 
 request = service.deployments().delete(project=project, deployment=deployment)
 response = request.execute()
@@ -125,7 +125,7 @@ service = discovery.build('deploymentmanager', 'v2', credentials=credentials)
 project = ''
 
 # * The name of the deployment for this request.
-deployment = ''
+deployment = '{MY-DEPLOYMENT}'
 
 request = service.deployments().get(project=project, deployment=deployment)
 response = request.execute()
@@ -165,7 +165,7 @@ service = discovery.build('deploymentmanager', 'v2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
 # * The project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 deployment_body = {
 # TODO: Add desired entries of the 'deployment_body' dict
@@ -207,7 +207,7 @@ service = discovery.build('deploymentmanager', 'v2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * The project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 deployments = service.deployments()
 request = deployments.list(project=project)
@@ -254,7 +254,7 @@ service = discovery.build('deploymentmanager', 'v2', credentials=credentials)
 project = ''
 
 # * The name of the deployment for this request.
-deployment = ''
+deployment = '{MY-DEPLOYMENT}'
 
 deployment_body = {
 # TODO: Add desired entries of the 'deployment_body' dict to be changed
@@ -301,7 +301,7 @@ service = discovery.build('deploymentmanager', 'v2', credentials=credentials)
 project = ''
 
 # * The name of the deployment for this request.
-deployment = ''
+deployment = '{MY-DEPLOYMENT}'
 
 deployments_stop_request_body = {
 # TODO: Add desired entries of the 'deployments_stop_request_body' dict
@@ -348,7 +348,7 @@ service = discovery.build('deploymentmanager', 'v2', credentials=credentials)
 project = ''
 
 # * The name of the deployment for this request.
-deployment = ''
+deployment = '{MY-DEPLOYMENT}'
 
 deployment_body = {
 # TODO: Add desired entries of the 'deployment_body' dict
@@ -398,7 +398,7 @@ project = ''
 deployment = ''
 
 # * The name of the manifest for this request.
-manifest = ''
+manifest = '{MY-MANIFEST}'
 
 request = service.manifests().get(project=project, deployment=deployment, manifest=manifest)
 response = request.execute()
@@ -439,7 +439,7 @@ service = discovery.build('deploymentmanager', 'v2', credentials=credentials)
 project = ''
 
 # * The name of the deployment for this request.
-deployment = ''
+deployment = '{MY-DEPLOYMENT}'
 
 manifests = service.manifests()
 request = manifests.list(project=project, deployment=deployment)
@@ -486,7 +486,7 @@ service = discovery.build('deploymentmanager', 'v2', credentials=credentials)
 project = ''
 
 # * The name of the operation for this request.
-operation = ''
+operation = '{MY-OPERATION}'
 
 request = service.operations().get(project=project, operation=operation)
 response = request.execute()
@@ -524,7 +524,7 @@ service = discovery.build('deploymentmanager', 'v2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * The project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 operations = service.operations()
 request = operations.list(project=project)
@@ -574,7 +574,7 @@ project = ''
 deployment = ''
 
 # * The name of the resource for this request.
-resource = ''
+resource = '{MY-RESOURCE}'
 
 request = service.resources().get(project=project, deployment=deployment, resource=resource)
 response = request.execute()
@@ -615,7 +615,7 @@ service = discovery.build('deploymentmanager', 'v2', credentials=credentials)
 project = ''
 
 # * The name of the deployment for this request.
-deployment = ''
+deployment = '{MY-DEPLOYMENT}'
 
 resources = service.resources()
 request = resources.list(project=project, deployment=deployment)
@@ -657,7 +657,7 @@ service = discovery.build('deploymentmanager', 'v2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * The project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 types = service.types()
 request = types.list(project=project)

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_deploymentmanager.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_deploymentmanager.v2.json.baseline
@@ -32,7 +32,7 @@ service = discovery.build('deploymentmanager', 'v2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'cancelPreview' method:
 
 # * The project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the deployment for this request.
 deployment = '{MY-DEPLOYMENT}'
@@ -79,7 +79,7 @@ service = discovery.build('deploymentmanager', 'v2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * The project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the deployment for this request.
 deployment = '{MY-DEPLOYMENT}'
@@ -122,7 +122,7 @@ service = discovery.build('deploymentmanager', 'v2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * The project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the deployment for this request.
 deployment = '{MY-DEPLOYMENT}'
@@ -251,7 +251,7 @@ service = discovery.build('deploymentmanager', 'v2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
 # * The project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the deployment for this request.
 deployment = '{MY-DEPLOYMENT}'
@@ -298,7 +298,7 @@ service = discovery.build('deploymentmanager', 'v2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'stop' method:
 
 # * The project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the deployment for this request.
 deployment = '{MY-DEPLOYMENT}'
@@ -345,7 +345,7 @@ service = discovery.build('deploymentmanager', 'v2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
 # * The project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the deployment for this request.
 deployment = '{MY-DEPLOYMENT}'
@@ -392,10 +392,10 @@ service = discovery.build('deploymentmanager', 'v2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * The project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the deployment for this request.
-deployment = ''
+deployment = '{MY-DEPLOYMENT}'
 
 # * The name of the manifest for this request.
 manifest = '{MY-MANIFEST}'
@@ -436,7 +436,7 @@ service = discovery.build('deploymentmanager', 'v2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * The project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the deployment for this request.
 deployment = '{MY-DEPLOYMENT}'
@@ -483,7 +483,7 @@ service = discovery.build('deploymentmanager', 'v2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * The project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the operation for this request.
 operation = '{MY-OPERATION}'
@@ -568,10 +568,10 @@ service = discovery.build('deploymentmanager', 'v2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * The project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the deployment for this request.
-deployment = ''
+deployment = '{MY-DEPLOYMENT}'
 
 # * The name of the resource for this request.
 resource = '{MY-RESOURCE}'
@@ -612,7 +612,7 @@ service = discovery.build('deploymentmanager', 'v2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * The project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the deployment for this request.
 deployment = '{MY-DEPLOYMENT}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_dns.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_dns.v1.json.baseline
@@ -32,7 +32,7 @@ service = discovery.build('dns', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'create' method:
 
 # * Identifies the project addressed by this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Identifies the managed zone addressed by this request. Can be the managed zone name or id.
 managedZone = '{MY-MANAGED-ZONE}'
@@ -79,10 +79,10 @@ service = discovery.build('dns', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Identifies the project addressed by this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-managedZone = ''
+managedZone = '{MY-MANAGED-ZONE}'
 
 # * The identifier of the requested change, from a previous ResourceRecordSetsChangeResponse.
 changeId = '{MY-CHANGE-ID}'
@@ -123,7 +123,7 @@ service = discovery.build('dns', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Identifies the project addressed by this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Identifies the managed zone addressed by this request. Can be the managed zone name or id.
 managedZone = '{MY-MANAGED-ZONE}'
@@ -212,7 +212,7 @@ service = discovery.build('dns', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Identifies the project addressed by this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Identifies the managed zone addressed by this request. Can be the managed zone name or id.
 managedZone = '{MY-MANAGED-ZONE}'
@@ -252,7 +252,7 @@ service = discovery.build('dns', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Identifies the project addressed by this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Identifies the managed zone addressed by this request. Can be the managed zone name or id.
 managedZone = '{MY-MANAGED-ZONE}'
@@ -375,7 +375,7 @@ service = discovery.build('dns', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Identifies the project addressed by this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Identifies the managed zone addressed by this request. Can be the managed zone name or id.
 managedZone = '{MY-MANAGED-ZONE}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_dns.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_dns.v1.json.baseline
@@ -35,7 +35,7 @@ service = discovery.build('dns', 'v1', credentials=credentials)
 project = ''
 
 # * Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-managedZone = ''
+managedZone = '{MY-MANAGED-ZONE}'
 
 change_body = {
 # TODO: Add desired entries of the 'change_body' dict
@@ -85,7 +85,7 @@ project = ''
 managedZone = ''
 
 # * The identifier of the requested change, from a previous ResourceRecordSetsChangeResponse.
-changeId = ''
+changeId = '{MY-CHANGE-ID}'
 
 request = service.changes().get(project=project, managedZone=managedZone, changeId=changeId)
 response = request.execute()
@@ -126,7 +126,7 @@ service = discovery.build('dns', 'v1', credentials=credentials)
 project = ''
 
 # * Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-managedZone = ''
+managedZone = '{MY-MANAGED-ZONE}'
 
 changes = service.changes()
 request = changes.list(project=project, managedZone=managedZone)
@@ -170,7 +170,7 @@ service = discovery.build('dns', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'create' method:
 
 # * Identifies the project addressed by this request.
-project = ''
+project = '{MY-PROJECT}'
 
 managed_zone_body = {
 # TODO: Add desired entries of the 'managed_zone_body' dict
@@ -215,7 +215,7 @@ service = discovery.build('dns', 'v1', credentials=credentials)
 project = ''
 
 # * Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-managedZone = ''
+managedZone = '{MY-MANAGED-ZONE}'
 
 request = service.managedZones().delete(project=project, managedZone=managedZone)
 request.execute()
@@ -255,7 +255,7 @@ service = discovery.build('dns', 'v1', credentials=credentials)
 project = ''
 
 # * Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-managedZone = ''
+managedZone = '{MY-MANAGED-ZONE}'
 
 request = service.managedZones().get(project=project, managedZone=managedZone)
 response = request.execute()
@@ -293,7 +293,7 @@ service = discovery.build('dns', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Identifies the project addressed by this request.
-project = ''
+project = '{MY-PROJECT}'
 
 managedZones = service.managedZones()
 request = managedZones.list(project=project)
@@ -337,7 +337,7 @@ service = discovery.build('dns', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Identifies the project addressed by this request.
-project = ''
+project = '{MY-PROJECT}'
 
 request = service.projects().get(project=project)
 response = request.execute()
@@ -378,7 +378,7 @@ service = discovery.build('dns', 'v1', credentials=credentials)
 project = ''
 
 # * Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-managedZone = ''
+managedZone = '{MY-MANAGED-ZONE}'
 
 resourceRecordSets = service.resourceRecordSets()
 request = resourceRecordSets.list(project=project, managedZone=managedZone)

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_prediction.v1.6.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_prediction.v1.6.json.baseline
@@ -35,7 +35,7 @@ service = discovery.build('prediction', 'v1.6', credentials=credentials)
 project = ''
 
 # * The name of a hosted model.
-hostedModelName = ''
+hostedModelName = '{MY-HOSTED-MODEL-NAME}'
 
 input__body = {
 # TODO: Add desired entries of the 'input__body' dict
@@ -82,7 +82,7 @@ service = discovery.build('prediction', 'v1.6', credentials=credentials)
 project = ''
 
 # * The unique name for the predictive model.
-id = ''
+id = '{MY-ID}'
 
 request = service.trainedmodels().analyze(project=project, id=id)
 response = request.execute()
@@ -123,7 +123,7 @@ service = discovery.build('prediction', 'v1.6', credentials=credentials)
 project = ''
 
 # * The unique name for the predictive model.
-id = ''
+id = '{MY-ID}'
 
 request = service.trainedmodels().delete(project=project, id=id)
 request.execute()
@@ -163,7 +163,7 @@ service = discovery.build('prediction', 'v1.6', credentials=credentials)
 project = ''
 
 # * The unique name for the predictive model.
-id = ''
+id = '{MY-ID}'
 
 request = service.trainedmodels().get(project=project, id=id)
 response = request.execute()
@@ -203,7 +203,7 @@ service = discovery.build('prediction', 'v1.6', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
 # * The project associated with the model.
-project = ''
+project = '{MY-PROJECT}'
 
 insert_body = {
 # TODO: Add desired entries of the 'insert_body' dict
@@ -245,7 +245,7 @@ service = discovery.build('prediction', 'v1.6', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * The project associated with the model.
-project = ''
+project = '{MY-PROJECT}'
 
 trainedmodels = service.trainedmodels()
 request = trainedmodels.list(project=project)
@@ -292,7 +292,7 @@ service = discovery.build('prediction', 'v1.6', credentials=credentials)
 project = ''
 
 # * The unique name for the predictive model.
-id = ''
+id = '{MY-ID}'
 
 input__body = {
 # TODO: Add desired entries of the 'input__body' dict
@@ -339,7 +339,7 @@ service = discovery.build('prediction', 'v1.6', credentials=credentials)
 project = ''
 
 # * The unique name for the predictive model.
-id = ''
+id = '{MY-ID}'
 
 update_body = {
 # TODO: Add desired entries of the 'update_body' dict

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_prediction.v1.6.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_prediction.v1.6.json.baseline
@@ -32,7 +32,7 @@ service = discovery.build('prediction', 'v1.6', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'predict' method:
 
 # * The project associated with the model.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of a hosted model.
 hostedModelName = '{MY-HOSTED-MODEL-NAME}'
@@ -79,7 +79,7 @@ service = discovery.build('prediction', 'v1.6', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'analyze' method:
 
 # * The project associated with the model.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The unique name for the predictive model.
 id = '{MY-ID}'
@@ -120,7 +120,7 @@ service = discovery.build('prediction', 'v1.6', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * The project associated with the model.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The unique name for the predictive model.
 id = '{MY-ID}'
@@ -160,7 +160,7 @@ service = discovery.build('prediction', 'v1.6', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * The project associated with the model.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The unique name for the predictive model.
 id = '{MY-ID}'
@@ -289,7 +289,7 @@ service = discovery.build('prediction', 'v1.6', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'predict' method:
 
 # * The project associated with the model.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The unique name for the predictive model.
 id = '{MY-ID}'
@@ -336,7 +336,7 @@ service = discovery.build('prediction', 'v1.6', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
 # * The project associated with the model.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The unique name for the predictive model.
 id = '{MY-ID}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_replicapoolupdater.v1beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_replicapoolupdater.v1beta1.json.baseline
@@ -32,10 +32,10 @@ service = discovery.build('replicapoolupdater', 'v1beta1', credentials=credentia
 # TODO: Change placeholders below to appropriate parameter values for the 'cancel' method:
 
 # * The Google Developers Console project name.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone in which the update's target resides.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the update.
 rollingUpdate = '{MY-ROLLING-UPDATE}'
@@ -78,10 +78,10 @@ service = discovery.build('replicapoolupdater', 'v1beta1', credentials=credentia
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * The Google Developers Console project name.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone in which the update's target resides.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the update.
 rollingUpdate = '{MY-ROLLING-UPDATE}'
@@ -124,7 +124,7 @@ service = discovery.build('replicapoolupdater', 'v1beta1', credentials=credentia
 # TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
 # * The Google Developers Console project name.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone in which the update's target resides.
 zone = '{MY-ZONE}'
@@ -169,7 +169,7 @@ service = discovery.build('replicapoolupdater', 'v1beta1', credentials=credentia
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * The Google Developers Console project name.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone in which the update's target resides.
 zone = '{MY-ZONE}'
@@ -214,10 +214,10 @@ service = discovery.build('replicapoolupdater', 'v1beta1', credentials=credentia
 # TODO: Change placeholders below to appropriate parameter values for the 'listInstanceUpdates' method:
 
 # * The Google Developers Console project name.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone in which the update's target resides.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the update.
 rollingUpdate = '{MY-ROLLING-UPDATE}'
@@ -264,10 +264,10 @@ service = discovery.build('replicapoolupdater', 'v1beta1', credentials=credentia
 # TODO: Change placeholders below to appropriate parameter values for the 'pause' method:
 
 # * The Google Developers Console project name.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone in which the update's target resides.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the update.
 rollingUpdate = '{MY-ROLLING-UPDATE}'
@@ -310,10 +310,10 @@ service = discovery.build('replicapoolupdater', 'v1beta1', credentials=credentia
 # TODO: Change placeholders below to appropriate parameter values for the 'resume' method:
 
 # * The Google Developers Console project name.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone in which the update's target resides.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the update.
 rollingUpdate = '{MY-ROLLING-UPDATE}'
@@ -356,10 +356,10 @@ service = discovery.build('replicapoolupdater', 'v1beta1', credentials=credentia
 # TODO: Change placeholders below to appropriate parameter values for the 'rollback' method:
 
 # * The Google Developers Console project name.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone in which the update's target resides.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the update.
 rollingUpdate = '{MY-ROLLING-UPDATE}'
@@ -402,10 +402,10 @@ service = discovery.build('replicapoolupdater', 'v1beta1', credentials=credentia
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Name of the project scoping this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the zone scoping this request.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * Name of the operation resource to return.
 operation = '{MY-OPERATION}'
@@ -446,7 +446,7 @@ service = discovery.build('replicapoolupdater', 'v1beta1', credentials=credentia
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Name of the project scoping this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the zone scoping this request.
 zone = '{MY-ZONE}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_replicapoolupdater.v1beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_replicapoolupdater.v1beta1.json.baseline
@@ -38,7 +38,7 @@ project = ''
 zone = ''
 
 # * The name of the update.
-rollingUpdate = ''
+rollingUpdate = '{MY-ROLLING-UPDATE}'
 
 request = service.rollingUpdates().cancel(project=project, zone=zone, rollingUpdate=rollingUpdate)
 response = request.execute()
@@ -84,7 +84,7 @@ project = ''
 zone = ''
 
 # * The name of the update.
-rollingUpdate = ''
+rollingUpdate = '{MY-ROLLING-UPDATE}'
 
 request = service.rollingUpdates().get(project=project, zone=zone, rollingUpdate=rollingUpdate)
 response = request.execute()
@@ -127,7 +127,7 @@ service = discovery.build('replicapoolupdater', 'v1beta1', credentials=credentia
 project = ''
 
 # * The name of the zone in which the update's target resides.
-zone = ''
+zone = '{MY-ZONE}'
 
 rolling_update_body = {
 # TODO: Add desired entries of the 'rolling_update_body' dict
@@ -172,7 +172,7 @@ service = discovery.build('replicapoolupdater', 'v1beta1', credentials=credentia
 project = ''
 
 # * The name of the zone in which the update's target resides.
-zone = ''
+zone = '{MY-ZONE}'
 
 rollingUpdates = service.rollingUpdates()
 request = rollingUpdates.list(project=project, zone=zone)
@@ -220,7 +220,7 @@ project = ''
 zone = ''
 
 # * The name of the update.
-rollingUpdate = ''
+rollingUpdate = '{MY-ROLLING-UPDATE}'
 
 rollingUpdates = service.rollingUpdates()
 request = rollingUpdates.listInstanceUpdates(project=project, zone=zone, rollingUpdate=rollingUpdate)
@@ -270,7 +270,7 @@ project = ''
 zone = ''
 
 # * The name of the update.
-rollingUpdate = ''
+rollingUpdate = '{MY-ROLLING-UPDATE}'
 
 request = service.rollingUpdates().pause(project=project, zone=zone, rollingUpdate=rollingUpdate)
 response = request.execute()
@@ -316,7 +316,7 @@ project = ''
 zone = ''
 
 # * The name of the update.
-rollingUpdate = ''
+rollingUpdate = '{MY-ROLLING-UPDATE}'
 
 request = service.rollingUpdates().resume(project=project, zone=zone, rollingUpdate=rollingUpdate)
 response = request.execute()
@@ -362,7 +362,7 @@ project = ''
 zone = ''
 
 # * The name of the update.
-rollingUpdate = ''
+rollingUpdate = '{MY-ROLLING-UPDATE}'
 
 request = service.rollingUpdates().rollback(project=project, zone=zone, rollingUpdate=rollingUpdate)
 response = request.execute()
@@ -408,7 +408,7 @@ project = ''
 zone = ''
 
 # * Name of the operation resource to return.
-operation = ''
+operation = '{MY-OPERATION}'
 
 request = service.zoneOperations().get(project=project, zone=zone, operation=operation)
 response = request.execute()
@@ -449,7 +449,7 @@ service = discovery.build('replicapoolupdater', 'v1beta1', credentials=credentia
 project = ''
 
 # * Name of the zone scoping this request.
-zone = ''
+zone = '{MY-ZONE}'
 
 zoneOperations = service.zoneOperations()
 request = zoneOperations.list(project=project, zone=zone)

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_sqladmin.v1beta4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_sqladmin.v1beta4.json.baseline
@@ -32,10 +32,10 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Project ID of the project that contains the instance.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Cloud SQL instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # * The ID of the Backup Run to delete. To find a Backup Run ID, use the list method.
 id = str(0L)
@@ -78,10 +78,10 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID of the project that contains the instance.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Cloud SQL instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # * The ID of this Backup Run.
 id = str(0L)
@@ -122,7 +122,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID of the project that contains the instance.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Cloud SQL instance ID. This does not include the project ID.
 instance = '{MY-INSTANCE}'
@@ -169,10 +169,10 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Project ID of the project that contains the instance.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Database instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # * Name of the database to be deleted in the instance.
 database = '{MY-DATABASE}'
@@ -215,10 +215,10 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID of the project that contains the instance.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Database instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # * Name of the database in the instance.
 database = '{MY-DATABASE}'
@@ -261,7 +261,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
 # * Project ID of the project that contains the instance.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Database instance ID. This does not include the project ID.
 instance = '{MY-INSTANCE}'
@@ -308,7 +308,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID of the project for which to list Cloud SQL instances.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Cloud SQL instance ID. This does not include the project ID.
 instance = '{MY-INSTANCE}'
@@ -351,10 +351,10 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
 # * Project ID of the project that contains the instance.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Database instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # * Name of the database to be updated in the instance.
 database = '{MY-DATABASE}'
@@ -401,10 +401,10 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
 # * Project ID of the project that contains the instance.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Database instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # * Name of the database to be updated in the instance.
 database = '{MY-DATABASE}'
@@ -487,7 +487,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'clone' method:
 
 # * Project ID of the source as well as the clone Cloud SQL instance.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The ID of the Cloud SQL instance to be cloned (source). This does not include the project ID.
 instance = '{MY-INSTANCE}'
@@ -534,7 +534,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Project ID of the project that contains the instance to be deleted.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Cloud SQL instance ID. This does not include the project ID.
 instance = '{MY-INSTANCE}'
@@ -577,7 +577,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'export' method:
 
 # * Project ID of the project that contains the instance to be exported.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Cloud SQL instance ID. This does not include the project ID.
 instance = '{MY-INSTANCE}'
@@ -624,7 +624,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'failover' method:
 
 # * ID of the project that contains the read replica.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Cloud SQL instance ID. This does not include the project ID.
 instance = '{MY-INSTANCE}'
@@ -671,7 +671,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID of the project that contains the instance.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Database instance ID. This does not include the project ID.
 instance = '{MY-INSTANCE}'
@@ -714,7 +714,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'import' method:
 
 # * Project ID of the project that contains the instance.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Cloud SQL instance ID. This does not include the project ID.
 instance = '{MY-INSTANCE}'
@@ -847,7 +847,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
 # * Project ID of the project that contains the instance.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Cloud SQL instance ID. This does not include the project ID.
 instance = '{MY-INSTANCE}'
@@ -894,7 +894,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'promoteReplica' method:
 
 # * ID of the project that contains the read replica.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Cloud SQL read replica instance name.
 instance = '{MY-INSTANCE}'
@@ -937,7 +937,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'resetSslConfig' method:
 
 # * Project ID of the project that contains the instance.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Cloud SQL instance ID. This does not include the project ID.
 instance = '{MY-INSTANCE}'
@@ -980,7 +980,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'restart' method:
 
 # * Project ID of the project that contains the instance to be restarted.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Cloud SQL instance ID. This does not include the project ID.
 instance = '{MY-INSTANCE}'
@@ -1023,7 +1023,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'restoreBackup' method:
 
 # * Project ID of the project that contains the instance.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Cloud SQL instance ID. This does not include the project ID.
 instance = '{MY-INSTANCE}'
@@ -1070,7 +1070,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'startReplica' method:
 
 # * ID of the project that contains the read replica.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Cloud SQL read replica instance name.
 instance = '{MY-INSTANCE}'
@@ -1113,7 +1113,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'stopReplica' method:
 
 # * ID of the project that contains the read replica.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Cloud SQL read replica instance name.
 instance = '{MY-INSTANCE}'
@@ -1156,7 +1156,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
 # * Project ID of the project that contains the instance.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Cloud SQL instance ID. This does not include the project ID.
 instance = '{MY-INSTANCE}'
@@ -1203,7 +1203,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID of the project that contains the instance.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Instance operation ID.
 operation = '{MY-OPERATION}'
@@ -1244,7 +1244,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID of the project that contains the instance.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Cloud SQL instance ID. This does not include the project ID.
 instance = '{MY-INSTANCE}'
@@ -1291,7 +1291,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'createEphemeral' method:
 
 # * Project ID of the Cloud SQL project.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Cloud SQL instance ID. This does not include the project ID.
 instance = '{MY-INSTANCE}'
@@ -1338,10 +1338,10 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Project ID of the project that contains the instance to be deleted.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Cloud SQL instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # * Sha1 FingerPrint.
 sha1Fingerprint = '{MY-SHA1-FINGERPRINT}'
@@ -1384,10 +1384,10 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Project ID of the project that contains the instance.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Cloud SQL instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # * Sha1 FingerPrint.
 sha1Fingerprint = '{MY-SHA1-FINGERPRINT}'
@@ -1430,7 +1430,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
 # * Project ID of the project to which the newly created Cloud SQL instances should belong.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Cloud SQL instance ID. This does not include the project ID.
 instance = '{MY-INSTANCE}'
@@ -1477,7 +1477,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID of the project for which to list Cloud SQL instances.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Cloud SQL instance ID. This does not include the project ID.
 instance = '{MY-INSTANCE}'
@@ -1560,13 +1560,13 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Project ID of the project that contains the instance.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Database instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # * Host of the user in the instance.
-host = ''
+host = '{MY-HOST}'
 
 # * Name of the user in the instance.
 name = '{MY-NAME}'
@@ -1609,7 +1609,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
 # * Project ID of the project that contains the instance.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Database instance ID. This does not include the project ID.
 instance = '{MY-INSTANCE}'
@@ -1656,7 +1656,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID of the project that contains the instance.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Database instance ID. This does not include the project ID.
 instance = '{MY-INSTANCE}'
@@ -1699,13 +1699,13 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
 # * Project ID of the project that contains the instance.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Database instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # * Host of the user in the instance.
-host = ''
+host = '{MY-HOST}'
 
 # * Name of the user in the instance.
 name = '{MY-NAME}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_sqladmin.v1beta4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_sqladmin.v1beta4.json.baseline
@@ -125,7 +125,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 project = ''
 
 # * Cloud SQL instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 backupRuns = service.backupRuns()
 request = backupRuns.list(project=project, instance=instance)
@@ -175,7 +175,7 @@ project = ''
 instance = ''
 
 # * Name of the database to be deleted in the instance.
-database = ''
+database = '{MY-DATABASE}'
 
 request = service.databases().delete(project=project, instance=instance, database=database)
 response = request.execute()
@@ -221,7 +221,7 @@ project = ''
 instance = ''
 
 # * Name of the database in the instance.
-database = ''
+database = '{MY-DATABASE}'
 
 request = service.databases().get(project=project, instance=instance, database=database)
 response = request.execute()
@@ -264,7 +264,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 project = ''
 
 # * Database instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 database_body = {
 # TODO: Add desired entries of the 'database_body' dict
@@ -311,7 +311,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 project = ''
 
 # * Cloud SQL instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 request = service.databases().list(project=project, instance=instance)
 response = request.execute()
@@ -357,7 +357,7 @@ project = ''
 instance = ''
 
 # * Name of the database to be updated in the instance.
-database = ''
+database = '{MY-DATABASE}'
 
 database_body = {
 # TODO: Add desired entries of the 'database_body' dict to be changed
@@ -407,7 +407,7 @@ project = ''
 instance = ''
 
 # * Name of the database to be updated in the instance.
-database = ''
+database = '{MY-DATABASE}'
 
 database_body = {
 # TODO: Add desired entries of the 'database_body' dict
@@ -490,7 +490,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 project = ''
 
 # * The ID of the Cloud SQL instance to be cloned (source). This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 instances_clone_request_body = {
 # TODO: Add desired entries of the 'instances_clone_request_body' dict
@@ -537,7 +537,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 project = ''
 
 # * Cloud SQL instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 request = service.instances().delete(project=project, instance=instance)
 response = request.execute()
@@ -580,7 +580,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 project = ''
 
 # * Cloud SQL instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 instances_export_request_body = {
 # TODO: Add desired entries of the 'instances_export_request_body' dict
@@ -627,7 +627,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 project = ''
 
 # * Cloud SQL instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 instances_failover_request_body = {
 # TODO: Add desired entries of the 'instances_failover_request_body' dict
@@ -674,7 +674,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 project = ''
 
 # * Database instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 request = service.instances().get(project=project, instance=instance)
 response = request.execute()
@@ -717,7 +717,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 project = ''
 
 # * Cloud SQL instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 instances_import_request_body = {
 # TODO: Add desired entries of the 'instances_import_request_body' dict
@@ -761,7 +761,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
 # * Project ID of the project to which the newly created Cloud SQL instances should belong.
-project = ''
+project = '{MY-PROJECT}'
 
 database_instance_body = {
 # TODO: Add desired entries of the 'database_instance_body' dict
@@ -803,7 +803,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID of the project for which to list Cloud SQL instances.
-project = ''
+project = '{MY-PROJECT}'
 
 instances = service.instances()
 request = instances.list(project=project)
@@ -850,7 +850,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 project = ''
 
 # * Cloud SQL instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 database_instance_body = {
 # TODO: Add desired entries of the 'database_instance_body' dict to be changed
@@ -897,7 +897,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 project = ''
 
 # * Cloud SQL read replica instance name.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 request = service.instances().promoteReplica(project=project, instance=instance)
 response = request.execute()
@@ -940,7 +940,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 project = ''
 
 # * Cloud SQL instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 request = service.instances().resetSslConfig(project=project, instance=instance)
 response = request.execute()
@@ -983,7 +983,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 project = ''
 
 # * Cloud SQL instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 request = service.instances().restart(project=project, instance=instance)
 response = request.execute()
@@ -1026,7 +1026,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 project = ''
 
 # * Cloud SQL instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 instances_restore_backup_request_body = {
 # TODO: Add desired entries of the 'instances_restore_backup_request_body' dict
@@ -1073,7 +1073,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 project = ''
 
 # * Cloud SQL read replica instance name.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 request = service.instances().startReplica(project=project, instance=instance)
 response = request.execute()
@@ -1116,7 +1116,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 project = ''
 
 # * Cloud SQL read replica instance name.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 request = service.instances().stopReplica(project=project, instance=instance)
 response = request.execute()
@@ -1159,7 +1159,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 project = ''
 
 # * Cloud SQL instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 database_instance_body = {
 # TODO: Add desired entries of the 'database_instance_body' dict
@@ -1206,7 +1206,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 project = ''
 
 # * Instance operation ID.
-operation = ''
+operation = '{MY-OPERATION}'
 
 request = service.operations().get(project=project, operation=operation)
 response = request.execute()
@@ -1247,7 +1247,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 project = ''
 
 # * Cloud SQL instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 operations = service.operations()
 request = operations.list(project=project, instance=instance)
@@ -1294,7 +1294,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 project = ''
 
 # * Cloud SQL instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 ssl_certs_create_ephemeral_request_body = {
 # TODO: Add desired entries of the 'ssl_certs_create_ephemeral_request_body' dict
@@ -1344,7 +1344,7 @@ project = ''
 instance = ''
 
 # * Sha1 FingerPrint.
-sha1Fingerprint = ''
+sha1Fingerprint = '{MY-SHA1-FINGERPRINT}'
 
 request = service.sslCerts().delete(project=project, instance=instance, sha1Fingerprint=sha1Fingerprint)
 response = request.execute()
@@ -1390,7 +1390,7 @@ project = ''
 instance = ''
 
 # * Sha1 FingerPrint.
-sha1Fingerprint = ''
+sha1Fingerprint = '{MY-SHA1-FINGERPRINT}'
 
 request = service.sslCerts().get(project=project, instance=instance, sha1Fingerprint=sha1Fingerprint)
 response = request.execute()
@@ -1433,7 +1433,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 project = ''
 
 # * Cloud SQL instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 ssl_certs_insert_request_body = {
 # TODO: Add desired entries of the 'ssl_certs_insert_request_body' dict
@@ -1480,7 +1480,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 project = ''
 
 # * Cloud SQL instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 request = service.sslCerts().list(project=project, instance=instance)
 response = request.execute()
@@ -1520,7 +1520,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Project ID of the project for which to list tiers.
-project = ''
+project = '{MY-PROJECT}'
 
 request = service.tiers().list(project=project)
 response = request.execute()
@@ -1569,7 +1569,7 @@ instance = ''
 host = ''
 
 # * Name of the user in the instance.
-name = ''
+name = '{MY-NAME}'
 
 request = service.users().delete(project=project, instance=instance, host=host, name=name)
 response = request.execute()
@@ -1612,7 +1612,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 project = ''
 
 # * Database instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 user_body = {
 # TODO: Add desired entries of the 'user_body' dict
@@ -1659,7 +1659,7 @@ service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 project = ''
 
 # * Database instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 request = service.users().list(project=project, instance=instance)
 response = request.execute()
@@ -1708,7 +1708,7 @@ instance = ''
 host = ''
 
 # * Name of the user in the instance.
-name = ''
+name = '{MY-NAME}'
 
 user_body = {
 # TODO: Add desired entries of the 'user_body' dict

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_storage.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_storage.v1.json.baseline
@@ -115,7 +115,7 @@ service = discovery.build('storage', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
 # * Name of a bucket.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 bucket_access_control_body = {
 # TODO: Add desired entries of the 'bucket_access_control_body' dict
@@ -159,7 +159,7 @@ service = discovery.build('storage', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Name of a bucket.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 request = service.bucketAccessControls().list(bucket=bucket)
 response = request.execute()
@@ -293,7 +293,7 @@ service = discovery.build('storage', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Name of a bucket.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 request = service.buckets().delete(bucket=bucket)
 request.execute()
@@ -330,7 +330,7 @@ service = discovery.build('storage', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Name of a bucket.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 request = service.buckets().get(bucket=bucket)
 response = request.execute()
@@ -370,7 +370,7 @@ service = discovery.build('storage', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
 # * A valid API project identifier.
-project = ''
+project = '{MY-PROJECT}'
 
 bucket_body = {
 # TODO: Add desired entries of the 'bucket_body' dict
@@ -412,7 +412,7 @@ service = discovery.build('storage', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * A valid API project identifier.
-project = ''
+project = '{MY-PROJECT}'
 
 buckets = service.buckets()
 request = buckets.list(project=project)
@@ -456,7 +456,7 @@ service = discovery.build('storage', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
 # * Name of a bucket.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 bucket_body = {
 # TODO: Add desired entries of the 'bucket_body' dict to be changed
@@ -500,7 +500,7 @@ service = discovery.build('storage', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
 # * Name of a bucket.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 bucket_body = {
 # TODO: Add desired entries of the 'bucket_body' dict
@@ -662,7 +662,7 @@ service = discovery.build('storage', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
 # * Name of a bucket.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 object_access_control_body = {
 # TODO: Add desired entries of the 'object_access_control_body' dict
@@ -706,7 +706,7 @@ service = discovery.build('storage', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Name of a bucket.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 request = service.defaultObjectAccessControls().list(bucket=bucket)
 response = request.execute()
@@ -1360,7 +1360,7 @@ service = discovery.build('storage', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Name of the bucket in which to look for objects.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 objects = service.objects()
 request = objects.list(bucket=bucket)
@@ -1557,7 +1557,7 @@ service = discovery.build('storage', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'watchAll' method:
 
 # * Name of the bucket in which to look for objects.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 channel_body = {
 # TODO: Add desired entries of the 'channel_body' dict

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_storage.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_storage.v1.json.baseline
@@ -30,11 +30,11 @@ service = discovery.build('storage', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Name of a bucket.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 # * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
 #   group-emailAddress, allUsers, or allAuthenticatedUsers.
-entity = ''
+entity = '{MY-ENTITY}'
 
 request = service.bucketAccessControls().delete(bucket=bucket, entity=entity)
 request.execute()
@@ -71,11 +71,11 @@ service = discovery.build('storage', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Name of a bucket.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 # * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
 #   group-emailAddress, allUsers, or allAuthenticatedUsers.
-entity = ''
+entity = '{MY-ENTITY}'
 
 request = service.bucketAccessControls().get(bucket=bucket, entity=entity)
 response = request.execute()
@@ -199,11 +199,11 @@ service = discovery.build('storage', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
 # * Name of a bucket.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 # * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
 #   group-emailAddress, allUsers, or allAuthenticatedUsers.
-entity = ''
+entity = '{MY-ENTITY}'
 
 bucket_access_control_body = {
 # TODO: Add desired entries of the 'bucket_access_control_body' dict to be changed
@@ -247,11 +247,11 @@ service = discovery.build('storage', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
 # * Name of a bucket.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 # * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
 #   group-emailAddress, allUsers, or allAuthenticatedUsers.
-entity = ''
+entity = '{MY-ENTITY}'
 
 bucket_access_control_body = {
 # TODO: Add desired entries of the 'bucket_access_control_body' dict
@@ -577,11 +577,11 @@ service = discovery.build('storage', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Name of a bucket.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 # * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
 #   group-emailAddress, allUsers, or allAuthenticatedUsers.
-entity = ''
+entity = '{MY-ENTITY}'
 
 request = service.defaultObjectAccessControls().delete(bucket=bucket, entity=entity)
 request.execute()
@@ -618,11 +618,11 @@ service = discovery.build('storage', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Name of a bucket.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 # * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
 #   group-emailAddress, allUsers, or allAuthenticatedUsers.
-entity = ''
+entity = '{MY-ENTITY}'
 
 request = service.defaultObjectAccessControls().get(bucket=bucket, entity=entity)
 response = request.execute()
@@ -746,11 +746,11 @@ service = discovery.build('storage', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
 # * Name of a bucket.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 # * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
 #   group-emailAddress, allUsers, or allAuthenticatedUsers.
-entity = ''
+entity = '{MY-ENTITY}'
 
 object_access_control_body = {
 # TODO: Add desired entries of the 'object_access_control_body' dict to be changed
@@ -794,11 +794,11 @@ service = discovery.build('storage', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
 # * Name of a bucket.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 # * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
 #   group-emailAddress, allUsers, or allAuthenticatedUsers.
-entity = ''
+entity = '{MY-ENTITY}'
 
 object_access_control_body = {
 # TODO: Add desired entries of the 'object_access_control_body' dict
@@ -840,15 +840,15 @@ service = discovery.build('storage', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Name of a bucket.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 # * Name of the object. For information about how to URL encode object names to be path safe, see
 #   Encoding URI Path Parts.
-object = ''
+object = '{MY-OBJECT}'
 
 # * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
 #   group-emailAddress, allUsers, or allAuthenticatedUsers.
-entity = ''
+entity = '{MY-ENTITY}'
 
 request = service.objectAccessControls().delete(bucket=bucket, object=object, entity=entity)
 request.execute()
@@ -885,15 +885,15 @@ service = discovery.build('storage', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Name of a bucket.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 # * Name of the object. For information about how to URL encode object names to be path safe, see
 #   Encoding URI Path Parts.
-object = ''
+object = '{MY-OBJECT}'
 
 # * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
 #   group-emailAddress, allUsers, or allAuthenticatedUsers.
-entity = ''
+entity = '{MY-ENTITY}'
 
 request = service.objectAccessControls().get(bucket=bucket, object=object, entity=entity)
 response = request.execute()
@@ -933,11 +933,11 @@ service = discovery.build('storage', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
 # * Name of a bucket.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 # * Name of the object. For information about how to URL encode object names to be path safe, see
 #   Encoding URI Path Parts.
-object = ''
+object = '{MY-OBJECT}'
 
 object_access_control_body = {
 # TODO: Add desired entries of the 'object_access_control_body' dict
@@ -981,11 +981,11 @@ service = discovery.build('storage', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * Name of a bucket.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 # * Name of the object. For information about how to URL encode object names to be path safe, see
 #   Encoding URI Path Parts.
-object = ''
+object = '{MY-OBJECT}'
 
 request = service.objectAccessControls().list(bucket=bucket, object=object)
 response = request.execute()
@@ -1025,15 +1025,15 @@ service = discovery.build('storage', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
 # * Name of a bucket.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 # * Name of the object. For information about how to URL encode object names to be path safe, see
 #   Encoding URI Path Parts.
-object = ''
+object = '{MY-OBJECT}'
 
 # * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
 #   group-emailAddress, allUsers, or allAuthenticatedUsers.
-entity = ''
+entity = '{MY-ENTITY}'
 
 object_access_control_body = {
 # TODO: Add desired entries of the 'object_access_control_body' dict to be changed
@@ -1077,15 +1077,15 @@ service = discovery.build('storage', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
 # * Name of a bucket.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 # * Name of the object. For information about how to URL encode object names to be path safe, see
 #   Encoding URI Path Parts.
-object = ''
+object = '{MY-OBJECT}'
 
 # * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
 #   group-emailAddress, allUsers, or allAuthenticatedUsers.
-entity = ''
+entity = '{MY-ENTITY}'
 
 object_access_control_body = {
 # TODO: Add desired entries of the 'object_access_control_body' dict
@@ -1129,11 +1129,11 @@ service = discovery.build('storage', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'compose' method:
 
 # * Name of the bucket in which to store the new object.
-destinationBucket = ''
+destinationBucket = '{MY-DESTINATION-BUCKET}'
 
 # * Name of the new object. For information about how to URL encode object names to be path safe, see
 #   Encoding URI Path Parts.
-destinationObject = ''
+destinationObject = '{MY-DESTINATION-OBJECT}'
 
 compose_request_body = {
 # TODO: Add desired entries of the 'compose_request_body' dict
@@ -1177,20 +1177,20 @@ service = discovery.build('storage', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'copy' method:
 
 # * Name of the bucket in which to find the source object.
-sourceBucket = ''
+sourceBucket = '{MY-SOURCE-BUCKET}'
 
 # * Name of the source object. For information about how to URL encode object names to be path safe,
 #   see Encoding URI Path Parts.
-sourceObject = ''
+sourceObject = '{MY-SOURCE-OBJECT}'
 
 # * Name of the bucket in which to store the new object. Overrides the provided object metadata's
 #   bucket value, if any.For information about how to URL encode object names to be path safe, see
 #   Encoding URI Path Parts.
-destinationBucket = ''
+destinationBucket = '{MY-DESTINATION-BUCKET}'
 
 # * Name of the new object. Required when the object metadata is not otherwise provided. Overrides the
 #   object metadata's name value, if any.
-destinationObject = ''
+destinationObject = '{MY-DESTINATION-OBJECT}'
 
 object__body = {
 # TODO: Add desired entries of the 'object__body' dict
@@ -1232,11 +1232,11 @@ service = discovery.build('storage', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * Name of the bucket in which the object resides.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 # * Name of the object. For information about how to URL encode object names to be path safe, see
 #   Encoding URI Path Parts.
-object = ''
+object = '{MY-OBJECT}'
 
 request = service.objects().delete(bucket=bucket, object=object)
 request.execute()
@@ -1273,11 +1273,11 @@ service = discovery.build('storage', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * Name of the bucket in which the object resides.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 # * Name of the object. For information about how to URL encode object names to be path safe, see
 #   Encoding URI Path Parts.
-object = ''
+object = '{MY-OBJECT}'
 
 request = service.objects().get(bucket=bucket, object=object)
 response = request.execute()
@@ -1318,7 +1318,7 @@ service = discovery.build('storage', 'v1', credentials=credentials)
 
 # * Name of the bucket in which to store the new object. Overrides the provided object metadata's
 #   bucket value, if any.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 object__body = {
 # TODO: Add desired entries of the 'object__body' dict
@@ -1404,11 +1404,11 @@ service = discovery.build('storage', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
 # * Name of the bucket in which the object resides.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 # * Name of the object. For information about how to URL encode object names to be path safe, see
 #   Encoding URI Path Parts.
-object = ''
+object = '{MY-OBJECT}'
 
 object__body = {
 # TODO: Add desired entries of the 'object__body' dict to be changed
@@ -1452,20 +1452,20 @@ service = discovery.build('storage', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'rewrite' method:
 
 # * Name of the bucket in which to find the source object.
-sourceBucket = ''
+sourceBucket = '{MY-SOURCE-BUCKET}'
 
 # * Name of the source object. For information about how to URL encode object names to be path safe,
 #   see Encoding URI Path Parts.
-sourceObject = ''
+sourceObject = '{MY-SOURCE-OBJECT}'
 
 # * Name of the bucket in which to store the new object. Overrides the provided object metadata's
 #   bucket value, if any.
-destinationBucket = ''
+destinationBucket = '{MY-DESTINATION-BUCKET}'
 
 # * Name of the new object. Required when the object metadata is not otherwise provided. Overrides the
 #   object metadata's name value, if any. For information about how to URL encode object names to be
 #   path safe, see Encoding URI Path Parts.
-destinationObject = ''
+destinationObject = '{MY-DESTINATION-OBJECT}'
 
 object__body = {
 # TODO: Add desired entries of the 'object__body' dict
@@ -1509,11 +1509,11 @@ service = discovery.build('storage', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
 # * Name of the bucket in which the object resides.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 # * Name of the object. For information about how to URL encode object names to be path safe, see
 #   Encoding URI Path Parts.
-object = ''
+object = '{MY-OBJECT}'
 
 object__body = {
 # TODO: Add desired entries of the 'object__body' dict

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_storagetransfer.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_storagetransfer.v1.json.baseline
@@ -149,7 +149,7 @@ service = discovery.build('storagetransfer', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * The job to get. Required.
-jobName = ''
+jobName = '{MY-JOB-NAME}'
 
 request = service.transferJobs().get(jobName=jobName)
 response = request.execute()
@@ -227,7 +227,7 @@ service = discovery.build('storagetransfer', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
 # * The name of job to update. Required.
-jobName = ''
+jobName = '{MY-JOB-NAME}'
 
 update_transfer_job_request_body = {
 # TODO: Add desired entries of the 'update_transfer_job_request_body' dict to be changed
@@ -269,7 +269,7 @@ service = discovery.build('storagetransfer', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'cancel' method:
 
 # * The name of the operation resource to be cancelled.
-name = ''
+name = '{MY-NAME}'
 
 request = service.transferOperations().cancel(name=name)
 request.execute()
@@ -304,7 +304,7 @@ service = discovery.build('storagetransfer', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * The name of the operation resource to be deleted.
-name = ''
+name = '{MY-NAME}'
 
 request = service.transferOperations().delete(name=name)
 request.execute()
@@ -341,7 +341,7 @@ service = discovery.build('storagetransfer', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * The name of the operation resource.
-name = ''
+name = '{MY-NAME}'
 
 request = service.transferOperations().get(name=name)
 response = request.execute()
@@ -379,7 +379,7 @@ service = discovery.build('storagetransfer', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * The value `transferOperations`.
-name = ''
+name = '{MY-NAME}'
 
 transferOperations = service.transferOperations()
 request = transferOperations.list(name=name)
@@ -421,7 +421,7 @@ service = discovery.build('storagetransfer', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'pause' method:
 
 # * The name of the transfer operation. Required.
-name = ''
+name = '{MY-NAME}'
 
 pause_transfer_operation_request_body = {
 # TODO: Add desired entries of the 'pause_transfer_operation_request_body' dict
@@ -460,7 +460,7 @@ service = discovery.build('storagetransfer', 'v1', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'resume' method:
 
 # * The name of the transfer operation. Required.
-name = ''
+name = '{MY-NAME}'
 
 resume_transfer_operation_request_body = {
 # TODO: Add desired entries of the 'resume_transfer_operation_request_body' dict

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_storagetransfer.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_storagetransfer.v1.json.baseline
@@ -69,7 +69,7 @@ service = discovery.build('storagetransfer', 'v1', credentials=credentials)
 
 # * The ID of the Google Developers Console project that the Google service account is associated
 #   with. Required.
-projectId = ''
+projectId = '{MY-PROJECT-ID}'
 
 request = service.googleServiceAccounts().get(projectId=projectId)
 response = request.execute()

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_taskqueue.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_taskqueue.v1beta2.json.baseline
@@ -35,7 +35,7 @@ service = discovery.build('taskqueue', 'v1beta2', credentials=credentials)
 project = ''
 
 # * The id of the taskqueue to get the properties of.
-taskqueue = ''
+taskqueue = '{MY-TASKQUEUE}'
 
 request = service.taskqueues().get(project=project, taskqueue=taskqueue)
 response = request.execute()
@@ -79,7 +79,7 @@ project = ''
 taskqueue = ''
 
 # * The id of the task to delete.
-task = ''
+task = '{MY-TASK}'
 
 request = service.tasks().delete(project=project, taskqueue=taskqueue, task=task)
 request.execute()
@@ -122,7 +122,7 @@ project = ''
 taskqueue = ''
 
 # * The task to get properties of.
-task = ''
+task = '{MY-TASK}'
 
 request = service.tasks().get(project=project, taskqueue=taskqueue, task=task)
 response = request.execute()
@@ -165,7 +165,7 @@ service = discovery.build('taskqueue', 'v1beta2', credentials=credentials)
 project = ''
 
 # * The taskqueue to insert the task into
-taskqueue = ''
+taskqueue = '{MY-TASKQUEUE}'
 
 task_body = {
 # TODO: Add desired entries of the 'task_body' dict
@@ -261,7 +261,7 @@ service = discovery.build('taskqueue', 'v1beta2', credentials=credentials)
 project = ''
 
 # * The id of the taskqueue to list tasks from.
-taskqueue = ''
+taskqueue = '{MY-TASKQUEUE}'
 
 request = service.tasks().list(project=project, taskqueue=taskqueue)
 response = request.execute()
@@ -301,7 +301,7 @@ service = discovery.build('taskqueue', 'v1beta2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'patch' method:
 
 # * The project under which the queue lies.
-project = ''
+project = '{MY-PROJECT}'
 
 
 taskqueue = ''
@@ -354,7 +354,7 @@ service = discovery.build('taskqueue', 'v1beta2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'update' method:
 
 # * The project under which the queue lies.
-project = ''
+project = '{MY-PROJECT}'
 
 
 taskqueue = ''

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_taskqueue.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_taskqueue.v1beta2.json.baseline
@@ -32,7 +32,7 @@ service = discovery.build('taskqueue', 'v1beta2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * The project under which the queue lies.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The id of the taskqueue to get the properties of.
 taskqueue = '{MY-TASKQUEUE}'
@@ -73,10 +73,10 @@ service = discovery.build('taskqueue', 'v1beta2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'delete' method:
 
 # * The project under which the queue lies.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The taskqueue to delete a task from.
-taskqueue = ''
+taskqueue = '{MY-TASKQUEUE}'
 
 # * The id of the task to delete.
 task = '{MY-TASK}'
@@ -116,10 +116,10 @@ service = discovery.build('taskqueue', 'v1beta2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'get' method:
 
 # * The project under which the queue lies.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The taskqueue in which the task belongs.
-taskqueue = ''
+taskqueue = '{MY-TASKQUEUE}'
 
 # * The task to get properties of.
 task = '{MY-TASK}'
@@ -162,7 +162,7 @@ service = discovery.build('taskqueue', 'v1beta2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'insert' method:
 
 # * The project under which the queue lies
-project = ''
+project = '{MY-PROJECT}'
 
 # * The taskqueue to insert the task into
 taskqueue = '{MY-TASKQUEUE}'
@@ -209,10 +209,10 @@ service = discovery.build('taskqueue', 'v1beta2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'lease' method:
 
 # * The project under which the queue lies.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The taskqueue to lease a task from.
-taskqueue = ''
+taskqueue = '{MY-TASKQUEUE}'
 
 # * The number of tasks to lease.
 numTasks = 0
@@ -258,7 +258,7 @@ service = discovery.build('taskqueue', 'v1beta2', credentials=credentials)
 # TODO: Change placeholders below to appropriate parameter values for the 'list' method:
 
 # * The project under which the queue lies.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The id of the taskqueue to list tasks from.
 taskqueue = '{MY-TASKQUEUE}'
@@ -304,10 +304,10 @@ service = discovery.build('taskqueue', 'v1beta2', credentials=credentials)
 project = '{MY-PROJECT}'
 
 
-taskqueue = ''
+taskqueue = '{MY-TASKQUEUE}'
 
 
-task = ''
+task = '{MY-TASK}'
 
 # * The new lease in seconds.
 newLeaseSeconds = 0
@@ -357,10 +357,10 @@ service = discovery.build('taskqueue', 'v1beta2', credentials=credentials)
 project = '{MY-PROJECT}'
 
 
-taskqueue = ''
+taskqueue = '{MY-TASKQUEUE}'
 
 
-task = ''
+task = '{MY-TASK}'
 
 # * The new lease in seconds.
 newLeaseSeconds = 0

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_translate.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_translate.v2.json.baseline
@@ -111,7 +111,7 @@ service = discovery.build('translate', 'v2', credentials=credentials)
 q = ''
 
 # * The target language into which the text should be translated
-target = ''
+target = '{MY-TARGET}'
 
 request = service.translations().list(q=q, target=target)
 response = request.execute()

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_adexchangebuyer.v1.4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_adexchangebuyer.v1.4.json.baseline
@@ -273,7 +273,7 @@ service.authorization = \
 account_id = 0
 
 # * The buyer-specific id for this creative.
-buyer_creative_id = ''
+buyer_creative_id = '{MY-BUYER-CREATIVE-ID}'
 
 # * The id of the deal id to associate with this creative.
 deal_id = ''
@@ -305,7 +305,7 @@ service.authorization = \
 account_id = 0
 
 # * The buyer-specific id for this creative.
-buyer_creative_id = ''
+buyer_creative_id = '{MY-BUYER-CREATIVE-ID}'
 
 # Perform the call
 response = service.get_creative(account_id, buyer_creative_id)
@@ -388,7 +388,7 @@ service.authorization = \
 account_id = 0
 
 # * The buyer-specific id for this creative.
-buyer_creative_id = ''
+buyer_creative_id = '{MY-BUYER-CREATIVE-ID}'
 
 # * The id of the deal id to disassociate with this creative.
 deal_id = ''
@@ -417,7 +417,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_marketplacedeal_order_deals' method:
 
 # * The proposalId to delete deals from.
-proposal_id = ''
+proposal_id = '{MY-PROPOSAL-ID}'
 
 delete_order_deals_request_object = Google::Apis::AdexchangebuyerV1_4::DeleteOrderDealsRequest.new
 
@@ -446,7 +446,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_marketplacedeal' method:
 
 # * proposalId for which deals need to be added.
-proposal_id = ''
+proposal_id = '{MY-PROPOSAL-ID}'
 
 add_order_deals_request_object = Google::Apis::AdexchangebuyerV1_4::AddOrderDealsRequest.new
 
@@ -476,7 +476,7 @@ service.authorization = \
 
 # * The proposalId to get deals for. To search across proposals specify order_id = '-' as part of the
 #   URL.
-proposal_id = ''
+proposal_id = '{MY-PROPOSAL-ID}'
 
 # Perform the call
 response = service.list_marketplacedeals(proposal_id)
@@ -502,7 +502,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'update_marketplacedeal' method:
 
 # * The proposalId to edit deals on.
-proposal_id = ''
+proposal_id = '{MY-PROPOSAL-ID}'
 
 edit_all_order_deals_request_object = Google::Apis::AdexchangebuyerV1_4::EditAllOrderDealsRequest.new
 
@@ -531,7 +531,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_marketplacenote' method:
 
 # * The proposalId to add notes for.
-proposal_id = ''
+proposal_id = '{MY-PROPOSAL-ID}'
 
 add_order_notes_request_object = Google::Apis::AdexchangebuyerV1_4::AddOrderNotesRequest.new
 
@@ -560,7 +560,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_marketplacenotes' method:
 
 # * The proposalId to get notes for.
-proposal_id = ''
+proposal_id = '{MY-PROPOSAL-ID}'
 
 # Perform the call
 response = service.list_marketplacenotes(proposal_id)
@@ -586,7 +586,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'update_marketplace_private_auction_proposal' method:
 
 # * The private auction id to be updated.
-private_auction_id = ''
+private_auction_id = '{MY-PRIVATE-AUCTION-ID}'
 
 update_private_auction_proposal_request_object = Google::Apis::AdexchangebuyerV1_4::UpdatePrivateAuctionProposalRequest.new
 
@@ -618,10 +618,10 @@ service.authorization = \
 account_id = ''
 
 # * The end time of the report in ISO 8601 timestamp format using UTC.
-end_date_time = ''
+end_date_time = '{MY-END-DATE-TIME}'
 
 # * The start time of the report in ISO 8601 timestamp format using UTC.
-start_date_time = ''
+start_date_time = '{MY-START-DATE-TIME}'
 
 # Perform the call
 response = service.list_performance_reports(account_id, end_date_time, start_date_time)
@@ -824,7 +824,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_product' method:
 
 # * The id for the product to get the head revision for.
-product_id = ''
+product_id = '{MY-PRODUCT-ID}'
 
 # Perform the call
 response = service.get_product(product_id)
@@ -873,7 +873,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_proposal' method:
 
 # * Id of the proposal to retrieve.
-proposal_id = ''
+proposal_id = '{MY-PROPOSAL-ID}'
 
 # Perform the call
 response = service.get_proposal(proposal_id)
@@ -925,7 +925,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'patch_proposal' method:
 
 # * The proposal id to update.
-proposal_id = ''
+proposal_id = '{MY-PROPOSAL-ID}'
 
 # * The last known revision number to update. If the head revision in the marketplace database has
 #   since changed, an error will be thrown. The caller should then fetch the latest proposal at head
@@ -933,7 +933,7 @@ proposal_id = ''
 revision_number = ''
 
 # * The proposed action to take on the proposal.
-update_action = ''
+update_action = '{MY-UPDATE-ACTION}'
 
 proposal_object = Google::Apis::AdexchangebuyerV1_4::Proposal.new
 
@@ -985,7 +985,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'proposal_setup_complete' method:
 
 # * The proposal id for which the setup is complete
-proposal_id = ''
+proposal_id = '{MY-PROPOSAL-ID}'
 
 # Perform the call
 service.proposal_setup_complete(proposal_id)
@@ -1011,7 +1011,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'update_proposal' method:
 
 # * The proposal id to update.
-proposal_id = ''
+proposal_id = '{MY-PROPOSAL-ID}'
 
 # * The last known revision number to update. If the head revision in the marketplace database has
 #   since changed, an error will be thrown. The caller should then fetch the latest proposal at head
@@ -1019,7 +1019,7 @@ proposal_id = ''
 revision_number = ''
 
 # * The proposed action to take on the proposal.
-update_action = ''
+update_action = '{MY-UPDATE-ACTION}'
 
 proposal_object = Google::Apis::AdexchangebuyerV1_4::Proposal.new
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_appengine.v1beta5.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_appengine.v1beta5.json.baseline
@@ -21,7 +21,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_app' method:
 
 # * Part of `name`. Name of the application to get. For example: "apps/myapp".
-apps_id = ''
+apps_id = '{MY-APPS-ID}'
 
 # Perform the call
 response = service.get_app(apps_id)
@@ -47,10 +47,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_app_operation' method:
 
 # * Part of `name`. The name of the operation resource.
-apps_id = ''
+apps_id = '{MY-APPS-ID}'
 
 # * Part of `name`. See documentation of `appsId`.
-operations_id = ''
+operations_id = '{MY-OPERATIONS-ID}'
 
 # Perform the call
 response = service.get_app_operation(apps_id, operations_id)
@@ -76,7 +76,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_app_operations' method:
 
 # * Part of `name`. The name of the operation collection.
-apps_id = ''
+apps_id = '{MY-APPS-ID}'
 
 # Perform the call
 result_list = service.fetch_all(items: :operations) { |token|
@@ -107,10 +107,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_app_service' method:
 
 # * Part of `name`. Name of the resource requested. For example: "apps/myapp/services/default".
-apps_id = ''
+apps_id = '{MY-APPS-ID}'
 
 # * Part of `name`. See documentation of `appsId`.
-services_id = ''
+services_id = '{MY-SERVICES-ID}'
 
 # Perform the call
 response = service.delete_app_service(apps_id, services_id)
@@ -136,10 +136,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_app_service' method:
 
 # * Part of `name`. Name of the resource requested. For example: "apps/myapp/services/default".
-apps_id = ''
+apps_id = '{MY-APPS-ID}'
 
 # * Part of `name`. See documentation of `appsId`.
-services_id = ''
+services_id = '{MY-SERVICES-ID}'
 
 # Perform the call
 response = service.get_app_service(apps_id, services_id)
@@ -165,7 +165,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_app_services' method:
 
 # * Part of `name`. Name of the resource requested. For example: "apps/myapp".
-apps_id = ''
+apps_id = '{MY-APPS-ID}'
 
 # Perform the call
 result_list = service.fetch_all(items: :services) { |token|
@@ -196,10 +196,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'patch_app_service' method:
 
 # * Part of `name`. Name of the resource to update. For example: "apps/myapp/services/default".
-apps_id = ''
+apps_id = '{MY-APPS-ID}'
 
 # * Part of `name`. See documentation of `appsId`.
-services_id = ''
+services_id = '{MY-SERVICES-ID}'
 
 service_object = Google::Apis::AppengineV1beta5::Service.new
 
@@ -228,10 +228,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'create_app_service_version' method:
 
 # * Part of `name`. Name of the resource to update. For example: "apps/myapp/services/default".
-apps_id = ''
+apps_id = '{MY-APPS-ID}'
 
 # * Part of `name`. See documentation of `appsId`.
-services_id = ''
+services_id = '{MY-SERVICES-ID}'
 
 version_object = Google::Apis::AppengineV1beta5::Version.new
 
@@ -261,13 +261,13 @@ service.authorization = \
 
 # * Part of `name`. Name of the resource requested. For example:
 #   "apps/myapp/services/default/versions/v1".
-apps_id = ''
+apps_id = '{MY-APPS-ID}'
 
 # * Part of `name`. See documentation of `appsId`.
-services_id = ''
+services_id = '{MY-SERVICES-ID}'
 
 # * Part of `name`. See documentation of `appsId`.
-versions_id = ''
+versions_id = '{MY-VERSIONS-ID}'
 
 # Perform the call
 response = service.delete_app_service_version(apps_id, services_id, versions_id)
@@ -294,13 +294,13 @@ service.authorization = \
 
 # * Part of `name`. Name of the resource requested. For example:
 #   "apps/myapp/services/default/versions/v1".
-apps_id = ''
+apps_id = '{MY-APPS-ID}'
 
 # * Part of `name`. See documentation of `appsId`.
-services_id = ''
+services_id = '{MY-SERVICES-ID}'
 
 # * Part of `name`. See documentation of `appsId`.
-versions_id = ''
+versions_id = '{MY-VERSIONS-ID}'
 
 # Perform the call
 response = service.get_app_service_version(apps_id, services_id, versions_id)
@@ -327,13 +327,13 @@ service.authorization = \
 
 # * Part of `name`. Name of the resource requested. For example:
 #   "apps/myapp/services/default/versions/v1".
-apps_id = ''
+apps_id = '{MY-APPS-ID}'
 
 # * Part of `name`. See documentation of `appsId`.
-services_id = ''
+services_id = '{MY-SERVICES-ID}'
 
 # * Part of `name`. See documentation of `appsId`.
-versions_id = ''
+versions_id = '{MY-VERSIONS-ID}'
 
 # Perform the call
 result_list = service.fetch_all(items: :instances) { |token|
@@ -364,10 +364,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_app_service_versions' method:
 
 # * Part of `name`. Name of the resource requested. For example: "apps/myapp/services/default".
-apps_id = ''
+apps_id = '{MY-APPS-ID}'
 
 # * Part of `name`. See documentation of `appsId`.
-services_id = ''
+services_id = '{MY-SERVICES-ID}'
 
 # Perform the call
 result_list = service.fetch_all(items: :versions) { |token|
@@ -399,13 +399,13 @@ service.authorization = \
 
 # * Part of `name`. Name of the resource to update. For example:
 #   "apps/myapp/services/default/versions/1".
-apps_id = ''
+apps_id = '{MY-APPS-ID}'
 
 # * Part of `name`. See documentation of `appsId`.
-services_id = ''
+services_id = '{MY-SERVICES-ID}'
 
 # * Part of `name`. See documentation of `appsId`.
-versions_id = ''
+versions_id = '{MY-VERSIONS-ID}'
 
 version_object = Google::Apis::AppengineV1beta5::Version.new
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_autoscaler.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_autoscaler.v1beta2.json.baseline
@@ -224,10 +224,10 @@ service.authorization = \
 project = ''
 
 
-zone = ''
+zone = 'us-central1-f'
 
 
-operation = ''
+operation = '{MY-OPERATION}'
 
 # Perform the call
 service.delete_zone_operation(project, zone, operation)
@@ -256,10 +256,10 @@ service.authorization = \
 project = ''
 
 
-zone = ''
+zone = 'us-central1-f'
 
 
-operation = ''
+operation = '{MY-OPERATION}'
 
 # Perform the call
 response = service.get_zone_operation(project, zone, operation)
@@ -288,7 +288,7 @@ service.authorization = \
 project = ''
 
 
-zone = ''
+zone = 'us-central1-f'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_autoscaler.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_autoscaler.v1beta2.json.baseline
@@ -21,13 +21,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_autoscaler' method:
 
 # * Project ID of Autoscaler resource.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Zone name of Autoscaler resource.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * Name of the Autoscaler resource.
-autoscaler = ''
+autoscaler = '{MY-AUTOSCALER}'
 
 # Perform the call
 response = service.delete_autoscaler(project, zone, autoscaler)
@@ -53,13 +53,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_autoscaler' method:
 
 # * Project ID of Autoscaler resource.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Zone name of Autoscaler resource.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * Name of the Autoscaler resource.
-autoscaler = ''
+autoscaler = '{MY-AUTOSCALER}'
 
 # Perform the call
 response = service.get_autoscaler(project, zone, autoscaler)
@@ -85,10 +85,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_autoscaler' method:
 
 # * Project ID of Autoscaler resource.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Zone name of Autoscaler resource.
-zone = ''
+zone = '{MY-ZONE}'
 
 autoscaler_object = Google::Apis::AutoscalerV1beta2::Autoscaler.new
 
@@ -117,10 +117,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_autoscalers' method:
 
 # * Project ID of Autoscaler resource.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Zone name of Autoscaler resource.
-zone = ''
+zone = '{MY-ZONE}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -151,13 +151,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'patch_autoscaler' method:
 
 # * Project ID of Autoscaler resource.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Zone name of Autoscaler resource.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * Name of the Autoscaler resource.
-autoscaler = ''
+autoscaler = '{MY-AUTOSCALER}'
 
 autoscaler_object = Google::Apis::AutoscalerV1beta2::Autoscaler.new
 
@@ -186,13 +186,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'update_autoscaler' method:
 
 # * Project ID of Autoscaler resource.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Zone name of Autoscaler resource.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * Name of the Autoscaler resource.
-autoscaler = ''
+autoscaler = '{MY-AUTOSCALER}'
 
 autoscaler_object = Google::Apis::AutoscalerV1beta2::Autoscaler.new
 
@@ -221,7 +221,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_zone_operation' method:
 
 
-project = ''
+project = '{MY-PROJECT}'
 
 
 zone = '{MY-ZONE}'  # eg. 'us-central1-f'
@@ -253,7 +253,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_zone_operation' method:
 
 
-project = ''
+project = '{MY-PROJECT}'
 
 
 zone = '{MY-ZONE}'  # eg. 'us-central1-f'
@@ -285,10 +285,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_zone_operations' method:
 
 
-project = ''
+project = '{MY-PROJECT}'
 
 
-zone = 'us-central1-f'
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -319,7 +319,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_zones' method:
 
 
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_autoscaler.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_autoscaler.v1beta2.json.baseline
@@ -224,7 +224,7 @@ service.authorization = \
 project = ''
 
 
-zone = 'us-central1-f'
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 
 operation = '{MY-OPERATION}'
@@ -256,7 +256,7 @@ service.authorization = \
 project = ''
 
 
-zone = 'us-central1-f'
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 
 operation = '{MY-OPERATION}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_bigquery.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_bigquery.v2.json.baseline
@@ -21,10 +21,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_dataset' method:
 
 # * Project ID of the dataset being deleted
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 # * Dataset ID of dataset being deleted
-dataset_id = ''
+dataset_id = '{MY-DATASET-ID}'
 
 # Perform the call
 service.delete_dataset(project_id, dataset_id)
@@ -50,10 +50,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_dataset' method:
 
 # * Project ID of the requested dataset
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 # * Dataset ID of the requested dataset
-dataset_id = ''
+dataset_id = '{MY-DATASET-ID}'
 
 # Perform the call
 response = service.get_dataset(project_id, dataset_id)
@@ -79,7 +79,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_dataset' method:
 
 # * Project ID of the new dataset
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 dataset_object = Google::Apis::BigqueryV2::Dataset.new
 
@@ -108,7 +108,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_datasets' method:
 
 # * Project ID of the datasets to be listed
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 # Perform the call
 result_list = service.fetch_all(items: :datasets) { |token|
@@ -139,10 +139,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'patch_dataset' method:
 
 # * Project ID of the dataset being updated
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 # * Dataset ID of the dataset being updated
-dataset_id = ''
+dataset_id = '{MY-DATASET-ID}'
 
 dataset_object = Google::Apis::BigqueryV2::Dataset.new
 
@@ -171,10 +171,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'update_dataset' method:
 
 # * Project ID of the dataset being updated
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 # * Dataset ID of the dataset being updated
-dataset_id = ''
+dataset_id = '{MY-DATASET-ID}'
 
 dataset_object = Google::Apis::BigqueryV2::Dataset.new
 
@@ -203,10 +203,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'cancel_job' method:
 
 # * [Required] Project ID of the job to cancel
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 # * [Required] Job ID of the job to cancel
-job_id = ''
+job_id = '{MY-JOB-ID}'
 
 # Perform the call
 response = service.cancel_job(project_id, job_id)
@@ -232,10 +232,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_job' method:
 
 # * [Required] Project ID of the requested job
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 # * [Required] Job ID of the requested job
-job_id = ''
+job_id = '{MY-JOB-ID}'
 
 # Perform the call
 response = service.get_job(project_id, job_id)
@@ -261,10 +261,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_job_query_results' method:
 
 # * [Required] Project ID of the query job
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 # * [Required] Job ID of the query job
-job_id = ''
+job_id = '{MY-JOB-ID}'
 
 # Perform the call
 response = service.get_job_query_results(project_id, job_id)
@@ -290,7 +290,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_job' method:
 
 # * Project ID of the project that will be billed for the job
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 job_object = Google::Apis::BigqueryV2::Job.new
 
@@ -319,7 +319,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_jobs' method:
 
 # * Project ID of the jobs to list
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 # Perform the call
 result_list = service.fetch_all(items: :jobs) { |token|
@@ -350,7 +350,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'query_job' method:
 
 # * Project ID of the project billed for the query
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 query_request_object = Google::Apis::BigqueryV2::QueryRequest.new
 
@@ -407,13 +407,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_all_table_data' method:
 
 # * Project ID of the destination table.
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 # * Dataset ID of the destination table.
-dataset_id = ''
+dataset_id = '{MY-DATASET-ID}'
 
 # * Table ID of the destination table.
-table_id = ''
+table_id = '{MY-TABLE-ID}'
 
 insert_all_table_data_request_object = Google::Apis::BigqueryV2::InsertAllTableDataRequest.new
 
@@ -442,13 +442,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_table_data' method:
 
 # * Project ID of the table to read
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 # * Dataset ID of the table to read
-dataset_id = ''
+dataset_id = '{MY-DATASET-ID}'
 
 # * Table ID of the table to read
-table_id = ''
+table_id = '{MY-TABLE-ID}'
 
 # Perform the call
 response = service.list_table_data(project_id, dataset_id, table_id)
@@ -474,13 +474,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_table' method:
 
 # * Project ID of the table to delete
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 # * Dataset ID of the table to delete
-dataset_id = ''
+dataset_id = '{MY-DATASET-ID}'
 
 # * Table ID of the table to delete
-table_id = ''
+table_id = '{MY-TABLE-ID}'
 
 # Perform the call
 service.delete_table(project_id, dataset_id, table_id)
@@ -506,13 +506,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_table' method:
 
 # * Project ID of the requested table
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 # * Dataset ID of the requested table
-dataset_id = ''
+dataset_id = '{MY-DATASET-ID}'
 
 # * Table ID of the requested table
-table_id = ''
+table_id = '{MY-TABLE-ID}'
 
 # Perform the call
 response = service.get_table(project_id, dataset_id, table_id)
@@ -538,10 +538,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_table' method:
 
 # * Project ID of the new table
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 # * Dataset ID of the new table
-dataset_id = ''
+dataset_id = '{MY-DATASET-ID}'
 
 table_object = Google::Apis::BigqueryV2::Table.new
 
@@ -570,10 +570,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_tables' method:
 
 # * Project ID of the tables to list
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 # * Dataset ID of the tables to list
-dataset_id = ''
+dataset_id = '{MY-DATASET-ID}'
 
 # Perform the call
 result_list = service.fetch_all(items: :tables) { |token|
@@ -604,13 +604,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'patch_table' method:
 
 # * Project ID of the table to update
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 # * Dataset ID of the table to update
-dataset_id = ''
+dataset_id = '{MY-DATASET-ID}'
 
 # * Table ID of the table to update
-table_id = ''
+table_id = '{MY-TABLE-ID}'
 
 table_object = Google::Apis::BigqueryV2::Table.new
 
@@ -639,13 +639,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'update_table' method:
 
 # * Project ID of the table to update
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 # * Dataset ID of the table to update
-dataset_id = ''
+dataset_id = '{MY-DATASET-ID}'
 
 # * Table ID of the table to update
-table_id = ''
+table_id = '{MY-TABLE-ID}'
 
 table_object = Google::Apis::BigqueryV2::Table.new
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_clouddebugger.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_clouddebugger.v2.json.baseline
@@ -21,7 +21,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_controller_debuggee_breakpoints' method:
 
 # * Identifies the debuggee.
-debuggee_id = ''
+debuggee_id = '{MY-DEBUGGEE-ID}'
 
 # Perform the call
 response = service.list_controller_debuggee_breakpoints(debuggee_id)
@@ -47,10 +47,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'update_active_breakpoint' method:
 
 # * Identifies the debuggee being debugged.
-debuggee_id = ''
+debuggee_id = '{MY-DEBUGGEE-ID}'
 
 # * Breakpoint identifier, unique in the scope of the debuggee.
-id = ''
+id = '{MY-ID}'
 
 update_active_breakpoint_request_object = Google::Apis::ClouddebuggerV2::UpdateActiveBreakpointRequest.new
 
@@ -105,10 +105,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_debugger_debuggee_breakpoint' method:
 
 # * ID of the debuggee whose breakpoint to delete.
-debuggee_id = ''
+debuggee_id = '{MY-DEBUGGEE-ID}'
 
 # * ID of the breakpoint to delete.
-breakpoint_id = ''
+breakpoint_id = '{MY-BREAKPOINT-ID}'
 
 # Perform the call
 service.delete_debugger_debuggee_breakpoint(debuggee_id, breakpoint_id)
@@ -134,10 +134,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_debugger_debuggee_breakpoint' method:
 
 # * ID of the debuggee whose breakpoint to get.
-debuggee_id = ''
+debuggee_id = '{MY-DEBUGGEE-ID}'
 
 # * ID of the breakpoint to get.
-breakpoint_id = ''
+breakpoint_id = '{MY-BREAKPOINT-ID}'
 
 # Perform the call
 response = service.get_debugger_debuggee_breakpoint(debuggee_id, breakpoint_id)
@@ -163,7 +163,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_debugger_debuggee_breakpoints' method:
 
 # * ID of the debuggee whose breakpoints to list.
-debuggee_id = ''
+debuggee_id = '{MY-DEBUGGEE-ID}'
 
 # Perform the call
 response = service.list_debugger_debuggee_breakpoints(debuggee_id)
@@ -189,7 +189,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'set_debugger_debuggee_breakpoint' method:
 
 # * ID of the debuggee where the breakpoint is to be set.
-debuggee_id = ''
+debuggee_id = '{MY-DEBUGGEE-ID}'
 
 breakpoint_object = Google::Apis::ClouddebuggerV2::Breakpoint.new
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_cloudmonitoring.v2beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_cloudmonitoring.v2beta2.json.baseline
@@ -21,7 +21,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'create_metric_descriptor' method:
 
 # * The project id. The value can be the numeric project ID or string-based project name.
-project = ''
+project = '{MY-PROJECT}'
 
 metric_descriptor_object = Google::Apis::CloudmonitoringV2beta2::MetricDescriptor.new
 
@@ -50,10 +50,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_metric_descriptor' method:
 
 # * The project ID to which the metric belongs.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the metric.
-metric = ''
+metric = '{MY-METRIC}'
 
 # Perform the call
 response = service.delete_metric_descriptor(project, metric)
@@ -79,7 +79,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_metric_descriptors' method:
 
 # * The project id. The value can be the numeric project ID or string-based project name.
-project = ''
+project = '{MY-PROJECT}'
 
 list_metric_descriptors_request_object = Google::Apis::CloudmonitoringV2beta2::ListMetricDescriptorsRequest.new
 
@@ -114,14 +114,14 @@ service.authorization = \
 
 # * The project ID to which this time series belongs. The value can be the numeric project ID or
 #   string-based project name.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Metric names are protocol-free URLs as listed in the Supported Metrics page. For example,
 #   compute.googleapis.com/instance/disk/read_ops_count.
-metric = ''
+metric = '{MY-METRIC}'
 
 # * End of the time interval (inclusive), which is expressed as an RFC 3339 timestamp.
-youngest = ''
+youngest = '{MY-YOUNGEST}'
 
 list_timeseries_request_object = Google::Apis::CloudmonitoringV2beta2::ListTimeseriesRequest.new
 
@@ -155,7 +155,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'write_timeseries' method:
 
 # * The project ID. The value can be the numeric project ID or string-based project name.
-project = ''
+project = '{MY-PROJECT}'
 
 write_timeseries_request_object = Google::Apis::CloudmonitoringV2beta2::WriteTimeseriesRequest.new
 
@@ -185,14 +185,14 @@ service.authorization = \
 
 # * The project ID to which this time series belongs. The value can be the numeric project ID or
 #   string-based project name.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Metric names are protocol-free URLs as listed in the Supported Metrics page. For example,
 #   compute.googleapis.com/instance/disk/read_ops_count.
-metric = ''
+metric = '{MY-METRIC}'
 
 # * End of the time interval (inclusive), which is expressed as an RFC 3339 timestamp.
-youngest = ''
+youngest = '{MY-YOUNGEST}'
 
 list_timeseries_descriptors_request_object = Google::Apis::CloudmonitoringV2beta2::ListTimeseriesDescriptorsRequest.new
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_cloudresourcemanager.v1beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_cloudresourcemanager.v1beta1.json.baseline
@@ -21,7 +21,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_organization' method:
 
 # * The id of the Organization resource to fetch.
-organization_id = ''
+organization_id = '{MY-ORGANIZATION-ID}'
 
 # Perform the call
 response = service.get_organization(organization_id)
@@ -49,7 +49,7 @@ service.authorization = \
 # * REQUIRED: The resource for which the policy is being requested. `resource` is usually specified as
 #   a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified
 #   in this value is resource specific and is specified in the `getIamPolicy` documentation.
-resource = ''
+resource = '{MY-RESOURCE}'
 
 get_iam_policy_request_object = Google::Apis::CloudresourcemanagerV1beta1::GetIamPolicyRequest.new
 
@@ -108,7 +108,7 @@ service.authorization = \
 # * REQUIRED: The resource for which the policy is being specified. `resource` is usually specified as
 #   a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified
 #   in this value is resource specific and is specified in the `setIamPolicy` documentation.
-resource = ''
+resource = '{MY-RESOURCE}'
 
 set_iam_policy_request_object = Google::Apis::CloudresourcemanagerV1beta1::SetIamPolicyRequest.new
 
@@ -140,7 +140,7 @@ service.authorization = \
 #   specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the
 #   path specified in this value is resource specific and is specified in the `testIamPermissions`
 #   documentation.
-resource = ''
+resource = '{MY-RESOURCE}'
 
 test_iam_permissions_request_object = Google::Apis::CloudresourcemanagerV1beta1::TestIamPermissionsRequest.new
 
@@ -170,7 +170,7 @@ service.authorization = \
 
 # * An immutable id for the Organization that is assigned on creation. This should be omitted when
 #   creating a new Organization. This field is read-only.
-organization_id = ''
+organization_id = '{MY-ORGANIZATION-ID}'
 
 organization_object = Google::Apis::CloudresourcemanagerV1beta1::Organization.new
 
@@ -225,7 +225,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_project' method:
 
 # * The Project ID (for example, `foo-bar-123`). Required.
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 # Perform the call
 service.delete_project(project_id)
@@ -251,7 +251,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_project' method:
 
 # * The Project ID (for example, `my-project-123`). Required.
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 # Perform the call
 response = service.get_project(project_id)
@@ -279,7 +279,7 @@ service.authorization = \
 # * REQUIRED: The resource for which the policy is being requested. `resource` is usually specified as
 #   a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified
 #   in this value is resource specific and is specified in the `getIamPolicy` documentation.
-resource = ''
+resource = '{MY-RESOURCE}'
 
 get_iam_policy_request_object = Google::Apis::CloudresourcemanagerV1beta1::GetIamPolicyRequest.new
 
@@ -338,7 +338,7 @@ service.authorization = \
 # * REQUIRED: The resource for which the policy is being specified. `resource` is usually specified as
 #   a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified
 #   in this value is resource specific and is specified in the `setIamPolicy` documentation.
-resource = ''
+resource = '{MY-RESOURCE}'
 
 set_iam_policy_request_object = Google::Apis::CloudresourcemanagerV1beta1::SetIamPolicyRequest.new
 
@@ -370,7 +370,7 @@ service.authorization = \
 #   specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the
 #   path specified in this value is resource specific and is specified in the `testIamPermissions`
 #   documentation.
-resource = ''
+resource = '{MY-RESOURCE}'
 
 test_iam_permissions_request_object = Google::Apis::CloudresourcemanagerV1beta1::TestIamPermissionsRequest.new
 
@@ -399,7 +399,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'undelete_project' method:
 
 # * The project ID (for example, `foo-bar-123`). Required.
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 undelete_project_request_object = Google::Apis::CloudresourcemanagerV1beta1::UndeleteProjectRequest.new
 
@@ -428,7 +428,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'update_project' method:
 
 # * The project ID (for example, `my-project-123`). Required.
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 project_object = Google::Apis::CloudresourcemanagerV1beta1::Project.new
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_cloudtrace.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_cloudtrace.v1.json.baseline
@@ -21,7 +21,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'patch_project_traces' method:
 
 # * ID of the Cloud project where the trace data is stored.
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 traces_object = Google::Apis::CloudtraceV1::Traces.new
 
@@ -50,10 +50,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_project_trace' method:
 
 # * ID of the Cloud project where the trace data is stored.
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 # * ID of the trace to return.
-trace_id = ''
+trace_id = '{MY-TRACE-ID}'
 
 # Perform the call
 response = service.get_project_trace(project_id, trace_id)
@@ -79,7 +79,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_project_traces' method:
 
 # * ID of the Cloud project where the trace data is stored.
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 # Perform the call
 result_list = service.fetch_all(items: :traces) { |token|

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_clouduseraccounts.beta.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_clouduseraccounts.beta.json.baseline
@@ -21,10 +21,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_global_accounts_operation' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the Operations resource to delete.
-operation = ''
+operation = '{MY-OPERATION}'
 
 # Perform the call
 service.delete_global_accounts_operation(project, operation)
@@ -50,10 +50,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_global_accounts_operation' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the Operations resource to return.
-operation = ''
+operation = '{MY-OPERATION}'
 
 # Perform the call
 response = service.get_global_accounts_operation(project, operation)
@@ -79,7 +79,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_global_accounts_operations' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -110,10 +110,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'add_group_member' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the group for this request.
-group_name = ''
+group_name = '{MY-GROUP-NAME}'
 
 groups_add_member_request_object = Google::Apis::ClouduseraccountsBeta::GroupsAddMemberRequest.new
 
@@ -142,10 +142,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_group' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the Group resource to delete.
-group_name = ''
+group_name = '{MY-GROUP-NAME}'
 
 # Perform the call
 response = service.delete_group(project, group_name)
@@ -171,10 +171,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_group' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the Group resource to return.
-group_name = ''
+group_name = '{MY-GROUP-NAME}'
 
 # Perform the call
 response = service.get_group(project, group_name)
@@ -200,7 +200,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_group' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 group_object = Google::Apis::ClouduseraccountsBeta::Group.new
 
@@ -229,7 +229,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_groups' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -260,10 +260,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'remove_group_member' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the group for this request.
-group_name = ''
+group_name = '{MY-GROUP-NAME}'
 
 groups_remove_member_request_object = Google::Apis::ClouduseraccountsBeta::GroupsRemoveMemberRequest.new
 
@@ -292,16 +292,16 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_linux_authorized_keys_view' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * The user account for which you want to get a list of authorized public keys.
-user = ''
+user = '{MY-USER}'
 
 # * The fully-qualified URL of the virtual machine requesting the view.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # Perform the call
 response = service.get_linux_authorized_keys_view(project, zone, user, instance)
@@ -327,13 +327,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_linux_linux_account_views' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * The fully-qualified URL of the virtual machine requesting the views.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # Perform the call
 response = service.get_linux_linux_account_views(project, zone, instance)
@@ -359,10 +359,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'add_user_public_key' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the user for this request.
-user = ''
+user = '{MY-USER}'
 
 public_key_object = Google::Apis::ClouduseraccountsBeta::PublicKey.new
 
@@ -391,10 +391,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_user' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the user resource to delete.
-user = ''
+user = '{MY-USER}'
 
 # Perform the call
 response = service.delete_user(project, user)
@@ -420,10 +420,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_user' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the user resource to return.
-user = ''
+user = '{MY-USER}'
 
 # Perform the call
 response = service.get_user(project, user)
@@ -449,7 +449,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_user' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 user_object = Google::Apis::ClouduseraccountsBeta::User.new
 
@@ -478,7 +478,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_users' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -509,14 +509,14 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'remove_user_public_key' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the user for this request.
-user = ''
+user = '{MY-USER}'
 
 # * The fingerprint of the public key to delete. Public keys are identified by their fingerprint,
 #   which is defined by RFC4716 to be the MD5 digest of the public key.
-fingerprint = ''
+fingerprint = '{MY-FINGERPRINT}'
 
 # Perform the call
 response = service.remove_user_public_key(project, user, fingerprint)

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_compute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_compute.v1.json.baseline
@@ -21,7 +21,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_aggregated_addresses' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -52,13 +52,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_address' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region for this request.
-region = ''
+region = '{MY-REGION}'
 
 # * Name of the address resource to delete.
-address = ''
+address = '{MY-ADDRESS}'
 
 # Perform the call
 response = service.delete_address(project, region, address)
@@ -84,13 +84,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_address' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region for this request.
-region = ''
+region = '{MY-REGION}'
 
 # * Name of the address resource to return.
-address = ''
+address = '{MY-ADDRESS}'
 
 # Perform the call
 response = service.get_address(project, region, address)
@@ -116,10 +116,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_address' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region for this request.
-region = ''
+region = '{MY-REGION}'
 
 address_object = Google::Apis::ComputeV1::Address.new
 
@@ -148,10 +148,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_addresses' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region for this request.
-region = ''
+region = '{MY-REGION}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -182,7 +182,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_aggregated_autoscalers' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -213,13 +213,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_autoscaler' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * Name of the autoscaler to delete.
-autoscaler = ''
+autoscaler = '{MY-AUTOSCALER}'
 
 # Perform the call
 response = service.delete_autoscaler(project, zone, autoscaler)
@@ -245,13 +245,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_autoscaler' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * Name of the autoscaler to return.
-autoscaler = ''
+autoscaler = '{MY-AUTOSCALER}'
 
 # Perform the call
 response = service.get_autoscaler(project, zone, autoscaler)
@@ -277,10 +277,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_autoscaler' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 autoscaler_object = Google::Apis::ComputeV1::Autoscaler.new
 
@@ -309,10 +309,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_autoscalers' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -343,13 +343,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'patch_autoscaler' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * Name of the autoscaler to update.
-autoscaler = ''
+autoscaler = '{MY-AUTOSCALER}'
 
 autoscaler_object = Google::Apis::ComputeV1::Autoscaler.new
 
@@ -378,10 +378,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'update_autoscaler' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 autoscaler_object = Google::Apis::ComputeV1::Autoscaler.new
 
@@ -410,10 +410,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_backend_service' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the BackendService resource to delete.
-backend_service = ''
+backend_service = '{MY-BACKEND-SERVICE}'
 
 # Perform the call
 response = service.delete_backend_service(project, backend_service)
@@ -439,10 +439,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_backend_service' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the BackendService resource to return.
-backend_service = ''
+backend_service = '{MY-BACKEND-SERVICE}'
 
 # Perform the call
 response = service.get_backend_service(project, backend_service)
@@ -468,10 +468,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_backend_service_health' method:
 
 
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the BackendService resource to which the queried instance belongs.
-backend_service = ''
+backend_service = '{MY-BACKEND-SERVICE}'
 
 resource_group_reference_object = Google::Apis::ComputeV1::ResourceGroupReference.new
 
@@ -500,7 +500,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_backend_service' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 backend_service_object = Google::Apis::ComputeV1::BackendService.new
 
@@ -529,7 +529,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_backend_services' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -560,10 +560,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'patch_backend_service' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the BackendService resource to update.
-backend_service = ''
+backend_service = '{MY-BACKEND-SERVICE}'
 
 backend_service_object = Google::Apis::ComputeV1::BackendService.new
 
@@ -592,10 +592,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'update_backend_service' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the BackendService resource to update.
-backend_service = ''
+backend_service = '{MY-BACKEND-SERVICE}'
 
 backend_service_object = Google::Apis::ComputeV1::BackendService.new
 
@@ -624,7 +624,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_aggregated_disk_types' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -655,13 +655,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_disk_type' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * Name of the disk type to return.
-disk_type = ''
+disk_type = '{MY-DISK-TYPE}'
 
 # Perform the call
 response = service.get_disk_type(project, zone, disk_type)
@@ -687,10 +687,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_disk_types' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -721,7 +721,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_aggregated_disk' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -752,13 +752,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'create_disk_snapshot' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * Name of the persistent disk to snapshot.
-disk = ''
+disk = '{MY-DISK}'
 
 snapshot_object = Google::Apis::ComputeV1::Snapshot.new
 
@@ -787,13 +787,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_disk' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * Name of the persistent disk to delete.
-disk = ''
+disk = '{MY-DISK}'
 
 # Perform the call
 response = service.delete_disk(project, zone, disk)
@@ -819,13 +819,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_disk' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * Name of the persistent disk to return.
-disk = ''
+disk = '{MY-DISK}'
 
 # Perform the call
 response = service.get_disk(project, zone, disk)
@@ -851,10 +851,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_disk' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 disk_object = Google::Apis::ComputeV1::Disk.new
 
@@ -883,10 +883,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_disks' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -917,10 +917,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_firewall' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the firewall rule to delete.
-firewall = ''
+firewall = '{MY-FIREWALL}'
 
 # Perform the call
 response = service.delete_firewall(project, firewall)
@@ -946,10 +946,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_firewall' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the firewall rule to return.
-firewall = ''
+firewall = '{MY-FIREWALL}'
 
 # Perform the call
 response = service.get_firewall(project, firewall)
@@ -975,7 +975,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_firewall' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 firewall_object = Google::Apis::ComputeV1::Firewall.new
 
@@ -1004,7 +1004,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_firewalls' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -1035,10 +1035,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'patch_firewall' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the firewall rule to update.
-firewall = ''
+firewall = '{MY-FIREWALL}'
 
 firewall_object = Google::Apis::ComputeV1::Firewall.new
 
@@ -1067,10 +1067,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'update_firewall' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the firewall rule to update.
-firewall = ''
+firewall = '{MY-FIREWALL}'
 
 firewall_object = Google::Apis::ComputeV1::Firewall.new
 
@@ -1099,7 +1099,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_aggregated_forwarding_rules' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -1130,13 +1130,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_forwarding_rule' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region scoping this request.
-region = ''
+region = '{MY-REGION}'
 
 # * Name of the ForwardingRule resource to delete.
-forwarding_rule = ''
+forwarding_rule = '{MY-FORWARDING-RULE}'
 
 # Perform the call
 response = service.delete_forwarding_rule(project, region, forwarding_rule)
@@ -1162,13 +1162,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_forwarding_rule' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region scoping this request.
-region = ''
+region = '{MY-REGION}'
 
 # * Name of the ForwardingRule resource to return.
-forwarding_rule = ''
+forwarding_rule = '{MY-FORWARDING-RULE}'
 
 # Perform the call
 response = service.get_forwarding_rule(project, region, forwarding_rule)
@@ -1194,10 +1194,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_forwarding_rule' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region scoping this request.
-region = ''
+region = '{MY-REGION}'
 
 forwarding_rule_object = Google::Apis::ComputeV1::ForwardingRule.new
 
@@ -1226,10 +1226,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_forwarding_rules' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region scoping this request.
-region = ''
+region = '{MY-REGION}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -1260,13 +1260,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'set_forwarding_rule_target' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region scoping this request.
-region = ''
+region = '{MY-REGION}'
 
 # * Name of the ForwardingRule resource in which target is to be set.
-forwarding_rule = ''
+forwarding_rule = '{MY-FORWARDING-RULE}'
 
 target_reference_object = Google::Apis::ComputeV1::TargetReference.new
 
@@ -1295,10 +1295,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_global_address' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the address resource to delete.
-address = ''
+address = '{MY-ADDRESS}'
 
 # Perform the call
 response = service.delete_global_address(project, address)
@@ -1324,10 +1324,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_global_address' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the address resource to return.
-address = ''
+address = '{MY-ADDRESS}'
 
 # Perform the call
 response = service.get_global_address(project, address)
@@ -1353,7 +1353,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_global_address' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 address_object = Google::Apis::ComputeV1::Address.new
 
@@ -1382,7 +1382,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_global_addresses' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -1413,10 +1413,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_global_forwarding_rule' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the ForwardingRule resource to delete.
-forwarding_rule = ''
+forwarding_rule = '{MY-FORWARDING-RULE}'
 
 # Perform the call
 response = service.delete_global_forwarding_rule(project, forwarding_rule)
@@ -1442,10 +1442,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_global_forwarding_rule' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the ForwardingRule resource to return.
-forwarding_rule = ''
+forwarding_rule = '{MY-FORWARDING-RULE}'
 
 # Perform the call
 response = service.get_global_forwarding_rule(project, forwarding_rule)
@@ -1471,7 +1471,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_global_forwarding_rule' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 forwarding_rule_object = Google::Apis::ComputeV1::ForwardingRule.new
 
@@ -1500,7 +1500,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_global_forwarding_rules' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -1531,10 +1531,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'set_global_forwarding_rule_target' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the ForwardingRule resource in which target is to be set.
-forwarding_rule = ''
+forwarding_rule = '{MY-FORWARDING-RULE}'
 
 target_reference_object = Google::Apis::ComputeV1::TargetReference.new
 
@@ -1563,7 +1563,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_aggregated_global_operation' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -1594,10 +1594,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_global_operation' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the Operations resource to delete.
-operation = ''
+operation = '{MY-OPERATION}'
 
 # Perform the call
 service.delete_global_operation(project, operation)
@@ -1623,10 +1623,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_global_operation' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the Operations resource to return.
-operation = ''
+operation = '{MY-OPERATION}'
 
 # Perform the call
 response = service.get_global_operation(project, operation)
@@ -1652,7 +1652,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_global_operations' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -1683,10 +1683,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_http_health_check' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the HttpHealthCheck resource to delete.
-http_health_check = ''
+http_health_check = '{MY-HTTP-HEALTH-CHECK}'
 
 # Perform the call
 response = service.delete_http_health_check(project, http_health_check)
@@ -1712,10 +1712,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_http_health_check' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the HttpHealthCheck resource to return.
-http_health_check = ''
+http_health_check = '{MY-HTTP-HEALTH-CHECK}'
 
 # Perform the call
 response = service.get_http_health_check(project, http_health_check)
@@ -1741,7 +1741,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_http_health_check' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 http_health_check_object = Google::Apis::ComputeV1::HttpHealthCheck.new
 
@@ -1770,7 +1770,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_http_health_checks' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -1801,10 +1801,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'patch_http_health_check' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the HttpHealthCheck resource to update.
-http_health_check = ''
+http_health_check = '{MY-HTTP-HEALTH-CHECK}'
 
 http_health_check_object = Google::Apis::ComputeV1::HttpHealthCheck.new
 
@@ -1833,10 +1833,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'update_http_health_check' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the HttpHealthCheck resource to update.
-http_health_check = ''
+http_health_check = '{MY-HTTP-HEALTH-CHECK}'
 
 http_health_check_object = Google::Apis::ComputeV1::HttpHealthCheck.new
 
@@ -1865,10 +1865,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_https_health_check' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the HttpsHealthCheck resource to delete.
-https_health_check = ''
+https_health_check = '{MY-HTTPS-HEALTH-CHECK}'
 
 # Perform the call
 response = service.delete_https_health_check(project, https_health_check)
@@ -1894,10 +1894,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_https_health_check' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the HttpsHealthCheck resource to return.
-https_health_check = ''
+https_health_check = '{MY-HTTPS-HEALTH-CHECK}'
 
 # Perform the call
 response = service.get_https_health_check(project, https_health_check)
@@ -1923,7 +1923,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_https_health_check' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 https_health_check_object = Google::Apis::ComputeV1::HttpsHealthCheck.new
 
@@ -1952,7 +1952,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_https_health_checks' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -1983,10 +1983,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'patch_https_health_check' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the HttpsHealthCheck resource to update.
-https_health_check = ''
+https_health_check = '{MY-HTTPS-HEALTH-CHECK}'
 
 https_health_check_object = Google::Apis::ComputeV1::HttpsHealthCheck.new
 
@@ -2015,10 +2015,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'update_https_health_check' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the HttpsHealthCheck resource to update.
-https_health_check = ''
+https_health_check = '{MY-HTTPS-HEALTH-CHECK}'
 
 https_health_check_object = Google::Apis::ComputeV1::HttpsHealthCheck.new
 
@@ -2047,10 +2047,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_image' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the image resource to delete.
-image = ''
+image = '{MY-IMAGE}'
 
 # Perform the call
 response = service.delete_image(project, image)
@@ -2076,10 +2076,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'deprecate_image' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Image name.
-image = ''
+image = '{MY-IMAGE}'
 
 deprecation_status_object = Google::Apis::ComputeV1::DeprecationStatus.new
 
@@ -2108,10 +2108,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_image' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the image resource to return.
-image = ''
+image = '{MY-IMAGE}'
 
 # Perform the call
 response = service.get_image(project, image)
@@ -2137,7 +2137,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_image' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 image_object = Google::Apis::ComputeV1::Image.new
 
@@ -2166,7 +2166,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_images' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -2197,13 +2197,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'abandon_instance_group_manager_instances' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone where the managed instance group is located.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the managed instance group.
-instance_group_manager = ''
+instance_group_manager = '{MY-INSTANCE-GROUP-MANAGER}'
 
 instance_group_managers_abandon_instances_request_object = Google::Apis::ComputeV1::InstanceGroupManagersAbandonInstancesRequest.new
 
@@ -2232,7 +2232,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_aggregated_instance_group_managers' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -2263,13 +2263,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_instance_group_manager' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone where the managed instance group is located.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the managed instance group to delete.
-instance_group_manager = ''
+instance_group_manager = '{MY-INSTANCE-GROUP-MANAGER}'
 
 # Perform the call
 response = service.delete_instance_group_manager(project, zone, instance_group_manager)
@@ -2295,13 +2295,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_instance_group_manager_instances' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone where the managed instance group is located.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the managed instance group.
-instance_group_manager = ''
+instance_group_manager = '{MY-INSTANCE-GROUP-MANAGER}'
 
 instance_group_managers_delete_instances_request_object = Google::Apis::ComputeV1::InstanceGroupManagersDeleteInstancesRequest.new
 
@@ -2330,13 +2330,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_instance_group_manager' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone where the managed instance group is located.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the managed instance group.
-instance_group_manager = ''
+instance_group_manager = '{MY-INSTANCE-GROUP-MANAGER}'
 
 # Perform the call
 response = service.get_instance_group_manager(project, zone, instance_group_manager)
@@ -2362,10 +2362,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_instance_group_manager' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone where you want to create the managed instance group.
-zone = ''
+zone = '{MY-ZONE}'
 
 instance_group_manager_object = Google::Apis::ComputeV1::InstanceGroupManager.new
 
@@ -2394,10 +2394,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_instance_group_managers' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone where the managed instance group is located.
-zone = ''
+zone = '{MY-ZONE}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -2428,13 +2428,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_instance_group_manager_managed_instances' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone where the managed instance group is located.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the managed instance group.
-instance_group_manager = ''
+instance_group_manager = '{MY-INSTANCE-GROUP-MANAGER}'
 
 # Perform the call
 response = service.list_instance_group_manager_managed_instances(project, zone, instance_group_manager)
@@ -2460,13 +2460,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'recreate_instance_group_manager_instances' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone where the managed instance group is located.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the managed instance group.
-instance_group_manager = ''
+instance_group_manager = '{MY-INSTANCE-GROUP-MANAGER}'
 
 instance_group_managers_recreate_instances_request_object = Google::Apis::ComputeV1::InstanceGroupManagersRecreateInstancesRequest.new
 
@@ -2495,13 +2495,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'resize_instance_group_manager' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone where the managed instance group is located.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the managed instance group.
-instance_group_manager = ''
+instance_group_manager = '{MY-INSTANCE-GROUP-MANAGER}'
 
 # * The number of running instances that the managed instance group should maintain at any given time.
 #   The group automatically adds or removes instances to maintain the number of instances specified by
@@ -2532,13 +2532,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'set_instance_group_manager_instance_template' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone where the managed instance group is located.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the managed instance group.
-instance_group_manager = ''
+instance_group_manager = '{MY-INSTANCE-GROUP-MANAGER}'
 
 instance_group_managers_set_instance_template_request_object = Google::Apis::ComputeV1::InstanceGroupManagersSetInstanceTemplateRequest.new
 
@@ -2567,13 +2567,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'set_instance_group_manager_target_pools' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone where the managed instance group is located.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the managed instance group.
-instance_group_manager = ''
+instance_group_manager = '{MY-INSTANCE-GROUP-MANAGER}'
 
 instance_group_managers_set_target_pools_request_object = Google::Apis::ComputeV1::InstanceGroupManagersSetTargetPoolsRequest.new
 
@@ -2602,13 +2602,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'add_instance_group_instances' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone where the instance group is located.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the instance group where you are adding instances.
-instance_group = ''
+instance_group = '{MY-INSTANCE-GROUP}'
 
 instance_groups_add_instances_request_object = Google::Apis::ComputeV1::InstanceGroupsAddInstancesRequest.new
 
@@ -2637,7 +2637,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_aggregated_instance_groups' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -2668,13 +2668,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_instance_group' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone where the instance group is located.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the instance group to delete.
-instance_group = ''
+instance_group = '{MY-INSTANCE-GROUP}'
 
 # Perform the call
 response = service.delete_instance_group(project, zone, instance_group)
@@ -2700,13 +2700,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_instance_group' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone where the instance group is located.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the instance group.
-instance_group = ''
+instance_group = '{MY-INSTANCE-GROUP}'
 
 # Perform the call
 response = service.get_instance_group(project, zone, instance_group)
@@ -2732,10 +2732,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_instance_group' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone where you want to create the instance group.
-zone = ''
+zone = '{MY-ZONE}'
 
 instance_group_object = Google::Apis::ComputeV1::InstanceGroup.new
 
@@ -2764,10 +2764,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_instance_groups' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone where the instance group is located.
-zone = ''
+zone = '{MY-ZONE}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -2798,13 +2798,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_instance_group_instances' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone where the instance group is located.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the instance group from which you want to generate a list of included instances.
-instance_group = ''
+instance_group = '{MY-INSTANCE-GROUP}'
 
 instance_groups_list_instances_request_object = Google::Apis::ComputeV1::InstanceGroupsListInstancesRequest.new
 
@@ -2838,13 +2838,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'remove_instance_group_instances' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone where the instance group is located.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the instance group where the specified instances will be removed.
-instance_group = ''
+instance_group = '{MY-INSTANCE-GROUP}'
 
 instance_groups_remove_instances_request_object = Google::Apis::ComputeV1::InstanceGroupsRemoveInstancesRequest.new
 
@@ -2873,13 +2873,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'set_instance_group_named_ports' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone where the instance group is located.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the instance group where the named ports are updated.
-instance_group = ''
+instance_group = '{MY-INSTANCE-GROUP}'
 
 instance_groups_set_named_ports_request_object = Google::Apis::ComputeV1::InstanceGroupsSetNamedPortsRequest.new
 
@@ -2908,10 +2908,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_instance_template' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the instance template to delete.
-instance_template = ''
+instance_template = '{MY-INSTANCE-TEMPLATE}'
 
 # Perform the call
 response = service.delete_instance_template(project, instance_template)
@@ -2937,10 +2937,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_instance_template' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the instance template.
-instance_template = ''
+instance_template = '{MY-INSTANCE-TEMPLATE}'
 
 # Perform the call
 response = service.get_instance_template(project, instance_template)
@@ -2966,7 +2966,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_instance_template' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 instance_template_object = Google::Apis::ComputeV1::InstanceTemplate.new
 
@@ -2995,7 +2995,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_instance_templates' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -3026,16 +3026,16 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'add_instance_access_config' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * The instance name for this request.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # * The name of the network interface to add to this instance.
-network_interface = ''
+network_interface = '{MY-NETWORK-INTERFACE}'
 
 access_config_object = Google::Apis::ComputeV1::AccessConfig.new
 
@@ -3064,7 +3064,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_aggregated_instances' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -3095,13 +3095,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'attach_disk' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * The instance name for this request.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 attached_disk_object = Google::Apis::ComputeV1::AttachedDisk.new
 
@@ -3130,13 +3130,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_instance' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * Name of the instance resource to delete.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # Perform the call
 response = service.delete_instance(project, zone, instance)
@@ -3162,19 +3162,19 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_instance_access_config' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * The instance name for this request.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # * The name of the access config to delete.
-access_config = ''
+access_config = '{MY-ACCESS-CONFIG}'
 
 # * The name of the network interface.
-network_interface = ''
+network_interface = '{MY-NETWORK-INTERFACE}'
 
 # Perform the call
 response = service.delete_instance_access_config(project, zone, instance, access_config, network_interface)
@@ -3200,16 +3200,16 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'detach_disk' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * Instance name.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # * Disk device name to detach.
-device_name = ''
+device_name = '{MY-DEVICE-NAME}'
 
 # Perform the call
 response = service.detach_disk(project, zone, instance, device_name)
@@ -3235,13 +3235,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_instance' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * Name of the instance resource to return.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # Perform the call
 response = service.get_instance(project, zone, instance)
@@ -3267,13 +3267,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_instance_serial_port_output' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * Name of the instance scoping this request.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # Perform the call
 response = service.get_instance_serial_port_output(project, zone, instance)
@@ -3299,10 +3299,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_instance' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 instance_object = Google::Apis::ComputeV1::Instance.new
 
@@ -3331,10 +3331,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_instances' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -3365,13 +3365,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'reset_instance' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * Name of the instance scoping this request.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # Perform the call
 response = service.reset_instance(project, zone, instance)
@@ -3397,19 +3397,19 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'set_disk_auto_delete' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * The instance name.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # * Whether to auto-delete the disk when the instance is deleted.
 auto_delete = false
 
 # * The device name of the disk to modify.
-device_name = ''
+device_name = '{MY-DEVICE-NAME}'
 
 # Perform the call
 response = service.set_disk_auto_delete(project, zone, instance, auto_delete, device_name)
@@ -3435,13 +3435,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'set_instance_machine_type' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * Name of the instance scoping this request.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 instances_set_machine_type_request_object = Google::Apis::ComputeV1::InstancesSetMachineTypeRequest.new
 
@@ -3470,13 +3470,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'set_instance_metadata' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * Name of the instance scoping this request.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 metadata_object = Google::Apis::ComputeV1::Metadata.new
 
@@ -3505,13 +3505,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'set_instance_scheduling' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * Instance name.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 scheduling_object = Google::Apis::ComputeV1::Scheduling.new
 
@@ -3540,13 +3540,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'set_instance_tags' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * Name of the instance scoping this request.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 tags_object = Google::Apis::ComputeV1::Tags.new
 
@@ -3575,13 +3575,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'start_instance' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * Name of the instance resource to start.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # Perform the call
 response = service.start_instance(project, zone, instance)
@@ -3607,13 +3607,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'stop_instance' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * Name of the instance resource to stop.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # Perform the call
 response = service.stop_instance(project, zone, instance)
@@ -3639,10 +3639,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_license' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the License resource to return.
-license = ''
+license = '{MY-LICENSE}'
 
 # Perform the call
 response = service.get_license(project, license)
@@ -3668,7 +3668,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_aggregated_machine_types' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -3699,13 +3699,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_machine_type' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * Name of the machine type to return.
-machine_type = ''
+machine_type = '{MY-MACHINE-TYPE}'
 
 # Perform the call
 response = service.get_machine_type(project, zone, machine_type)
@@ -3731,10 +3731,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_machine_types' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -3765,10 +3765,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_network' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the network to delete.
-network = ''
+network = '{MY-NETWORK}'
 
 # Perform the call
 response = service.delete_network(project, network)
@@ -3794,10 +3794,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_network' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the network to return.
-network = ''
+network = '{MY-NETWORK}'
 
 # Perform the call
 response = service.get_network(project, network)
@@ -3823,7 +3823,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_network' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 network_object = Google::Apis::ComputeV1::Network.new
 
@@ -3852,7 +3852,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_networks' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -3883,7 +3883,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_project' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 response = service.get_project(project)
@@ -3909,7 +3909,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'move_disk' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 move_disk_request_object = Google::Apis::ComputeV1::MoveDiskRequest.new
 
@@ -3938,7 +3938,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'move_instance' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 move_instance_request_object = Google::Apis::ComputeV1::MoveInstanceRequest.new
 
@@ -3967,7 +3967,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'set_common_instance_metadata' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 metadata_object = Google::Apis::ComputeV1::Metadata.new
 
@@ -3996,7 +3996,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'set_usage_export_bucket' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 usage_export_location_object = Google::Apis::ComputeV1::UsageExportLocation.new
 
@@ -4025,13 +4025,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_region_operation' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region for this request.
-region = ''
+region = '{MY-REGION}'
 
 # * Name of the Operations resource to delete.
-operation = ''
+operation = '{MY-OPERATION}'
 
 # Perform the call
 service.delete_region_operation(project, region, operation)
@@ -4057,13 +4057,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_region_operation' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region for this request.
-region = ''
+region = '{MY-REGION}'
 
 # * Name of the Operations resource to return.
-operation = ''
+operation = '{MY-OPERATION}'
 
 # Perform the call
 response = service.get_region_operation(project, region, operation)
@@ -4089,10 +4089,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_region_operations' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region for this request.
-region = ''
+region = '{MY-REGION}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -4123,10 +4123,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_region' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region resource to return.
-region = ''
+region = '{MY-REGION}'
 
 # Perform the call
 response = service.get_region(project, region)
@@ -4152,7 +4152,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_regions' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -4183,10 +4183,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_route' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the Route resource to delete.
-route = ''
+route = '{MY-ROUTE}'
 
 # Perform the call
 response = service.delete_route(project, route)
@@ -4212,10 +4212,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_route' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the Route resource to return.
-route = ''
+route = '{MY-ROUTE}'
 
 # Perform the call
 response = service.get_route(project, route)
@@ -4241,7 +4241,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_route' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 route_object = Google::Apis::ComputeV1::Route.new
 
@@ -4270,7 +4270,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_routes' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -4301,10 +4301,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_snapshot' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the Snapshot resource to delete.
-snapshot = ''
+snapshot = '{MY-SNAPSHOT}'
 
 # Perform the call
 response = service.delete_snapshot(project, snapshot)
@@ -4330,10 +4330,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_snapshot' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the Snapshot resource to return.
-snapshot = ''
+snapshot = '{MY-SNAPSHOT}'
 
 # Perform the call
 response = service.get_snapshot(project, snapshot)
@@ -4359,7 +4359,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_snapshots' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -4390,10 +4390,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_ssl_certificate' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the SslCertificate resource to delete.
-ssl_certificate = ''
+ssl_certificate = '{MY-SSL-CERTIFICATE}'
 
 # Perform the call
 response = service.delete_ssl_certificate(project, ssl_certificate)
@@ -4419,10 +4419,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_ssl_certificate' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the SslCertificate resource to return.
-ssl_certificate = ''
+ssl_certificate = '{MY-SSL-CERTIFICATE}'
 
 # Perform the call
 response = service.get_ssl_certificate(project, ssl_certificate)
@@ -4448,7 +4448,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_ssl_certificate' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 ssl_certificate_object = Google::Apis::ComputeV1::SslCertificate.new
 
@@ -4477,7 +4477,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_ssl_certificates' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -4508,7 +4508,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'aggregated_subnetwork_list' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -4539,13 +4539,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_subnetwork' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region scoping this request.
-region = ''
+region = '{MY-REGION}'
 
 # * Name of the Subnetwork resource to delete.
-subnetwork = ''
+subnetwork = '{MY-SUBNETWORK}'
 
 # Perform the call
 response = service.delete_subnetwork(project, region, subnetwork)
@@ -4571,13 +4571,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_subnetwork' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region scoping this request.
-region = ''
+region = '{MY-REGION}'
 
 # * Name of the Subnetwork resource to return.
-subnetwork = ''
+subnetwork = '{MY-SUBNETWORK}'
 
 # Perform the call
 response = service.get_subnetwork(project, region, subnetwork)
@@ -4603,10 +4603,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_subnetwork' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region scoping this request.
-region = ''
+region = '{MY-REGION}'
 
 subnetwork_object = Google::Apis::ComputeV1::Subnetwork.new
 
@@ -4635,10 +4635,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_subnetworks' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region scoping this request.
-region = ''
+region = '{MY-REGION}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -4669,10 +4669,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_target_http_proxy' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the TargetHttpProxy resource to delete.
-target_http_proxy = ''
+target_http_proxy = '{MY-TARGET-HTTP-PROXY}'
 
 # Perform the call
 response = service.delete_target_http_proxy(project, target_http_proxy)
@@ -4698,10 +4698,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_target_http_proxy' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the TargetHttpProxy resource to return.
-target_http_proxy = ''
+target_http_proxy = '{MY-TARGET-HTTP-PROXY}'
 
 # Perform the call
 response = service.get_target_http_proxy(project, target_http_proxy)
@@ -4727,7 +4727,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_target_http_proxy' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 target_http_proxy_object = Google::Apis::ComputeV1::TargetHttpProxy.new
 
@@ -4756,7 +4756,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_target_http_proxies' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -4787,10 +4787,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'set_target_http_proxy_url_map' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the TargetHttpProxy to set a URL map for.
-target_http_proxy = ''
+target_http_proxy = '{MY-TARGET-HTTP-PROXY}'
 
 url_map_reference_object = Google::Apis::ComputeV1::UrlMapReference.new
 
@@ -4819,10 +4819,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_target_https_proxy' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the TargetHttpsProxy resource to delete.
-target_https_proxy = ''
+target_https_proxy = '{MY-TARGET-HTTPS-PROXY}'
 
 # Perform the call
 response = service.delete_target_https_proxy(project, target_https_proxy)
@@ -4848,10 +4848,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_target_https_proxy' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the TargetHttpsProxy resource to return.
-target_https_proxy = ''
+target_https_proxy = '{MY-TARGET-HTTPS-PROXY}'
 
 # Perform the call
 response = service.get_target_https_proxy(project, target_https_proxy)
@@ -4877,7 +4877,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_target_https_proxy' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 target_https_proxy_object = Google::Apis::ComputeV1::TargetHttpsProxy.new
 
@@ -4906,7 +4906,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_target_https_proxies' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -4937,10 +4937,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'set_target_https_proxy_ssl_certificates' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the TargetHttpsProxy resource to set an SslCertificates resource for.
-target_https_proxy = ''
+target_https_proxy = '{MY-TARGET-HTTPS-PROXY}'
 
 target_https_proxies_set_ssl_certificates_request_object = Google::Apis::ComputeV1::TargetHttpsProxiesSetSslCertificatesRequest.new
 
@@ -4969,10 +4969,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'set_target_https_proxy_url_map' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the TargetHttpsProxy resource whose URL map is to be set.
-target_https_proxy = ''
+target_https_proxy = '{MY-TARGET-HTTPS-PROXY}'
 
 url_map_reference_object = Google::Apis::ComputeV1::UrlMapReference.new
 
@@ -5001,7 +5001,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_aggregated_target_instance' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -5032,13 +5032,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_target_instance' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the zone scoping this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * Name of the TargetInstance resource to delete.
-target_instance = ''
+target_instance = '{MY-TARGET-INSTANCE}'
 
 # Perform the call
 response = service.delete_target_instance(project, zone, target_instance)
@@ -5064,13 +5064,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_target_instance' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the zone scoping this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * Name of the TargetInstance resource to return.
-target_instance = ''
+target_instance = '{MY-TARGET-INSTANCE}'
 
 # Perform the call
 response = service.get_target_instance(project, zone, target_instance)
@@ -5096,10 +5096,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_target_instance' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the zone scoping this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 target_instance_object = Google::Apis::ComputeV1::TargetInstance.new
 
@@ -5128,10 +5128,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_target_instances' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the zone scoping this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -5162,13 +5162,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'add_target_pool_health_check' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region scoping this request.
-region = ''
+region = '{MY-REGION}'
 
 # * Name of the target pool to add a health check to.
-target_pool = ''
+target_pool = '{MY-TARGET-POOL}'
 
 add_target_pools_health_check_request_object = Google::Apis::ComputeV1::AddTargetPoolsHealthCheckRequest.new
 
@@ -5197,13 +5197,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'add_target_pool_instance' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region scoping this request.
-region = ''
+region = '{MY-REGION}'
 
 # * Name of the TargetPool resource to add instances to.
-target_pool = ''
+target_pool = '{MY-TARGET-POOL}'
 
 add_target_pools_instance_request_object = Google::Apis::ComputeV1::AddTargetPoolsInstanceRequest.new
 
@@ -5232,7 +5232,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_aggregated_target_pools' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -5263,13 +5263,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_target_pool' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region scoping this request.
-region = ''
+region = '{MY-REGION}'
 
 # * Name of the TargetPool resource to delete.
-target_pool = ''
+target_pool = '{MY-TARGET-POOL}'
 
 # Perform the call
 response = service.delete_target_pool(project, region, target_pool)
@@ -5295,13 +5295,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_target_pool' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region scoping this request.
-region = ''
+region = '{MY-REGION}'
 
 # * Name of the TargetPool resource to return.
-target_pool = ''
+target_pool = '{MY-TARGET-POOL}'
 
 # Perform the call
 response = service.get_target_pool(project, region, target_pool)
@@ -5327,13 +5327,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_target_pool_health' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region scoping this request.
-region = ''
+region = '{MY-REGION}'
 
 # * Name of the TargetPool resource to which the queried instance belongs.
-target_pool = ''
+target_pool = '{MY-TARGET-POOL}'
 
 instance_reference_object = Google::Apis::ComputeV1::InstanceReference.new
 
@@ -5362,10 +5362,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_target_pool' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region scoping this request.
-region = ''
+region = '{MY-REGION}'
 
 target_pool_object = Google::Apis::ComputeV1::TargetPool.new
 
@@ -5394,10 +5394,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_target_pools' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region scoping this request.
-region = ''
+region = '{MY-REGION}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -5428,13 +5428,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'remove_target_pool_health_check' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region for this request.
-region = ''
+region = '{MY-REGION}'
 
 # * Name of the target pool to remove health checks from.
-target_pool = ''
+target_pool = '{MY-TARGET-POOL}'
 
 remove_target_pools_health_check_request_object = Google::Apis::ComputeV1::RemoveTargetPoolsHealthCheckRequest.new
 
@@ -5463,13 +5463,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'remove_target_pool_instance' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region scoping this request.
-region = ''
+region = '{MY-REGION}'
 
 # * Name of the TargetPool resource to remove instances from.
-target_pool = ''
+target_pool = '{MY-TARGET-POOL}'
 
 remove_target_pools_instance_request_object = Google::Apis::ComputeV1::RemoveTargetPoolsInstanceRequest.new
 
@@ -5498,13 +5498,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'set_target_pool_backup' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region scoping this request.
-region = ''
+region = '{MY-REGION}'
 
 # * Name of the TargetPool resource to set a backup pool for.
-target_pool = ''
+target_pool = '{MY-TARGET-POOL}'
 
 target_reference_object = Google::Apis::ComputeV1::TargetReference.new
 
@@ -5533,7 +5533,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_aggregated_target_vpn_gateways' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -5564,13 +5564,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_target_vpn_gateway' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region for this request.
-region = ''
+region = '{MY-REGION}'
 
 # * Name of the target VPN gateway to delete.
-target_vpn_gateway = ''
+target_vpn_gateway = '{MY-TARGET-VPN-GATEWAY}'
 
 # Perform the call
 response = service.delete_target_vpn_gateway(project, region, target_vpn_gateway)
@@ -5596,13 +5596,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_target_vpn_gateway' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region for this request.
-region = ''
+region = '{MY-REGION}'
 
 # * Name of the target VPN gateway to return.
-target_vpn_gateway = ''
+target_vpn_gateway = '{MY-TARGET-VPN-GATEWAY}'
 
 # Perform the call
 response = service.get_target_vpn_gateway(project, region, target_vpn_gateway)
@@ -5628,10 +5628,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_target_vpn_gateway' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region for this request.
-region = ''
+region = '{MY-REGION}'
 
 target_vpn_gateway_object = Google::Apis::ComputeV1::TargetVpnGateway.new
 
@@ -5660,10 +5660,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_target_vpn_gateways' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region for this request.
-region = ''
+region = '{MY-REGION}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -5694,10 +5694,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_url_map' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the UrlMap resource to delete.
-url_map = ''
+url_map = '{MY-URL-MAP}'
 
 # Perform the call
 response = service.delete_url_map(project, url_map)
@@ -5723,10 +5723,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_url_map' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the UrlMap resource to return.
-url_map = ''
+url_map = '{MY-URL-MAP}'
 
 # Perform the call
 response = service.get_url_map(project, url_map)
@@ -5752,7 +5752,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_url_map' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 url_map_object = Google::Apis::ComputeV1::UrlMap.new
 
@@ -5781,7 +5781,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_url_maps' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -5812,10 +5812,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'patch_url_map' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the UrlMap resource to update.
-url_map = ''
+url_map = '{MY-URL-MAP}'
 
 url_map_object = Google::Apis::ComputeV1::UrlMap.new
 
@@ -5844,10 +5844,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'update_url_map' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the UrlMap resource to update.
-url_map = ''
+url_map = '{MY-URL-MAP}'
 
 url_map_object = Google::Apis::ComputeV1::UrlMap.new
 
@@ -5876,10 +5876,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'validate_url_map' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the UrlMap resource to be validated as.
-url_map = ''
+url_map = '{MY-URL-MAP}'
 
 validate_url_maps_request_object = Google::Apis::ComputeV1::ValidateUrlMapsRequest.new
 
@@ -5908,7 +5908,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_aggregated_vpn_tunnel' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -5939,13 +5939,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_vpn_tunnel' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region for this request.
-region = ''
+region = '{MY-REGION}'
 
 # * Name of the VpnTunnel resource to delete.
-vpn_tunnel = ''
+vpn_tunnel = '{MY-VPN-TUNNEL}'
 
 # Perform the call
 response = service.delete_vpn_tunnel(project, region, vpn_tunnel)
@@ -5971,13 +5971,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_vpn_tunnel' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region for this request.
-region = ''
+region = '{MY-REGION}'
 
 # * Name of the VpnTunnel resource to return.
-vpn_tunnel = ''
+vpn_tunnel = '{MY-VPN-TUNNEL}'
 
 # Perform the call
 response = service.get_vpn_tunnel(project, region, vpn_tunnel)
@@ -6003,10 +6003,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_vpn_tunnel' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region for this request.
-region = ''
+region = '{MY-REGION}'
 
 vpn_tunnel_object = Google::Apis::ComputeV1::VpnTunnel.new
 
@@ -6035,10 +6035,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_vpn_tunnels' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the region for this request.
-region = ''
+region = '{MY-REGION}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -6069,13 +6069,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_zone_operation' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * Name of the Operations resource to delete.
-operation = ''
+operation = '{MY-OPERATION}'
 
 # Perform the call
 service.delete_zone_operation(project, zone, operation)
@@ -6101,13 +6101,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_zone_operation' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the zone for this request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # * Name of the Operations resource to return.
-operation = ''
+operation = '{MY-OPERATION}'
 
 # Perform the call
 response = service.get_zone_operation(project, zone, operation)
@@ -6133,10 +6133,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_zone_operations' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the zone for request.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -6167,10 +6167,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_zone' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the zone resource to return.
-zone = ''
+zone = '{MY-ZONE}'  # eg. 'us-central1-f'
 
 # Perform the call
 response = service.get_zone(project, zone)
@@ -6196,7 +6196,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_zones' method:
 
 # * Project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_container.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_container.v1.json.baseline
@@ -22,11 +22,11 @@ service.authorization = \
 
 # * The Google Developers Console [project ID or project number]
 #   (https://developers.google.com/console/help/new/#projectnumber).
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 # * The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
 #   resides.
-zone = ''
+zone = '{MY-ZONE}'
 
 create_cluster_request_object = Google::Apis::ContainerV1::CreateClusterRequest.new
 
@@ -56,14 +56,14 @@ service.authorization = \
 
 # * The Google Developers Console [project ID or project number]
 #   (https://developers.google.com/console/help/new/#projectnumber).
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 # * The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
 #   resides.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the cluster to delete.
-cluster_id = ''
+cluster_id = '{MY-CLUSTER-ID}'
 
 # Perform the call
 response = service.delete_zone_cluster(project_id, zone, cluster_id)
@@ -90,14 +90,14 @@ service.authorization = \
 
 # * The Google Developers Console [project ID or project number]
 #   (https://developers.google.com/console/help/new/#projectnumber).
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 # * The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
 #   resides.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the cluster to retrieve.
-cluster_id = ''
+cluster_id = '{MY-CLUSTER-ID}'
 
 # Perform the call
 response = service.get_zone_cluster(project_id, zone, cluster_id)
@@ -124,11 +124,11 @@ service.authorization = \
 
 # * The Google Developers Console [project ID or project number]
 #   (https://developers.google.com/console/help/new/#projectnumber).
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 # * The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
 #   resides, or "-" for all zones.
-zone = ''
+zone = '{MY-ZONE}'
 
 # Perform the call
 response = service.list_zone_clusters(project_id, zone)
@@ -155,14 +155,14 @@ service.authorization = \
 
 # * The Google Developers Console [project ID or project number]
 #   (https://developers.google.com/console/help/new/#projectnumber).
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 # * The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
 #   resides.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the cluster to upgrade.
-cluster_id = ''
+cluster_id = '{MY-CLUSTER-ID}'
 
 update_cluster_request_object = Google::Apis::ContainerV1::UpdateClusterRequest.new
 
@@ -192,11 +192,11 @@ service.authorization = \
 
 # * The Google Developers Console [project ID or project number]
 #   (https://developers.google.com/console/help/new/#projectnumber).
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 # * The name of the Google Compute Engine [zone](/compute/docs/zones#available) to return operations
 #   for, or "-" for all zones.
-zone = ''
+zone = '{MY-ZONE}'
 
 # Perform the call
 response = service.get_project_zone_serverconfig(project_id, zone)
@@ -223,14 +223,14 @@ service.authorization = \
 
 # * The Google Developers Console [project ID or project number]
 #   (https://developers.google.com/console/help/new/#projectnumber).
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 # * The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster
 #   resides.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The server-assigned `name` of the operation.
-operation_id = ''
+operation_id = '{MY-OPERATION-ID}'
 
 # Perform the call
 response = service.get_zone_operation(project_id, zone, operation_id)
@@ -257,11 +257,11 @@ service.authorization = \
 
 # * The Google Developers Console [project ID or project number]
 #   (https://developers.google.com/console/help/new/#projectnumber).
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 # * The name of the Google Compute Engine [zone](/compute/docs/zones#available) to return operations
 #   for, or "-" for all zones.
-zone = ''
+zone = '{MY-ZONE}'
 
 # Perform the call
 response = service.list_zone_operations(project_id, zone)

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_dataproc.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_dataproc.v1.json.baseline
@@ -21,10 +21,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'create_cluster' method:
 
 # * [Required] The ID of the Google Cloud Platform project that the cluster belongs to.
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 # * [Required] The Cloud Dataproc region in which to handle the request.
-region = ''
+region = '{MY-REGION}'
 
 cluster_object = Google::Apis::DataprocV1::Cluster.new
 
@@ -53,13 +53,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_cluster' method:
 
 # * [Required] The ID of the Google Cloud Platform project that the cluster belongs to.
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 # * [Required] The Cloud Dataproc region in which to handle the request.
-region = ''
+region = '{MY-REGION}'
 
 # * [Required] The cluster name.
-cluster_name = ''
+cluster_name = '{MY-CLUSTER-NAME}'
 
 # Perform the call
 response = service.delete_cluster(project_id, region, cluster_name)
@@ -85,13 +85,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'diagnose_cluster' method:
 
 # * [Required] The ID of the Google Cloud Platform project that the cluster belongs to.
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 # * [Required] The Cloud Dataproc region in which to handle the request.
-region = ''
+region = '{MY-REGION}'
 
 # * [Required] The cluster name.
-cluster_name = ''
+cluster_name = '{MY-CLUSTER-NAME}'
 
 diagnose_cluster_request_object = Google::Apis::DataprocV1::DiagnoseClusterRequest.new
 
@@ -120,13 +120,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_cluster' method:
 
 # * [Required] The ID of the Google Cloud Platform project that the cluster belongs to.
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 # * [Required] The Cloud Dataproc region in which to handle the request.
-region = ''
+region = '{MY-REGION}'
 
 # * [Required] The cluster name.
-cluster_name = ''
+cluster_name = '{MY-CLUSTER-NAME}'
 
 # Perform the call
 response = service.get_cluster(project_id, region, cluster_name)
@@ -152,10 +152,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_clusters' method:
 
 # * [Required] The ID of the Google Cloud Platform project that the cluster belongs to.
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 # * [Required] The Cloud Dataproc region in which to handle the request.
-region = ''
+region = '{MY-REGION}'
 
 # Perform the call
 result_list = service.fetch_all(items: :clusters) { |token|
@@ -186,13 +186,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'patch_cluster' method:
 
 # * [Required] The ID of the Google Cloud Platform project the cluster belongs to.
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 # * [Required] The Cloud Dataproc region in which to handle the request.
-region = ''
+region = '{MY-REGION}'
 
 # * [Required] The cluster name.
-cluster_name = ''
+cluster_name = '{MY-CLUSTER-NAME}'
 
 cluster_object = Google::Apis::DataprocV1::Cluster.new
 
@@ -221,13 +221,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'cancel_job' method:
 
 # * [Required] The ID of the Google Cloud Platform project that the job belongs to.
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 # * [Required] The Cloud Dataproc region in which to handle the request.
-region = ''
+region = '{MY-REGION}'
 
 # * [Required] The job ID.
-job_id = ''
+job_id = '{MY-JOB-ID}'
 
 cancel_job_request_object = Google::Apis::DataprocV1::CancelJobRequest.new
 
@@ -256,13 +256,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_job' method:
 
 # * [Required] The ID of the Google Cloud Platform project that the job belongs to.
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 # * [Required] The Cloud Dataproc region in which to handle the request.
-region = ''
+region = '{MY-REGION}'
 
 # * [Required] The job ID.
-job_id = ''
+job_id = '{MY-JOB-ID}'
 
 # Perform the call
 service.delete_job(project_id, region, job_id)
@@ -288,13 +288,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_job' method:
 
 # * [Required] The ID of the Google Cloud Platform project that the job belongs to.
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 # * [Required] The Cloud Dataproc region in which to handle the request.
-region = ''
+region = '{MY-REGION}'
 
 # * [Required] The job ID.
-job_id = ''
+job_id = '{MY-JOB-ID}'
 
 # Perform the call
 response = service.get_job(project_id, region, job_id)
@@ -320,10 +320,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_jobs' method:
 
 # * [Required] The ID of the Google Cloud Platform project that the job belongs to.
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 # * [Required] The Cloud Dataproc region in which to handle the request.
-region = ''
+region = '{MY-REGION}'
 
 # Perform the call
 result_list = service.fetch_all(items: :jobs) { |token|
@@ -354,10 +354,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'submit_job' method:
 
 # * [Required] The ID of the Google Cloud Platform project that the job belongs to.
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 # * [Required] The Cloud Dataproc region in which to handle the request.
-region = ''
+region = '{MY-REGION}'
 
 submit_job_request_object = Google::Apis::DataprocV1::SubmitJobRequest.new
 
@@ -464,7 +464,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_operations' method:
 
 # * The name of the operation collection.
-name = ''
+name = '{MY-NAME}'
 
 # Perform the call
 result_list = service.fetch_all(items: :operations) { |token|

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_datastore.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_datastore.v1beta2.json.baseline
@@ -21,7 +21,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'allocate_dataset_ids' method:
 
 # * Identifies the dataset.
-dataset_id = ''
+dataset_id = '{MY-DATASET-ID}'
 
 allocate_ids_request_object = Google::Apis::DatastoreV1beta2::AllocateIdsRequest.new
 
@@ -50,7 +50,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'begin_dataset_transaction' method:
 
 # * Identifies the dataset.
-dataset_id = ''
+dataset_id = '{MY-DATASET-ID}'
 
 begin_transaction_request_object = Google::Apis::DatastoreV1beta2::BeginTransactionRequest.new
 
@@ -79,7 +79,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'commit_dataset' method:
 
 # * Identifies the dataset.
-dataset_id = ''
+dataset_id = '{MY-DATASET-ID}'
 
 commit_request_object = Google::Apis::DatastoreV1beta2::CommitRequest.new
 
@@ -108,7 +108,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'lookup_dataset' method:
 
 # * Identifies the dataset.
-dataset_id = ''
+dataset_id = '{MY-DATASET-ID}'
 
 lookup_request_object = Google::Apis::DatastoreV1beta2::LookupRequest.new
 
@@ -137,7 +137,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'rollback_dataset' method:
 
 # * Identifies the dataset.
-dataset_id = ''
+dataset_id = '{MY-DATASET-ID}'
 
 rollback_request_object = Google::Apis::DatastoreV1beta2::RollbackRequest.new
 
@@ -166,7 +166,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'run_dataset_query' method:
 
 # * Identifies the dataset.
-dataset_id = ''
+dataset_id = '{MY-DATASET-ID}'
 
 run_query_request_object = Google::Apis::DatastoreV1beta2::RunQueryRequest.new
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_deploymentmanager.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_deploymentmanager.v2.json.baseline
@@ -21,10 +21,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'cancel_deployment_preview' method:
 
 # * The project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the deployment for this request.
-deployment = ''
+deployment = '{MY-DEPLOYMENT}'
 
 deployments_cancel_preview_request_object = Google::Apis::DeploymentmanagerV2::DeploymentsCancelPreviewRequest.new
 
@@ -53,10 +53,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_deployment' method:
 
 # * The project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the deployment for this request.
-deployment = ''
+deployment = '{MY-DEPLOYMENT}'
 
 # Perform the call
 response = service.delete_deployment(project, deployment)
@@ -82,10 +82,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_deployment' method:
 
 # * The project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the deployment for this request.
-deployment = ''
+deployment = '{MY-DEPLOYMENT}'
 
 # Perform the call
 response = service.get_deployment(project, deployment)
@@ -111,7 +111,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_deployment' method:
 
 # * The project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 deployment_object = Google::Apis::DeploymentmanagerV2::Deployment.new
 
@@ -140,7 +140,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_deployments' method:
 
 # * The project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 result_list = service.fetch_all(items: :deployments) { |token|
@@ -171,10 +171,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'patch_deployment' method:
 
 # * The project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the deployment for this request.
-deployment = ''
+deployment = '{MY-DEPLOYMENT}'
 
 deployment_object = Google::Apis::DeploymentmanagerV2::Deployment.new
 
@@ -203,10 +203,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'stop_deployment' method:
 
 # * The project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the deployment for this request.
-deployment = ''
+deployment = '{MY-DEPLOYMENT}'
 
 deployments_stop_request_object = Google::Apis::DeploymentmanagerV2::DeploymentsStopRequest.new
 
@@ -235,10 +235,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'update_deployment' method:
 
 # * The project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the deployment for this request.
-deployment = ''
+deployment = '{MY-DEPLOYMENT}'
 
 deployment_object = Google::Apis::DeploymentmanagerV2::Deployment.new
 
@@ -267,13 +267,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_manifest' method:
 
 # * The project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the deployment for this request.
-deployment = ''
+deployment = '{MY-DEPLOYMENT}'
 
 # * The name of the manifest for this request.
-manifest = ''
+manifest = '{MY-MANIFEST}'
 
 # Perform the call
 response = service.get_manifest(project, deployment, manifest)
@@ -299,10 +299,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_manifests' method:
 
 # * The project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the deployment for this request.
-deployment = ''
+deployment = '{MY-DEPLOYMENT}'
 
 # Perform the call
 result_list = service.fetch_all(items: :manifests) { |token|
@@ -333,10 +333,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_operation' method:
 
 # * The project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the operation for this request.
-operation = ''
+operation = '{MY-OPERATION}'
 
 # Perform the call
 response = service.get_operation(project, operation)
@@ -362,7 +362,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_operations' method:
 
 # * The project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 result_list = service.fetch_all(items: :operations) { |token|
@@ -393,13 +393,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_resource' method:
 
 # * The project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the deployment for this request.
-deployment = ''
+deployment = '{MY-DEPLOYMENT}'
 
 # * The name of the resource for this request.
-resource = ''
+resource = '{MY-RESOURCE}'
 
 # Perform the call
 response = service.get_resource(project, deployment, resource)
@@ -425,10 +425,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_resources' method:
 
 # * The project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the deployment for this request.
-deployment = ''
+deployment = '{MY-DEPLOYMENT}'
 
 # Perform the call
 result_list = service.fetch_all(items: :resources) { |token|
@@ -459,7 +459,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_types' method:
 
 # * The project ID for this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 result_list = service.fetch_all(items: :types) { |token|

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_dns.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_dns.v1.json.baseline
@@ -21,10 +21,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'create_change' method:
 
 # * Identifies the project addressed by this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-managed_zone = ''
+managed_zone = '{MY-MANAGED-ZONE}'
 
 change_object = Google::Apis::DnsV1::Change.new
 
@@ -53,13 +53,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_change' method:
 
 # * Identifies the project addressed by this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-managed_zone = ''
+managed_zone = '{MY-MANAGED-ZONE}'
 
 # * The identifier of the requested change, from a previous ResourceRecordSetsChangeResponse.
-change_id = ''
+change_id = '{MY-CHANGE-ID}'
 
 # Perform the call
 response = service.get_change(project, managed_zone, change_id)
@@ -85,10 +85,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_changes' method:
 
 # * Identifies the project addressed by this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-managed_zone = ''
+managed_zone = '{MY-MANAGED-ZONE}'
 
 # Perform the call
 result_list = service.fetch_all(items: :changes) { |token|
@@ -119,7 +119,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'create_managed_zone' method:
 
 # * Identifies the project addressed by this request.
-project = ''
+project = '{MY-PROJECT}'
 
 managed_zone_object = Google::Apis::DnsV1::ManagedZone.new
 
@@ -148,10 +148,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_managed_zone' method:
 
 # * Identifies the project addressed by this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-managed_zone = ''
+managed_zone = '{MY-MANAGED-ZONE}'
 
 # Perform the call
 service.delete_managed_zone(project, managed_zone)
@@ -177,10 +177,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_managed_zone' method:
 
 # * Identifies the project addressed by this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-managed_zone = ''
+managed_zone = '{MY-MANAGED-ZONE}'
 
 # Perform the call
 response = service.get_managed_zone(project, managed_zone)
@@ -206,7 +206,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_managed_zones' method:
 
 # * Identifies the project addressed by this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 result_list = service.fetch_all(items: :managedZones) { |token|
@@ -237,7 +237,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_project' method:
 
 # * Identifies the project addressed by this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 response = service.get_project(project)
@@ -263,10 +263,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_resource_record_sets' method:
 
 # * Identifies the project addressed by this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Identifies the managed zone addressed by this request. Can be the managed zone name or id.
-managed_zone = ''
+managed_zone = '{MY-MANAGED-ZONE}'
 
 # Perform the call
 result_list = service.fetch_all(items: :rrsets) { |token|

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_prediction.v1.6.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_prediction.v1.6.json.baseline
@@ -21,10 +21,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'predict_hosted_model' method:
 
 # * The project associated with the model.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of a hosted model.
-hosted_model_name = ''
+hosted_model_name = '{MY-HOSTED-MODEL-NAME}'
 
 input_object = Google::Apis::PredictionV1_6::Input.new
 
@@ -53,10 +53,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'analyze_trained_model' method:
 
 # * The project associated with the model.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The unique name for the predictive model.
-id = ''
+id = '{MY-ID}'
 
 # Perform the call
 response = service.analyze_trained_model(project, id)
@@ -82,10 +82,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_trained_model' method:
 
 # * The project associated with the model.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The unique name for the predictive model.
-id = ''
+id = '{MY-ID}'
 
 # Perform the call
 service.delete_trained_model(project, id)
@@ -111,10 +111,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_trained_model' method:
 
 # * The project associated with the model.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The unique name for the predictive model.
-id = ''
+id = '{MY-ID}'
 
 # Perform the call
 response = service.get_trained_model(project, id)
@@ -140,7 +140,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_trained_model' method:
 
 # * The project associated with the model.
-project = ''
+project = '{MY-PROJECT}'
 
 insert_object = Google::Apis::PredictionV1_6::Insert.new
 
@@ -169,7 +169,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_trained_models' method:
 
 # * The project associated with the model.
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -200,10 +200,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'predict_trained_model' method:
 
 # * The project associated with the model.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The unique name for the predictive model.
-id = ''
+id = '{MY-ID}'
 
 input_object = Google::Apis::PredictionV1_6::Input.new
 
@@ -232,10 +232,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'update_trained_model' method:
 
 # * The project associated with the model.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The unique name for the predictive model.
-id = ''
+id = '{MY-ID}'
 
 update_object = Google::Apis::PredictionV1_6::Update.new
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_replicapoolupdater.v1beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_replicapoolupdater.v1beta1.json.baseline
@@ -21,13 +21,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'cancel_rolling_update' method:
 
 # * The Google Developers Console project name.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone in which the update's target resides.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the update.
-rolling_update = ''
+rolling_update = '{MY-ROLLING-UPDATE}'
 
 # Perform the call
 response = service.cancel_rolling_update(project, zone, rolling_update)
@@ -53,13 +53,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_rolling_update' method:
 
 # * The Google Developers Console project name.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone in which the update's target resides.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the update.
-rolling_update = ''
+rolling_update = '{MY-ROLLING-UPDATE}'
 
 # Perform the call
 response = service.get_rolling_update(project, zone, rolling_update)
@@ -85,10 +85,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_rolling_update' method:
 
 # * The Google Developers Console project name.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone in which the update's target resides.
-zone = ''
+zone = '{MY-ZONE}'
 
 rolling_update_object = Google::Apis::ReplicapoolupdaterV1beta1::RollingUpdate.new
 
@@ -117,10 +117,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_rolling_updates' method:
 
 # * The Google Developers Console project name.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone in which the update's target resides.
-zone = ''
+zone = '{MY-ZONE}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -151,13 +151,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_instance_updates' method:
 
 # * The Google Developers Console project name.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone in which the update's target resides.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the update.
-rolling_update = ''
+rolling_update = '{MY-ROLLING-UPDATE}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -188,13 +188,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'pause_rolling_update' method:
 
 # * The Google Developers Console project name.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone in which the update's target resides.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the update.
-rolling_update = ''
+rolling_update = '{MY-ROLLING-UPDATE}'
 
 # Perform the call
 response = service.pause_rolling_update(project, zone, rolling_update)
@@ -220,13 +220,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'resume_rolling_update' method:
 
 # * The Google Developers Console project name.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone in which the update's target resides.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the update.
-rolling_update = ''
+rolling_update = '{MY-ROLLING-UPDATE}'
 
 # Perform the call
 response = service.resume_rolling_update(project, zone, rolling_update)
@@ -252,13 +252,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'rollback_rolling_update' method:
 
 # * The Google Developers Console project name.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The name of the zone in which the update's target resides.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * The name of the update.
-rolling_update = ''
+rolling_update = '{MY-ROLLING-UPDATE}'
 
 # Perform the call
 response = service.rollback_rolling_update(project, zone, rolling_update)
@@ -284,13 +284,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_zone_operation' method:
 
 # * Name of the project scoping this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the zone scoping this request.
-zone = ''
+zone = '{MY-ZONE}'
 
 # * Name of the operation resource to return.
-operation = ''
+operation = '{MY-OPERATION}'
 
 # Perform the call
 response = service.get_zone_operation(project, zone, operation)
@@ -316,10 +316,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_zone_operations' method:
 
 # * Name of the project scoping this request.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Name of the zone scoping this request.
-zone = ''
+zone = '{MY-ZONE}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_sqladmin.v1beta4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_sqladmin.v1beta4.json.baseline
@@ -21,10 +21,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_backup_run' method:
 
 # * Project ID of the project that contains the instance.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Cloud SQL instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # * The ID of the Backup Run to delete. To find a Backup Run ID, use the list method.
 id = ''
@@ -53,10 +53,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_backup_run' method:
 
 # * Project ID of the project that contains the instance.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Cloud SQL instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # * The ID of this Backup Run.
 id = ''
@@ -85,10 +85,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_backup_runs' method:
 
 # * Project ID of the project that contains the instance.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Cloud SQL instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -119,13 +119,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_database' method:
 
 # * Project ID of the project that contains the instance.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Database instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # * Name of the database to be deleted in the instance.
-database = ''
+database = '{MY-DATABASE}'
 
 # Perform the call
 response = service.delete_database(project, instance, database)
@@ -151,13 +151,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_database' method:
 
 # * Project ID of the project that contains the instance.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Database instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # * Name of the database in the instance.
-database = ''
+database = '{MY-DATABASE}'
 
 # Perform the call
 response = service.get_database(project, instance, database)
@@ -183,10 +183,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_database' method:
 
 # * Project ID of the project that contains the instance.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Database instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 database_object = Google::Apis::SqladminV1beta4::Database.new
 
@@ -215,10 +215,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_databases' method:
 
 # * Project ID of the project for which to list Cloud SQL instances.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Cloud SQL instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # Perform the call
 response = service.list_databases(project, instance)
@@ -244,13 +244,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'patch_database' method:
 
 # * Project ID of the project that contains the instance.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Database instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # * Name of the database to be updated in the instance.
-database = ''
+database = '{MY-DATABASE}'
 
 database_object = Google::Apis::SqladminV1beta4::Database.new
 
@@ -279,13 +279,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'update_database' method:
 
 # * Project ID of the project that contains the instance.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Database instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # * Name of the database to be updated in the instance.
-database = ''
+database = '{MY-DATABASE}'
 
 database_object = Google::Apis::SqladminV1beta4::Database.new
 
@@ -337,10 +337,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'clone_instance' method:
 
 # * Project ID of the source as well as the clone Cloud SQL instance.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The ID of the Cloud SQL instance to be cloned (source). This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 clone_instances_request_object = Google::Apis::SqladminV1beta4::CloneInstancesRequest.new
 
@@ -369,10 +369,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_instance' method:
 
 # * Project ID of the project that contains the instance to be deleted.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Cloud SQL instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # Perform the call
 response = service.delete_instance(project, instance)
@@ -398,10 +398,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'export_instance' method:
 
 # * Project ID of the project that contains the instance to be exported.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Cloud SQL instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 export_instances_request_object = Google::Apis::SqladminV1beta4::ExportInstancesRequest.new
 
@@ -430,10 +430,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'failover_instance' method:
 
 # * ID of the project that contains the read replica.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Cloud SQL instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 instances_failover_request_object = Google::Apis::SqladminV1beta4::InstancesFailoverRequest.new
 
@@ -462,10 +462,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_instance' method:
 
 # * Project ID of the project that contains the instance.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Database instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # Perform the call
 response = service.get_instance(project, instance)
@@ -491,10 +491,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'import_instance' method:
 
 # * Project ID of the project that contains the instance.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Cloud SQL instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 import_instances_request_object = Google::Apis::SqladminV1beta4::ImportInstancesRequest.new
 
@@ -523,7 +523,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_instance' method:
 
 # * Project ID of the project to which the newly created Cloud SQL instances should belong.
-project = ''
+project = '{MY-PROJECT}'
 
 database_instance_object = Google::Apis::SqladminV1beta4::DatabaseInstance.new
 
@@ -552,7 +552,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_instances' method:
 
 # * Project ID of the project for which to list Cloud SQL instances.
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -583,10 +583,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'patch_instance' method:
 
 # * Project ID of the project that contains the instance.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Cloud SQL instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 database_instance_object = Google::Apis::SqladminV1beta4::DatabaseInstance.new
 
@@ -615,10 +615,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'promote_instance_replica' method:
 
 # * ID of the project that contains the read replica.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Cloud SQL read replica instance name.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # Perform the call
 response = service.promote_instance_replica(project, instance)
@@ -644,10 +644,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'reset_instance_ssl_config' method:
 
 # * Project ID of the project that contains the instance.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Cloud SQL instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # Perform the call
 response = service.reset_instance_ssl_config(project, instance)
@@ -673,10 +673,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'restart_instance' method:
 
 # * Project ID of the project that contains the instance to be restarted.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Cloud SQL instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # Perform the call
 response = service.restart_instance(project, instance)
@@ -702,10 +702,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'restore_instance_backup' method:
 
 # * Project ID of the project that contains the instance.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Cloud SQL instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 restore_instances_backup_request_object = Google::Apis::SqladminV1beta4::RestoreInstancesBackupRequest.new
 
@@ -734,10 +734,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'start_instance_replica' method:
 
 # * ID of the project that contains the read replica.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Cloud SQL read replica instance name.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # Perform the call
 response = service.start_instance_replica(project, instance)
@@ -763,10 +763,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'stop_instance_replica' method:
 
 # * ID of the project that contains the read replica.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Cloud SQL read replica instance name.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # Perform the call
 response = service.stop_instance_replica(project, instance)
@@ -792,10 +792,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'update_instance' method:
 
 # * Project ID of the project that contains the instance.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Cloud SQL instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 database_instance_object = Google::Apis::SqladminV1beta4::DatabaseInstance.new
 
@@ -824,10 +824,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_operation' method:
 
 # * Project ID of the project that contains the instance.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Instance operation ID.
-operation = ''
+operation = '{MY-OPERATION}'
 
 # Perform the call
 response = service.get_operation(project, operation)
@@ -853,10 +853,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_operations' method:
 
 # * Project ID of the project that contains the instance.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Cloud SQL instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -887,10 +887,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'create_ssl_cert_ephemeral' method:
 
 # * Project ID of the Cloud SQL project.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Cloud SQL instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 ssl_certs_create_ephemeral_request_object = Google::Apis::SqladminV1beta4::SslCertsCreateEphemeralRequest.new
 
@@ -919,13 +919,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_ssl_cert' method:
 
 # * Project ID of the project that contains the instance to be deleted.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Cloud SQL instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # * Sha1 FingerPrint.
-sha1_fingerprint = ''
+sha1_fingerprint = '{MY-SHA1-FINGERPRINT}'
 
 # Perform the call
 response = service.delete_ssl_cert(project, instance, sha1_fingerprint)
@@ -951,13 +951,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_ssl_cert' method:
 
 # * Project ID of the project that contains the instance.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Cloud SQL instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # * Sha1 FingerPrint.
-sha1_fingerprint = ''
+sha1_fingerprint = '{MY-SHA1-FINGERPRINT}'
 
 # Perform the call
 response = service.get_ssl_cert(project, instance, sha1_fingerprint)
@@ -983,10 +983,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_ssl_cert' method:
 
 # * Project ID of the project to which the newly created Cloud SQL instances should belong.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Cloud SQL instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 insert_ssl_certs_request_object = Google::Apis::SqladminV1beta4::InsertSslCertsRequest.new
 
@@ -1015,10 +1015,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_ssl_certs' method:
 
 # * Project ID of the project for which to list Cloud SQL instances.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Cloud SQL instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # Perform the call
 response = service.list_ssl_certs(project, instance)
@@ -1044,7 +1044,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_tiers' method:
 
 # * Project ID of the project for which to list tiers.
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 response = service.list_tiers(project)
@@ -1070,16 +1070,16 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_user' method:
 
 # * Project ID of the project that contains the instance.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Database instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # * Host of the user in the instance.
-host = ''
+host = '{MY-HOST}'
 
 # * Name of the user in the instance.
-name = ''
+name = '{MY-NAME}'
 
 # Perform the call
 response = service.delete_user(project, instance, host, name)
@@ -1105,10 +1105,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_user' method:
 
 # * Project ID of the project that contains the instance.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Database instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 user_object = Google::Apis::SqladminV1beta4::User.new
 
@@ -1137,10 +1137,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_users' method:
 
 # * Project ID of the project that contains the instance.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Database instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # Perform the call
 response = service.list_users(project, instance)
@@ -1166,16 +1166,16 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'update_user' method:
 
 # * Project ID of the project that contains the instance.
-project = ''
+project = '{MY-PROJECT}'
 
 # * Database instance ID. This does not include the project ID.
-instance = ''
+instance = '{MY-INSTANCE}'
 
 # * Host of the user in the instance.
-host = ''
+host = '{MY-HOST}'
 
 # * Name of the user in the instance.
-name = ''
+name = '{MY-NAME}'
 
 user_object = Google::Apis::SqladminV1beta4::User.new
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_storage.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_storage.v1.json.baseline
@@ -21,11 +21,11 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_bucket_access_control' method:
 
 # * Name of a bucket.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 # * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
 #   group-emailAddress, allUsers, or allAuthenticatedUsers.
-entity = ''
+entity = '{MY-ENTITY}'
 
 # Perform the call
 service.delete_bucket_access_control(bucket, entity)
@@ -51,11 +51,11 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_bucket_access_control' method:
 
 # * Name of a bucket.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 # * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
 #   group-emailAddress, allUsers, or allAuthenticatedUsers.
-entity = ''
+entity = '{MY-ENTITY}'
 
 # Perform the call
 response = service.get_bucket_access_control(bucket, entity)
@@ -81,7 +81,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_bucket_access_control' method:
 
 # * Name of a bucket.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 bucket_access_control_object = Google::Apis::StorageV1::BucketAccessControl.new
 
@@ -110,7 +110,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_bucket_access_controls' method:
 
 # * Name of a bucket.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 # Perform the call
 response = service.list_bucket_access_controls(bucket)
@@ -136,11 +136,11 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'patch_bucket_access_control' method:
 
 # * Name of a bucket.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 # * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
 #   group-emailAddress, allUsers, or allAuthenticatedUsers.
-entity = ''
+entity = '{MY-ENTITY}'
 
 bucket_access_control_object = Google::Apis::StorageV1::BucketAccessControl.new
 
@@ -169,11 +169,11 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'update_bucket_access_control' method:
 
 # * Name of a bucket.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 # * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
 #   group-emailAddress, allUsers, or allAuthenticatedUsers.
-entity = ''
+entity = '{MY-ENTITY}'
 
 bucket_access_control_object = Google::Apis::StorageV1::BucketAccessControl.new
 
@@ -202,7 +202,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_bucket' method:
 
 # * Name of a bucket.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 # Perform the call
 service.delete_bucket(bucket)
@@ -228,7 +228,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_bucket' method:
 
 # * Name of a bucket.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 # Perform the call
 response = service.get_bucket(bucket)
@@ -254,7 +254,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_bucket' method:
 
 # * A valid API project identifier.
-project = ''
+project = '{MY-PROJECT}'
 
 bucket_object = Google::Apis::StorageV1::Bucket.new
 
@@ -283,7 +283,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_buckets' method:
 
 # * A valid API project identifier.
-project = ''
+project = '{MY-PROJECT}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -314,7 +314,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'patch_bucket' method:
 
 # * Name of a bucket.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 bucket_object = Google::Apis::StorageV1::Bucket.new
 
@@ -343,7 +343,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'update_bucket' method:
 
 # * Name of a bucket.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 bucket_object = Google::Apis::StorageV1::Bucket.new
 
@@ -398,11 +398,11 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_default_object_access_control' method:
 
 # * Name of a bucket.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 # * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
 #   group-emailAddress, allUsers, or allAuthenticatedUsers.
-entity = ''
+entity = '{MY-ENTITY}'
 
 # Perform the call
 service.delete_default_object_access_control(bucket, entity)
@@ -428,11 +428,11 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_default_object_access_control' method:
 
 # * Name of a bucket.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 # * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
 #   group-emailAddress, allUsers, or allAuthenticatedUsers.
-entity = ''
+entity = '{MY-ENTITY}'
 
 # Perform the call
 response = service.get_default_object_access_control(bucket, entity)
@@ -458,7 +458,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_default_object_access_control' method:
 
 # * Name of a bucket.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 object_access_control_object = Google::Apis::StorageV1::ObjectAccessControl.new
 
@@ -487,7 +487,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_default_object_access_controls' method:
 
 # * Name of a bucket.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 # Perform the call
 response = service.list_default_object_access_controls(bucket)
@@ -513,11 +513,11 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'patch_default_object_access_control' method:
 
 # * Name of a bucket.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 # * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
 #   group-emailAddress, allUsers, or allAuthenticatedUsers.
-entity = ''
+entity = '{MY-ENTITY}'
 
 object_access_control_object = Google::Apis::StorageV1::ObjectAccessControl.new
 
@@ -546,11 +546,11 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'update_default_object_access_control' method:
 
 # * Name of a bucket.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 # * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
 #   group-emailAddress, allUsers, or allAuthenticatedUsers.
-entity = ''
+entity = '{MY-ENTITY}'
 
 object_access_control_object = Google::Apis::StorageV1::ObjectAccessControl.new
 
@@ -579,15 +579,15 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_object_access_control' method:
 
 # * Name of a bucket.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 # * Name of the object. For information about how to URL encode object names to be path safe, see
 #   Encoding URI Path Parts.
-object = ''
+object = '{MY-OBJECT}'
 
 # * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
 #   group-emailAddress, allUsers, or allAuthenticatedUsers.
-entity = ''
+entity = '{MY-ENTITY}'
 
 # Perform the call
 service.delete_object_access_control(bucket, object, entity)
@@ -613,15 +613,15 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_object_access_control' method:
 
 # * Name of a bucket.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 # * Name of the object. For information about how to URL encode object names to be path safe, see
 #   Encoding URI Path Parts.
-object = ''
+object = '{MY-OBJECT}'
 
 # * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
 #   group-emailAddress, allUsers, or allAuthenticatedUsers.
-entity = ''
+entity = '{MY-ENTITY}'
 
 # Perform the call
 response = service.get_object_access_control(bucket, object, entity)
@@ -647,11 +647,11 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_object_access_control' method:
 
 # * Name of a bucket.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 # * Name of the object. For information about how to URL encode object names to be path safe, see
 #   Encoding URI Path Parts.
-object = ''
+object = '{MY-OBJECT}'
 
 object_access_control_object = Google::Apis::StorageV1::ObjectAccessControl.new
 
@@ -680,11 +680,11 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_object_access_controls' method:
 
 # * Name of a bucket.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 # * Name of the object. For information about how to URL encode object names to be path safe, see
 #   Encoding URI Path Parts.
-object = ''
+object = '{MY-OBJECT}'
 
 # Perform the call
 response = service.list_object_access_controls(bucket, object)
@@ -710,15 +710,15 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'patch_object_access_control' method:
 
 # * Name of a bucket.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 # * Name of the object. For information about how to URL encode object names to be path safe, see
 #   Encoding URI Path Parts.
-object = ''
+object = '{MY-OBJECT}'
 
 # * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
 #   group-emailAddress, allUsers, or allAuthenticatedUsers.
-entity = ''
+entity = '{MY-ENTITY}'
 
 object_access_control_object = Google::Apis::StorageV1::ObjectAccessControl.new
 
@@ -747,15 +747,15 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'update_object_access_control' method:
 
 # * Name of a bucket.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 # * Name of the object. For information about how to URL encode object names to be path safe, see
 #   Encoding URI Path Parts.
-object = ''
+object = '{MY-OBJECT}'
 
 # * The entity holding the permission. Can be user-userId, user-emailAddress, group-groupId,
 #   group-emailAddress, allUsers, or allAuthenticatedUsers.
-entity = ''
+entity = '{MY-ENTITY}'
 
 object_access_control_object = Google::Apis::StorageV1::ObjectAccessControl.new
 
@@ -784,11 +784,11 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'compose_object' method:
 
 # * Name of the bucket in which to store the new object.
-destination_bucket = ''
+destination_bucket = '{MY-DESTINATION-BUCKET}'
 
 # * Name of the new object. For information about how to URL encode object names to be path safe, see
 #   Encoding URI Path Parts.
-destination_object = ''
+destination_object = '{MY-DESTINATION-OBJECT}'
 
 compose_request_object = Google::Apis::StorageV1::ComposeRequest.new
 
@@ -817,20 +817,20 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'copy_object' method:
 
 # * Name of the bucket in which to find the source object.
-source_bucket = ''
+source_bucket = '{MY-SOURCE-BUCKET}'
 
 # * Name of the source object. For information about how to URL encode object names to be path safe,
 #   see Encoding URI Path Parts.
-source_object = ''
+source_object = '{MY-SOURCE-OBJECT}'
 
 # * Name of the bucket in which to store the new object. Overrides the provided object metadata's
 #   bucket value, if any.For information about how to URL encode object names to be path safe, see
 #   Encoding URI Path Parts.
-destination_bucket = ''
+destination_bucket = '{MY-DESTINATION-BUCKET}'
 
 # * Name of the new object. Required when the object metadata is not otherwise provided. Overrides the
 #   object metadata's name value, if any.
-destination_object = ''
+destination_object = '{MY-DESTINATION-OBJECT}'
 
 object_object = Google::Apis::StorageV1::Object.new
 
@@ -859,11 +859,11 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_object' method:
 
 # * Name of the bucket in which the object resides.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 # * Name of the object. For information about how to URL encode object names to be path safe, see
 #   Encoding URI Path Parts.
-object = ''
+object = '{MY-OBJECT}'
 
 # Perform the call
 service.delete_object(bucket, object)
@@ -889,11 +889,11 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_object' method:
 
 # * Name of the bucket in which the object resides.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 # * Name of the object. For information about how to URL encode object names to be path safe, see
 #   Encoding URI Path Parts.
-object = ''
+object = '{MY-OBJECT}'
 
 # Perform the call
 response = service.get_object(bucket, object)
@@ -920,7 +920,7 @@ service.authorization = \
 
 # * Name of the bucket in which to store the new object. Overrides the provided object metadata's
 #   bucket value, if any.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 object_object = Google::Apis::StorageV1::Object.new
 
@@ -949,7 +949,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_objects' method:
 
 # * Name of the bucket in which to look for objects.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 # Perform the call
 result_list = service.fetch_all(items: :items) { |token|
@@ -980,11 +980,11 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'patch_object' method:
 
 # * Name of the bucket in which the object resides.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 # * Name of the object. For information about how to URL encode object names to be path safe, see
 #   Encoding URI Path Parts.
-object = ''
+object = '{MY-OBJECT}'
 
 object_object = Google::Apis::StorageV1::Object.new
 
@@ -1013,20 +1013,20 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'rewrite_object' method:
 
 # * Name of the bucket in which to find the source object.
-source_bucket = ''
+source_bucket = '{MY-SOURCE-BUCKET}'
 
 # * Name of the source object. For information about how to URL encode object names to be path safe,
 #   see Encoding URI Path Parts.
-source_object = ''
+source_object = '{MY-SOURCE-OBJECT}'
 
 # * Name of the bucket in which to store the new object. Overrides the provided object metadata's
 #   bucket value, if any.
-destination_bucket = ''
+destination_bucket = '{MY-DESTINATION-BUCKET}'
 
 # * Name of the new object. Required when the object metadata is not otherwise provided. Overrides the
 #   object metadata's name value, if any. For information about how to URL encode object names to be
 #   path safe, see Encoding URI Path Parts.
-destination_object = ''
+destination_object = '{MY-DESTINATION-OBJECT}'
 
 object_object = Google::Apis::StorageV1::Object.new
 
@@ -1055,11 +1055,11 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'update_object' method:
 
 # * Name of the bucket in which the object resides.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 # * Name of the object. For information about how to URL encode object names to be path safe, see
 #   Encoding URI Path Parts.
-object = ''
+object = '{MY-OBJECT}'
 
 object_object = Google::Apis::StorageV1::Object.new
 
@@ -1088,7 +1088,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'watch_all_objects' method:
 
 # * Name of the bucket in which to look for objects.
-bucket = ''
+bucket = '{MY-BUCKET}'
 
 channel_object = Google::Apis::StorageV1::Channel.new
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_storagetransfer.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_storagetransfer.v1.json.baseline
@@ -45,7 +45,7 @@ service.authorization = \
 
 # * The ID of the Google Developers Console project that the Google service account is associated
 #   with. Required.
-project_id = ''
+project_id = '{MY-PROJECT-ID}'
 
 # Perform the call
 response = service.get_google_service_account(project_id)
@@ -97,7 +97,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_transfer_job' method:
 
 # * The job to get. Required.
-job_name = ''
+job_name = '{MY-JOB-NAME}'
 
 # Perform the call
 response = service.get_transfer_job(job_name)
@@ -151,7 +151,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'patch_transfer_job' method:
 
 # * The name of job to update. Required.
-job_name = ''
+job_name = '{MY-JOB-NAME}'
 
 update_transfer_job_request_object = Google::Apis::StoragetransferV1::UpdateTransferJobRequest.new
 
@@ -180,7 +180,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'cancel_transfer_operation' method:
 
 # * The name of the operation resource to be cancelled.
-name = ''
+name = '{MY-NAME}'
 
 # Perform the call
 service.cancel_transfer_operation(name)
@@ -206,7 +206,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_transfer_operation' method:
 
 # * The name of the operation resource to be deleted.
-name = ''
+name = '{MY-NAME}'
 
 # Perform the call
 service.delete_transfer_operation(name)
@@ -232,7 +232,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_transfer_operation' method:
 
 # * The name of the operation resource.
-name = ''
+name = '{MY-NAME}'
 
 # Perform the call
 response = service.get_transfer_operation(name)
@@ -258,7 +258,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_transfer_operations' method:
 
 # * The value `transferOperations`.
-name = ''
+name = '{MY-NAME}'
 
 # Perform the call
 result_list = service.fetch_all(items: :operations) { |token|
@@ -289,7 +289,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'pause_transfer_operation' method:
 
 # * The name of the transfer operation. Required.
-name = ''
+name = '{MY-NAME}'
 
 pause_transfer_operation_request_object = Google::Apis::StoragetransferV1::PauseTransferOperationRequest.new
 
@@ -318,7 +318,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'resume_transfer_operation' method:
 
 # * The name of the transfer operation. Required.
-name = ''
+name = '{MY-NAME}'
 
 resume_transfer_operation_request_object = Google::Apis::StoragetransferV1::ResumeTransferOperationRequest.new
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_taskqueue.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_taskqueue.v1beta2.json.baseline
@@ -213,10 +213,10 @@ service.authorization = \
 project = ''
 
 
-taskqueue = ''
+taskqueue = '{MY-TASKQUEUE}'
 
 
-task = ''
+task = '{MY-TASK}'
 
 # * The new lease in seconds.
 new_lease_seconds = 0
@@ -251,10 +251,10 @@ service.authorization = \
 project = ''
 
 
-taskqueue = ''
+taskqueue = '{MY-TASKQUEUE}'
 
 
-task = ''
+task = '{MY-TASK}'
 
 # * The new lease in seconds.
 new_lease_seconds = 0

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_taskqueue.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_taskqueue.v1beta2.json.baseline
@@ -21,10 +21,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_taskqueue' method:
 
 # * The project under which the queue lies.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The id of the taskqueue to get the properties of.
-taskqueue = ''
+taskqueue = '{MY-TASKQUEUE}'
 
 # Perform the call
 response = service.get_taskqueue(project, taskqueue)
@@ -50,13 +50,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'delete_task' method:
 
 # * The project under which the queue lies.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The taskqueue to delete a task from.
-taskqueue = ''
+taskqueue = '{MY-TASKQUEUE}'
 
 # * The id of the task to delete.
-task = ''
+task = '{MY-TASK}'
 
 # Perform the call
 service.delete_task(project, taskqueue, task)
@@ -82,13 +82,13 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'get_task' method:
 
 # * The project under which the queue lies.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The taskqueue in which the task belongs.
-taskqueue = ''
+taskqueue = '{MY-TASKQUEUE}'
 
 # * The task to get properties of.
-task = ''
+task = '{MY-TASK}'
 
 # Perform the call
 response = service.get_task(project, taskqueue, task)
@@ -114,10 +114,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'insert_task' method:
 
 # * The project under which the queue lies
-project = ''
+project = '{MY-PROJECT}'
 
 # * The taskqueue to insert the task into
-taskqueue = ''
+taskqueue = '{MY-TASKQUEUE}'
 
 task_object = Google::Apis::TaskqueueV1beta2::Task.new
 
@@ -146,10 +146,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'lease_task' method:
 
 # * The project under which the queue lies.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The taskqueue to lease a task from.
-taskqueue = ''
+taskqueue = '{MY-TASKQUEUE}'
 
 # * The number of tasks to lease.
 num_tasks = 0
@@ -181,10 +181,10 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'list_tasks' method:
 
 # * The project under which the queue lies.
-project = ''
+project = '{MY-PROJECT}'
 
 # * The id of the taskqueue to list tasks from.
-taskqueue = ''
+taskqueue = '{MY-TASKQUEUE}'
 
 # Perform the call
 response = service.list_tasks(project, taskqueue)
@@ -210,7 +210,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'patch_task' method:
 
 # * The project under which the queue lies.
-project = ''
+project = '{MY-PROJECT}'
 
 
 taskqueue = '{MY-TASKQUEUE}'
@@ -248,7 +248,7 @@ service.authorization = \
 # TODO: Change placeholders below to appropriate parameter values for the 'update_task' method:
 
 # * The project under which the queue lies.
-project = ''
+project = '{MY-PROJECT}'
 
 
 taskqueue = '{MY-TASKQUEUE}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_translate.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_translate.v2.json.baseline
@@ -73,7 +73,7 @@ service.authorization = \
 q = []
 
 # * The target language into which the text should be translated
-target = ''
+target = '{MY-TARGET}'
 
 # Perform the call
 response = service.list_translations(q, target)


### PR DESCRIPTION
Previously, most strings are blank.
The only non-blank ones were in the slash-separated-resources format:
  projects/{MY-PROJECT}/topics/{MY-TOPICS}

This commit gives more informative default values.
* Some API-field-pattern tuples are special-cased.
  Eg, default string for zones is "us-central1-f"
* If not special-cased, slash-separated format still works
* Otherwise, we generate dummy strings
  Eg, default string for project name is "{MY-PROJECT-NAME}"