### PR TITLE
Updates to sample initialization

### DIFF
--- a/src/main/java/com/google/api/codegen/java/JavaGapicContext.java
+++ b/src/main/java/com/google/api/codegen/java/JavaGapicContext.java
@@ -332,4 +332,34 @@ public class JavaGapicContext extends GapicContext implements JavaContext {
   public JavaDocConfig.Builder newJavaDocConfigBuilder() {
     return JavaDocConfig.newBuilder();
   }
+
+  /**
+   * Get a Java formatted primitive value, given a primitive type and a string representation of
+   * that value. The value must be a valid example of that type. Values of type String and Bytes
+   * must contain quote characters. Values of type Bool must be either the string 'true' or 'false'
+   * (other capitalizations are permitted).
+   */
+  public String renderPrimitiveValue(TypeRef type, String value) {
+    Type primitiveType = type.getKind();
+    if (!PRIMITIVE_TYPE_MAP.containsKey(primitiveType)) {
+      throw new IllegalArgumentException(
+          "Initial values are only supported for primitive types, got type "
+              + type
+              + ", with value "
+              + value);
+    }
+    switch (primitiveType) {
+      case TYPE_BOOL:
+        return value.toLowerCase();
+      case TYPE_FLOAT:
+        return value + "F";
+      case TYPE_INT64:
+      case TYPE_UINT64:
+        return value + "L";
+      case TYPE_BYTES:
+        return "ByteString.copyFromUtf8(" + value + ")";
+      default:
+        return value;
+    }
+  }
 }

--- a/src/main/java/com/google/api/codegen/java/JavaGapicContext.java
+++ b/src/main/java/com/google/api/codegen/java/JavaGapicContext.java
@@ -335,9 +335,8 @@ public class JavaGapicContext extends GapicContext implements JavaContext {
 
   /**
    * Get a Java formatted primitive value, given a primitive type and a string representation of
-   * that value. The value must be a valid example of that type. Values of type String and Bytes
-   * must contain quote characters. Values of type Bool must be either the string 'true' or 'false'
-   * (other capitalizations are permitted).
+   * that value. The value must be a valid example of that type. Values of type Bool must be either
+   * the string 'true' or 'false' (other capitalizations are permitted).
    */
   public String renderPrimitiveValue(TypeRef type, String value) {
     Type primitiveType = type.getKind();
@@ -356,9 +355,12 @@ public class JavaGapicContext extends GapicContext implements JavaContext {
       case TYPE_INT64:
       case TYPE_UINT64:
         return value + "L";
+      case TYPE_STRING:
+        return "\"" + value + "\"";
       case TYPE_BYTES:
-        return "ByteString.copyFromUtf8(" + value + ")";
+        return "ByteString.copyFromUtf8(\"" + value + "\")";
       default:
+        // Types that do not need to be modified (e.g. TYPE_INT32) are handled here
         return value;
     }
   }

--- a/src/main/java/com/google/api/codegen/metacode/FieldSpec.java
+++ b/src/main/java/com/google/api/codegen/metacode/FieldSpec.java
@@ -1,0 +1,73 @@
+/* Copyright 2016 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.metacode;
+
+import com.google.auto.value.AutoValue;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@AutoValue
+public abstract class FieldSpec implements Spec {
+
+  public static FieldSpec create(String name, Object subStructure) {
+    return new AutoValue_FieldSpec(name, subStructure);
+  }
+
+  public abstract String getName();
+
+  public abstract Object getSubStructure();
+
+  @Override
+  public Object merge(Object mergedStructure) {
+    if (mergedStructure instanceof InitValueConfig) {
+      InitValueConfig metadata = (InitValueConfig) mergedStructure;
+      if (!metadata.isEmpty()) {
+        throw new IllegalArgumentException(
+            "Inconsistent: found both substructure and initialization metadata");
+      }
+      // we encountered a partially-specified structure, so replace it with a
+      // map
+      mergedStructure = new HashMap<>();
+    } else if (!(mergedStructure instanceof Map)) {
+      String mergedTypeName = mergedStructure.getClass().getName();
+      if (mergedStructure instanceof List) {
+        mergedTypeName = "list";
+      }
+      throw new IllegalArgumentException(
+          "Inconsistent structure: " + mergedTypeName + " encountered first, then field");
+    }
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> mergedMap = (Map<String, Object>) mergedStructure;
+
+    if (mergedMap.containsKey(getName())) {
+      Object mergedSubStructure = mergedMap.get(getName());
+      Object newSubStructure = FieldStructureParser.merge(mergedSubStructure, getSubStructure());
+      mergedMap.put(getName(), newSubStructure);
+    } else {
+      mergedMap.put(getName(), FieldStructureParser.populate(getSubStructure()));
+    }
+    return mergedStructure;
+  }
+
+  @Override
+  public Object populate() {
+    Map<String, Object> mergedMap = new HashMap<>();
+    mergedMap.put(getName(), FieldStructureParser.populate(getSubStructure()));
+    return mergedMap;
+  }
+}

--- a/src/main/java/com/google/api/codegen/metacode/FieldSpec.java
+++ b/src/main/java/com/google/api/codegen/metacode/FieldSpec.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 @AutoValue
-public abstract class FieldSpec implements Spec {
+public abstract class FieldSpec implements PathSpec {
 
   public static FieldSpec create(String name, Object subStructure) {
     return new AutoValue_FieldSpec(name, subStructure);

--- a/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
+++ b/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
@@ -32,7 +32,7 @@ import java.util.regex.Pattern;
  */
 public class FieldStructureParser {
 
-  private static Pattern fieldStructurePattern = Pattern.compile("(.+)[.]([^.]+)");
+  private static Pattern fieldStructurePattern = Pattern.compile("(.+)[.]([^.\\{\\[]+)");
   private static Pattern fieldListPattern = Pattern.compile("(.+)\\[([^\\]]+)\\]");
   private static Pattern fieldMapPattern = Pattern.compile("(.+)\\{([^\\}]+)\\}");
 
@@ -90,15 +90,15 @@ public class FieldStructureParser {
         Matcher mapMatcher = fieldMapPattern.matcher(toMatch);
         if (structureMatcher.matches()) {
           String key = structureMatcher.group(2);
-          topLevel = new AutoValue_FieldStructureParser_FieldSpec(key, topLevel);
+          topLevel = FieldSpec.create(key, topLevel);
           toMatch = structureMatcher.group(1);
         } else if (listMatcher.matches()) {
           String index = listMatcher.group(2);
-          topLevel = new AutoValue_FieldStructureParser_ListElementSpec(index, topLevel);
+          topLevel = ListElementSpec.create(index, topLevel);
           toMatch = listMatcher.group(1);
         } else if (mapMatcher.matches()) {
           String key = mapMatcher.group(2);
-          topLevel = new AutoValue_FieldStructureParser_MapElementSpec(key, topLevel);
+          topLevel = MapElementSpec.create(key, topLevel);
           toMatch = mapMatcher.group(1);
         } else {
           // No pattern match implies toMatch contains simple field (with no "." separators)
@@ -162,6 +162,10 @@ public class FieldStructureParser {
   @AutoValue
   abstract static class FieldSpec implements Spec {
 
+    public static FieldSpec create(String name, Object subStructure) {
+      return new AutoValue_FieldStructureParser_FieldSpec(name, subStructure);
+    }
+
     public abstract String getName();
 
     public abstract Object getSubStructure();
@@ -209,6 +213,11 @@ public class FieldStructureParser {
 
   @AutoValue
   abstract static class ListElementSpec implements Spec {
+
+    public static ListElementSpec create(String index, Object subStructure) {
+      return new AutoValue_FieldStructureParser_ListElementSpec(index, subStructure);
+    }
+
     public abstract String getIndex();
 
     public abstract Object getSubStructure();
@@ -267,6 +276,10 @@ public class FieldStructureParser {
 
   @AutoValue
   abstract static class MapElementSpec implements Spec {
+
+    public static MapElementSpec create(String key, Object subStructure) {
+      return new AutoValue_FieldStructureParser_MapElementSpec(key, subStructure);
+    }
 
     public abstract String getKey();
 

--- a/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
+++ b/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
@@ -119,8 +119,8 @@ public class FieldStructureParser {
   }
 
   public static Object merge(Object mergedStructure, Object unmergedStructure) {
-    if (unmergedStructure instanceof Spec) {
-      return ((Spec) unmergedStructure).merge(mergedStructure);
+    if (unmergedStructure instanceof PathSpec) {
+      return ((PathSpec) unmergedStructure).merge(mergedStructure);
     } else if (unmergedStructure instanceof InitValueConfig) {
       // Only valid to merge an InitValueConfig if the existing merged structure is
       // an empty InitValueConfig
@@ -145,8 +145,8 @@ public class FieldStructureParser {
   }
 
   public static Object populate(Object unmergedStructure) {
-    if (unmergedStructure instanceof Spec) {
-      return ((Spec) unmergedStructure).populate();
+    if (unmergedStructure instanceof PathSpec) {
+      return ((PathSpec) unmergedStructure).populate();
     } else {
       return unmergedStructure;
     }

--- a/src/main/java/com/google/api/codegen/metacode/InitCodeGenerator.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitCodeGenerator.java
@@ -146,6 +146,7 @@ public class InitCodeGenerator {
   private InitCodeLine generateSampleCodeInitMap(
       String suggestedName, TypeRef typeRef, Map<String, Object> thisFieldInitMap) {
     TypeRef keyTypeRef = typeRef.getMapKeyField().getType();
+    TypeRef elementType = typeRef.getMapValueField().getType();
     Map<String, String> elementIdentifierMap = new HashMap<String, String>();
     for (String keyString : thisFieldInitMap.keySet()) {
       String validatedKeyString = validateValue(keyTypeRef, keyString);
@@ -163,7 +164,6 @@ public class InitCodeGenerator {
 
       Object elementInitStructure = thisFieldInitMap.get(keyString);
       String suggestedElementName = suggestedName + "_item";
-      TypeRef elementType = typeRef.getMapValueField().getType();
       InitCodeLine subFieldInit =
           generateSampleCodeInit(suggestedElementName, elementType, elementInitStructure);
       initLineSpecs.add(subFieldInit);
@@ -174,7 +174,8 @@ public class InitCodeGenerator {
     // get a new symbol for this object after elements, in order to preserve
     // numerical ordering in the case of conflicts
     String identifier = getNewSymbol(suggestedName);
-    return MapInitCodeLine.create(keyTypeRef, typeRef, identifier, elementIdentifierMap);
+    return MapInitCodeLine.create(
+        keyTypeRef, elementType, typeRef, identifier, elementIdentifierMap);
   }
 
   private InitCodeLine generateSampleCodeInit(

--- a/src/main/java/com/google/api/codegen/metacode/InitCodeLineType.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitCodeLineType.java
@@ -20,5 +20,6 @@ package com.google.api.codegen.metacode;
 public enum InitCodeLineType {
   StructureInitLine,
   ListInitLine,
-  SimpleInitLine
+  SimpleInitLine,
+  MapInitLine
 }

--- a/src/main/java/com/google/api/codegen/metacode/InitValueConfig.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitValueConfig.java
@@ -25,11 +25,15 @@ import javax.annotation.Nullable;
 @AutoValue
 public abstract class InitValueConfig {
   public static InitValueConfig create() {
-    return new AutoValue_InitValueConfig(null, null);
+    return new AutoValue_InitValueConfig(null, null, null);
+  }
+
+  public static InitValueConfig createWithValue(String value) {
+    return new AutoValue_InitValueConfig(null, null, value);
   }
 
   public static InitValueConfig create(String apiWrapperName, CollectionConfig collectionConfig) {
-    return new AutoValue_InitValueConfig(apiWrapperName, collectionConfig);
+    return new AutoValue_InitValueConfig(apiWrapperName, collectionConfig, null);
   }
 
   @Nullable
@@ -38,11 +42,18 @@ public abstract class InitValueConfig {
   @Nullable
   public abstract CollectionConfig getCollectionConfig();
 
+  @Nullable
+  public abstract String getInitialValue();
+
   public boolean isEmpty() {
     return getCollectionConfig() == null;
   }
 
   public boolean hasFormattingConfig() {
     return getCollectionConfig() != null;
+  }
+
+  public boolean hasInitialValue() {
+    return getInitialValue() != null;
   }
 }

--- a/src/main/java/com/google/api/codegen/metacode/InitValueConfig.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitValueConfig.java
@@ -24,6 +24,7 @@ import javax.annotation.Nullable;
  */
 @AutoValue
 public abstract class InitValueConfig {
+
   public static InitValueConfig create() {
     return new AutoValue_InitValueConfig(null, null, null);
   }
@@ -44,6 +45,13 @@ public abstract class InitValueConfig {
 
   @Nullable
   public abstract String getInitialValue();
+
+  /**
+   * Creates an updated InitValueConfig with the provided value.
+   */
+  public InitValueConfig withInitialValue(String string) {
+    return new AutoValue_InitValueConfig(getApiWrapperName(), getCollectionConfig(), string);
+  }
 
   public boolean isEmpty() {
     return getCollectionConfig() == null;

--- a/src/main/java/com/google/api/codegen/metacode/ListElementSpec.java
+++ b/src/main/java/com/google/api/codegen/metacode/ListElementSpec.java
@@ -1,0 +1,81 @@
+/* Copyright 2016 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.metacode;
+
+import com.google.auto.value.AutoValue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+@AutoValue
+public abstract class ListElementSpec implements Spec {
+
+  public static ListElementSpec create(String index, Object subStructure) {
+    return new AutoValue_ListElementSpec(index, subStructure);
+  }
+
+  public abstract String getIndex();
+
+  public abstract Object getSubStructure();
+
+  @Override
+  public Object merge(Object mergedStructure) {
+    if (mergedStructure instanceof InitValueConfig) {
+      InitValueConfig metadata = (InitValueConfig) mergedStructure;
+      if (!metadata.isEmpty()) {
+        throw new IllegalArgumentException(
+            "Inconsistent: found both substructure and initialization metadata");
+      }
+      // we encountered a partially-specified structure, so replace it with a
+      // list
+      mergedStructure = new ArrayList<>();
+    } else if (!(mergedStructure instanceof List)) {
+      String mergedTypeName = mergedStructure.getClass().getName();
+      if (mergedStructure instanceof Map) {
+        mergedTypeName = "field";
+      }
+      throw new IllegalArgumentException(
+          "Inconsistent structure: " + mergedTypeName + " encountered first, then list");
+    }
+
+    @SuppressWarnings("unchecked")
+    List<Object> mergedList = (List<Object>) mergedStructure;
+
+    int index = Integer.valueOf(getIndex());
+    if (index < mergedList.size()) {
+      Object mergedSubStructure = mergedList.get(index);
+      Object newSubStructure = FieldStructureParser.merge(mergedSubStructure, getSubStructure());
+      mergedList.set(index, newSubStructure);
+    } else if (index == mergedList.size()) {
+      mergedList.add(FieldStructureParser.populate(getSubStructure()));
+    } else {
+      throw new IllegalArgumentException(
+          "Index leaves gap: last index = " + (mergedList.size() - 1) + ", this index = " + index);
+    }
+    return mergedStructure;
+  }
+
+  @Override
+  public Object populate() {
+    int index = Integer.valueOf(getIndex());
+    if (index != 0) {
+      throw new IllegalArgumentException("First element in list must have index 0");
+    }
+    List<Object> list = new ArrayList<>();
+    list.add(FieldStructureParser.populate(getSubStructure()));
+    return list;
+  }
+}

--- a/src/main/java/com/google/api/codegen/metacode/ListElementSpec.java
+++ b/src/main/java/com/google/api/codegen/metacode/ListElementSpec.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 @AutoValue
-public abstract class ListElementSpec implements Spec {
+public abstract class ListElementSpec implements PathSpec {
 
   public static ListElementSpec create(String index, Object subStructure) {
     return new AutoValue_ListElementSpec(index, subStructure);

--- a/src/main/java/com/google/api/codegen/metacode/MapElementSpec.java
+++ b/src/main/java/com/google/api/codegen/metacode/MapElementSpec.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 @AutoValue
-public abstract class MapElementSpec implements Spec {
+public abstract class MapElementSpec implements PathSpec {
 
   public static MapElementSpec create(String key, Object subStructure) {
     return new AutoValue_MapElementSpec(key, subStructure);

--- a/src/main/java/com/google/api/codegen/metacode/MapElementSpec.java
+++ b/src/main/java/com/google/api/codegen/metacode/MapElementSpec.java
@@ -1,0 +1,73 @@
+/* Copyright 2016 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.metacode;
+
+import com.google.auto.value.AutoValue;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@AutoValue
+public abstract class MapElementSpec implements Spec {
+
+  public static MapElementSpec create(String key, Object subStructure) {
+    return new AutoValue_MapElementSpec(key, subStructure);
+  }
+
+  public abstract String getKey();
+
+  public abstract Object getSubStructure();
+
+  @Override
+  public Object merge(Object mergedStructure) {
+    if (mergedStructure instanceof InitValueConfig) {
+      InitValueConfig metadata = (InitValueConfig) mergedStructure;
+      if (!metadata.isEmpty()) {
+        throw new IllegalArgumentException(
+            "Inconsistent: found both substructure and initialization metadata");
+      }
+      // we encountered a partially-specified structure, so replace it with a
+      // map
+      mergedStructure = new HashMap<>();
+    } else if (!(mergedStructure instanceof Map)) {
+      String mergedTypeName = mergedStructure.getClass().getName();
+      if (mergedStructure instanceof List) {
+        mergedTypeName = "list";
+      }
+      throw new IllegalArgumentException(
+          "Inconsistent structure: " + mergedTypeName + " encountered first, then map");
+    }
+
+    @SuppressWarnings("unchecked")
+    HashMap<String, Object> mergedMap = (HashMap<String, Object>) mergedStructure;
+
+    if (mergedMap.containsKey(getKey())) {
+      Object mergedSubStructure = mergedMap.get(getKey());
+      Object newSubStructure = FieldStructureParser.merge(mergedSubStructure, getSubStructure());
+      mergedMap.put(getKey(), newSubStructure);
+    } else {
+      mergedMap.put(getKey(), FieldStructureParser.populate(getSubStructure()));
+    }
+    return mergedStructure;
+  }
+
+  @Override
+  public Object populate() {
+    Map<String, Object> map = new HashMap<String, Object>();
+    map.put(getKey(), FieldStructureParser.populate(getSubStructure()));
+    return map;
+  }
+}

--- a/src/main/java/com/google/api/codegen/metacode/MapInitCodeLine.java
+++ b/src/main/java/com/google/api/codegen/metacode/MapInitCodeLine.java
@@ -28,13 +28,17 @@ public abstract class MapInitCodeLine implements InitCodeLine {
 
   public static MapInitCodeLine create(
       TypeRef keyType,
+      TypeRef valueType,
       TypeRef elementType,
       String identifier,
       Map<String, String> elementIdentifierMap) {
-    return new AutoValue_MapInitCodeLine(keyType, elementType, identifier, elementIdentifierMap);
+    return new AutoValue_MapInitCodeLine(
+        keyType, valueType, elementType, identifier, elementIdentifierMap);
   }
 
   public abstract TypeRef getKeyType();
+
+  public abstract TypeRef getValueType();
 
   public abstract TypeRef getElementType();
 

--- a/src/main/java/com/google/api/codegen/metacode/MapInitCodeLine.java
+++ b/src/main/java/com/google/api/codegen/metacode/MapInitCodeLine.java
@@ -1,0 +1,63 @@
+/* Copyright 2016 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.metacode;
+
+import com.google.api.tools.framework.model.TypeRef;
+import com.google.auto.value.AutoValue;
+
+import java.util.Map;
+
+/**
+ * MapInitCodeLine represents an InitCodeLine that initializes a map with the provided keys, and
+ * values from other variables.
+ */
+@AutoValue
+public abstract class MapInitCodeLine implements InitCodeLine {
+
+  public static MapInitCodeLine create(
+      TypeRef keyType,
+      TypeRef elementType,
+      String identifier,
+      Map<String, String> elementIdentifierMap) {
+    return new AutoValue_MapInitCodeLine(keyType, elementType, identifier, elementIdentifierMap);
+  }
+
+  public abstract TypeRef getKeyType();
+
+  public abstract TypeRef getElementType();
+
+  @Override
+  public abstract String getIdentifier();
+
+  public abstract Map<String, String> getElementIdentifierMap();
+
+  public Iterable<String> getElementIdentifierKeys() {
+    return getElementIdentifierMap().keySet();
+  }
+
+  public String getElementIdentifierValue(String key) {
+    return getElementIdentifierMap().get(key);
+  }
+
+  @Override
+  public InitCodeLineType getLineType() {
+    return InitCodeLineType.MapInitLine;
+  }
+
+  @Override
+  public InitValueConfig getInitValueConfig() {
+    return InitValueConfig.create();
+  }
+}

--- a/src/main/java/com/google/api/codegen/metacode/PathSpec.java
+++ b/src/main/java/com/google/api/codegen/metacode/PathSpec.java
@@ -14,7 +14,10 @@
  */
 package com.google.api.codegen.metacode;
 
-public interface Spec {
+/**
+ * Interface for components of a dotted path specification
+ */
+public interface PathSpec {
   Object merge(Object mergedStructure);
 
   Object populate();

--- a/src/main/java/com/google/api/codegen/metacode/Spec.java
+++ b/src/main/java/com/google/api/codegen/metacode/Spec.java
@@ -1,0 +1,21 @@
+/* Copyright 2016 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.metacode;
+
+public interface Spec {
+  Object merge(Object mergedStructure);
+
+  Object populate();
+}

--- a/src/main/java/com/google/api/codegen/php/PhpGapicContext.java
+++ b/src/main/java/com/google/api/codegen/php/PhpGapicContext.java
@@ -231,6 +231,32 @@ public class PhpGapicContext extends GapicContext implements PhpContext {
     return PhpDocConfig.newBuilder();
   }
 
+  /**
+   * Get a Php formatted primitive value, given a primitive type and a string representation of that
+   * value. The value must be a valid example of that type. Values of type Bool must be either the
+   * string 'true' or 'false' (other capitalizations are permitted).
+   */
+  public String renderPrimitiveValue(TypeRef type, String value) {
+    Type primitiveType = type.getKind();
+    if (!PRIMITIVE_TYPE_MAP.containsKey(primitiveType)) {
+      throw new IllegalArgumentException(
+          "Initial values are only supported for primitive types, got type "
+              + type
+              + ", with value "
+              + value);
+    }
+    switch (primitiveType) {
+      case TYPE_BOOL:
+        return value.toLowerCase();
+      case TYPE_STRING:
+      case TYPE_BYTES:
+        return "\"" + value + "\"";
+      default:
+        // Types that do not need to be modified (e.g. TYPE_INT32) are handled here
+        return value;
+    }
+  }
+
   // Constants
   // =========
 

--- a/src/main/java/com/google/api/codegen/php/PhpGapicContext.java
+++ b/src/main/java/com/google/api/codegen/php/PhpGapicContext.java
@@ -16,6 +16,9 @@ package com.google.api.codegen.php;
 
 import com.google.api.codegen.ApiConfig;
 import com.google.api.codegen.GapicContext;
+import com.google.api.codegen.metacode.FieldSetting;
+import com.google.api.codegen.metacode.InitCode;
+import com.google.api.codegen.metacode.InitCodeLine;
 import com.google.api.tools.framework.model.Interface;
 import com.google.api.tools.framework.model.Method;
 import com.google.api.tools.framework.model.Model;
@@ -255,6 +258,20 @@ public class PhpGapicContext extends GapicContext implements PhpContext {
         // Types that do not need to be modified (e.g. TYPE_INT32) are handled here
         return value;
     }
+  }
+
+  /**
+   * Determine whether a given InitCodeLine is a method parameter. This is important for map fields
+   * because flattened map parameters accept an associative array, while map fields on a request
+   * object must be a sequential array of MapEntry objects.
+   */
+  public boolean initLineIsParameter(InitCode initCode, InitCodeLine initCodeLine) {
+    for (FieldSetting fieldSetting : initCode.getArgFields()) {
+      if (initCodeLine.getIdentifier().equals(fieldSetting.getIdentifier())) {
+        return true;
+      }
+    }
+    return false;
   }
 
   // Constants

--- a/src/main/java/com/google/api/codegen/py/PythonGapicContext.java
+++ b/src/main/java/com/google/api/codegen/py/PythonGapicContext.java
@@ -368,4 +368,31 @@ public class PythonGapicContext extends GapicContext {
   private String getSphinxifiedScopedDescription(ProtoElement element) {
     return PythonSphinxCommentFixer.sphinxify(DocumentationUtil.getScopedDescription(element));
   }
+
+  /**
+   * Get a Python formatted primitive value, given a primitive type and a string representation of
+   * that value. The value must be a valid example of that type. Values of type Bool must be either
+   * the string 'true' or 'false' (other capitalizations are permitted).
+   */
+  public String renderPrimitiveValue(TypeRef type, String value) {
+    Type primitiveType = type.getKind();
+    if (!PRIMITIVE_TYPE_NAMES.containsKey(primitiveType)) {
+      throw new IllegalArgumentException(
+          "Initial values are only supported for primitive types, got type "
+              + type
+              + ", with value "
+              + value);
+    }
+    switch (primitiveType) {
+      case TYPE_BOOL:
+        // Capitalize first letter
+        return lowerCamelToUpperCamel(value.toLowerCase());
+      case TYPE_STRING:
+      case TYPE_BYTES:
+        return "'" + value + "'";
+      default:
+        // Types that do not need to be modified (e.g. TYPE_INT32) are handled here
+        return value;
+    }
+  }
 }

--- a/src/main/resources/com/google/api/codegen/java/method_sample.snip
+++ b/src/main/resources/com/google/api/codegen/java/method_sample.snip
@@ -60,6 +60,8 @@
       {@initLineStructure(line)}
     @case "ListInitLine"
       {@initLineList(line)}
+    @case "MapInitLine"
+      {@initLineMap(line)}
     @case "SimpleInitLine"
       {@initLineSimple(line)}
     @default
@@ -82,6 +84,16 @@
 # Generate a List argument
 @private initLineList(line)
   List<{@context.basicTypeNameBoxed(line.getElementType)}> {@formattedIdentifier(line)} = Arrays.asList({@initList(line)});
+@end
+
+# Generate a Map argument
+@private initLineMap(line)
+  Map<{@context.basicTypeNameBoxed(line.getKeyType)}, {@context.basicTypeNameBoxed(line.getElementType)}> {@formattedIdentifier(line)} = new HashMap<>();
+  @join key : line.getElementIdentifierKeys vertical
+    @let identifierValue = line.getElementIdentifierValue(key)
+      {@formattedIdentifier(line)}.put({@key}, {@context.lowerUnderscoreToLowerCamel(identifierValue)});
+    @end
+  @end
 @end
 
 # Helper method for initLineList()
@@ -111,7 +123,11 @@
     @if metadata.hasFormattingConfig()
       {@metadata.getApiWrapperName}.{@formatResourceFunctionName(metadata.getCollectionConfig)}({@formatResourceFunctionArgs(metadata.getCollectionConfig)})
     @else
-      {@context.zeroValue(line.getType)}
+      @if metadata.hasInitialValue()
+        {@context.renderPrimitiveValue(line.getType, metadata.getInitialValue)}
+      @else
+        {@context.zeroValue(line.getType)}
+      @end
     @end
   @end
 @end

--- a/src/main/resources/com/google/api/codegen/java/method_sample.snip
+++ b/src/main/resources/com/google/api/codegen/java/method_sample.snip
@@ -88,7 +88,7 @@
 
 # Generate a Map argument
 @private initLineMap(line)
-  Map<{@context.basicTypeNameBoxed(line.getKeyType)}, {@context.basicTypeNameBoxed(line.getElementType)}> {@formattedIdentifier(line)} = new HashMap<>();
+  Map<{@context.basicTypeNameBoxed(line.getKeyType)}, {@context.basicTypeNameBoxed(line.getValueType)}> {@formattedIdentifier(line)} = new HashMap<>();
   @join key : line.getElementIdentifierKeys vertical
     @let identifierValue = line.getElementIdentifierValue(key)
       {@formattedIdentifier(line)}.put({@context.renderPrimitiveValue(line.getKeyType, key)}, {@context.lowerUnderscoreToLowerCamel(identifierValue)});

--- a/src/main/resources/com/google/api/codegen/java/method_sample.snip
+++ b/src/main/resources/com/google/api/codegen/java/method_sample.snip
@@ -91,7 +91,7 @@
   Map<{@context.basicTypeNameBoxed(line.getKeyType)}, {@context.basicTypeNameBoxed(line.getElementType)}> {@formattedIdentifier(line)} = new HashMap<>();
   @join key : line.getElementIdentifierKeys vertical
     @let identifierValue = line.getElementIdentifierValue(key)
-      {@formattedIdentifier(line)}.put({@key}, {@context.lowerUnderscoreToLowerCamel(identifierValue)});
+      {@formattedIdentifier(line)}.put({@context.renderPrimitiveValue(line.getKeyType, key)}, {@context.lowerUnderscoreToLowerCamel(identifierValue)});
     @end
   @end
 @end

--- a/src/main/resources/com/google/api/codegen/php/main.snip
+++ b/src/main/resources/com/google/api/codegen/php/main.snip
@@ -408,8 +408,12 @@
     @let paramUpperCamel = context.lowerUnderscoreToUpperCamel(field.getSimpleName), \
          paramLowerCamel = context.lowerUnderscoreToLowerCamel(field.getSimpleName)
         @if field.getType.isMap
-            // TODO make this work
-            putAll...
+            @let fullyQualifiedEntryName = context.fullyQualifiedName(field.getType), \
+                  entryName = context.getTypeName(fullyQualifiedEntryName)
+                foreach (${@paramLowerCamel} as $key => $value) {
+                    $request->add{@paramUpperCamel}((new {@entryName}())->setKey($key)->setValue($value));
+                }
+            @end
         @else
             @if field.isRepeated
                 foreach (${@paramLowerCamel} as $elem) {

--- a/src/main/resources/com/google/api/codegen/php/method_sample.snip
+++ b/src/main/resources/com/google/api/codegen/php/method_sample.snip
@@ -39,6 +39,8 @@
       {@initLineList(line)}
     @case "SimpleInitLine"
       {@initLineSimple(line)}
+    @case "MapInitLine"
+      {@initLineMap(line)}
     @default
       {@unhandledCase()}
     @end
@@ -58,9 +60,21 @@
   {@formattedIdentifier(line)} = [{@initList(line)}];
 @end
 
+@private initLineMap(line)
+  {@formattedIdentifier(line)} = [{@initMap(line)}];
+@end
+
 @private initList(line)
   @join identifier : line.getElementIdentifiers on ", "
     {@unformattedIdentifier(identifier)}
+  @end
+@end
+
+@private initMap(line)
+  @join key : line.getElementIdentifierKeys vertical
+    @let identifierValue = line.getElementIdentifierValue(key)
+      {@context.renderPrimitiveValue(line.getKeyType, key)}, {@identifierValue},
+    @end
   @end
 @end
 

--- a/src/main/resources/com/google/api/codegen/php/method_sample.snip
+++ b/src/main/resources/com/google/api/codegen/php/method_sample.snip
@@ -40,7 +40,7 @@
     @case "SimpleInitLine"
       {@initLineSimple(line)}
     @case "MapInitLine"
-      {@initLineMap(line)}
+      {@initLineMap(initCodeSpec, line)}
     @default
       {@unhandledCase()}
     @end
@@ -60,26 +60,46 @@
   {@formattedIdentifier(line)} = [{@initList(line)}];
 @end
 
-@private initLineMap(line)
-  {@formattedIdentifier(line)} = [{@initMap(line)}];
-@end
-
 @private initList(line)
   @join identifier : line.getElementIdentifiers on ", "
     {@unformattedIdentifier(identifier)}
   @end
 @end
 
+@private initLineMap(initCodeSpec, line)
+  @if context.initLineIsParameter(initCodeSpec, line)
+    {@formattedIdentifier(line)} = [{@initMap(line)}];
+  @else
+    {@formattedIdentifier(line)} = [];
+    @join key : line.getElementIdentifierKeys vertical
+      @let identifierValue = line.getElementIdentifierValue(key),\
+          entryIdentifier = getEntryIdentifier(line), \
+          fullyQualifiedEntryName = context.fullyQualifiedName(line.getElementType), \
+          entryName = context.getTypeName(fullyQualifiedEntryName)
+        {@entryIdentifier} = new {@entryName}();
+        {@entryIdentifier}->setKey({@context.renderPrimitiveValue(line.getKeyType, key)});
+        {@entryIdentifier}->setValue({@unformattedIdentifier(identifierValue)});
+        array_push({@formattedIdentifier(line)}, {@entryIdentifier});
+      @end
+    @end
+  @end
+@end
+
 @private initMap(line)
   @join key : line.getElementIdentifierKeys vertical
-    @let identifierValue = line.getElementIdentifierValue(key)
-      {@context.renderPrimitiveValue(line.getKeyType, key)}, {@identifierValue},
+    @let identifierValue = line.getElementIdentifierValue(key),\
+        entryIdentifier = getEntryIdentifier(line)
+      {@context.renderPrimitiveValue(line.getKeyType, key)} => {@unformattedIdentifier(identifierValue)},
     @end
   @end
 @end
 
 @private initLineSimple(line)
   {@formattedIdentifier(line)} = {@initValue(line)};
+@end
+
+@private getEntryIdentifier(lineOrFieldSetting)
+  {@unformattedIdentifier(lineOrFieldSetting.getIdentifier)}Entry
 @end
 
 @private formattedIdentifier(lineOrFieldSetting)

--- a/src/main/resources/com/google/api/codegen/py/method_sample.snip
+++ b/src/main/resources/com/google/api/codegen/py/method_sample.snip
@@ -47,6 +47,8 @@
       {@prompt} {@initLineList(line)}
     @case "SimpleInitLine"
       {@prompt} {@initLineSimple(line)}
+    @case "MapInitLine"
+      {@prompt} {@initLineMap(line)}
     @default
       {@unhandledCase()}
     @end
@@ -75,10 +77,24 @@
   {@formattedIdentifier(line)} = [{@initList(line)}]
 @end
 
+# Generate a Map argument
+@private initLineMap(line)
+  {@formattedIdentifier(line)} = {{@initMap(line)}}
+@end
+
 # Helper method for initLineList()
 @private initList(line)
   @join identifier : line.getElementIdentifiers on ", "
     {@identifier}
+  @end
+@end
+
+# Helper method for initLineMap()
+@private initMap(line)
+  @join key : line.getElementIdentifierKeys vertical
+    @let identifierValue = line.getElementIdentifierValue(key)
+      {@context.renderPrimitiveValue(line.getKeyType, key)}, {@identifierValue},
+    @end
   @end
 @end
 

--- a/src/main/resources/com/google/api/codegen/py/method_sample.snip
+++ b/src/main/resources/com/google/api/codegen/py/method_sample.snip
@@ -91,9 +91,9 @@
 
 # Helper method for initLineMap()
 @private initMap(line)
-  @join key : line.getElementIdentifierKeys vertical
+  @join key : line.getElementIdentifierKeys vertical on ","
     @let identifierValue = line.getElementIdentifierValue(key)
-      {@context.renderPrimitiveValue(line.getKeyType, key)}, {@identifierValue},
+      {@context.renderPrimitiveValue(line.getKeyType, key)}: {@identifierValue}
     @end
   @end
 @end

--- a/src/test/java/com/google/api/codegen/metacode/FieldStructureTest.java
+++ b/src/test/java/com/google/api/codegen/metacode/FieldStructureTest.java
@@ -30,8 +30,10 @@ public class FieldStructureTest {
 
   @Test
   public void testRegex() throws Exception {
+    Pattern fieldPattern = FieldStructureParser.getFieldStructurePattern();
     Pattern listPattern = FieldStructureParser.getFieldListPattern();
     Pattern mapPattern = FieldStructureParser.getFieldMapPattern();
+
     Matcher matcher = listPattern.matcher("mylist[0][0]");
     Truth.assertThat(matcher.matches()).isTrue();
     Truth.assertThat(matcher.group(1)).isEqualTo("mylist[0]");
@@ -44,6 +46,13 @@ public class FieldStructureTest {
     Truth.assertThat(matcher.matches()).isTrue();
     Truth.assertThat(matcher.group(1)).isEqualTo("mymap[0]");
     Truth.assertThat(matcher.group(2)).isEqualTo("key");
+
+    Matcher fieldMatcher = fieldPattern.matcher("myfield.mynextfield");
+    Truth.assertThat(fieldMatcher.matches()).isTrue();
+    Truth.assertThat(fieldMatcher.group(1)).isEqualTo("myfield");
+    Truth.assertThat(fieldMatcher.group(2)).isEqualTo("mynextfield");
+
+    Truth.assertThat(fieldPattern.matcher("singlefield").matches()).isFalse();
   }
 
   @Test
@@ -113,6 +122,18 @@ public class FieldStructureTest {
         Collections.singletonMap("key", (Object) InitValueConfig.create());
     List<Object> innerList = Collections.singletonList((Object) innerMap);
     Map<String, Object> expectedStructure = Collections.singletonMap("mylist", (Object) innerList);
+
+    Map<String, Object> actualStructure = FieldStructureParser.parseFields(fieldSpecs);
+    Truth.assertThat(actualStructure).isEqualTo(expectedStructure);
+  }
+
+  @Test
+  public void testAssignment() throws Exception {
+    List<String> fieldSpecs = Arrays.asList("myfield=\"default\"");
+
+    Map<String, Object> expectedStructure =
+        Collections.singletonMap(
+            "myfield", (Object) InitValueConfig.createWithValue("\"default\""));
 
     Map<String, Object> actualStructure = FieldStructureParser.parseFields(fieldSpecs);
     Truth.assertThat(actualStructure).isEqualTo(expectedStructure);

--- a/src/test/java/com/google/api/codegen/metacode/FieldStructureTest.java
+++ b/src/test/java/com/google/api/codegen/metacode/FieldStructureTest.java
@@ -53,6 +53,8 @@ public class FieldStructureTest {
     Truth.assertThat(fieldMatcher.group(2)).isEqualTo("mynextfield");
 
     Truth.assertThat(fieldPattern.matcher("singlefield").matches()).isFalse();
+    Truth.assertThat(fieldPattern.matcher("myfield.mylist[0]").matches()).isFalse();
+    Truth.assertThat(fieldPattern.matcher("myfield.mymap{key}").matches()).isFalse();
   }
 
   @Test
@@ -171,6 +173,20 @@ public class FieldStructureTest {
         Collections.singletonMap("myfield", (Object) InitValueConfig.create());
     List<Object> innerList = Collections.singletonList((Object) innerStructure);
     Map<String, Object> expectedStructure = Collections.singletonMap("mylist", (Object) innerList);
+
+    Map<String, Object> actualStructure = FieldStructureParser.parseFields(fieldSpecs);
+    Truth.assertThat(actualStructure).isEqualTo(expectedStructure);
+  }
+
+  @Test
+  public void testEmbeddedFieldList() throws Exception {
+    List<String> fieldSpecs = Arrays.asList("myfield.mylist[0]");
+
+    List<Object> innerList = Collections.singletonList((Object) InitValueConfig.create());
+    Map<String, Object> innerStructure = Collections.singletonMap("mylist", (Object) innerList);
+
+    Map<String, Object> expectedStructure =
+        Collections.singletonMap("myfield", (Object) innerStructure);
 
     Map<String, Object> actualStructure = FieldStructureParser.parseFields(fieldSpecs);
     Truth.assertThat(actualStructure).isEqualTo(expectedStructure);

--- a/src/test/java/com/google/api/codegen/testdata/client_config_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/client_config_json_library.baseline
@@ -89,6 +89,10 @@
         "GetBookFromArchive": {
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
+        },
+        "UpdateBookIndex": {
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
         }
       }
     }

--- a/src/test/java/com/google/api/codegen/testdata/csharp_wrapper_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/csharp_wrapper_library.baseline
@@ -82,6 +82,7 @@ namespace Google.Example.Library.V1
             ListStringsSettings = existing.ListStringsSettings?.Clone();
             AddCommentsSettings = existing.AddCommentsSettings?.Clone();
             GetBookFromArchiveSettings = existing.GetBookFromArchiveSettings?.Clone();
+            UpdateBookIndexSettings = existing.UpdateBookIndexSettings?.Clone();
         }
 
         /// <summary>
@@ -625,6 +626,39 @@ namespace Google.Example.Library.V1
         /// Default RPC expiration is 30000 milliseconds.
         /// </remarks>
         public CallSettings GetBookFromArchiveSettings { get; set; } = new CallSettings
+        {
+            Timing = CallTiming.FromRetry(new RetrySettings
+            {
+                RetryBackoff = GetDefaultRetryBackoff(),
+                TimeoutBackoff = GetDefaultTimeoutBackoff(),
+                RetryFilter = IdempotentRetryFilter,
+                TotalExpiration = Expiration.FromTimeout(TimeSpan.FromMilliseconds(30000)),
+            }),
+        };
+
+        /// <summary>
+        /// <see cref="CallSettings"/> for synchronous and asynchronous calls to
+        /// <see cref="LibraryServiceClient.UpdateBookIndex"/> and <see cref="LibraryServiceClient.UpdateBookIndexAsync"/>.
+        /// </summary>
+        /// <remarks>
+        /// The default <see cref="LibraryServiceClient.UpdateBookIndex"/> and
+        /// <see cref="LibraryServiceClient.UpdateBookIndexAsync"/> <see cref="RetrySettings"/> are:
+        /// <list type="bullet">
+        /// <item><description>Initial retry delay: 100 milliseconds</description></item>
+        /// <item><description>Retry delay multiplier: 1.2</description></item>
+        /// <item><description>Retry maximum delay: 1000 milliseconds</description></item>
+        /// <item><description>Initial timeout: 300 milliseconds</description></item>
+        /// <item><description>Timeout multiplier: 1.3</description></item>
+        /// <item><description>Timeout maximum delay: 3000 milliseconds</description></item>
+        /// </list>
+        /// Retry will be attempted on the following response status codes:
+        /// <list>
+        /// <item><description><see cref="StatusCode.DeadlineExceeded"/></description></item>
+        /// <item><description><see cref="StatusCode.Unavailable"/></description></item>
+        /// </list>
+        /// Default RPC expiration is 30000 milliseconds.
+        /// </remarks>
+        public CallSettings UpdateBookIndexSettings { get; set; } = new CallSettings
         {
             Timing = CallTiming.FromRetry(new RetrySettings
             {
@@ -1569,6 +1603,58 @@ namespace Google.Example.Library.V1
             throw new NotImplementedException();
         }
 
+        /// <summary>
+        /// Updates the index of a book.
+        /// </summary>
+        /// <param name="name">The name of the book to update.</param>
+        /// <param name="indexName">The name of the index for the book</param>
+        /// <param name="indexMap">The index to update the book with</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A Task containing the RPC response.</returns>
+        public virtual Task UpdateBookIndexAsync(
+            string name,
+            string indexName,
+            IDictionary<string, string> indexMap,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Updates the index of a book.
+        /// </summary>
+        /// <param name="name">The name of the book to update.</param>
+        /// <param name="indexName">The name of the index for the book</param>
+        /// <param name="indexMap">The index to update the book with</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to use for this RPC.</param>
+        /// <returns>A Task containing the RPC response.</returns>
+        public virtual Task UpdateBookIndexAsync(
+            string name,
+            string indexName,
+            IDictionary<string, string> indexMap,
+            CancellationToken cancellationToken) => UpdateBookIndexAsync(
+                name,
+                indexName,
+                indexMap,
+                new CallSettings { CancellationToken = cancellationToken });
+
+        /// <summary>
+        /// Updates the index of a book.
+        /// </summary>
+        /// <param name="name">The name of the book to update.</param>
+        /// <param name="indexName">The name of the index for the book</param>
+        /// <param name="indexMap">The index to update the book with</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>The RPC response.</returns>
+        public virtual void UpdateBookIndex(
+            string name,
+            string indexName,
+            IDictionary<string, string> indexMap,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
     }
 
     public sealed partial class LibraryServiceClientImpl : LibraryServiceClient
@@ -1589,6 +1675,7 @@ namespace Google.Example.Library.V1
         private readonly ApiCall<ListStringsRequest, ListStringsResponse> _callListStrings;
         private readonly ApiCall<AddCommentsRequest, Empty> _callAddComments;
         private readonly ApiCall<GetBookFromArchiveRequest, Book> _callGetBookFromArchive;
+        private readonly ApiCall<UpdateBookIndexRequest, Empty> _callUpdateBookIndex;
 
         public LibraryServiceClientImpl(LibraryService.LibraryServiceClient grpcClient, LibraryServiceSettings settings)
         {
@@ -1625,6 +1712,8 @@ namespace Google.Example.Library.V1
                 GrpcClient.AddCommentsAsync, GrpcClient.AddComments, effectiveSettings.AddCommentsSettings);
             _callGetBookFromArchive = _clientHelper.BuildApiCall<GetBookFromArchiveRequest, Book>(
                 GrpcClient.GetBookFromArchiveAsync, GrpcClient.GetBookFromArchive, effectiveSettings.GetBookFromArchiveSettings);
+            _callUpdateBookIndex = _clientHelper.BuildApiCall<UpdateBookIndexRequest, Empty>(
+                GrpcClient.UpdateBookIndexAsync, GrpcClient.UpdateBookIndex, effectiveSettings.UpdateBookIndexSettings);
         }
 
         public override LibraryService.LibraryServiceClient GrpcClient { get; }
@@ -2302,6 +2391,48 @@ namespace Google.Example.Library.V1
                 new GetBookFromArchiveRequest
                 {
                     Name = name,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Updates the index of a book.
+        /// </summary>
+        /// <param name="name">The name of the book to update.</param>
+        /// <param name="indexName">The name of the index for the book</param>
+        /// <param name="indexMap">The index to update the book with</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>A Task containing the RPC response.</returns>
+        public override Task UpdateBookIndexAsync(
+            string name,
+            string indexName,
+            IDictionary<string, string> indexMap,
+            CallSettings callSettings = null) => _callUpdateBookIndex.Async(
+                new UpdateBookIndexRequest
+                {
+                    Name = name,
+                    IndexName = indexName,
+                    IndexMap = { indexMap },
+                },
+                callSettings);
+
+        /// <summary>
+        /// Updates the index of a book.
+        /// </summary>
+        /// <param name="name">The name of the book to update.</param>
+        /// <param name="indexName">The name of the index for the book</param>
+        /// <param name="indexMap">The index to update the book with</param>
+        /// <param name="callSettings">If not null, applies overrides to this RPC call.</param>
+        /// <returns>The RPC response.</returns>
+        public override void UpdateBookIndex(
+            string name,
+            string indexName,
+            IDictionary<string, string> indexMap,
+            CallSettings callSettings = null) => _callUpdateBookIndex.Sync(
+                new UpdateBookIndexRequest
+                {
+                    Name = name,
+                    IndexName = indexName,
+                    IndexMap = { indexMap },
                 },
                 callSettings);
 

--- a/src/test/java/com/google/api/codegen/testdata/go_example_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_example_library.baseline
@@ -214,9 +214,15 @@ func ExampleClient_GetBookFromArchive() {
 func ExampleClient_UpdateBookIndex() {
     ctx := context.Background()
     c, err := library.NewClient(ctx)
-    _ = err // Handle error.
+    if err != nil {
+        // TODO: Handle error.
+    }
 
-    req := &google_example_library_v1.UpdateBookIndexRequest{ /* Data... */ }
+    req := &google_example_library_v1.UpdateBookIndexRequest{
+        // TODO: Fill request struct fields.
+    }
     err = c.UpdateBookIndex(ctx, req)
-    _ = err // Handle error.
+    if err != nil {
+        // TODO: Handle error.
+    }
 }

--- a/src/test/java/com/google/api/codegen/testdata/go_example_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_example_library.baseline
@@ -210,3 +210,13 @@ func ExampleClient_GetBookFromArchive() {
     resp, err = c.GetBookFromArchive(ctx, req)
     _, _ = resp, err // Handle error.
 }
+
+func ExampleClient_UpdateBookIndex() {
+    ctx := context.Background()
+    c, err := library.NewClient(ctx)
+    _ = err // Handle error.
+
+    req := &google_example_library_v1.UpdateBookIndexRequest{ /* Data... */ }
+    err = c.UpdateBookIndex(ctx, req)
+    _ = err // Handle error.
+}

--- a/src/test/java/com/google/api/codegen/testdata/go_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_main_library.baseline
@@ -72,6 +72,7 @@ func defaultClientSettings() gax.ClientSettings {
             "ListStrings": append([]gax.CallOption{withIdempotentRetryCodes}, defaultRetryOptions...),
             "AddComments": defaultRetryOptions,
             "GetBookFromArchive": append([]gax.CallOption{withIdempotentRetryCodes}, defaultRetryOptions...),
+            "UpdateBookIndex": append([]gax.CallOption{withIdempotentRetryCodes}, defaultRetryOptions...),
         },
     }
 }
@@ -431,6 +432,18 @@ func (c *Client) GetBookFromArchive(ctx context.Context, req *google_example_lib
         return nil, err
     }
     return resp, nil
+}
+
+
+// UpdateBookIndex updates the index of a book.
+func (c *Client) UpdateBookIndex(ctx context.Context, req *google_example_library_v1.UpdateBookIndexRequest) error {
+    ctx = metadata.NewContext(ctx, c.metadata)
+    err := gax.Invoke(ctx, func (ctx context.Context) error {
+        var err error
+        _, err = c.client.UpdateBookIndex(ctx, req)
+        return err
+    }, c.callOptions["UpdateBookIndex"]...)
+    return err
 }
 
 

--- a/src/test/java/com/google/api/codegen/testdata/java_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_main_library.baseline
@@ -45,6 +45,7 @@ import com.google.example.library.v1.CreateShelfRequest;
 import com.google.example.library.v1.DeleteBookRequest;
 import com.google.example.library.v1.DeleteShelfRequest;
 import com.google.example.library.v1.GetBookFromArchiveRequest;
+import com.google.example.library.v1.GetBookFromArchiveRequest.CommentMapEntry;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.GetShelfRequest;
 import com.google.example.library.v1.ListBooksRequest;
@@ -1764,8 +1765,15 @@ public class LibraryServiceApi implements AutoCloseable {
    * <pre><code>
    * try (LibraryServiceApi libraryServiceApi = LibraryServiceApi.createWithDefaults()) {
    *   String formattedName = LibraryServiceApi.formatArchivedBookName("[ARCHIVE_PATH]", "[BOOK]");
+   *   ByteString comment = ByteString.copyFromUtf8("default comment");
+   *   Comment commentMapItem = Comment.newBuilder()
+   *     .setComment(comment)
+   *     .build();
+   *   Map&lt;String, GetBookFromArchiveRequest.CommentMapEntry&gt; commentMap = new HashMap&lt;&gt;();
+   *   commentMap.put("comment_key", commentMapItem);
    *   GetBookFromArchiveRequest request = GetBookFromArchiveRequest.newBuilder()
    *     .setName(formattedName)
+   *     .putAllCommentMap(commentMap)
    *     .build();
    *   Book response = libraryServiceApi.getBookFromArchive(request);
    * }
@@ -1789,8 +1797,15 @@ public class LibraryServiceApi implements AutoCloseable {
    * <pre><code>
    * try (LibraryServiceApi libraryServiceApi = LibraryServiceApi.createWithDefaults()) {
    *   String formattedName = LibraryServiceApi.formatArchivedBookName("[ARCHIVE_PATH]", "[BOOK]");
+   *   ByteString comment = ByteString.copyFromUtf8("default comment");
+   *   Comment commentMapItem = Comment.newBuilder()
+   *     .setComment(comment)
+   *     .build();
+   *   Map&lt;String, GetBookFromArchiveRequest.CommentMapEntry&gt; commentMap = new HashMap&lt;&gt;();
+   *   commentMap.put("comment_key", commentMapItem);
    *   GetBookFromArchiveRequest request = GetBookFromArchiveRequest.newBuilder()
    *     .setName(formattedName)
+   *     .putAllCommentMap(commentMap)
    *     .build();
    *   ListenableFuture&lt;Book&gt; future = libraryServiceApi.getBookFromArchiveCallable().futureCall(request);
    *   // Do something

--- a/src/test/java/com/google/api/codegen/testdata/java_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_main_library.baseline
@@ -45,7 +45,6 @@ import com.google.example.library.v1.CreateShelfRequest;
 import com.google.example.library.v1.DeleteBookRequest;
 import com.google.example.library.v1.DeleteShelfRequest;
 import com.google.example.library.v1.GetBookFromArchiveRequest;
-import com.google.example.library.v1.GetBookFromArchiveRequest.CommentMapEntry;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.GetShelfRequest;
 import com.google.example.library.v1.ListBooksRequest;
@@ -60,6 +59,8 @@ import com.google.example.library.v1.PublishSeriesRequest;
 import com.google.example.library.v1.PublishSeriesResponse;
 import com.google.example.library.v1.Shelf;
 import com.google.example.library.v1.SomeMessage;
+import com.google.example.library.v1.UpdateBookIndexRequest;
+import com.google.example.library.v1.UpdateBookIndexRequest.IndexMapEntry;
 import com.google.example.library.v1.UpdateBookRequest;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Empty;
@@ -69,6 +70,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 
 // Manually-added imports: add custom (non-generated) imports after this point.
@@ -169,6 +171,7 @@ public class LibraryServiceApi implements AutoCloseable {
       listStringsPagedCallable;
   private final ApiCallable<AddCommentsRequest, Empty> addCommentsCallable;
   private final ApiCallable<GetBookFromArchiveRequest, Book> getBookFromArchiveCallable;
+  private final ApiCallable<UpdateBookIndexRequest, Empty> updateBookIndexCallable;
 
   public final LibraryServiceSettings getSettings() {
     return settings;
@@ -334,6 +337,7 @@ public class LibraryServiceApi implements AutoCloseable {
         ApiCallable.createPagedVariant(settings.listStringsSettings(), this.channel, this.executor);
     this.addCommentsCallable = ApiCallable.create(settings.addCommentsSettings(), this.channel, this.executor);
     this.getBookFromArchiveCallable = ApiCallable.create(settings.getBookFromArchiveSettings(), this.channel, this.executor);
+    this.updateBookIndexCallable = ApiCallable.create(settings.updateBookIndexSettings(), this.channel, this.executor);
 
     if (settings.getChannelProvider().shouldAutoClose()) {
       closeables.add(
@@ -1765,15 +1769,8 @@ public class LibraryServiceApi implements AutoCloseable {
    * <pre><code>
    * try (LibraryServiceApi libraryServiceApi = LibraryServiceApi.createWithDefaults()) {
    *   String formattedName = LibraryServiceApi.formatArchivedBookName("[ARCHIVE_PATH]", "[BOOK]");
-   *   ByteString comment = ByteString.copyFromUtf8("default comment");
-   *   Comment commentMapItem = Comment.newBuilder()
-   *     .setComment(comment)
-   *     .build();
-   *   Map&lt;String, GetBookFromArchiveRequest.CommentMapEntry&gt; commentMap = new HashMap&lt;&gt;();
-   *   commentMap.put("comment_key", commentMapItem);
    *   GetBookFromArchiveRequest request = GetBookFromArchiveRequest.newBuilder()
    *     .setName(formattedName)
-   *     .putAllCommentMap(commentMap)
    *     .build();
    *   Book response = libraryServiceApi.getBookFromArchive(request);
    * }
@@ -1797,15 +1794,8 @@ public class LibraryServiceApi implements AutoCloseable {
    * <pre><code>
    * try (LibraryServiceApi libraryServiceApi = LibraryServiceApi.createWithDefaults()) {
    *   String formattedName = LibraryServiceApi.formatArchivedBookName("[ARCHIVE_PATH]", "[BOOK]");
-   *   ByteString comment = ByteString.copyFromUtf8("default comment");
-   *   Comment commentMapItem = Comment.newBuilder()
-   *     .setComment(comment)
-   *     .build();
-   *   Map&lt;String, GetBookFromArchiveRequest.CommentMapEntry&gt; commentMap = new HashMap&lt;&gt;();
-   *   commentMap.put("comment_key", commentMapItem);
    *   GetBookFromArchiveRequest request = GetBookFromArchiveRequest.newBuilder()
    *     .setName(formattedName)
-   *     .putAllCommentMap(commentMap)
    *     .build();
    *   ListenableFuture&lt;Book&gt; future = libraryServiceApi.getBookFromArchiveCallable().futureCall(request);
    *   // Do something
@@ -1818,6 +1808,106 @@ public class LibraryServiceApi implements AutoCloseable {
    */
   public final ApiCallable<GetBookFromArchiveRequest, Book> getBookFromArchiveCallable() {
     return getBookFromArchiveCallable;
+  }
+
+  // ----- updateBookIndex -----
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD - see instructions at the top of the file for editing.
+  /**
+   * Updates the index of a book.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryServiceApi libraryServiceApi = LibraryServiceApi.createWithDefaults()) {
+   *   String formattedName = LibraryServiceApi.formatBookName("[SHELF]", "[BOOK]");
+   *   String indexName = "default index";
+   *   String indexMapItem = "";
+   *   Map&lt;String, UpdateBookIndexRequest.IndexMapEntry&gt; indexMap = new HashMap&lt;&gt;();
+   *   indexMap.put("default_key", indexMapItem);
+   *   libraryServiceApi.updateBookIndex(formattedName, indexName, indexMap);
+   * }
+   * </code></pre>
+   *
+   * <!-- manual edit -->
+   * <!-- end manual edit -->
+   *
+   * @param name The name of the book to update.
+   * @param indexName The name of the index for the book
+   * @param indexMap The index to update the book with
+   * @throws com.google.api.gax.grpc.ApiException if the remote call fails
+   */
+  public final void updateBookIndex(String name, String indexName, Map<String, String> indexMap) {
+    BOOK_PATH_TEMPLATE.validate(name);
+
+
+    UpdateBookIndexRequest request =
+        UpdateBookIndexRequest.newBuilder()
+        .setName(name)
+        .setIndexName(indexName)
+        .putAllIndexMap(indexMap)
+        .build();
+    updateBookIndex(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD - see instructions at the top of the file for editing.
+  /**
+   * Updates the index of a book.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryServiceApi libraryServiceApi = LibraryServiceApi.createWithDefaults()) {
+   *   String formattedName = LibraryServiceApi.formatBookName("[SHELF]", "[BOOK]");
+   *   String indexName = "default index";
+   *   String indexMapItem = "";
+   *   Map&lt;String, UpdateBookIndexRequest.IndexMapEntry&gt; indexMap = new HashMap&lt;&gt;();
+   *   indexMap.put("default_key", indexMapItem);
+   *   UpdateBookIndexRequest request = UpdateBookIndexRequest.newBuilder()
+   *     .setName(formattedName)
+   *     .setIndexName(indexName)
+   *     .putAllIndexMap(indexMap)
+   *     .build();
+   *   libraryServiceApi.updateBookIndex(request);
+   * }
+   * </code></pre>
+   *
+   * <!-- manual edit -->
+   * <!-- end manual edit -->
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.grpc.ApiException if the remote call fails
+   */
+  public void updateBookIndex(UpdateBookIndexRequest request) {
+    updateBookIndexCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD - see instructions at the top of the file for editing.
+  /**
+   * Updates the index of a book.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryServiceApi libraryServiceApi = LibraryServiceApi.createWithDefaults()) {
+   *   String formattedName = LibraryServiceApi.formatBookName("[SHELF]", "[BOOK]");
+   *   String indexName = "default index";
+   *   String indexMapItem = "";
+   *   Map&lt;String, UpdateBookIndexRequest.IndexMapEntry&gt; indexMap = new HashMap&lt;&gt;();
+   *   indexMap.put("default_key", indexMapItem);
+   *   UpdateBookIndexRequest request = UpdateBookIndexRequest.newBuilder()
+   *     .setName(formattedName)
+   *     .setIndexName(indexName)
+   *     .putAllIndexMap(indexMap)
+   *     .build();
+   *   ListenableFuture&lt;Void&gt; future = libraryServiceApi.updateBookIndexCallable().futureCall(request);
+   *   // Do something
+   *   future.get();
+   * }
+   * </code></pre>
+   *
+   * <!-- manual edit -->
+   * <!-- end manual edit -->
+   */
+  public final ApiCallable<UpdateBookIndexRequest, Empty> updateBookIndexCallable() {
+    return updateBookIndexCallable;
   }
 
 

--- a/src/test/java/com/google/api/codegen/testdata/java_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_main_library.baseline
@@ -60,7 +60,6 @@ import com.google.example.library.v1.PublishSeriesResponse;
 import com.google.example.library.v1.Shelf;
 import com.google.example.library.v1.SomeMessage;
 import com.google.example.library.v1.UpdateBookIndexRequest;
-import com.google.example.library.v1.UpdateBookIndexRequest.IndexMapEntry;
 import com.google.example.library.v1.UpdateBookRequest;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Empty;
@@ -1822,7 +1821,7 @@ public class LibraryServiceApi implements AutoCloseable {
    *   String formattedName = LibraryServiceApi.formatBookName("[SHELF]", "[BOOK]");
    *   String indexName = "default index";
    *   String indexMapItem = "";
-   *   Map&lt;String, UpdateBookIndexRequest.IndexMapEntry&gt; indexMap = new HashMap&lt;&gt;();
+   *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
    *   indexMap.put("default_key", indexMapItem);
    *   libraryServiceApi.updateBookIndex(formattedName, indexName, indexMap);
    * }
@@ -1859,7 +1858,7 @@ public class LibraryServiceApi implements AutoCloseable {
    *   String formattedName = LibraryServiceApi.formatBookName("[SHELF]", "[BOOK]");
    *   String indexName = "default index";
    *   String indexMapItem = "";
-   *   Map&lt;String, UpdateBookIndexRequest.IndexMapEntry&gt; indexMap = new HashMap&lt;&gt;();
+   *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
    *   indexMap.put("default_key", indexMapItem);
    *   UpdateBookIndexRequest request = UpdateBookIndexRequest.newBuilder()
    *     .setName(formattedName)
@@ -1890,7 +1889,7 @@ public class LibraryServiceApi implements AutoCloseable {
    *   String formattedName = LibraryServiceApi.formatBookName("[SHELF]", "[BOOK]");
    *   String indexName = "default index";
    *   String indexMapItem = "";
-   *   Map&lt;String, UpdateBookIndexRequest.IndexMapEntry&gt; indexMap = new HashMap&lt;&gt;();
+   *   Map&lt;String, String&gt; indexMap = new HashMap&lt;&gt;();
    *   indexMap.put("default_key", indexMapItem);
    *   UpdateBookIndexRequest request = UpdateBookIndexRequest.newBuilder()
    *     .setName(formattedName)

--- a/src/test/java/com/google/api/codegen/testdata/java_settings_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_settings_library.baseline
@@ -72,6 +72,7 @@ import com.google.example.library.v1.MoveBookRequest;
 import com.google.example.library.v1.PublishSeriesRequest;
 import com.google.example.library.v1.PublishSeriesResponse;
 import com.google.example.library.v1.Shelf;
+import com.google.example.library.v1.UpdateBookIndexRequest;
 import com.google.example.library.v1.UpdateBookRequest;
 import com.google.protobuf.Empty;
 import io.grpc.ManagedChannel;
@@ -172,6 +173,7 @@ public class LibraryServiceSettings extends ServiceApiSettings {
 
   private final SimpleCallSettings<AddCommentsRequest, Empty> addCommentsSettings;
   private final SimpleCallSettings<GetBookFromArchiveRequest, Book> getBookFromArchiveSettings;
+  private final SimpleCallSettings<UpdateBookIndexRequest, Empty> updateBookIndexSettings;
 
   /**
    * Returns the object with the settings used for calls to createShelf.
@@ -281,6 +283,13 @@ public class LibraryServiceSettings extends ServiceApiSettings {
     return getBookFromArchiveSettings;
   }
 
+  /**
+   * Returns the object with the settings used for calls to updateBookIndex.
+   */
+  public SimpleCallSettings<UpdateBookIndexRequest, Empty> updateBookIndexSettings() {
+    return updateBookIndexSettings;
+  }
+
 
   /**
    * Returns a builder for this class with recommended defaults.
@@ -326,6 +335,7 @@ public class LibraryServiceSettings extends ServiceApiSettings {
     listStringsSettings = settingsBuilder.listStringsSettings().build();
     addCommentsSettings = settingsBuilder.addCommentsSettings().build();
     getBookFromArchiveSettings = settingsBuilder.getBookFromArchiveSettings().build();
+    updateBookIndexSettings = settingsBuilder.updateBookIndexSettings().build();
   }
 
   private static PageStreamingDescriptor<ListShelvesRequest, ListShelvesResponse, Shelf> LIST_SHELVES_PAGE_STR_DESC =
@@ -488,6 +498,7 @@ public class LibraryServiceSettings extends ServiceApiSettings {
         listStringsSettings;
     private SimpleCallSettings.Builder<AddCommentsRequest, Empty> addCommentsSettings;
     private SimpleCallSettings.Builder<GetBookFromArchiveRequest, Book> getBookFromArchiveSettings;
+    private SimpleCallSettings.Builder<UpdateBookIndexRequest, Empty> updateBookIndexSettings;
 
     private static final ImmutableMap<String, ImmutableSet<Status.Code>> RETRYABLE_CODE_DEFINITIONS;
 
@@ -561,6 +572,8 @@ public class LibraryServiceSettings extends ServiceApiSettings {
 
       getBookFromArchiveSettings = SimpleCallSettings.newBuilder(LibraryServiceGrpc.METHOD_GET_BOOK_FROM_ARCHIVE);
 
+      updateBookIndexSettings = SimpleCallSettings.newBuilder(LibraryServiceGrpc.METHOD_UPDATE_BOOK_INDEX);
+
       methodSettingsBuilders = ImmutableList.<ApiCallSettings.Builder>of(
           createShelfSettings,
           getShelfSettings,
@@ -576,7 +589,8 @@ public class LibraryServiceSettings extends ServiceApiSettings {
           moveBookSettings,
           listStringsSettings,
           addCommentsSettings,
-          getBookFromArchiveSettings
+          getBookFromArchiveSettings,
+          updateBookIndexSettings
       );
     }
 
@@ -649,6 +663,10 @@ public class LibraryServiceSettings extends ServiceApiSettings {
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
           .setRetrySettingsBuilder(RETRY_PARAM_DEFINITIONS.get("default"));
 
+      builder.updateBookIndexSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
+          .setRetrySettingsBuilder(RETRY_PARAM_DEFINITIONS.get("default"));
+
       return builder;
     }
 
@@ -670,6 +688,7 @@ public class LibraryServiceSettings extends ServiceApiSettings {
       listStringsSettings = settings.listStringsSettings.toBuilder();
       addCommentsSettings = settings.addCommentsSettings.toBuilder();
       getBookFromArchiveSettings = settings.getBookFromArchiveSettings.toBuilder();
+      updateBookIndexSettings = settings.updateBookIndexSettings.toBuilder();
 
       methodSettingsBuilders = ImmutableList.<ApiCallSettings.Builder>of(
           createShelfSettings,
@@ -686,7 +705,8 @@ public class LibraryServiceSettings extends ServiceApiSettings {
           moveBookSettings,
           listStringsSettings,
           addCommentsSettings,
-          getBookFromArchiveSettings
+          getBookFromArchiveSettings,
+          updateBookIndexSettings
       );
     }
 
@@ -846,6 +866,13 @@ public class LibraryServiceSettings extends ServiceApiSettings {
      */
     public SimpleCallSettings.Builder<GetBookFromArchiveRequest, Book> getBookFromArchiveSettings() {
       return getBookFromArchiveSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to updateBookIndex.
+     */
+    public SimpleCallSettings.Builder<UpdateBookIndexRequest, Empty> updateBookIndexSettings() {
+      return updateBookIndexSettings;
     }
 
     @Override

--- a/src/test/java/com/google/api/codegen/testdata/library.proto
+++ b/src/test/java/com/google/api/codegen/testdata/library.proto
@@ -110,7 +110,7 @@ service LibraryService {
 
   // Gets a book from an archive.
   rpc GetBookFromArchive(GetBookFromArchiveRequest) returns (Book) {
-    option (google.api.http) = { get: "/v1/{name=archives/**/books/*}" };
+    option (google.api.http) = { post: "/v1/{name=archives/**/books/*}" body: "*" };
   }
 
 }
@@ -371,4 +371,7 @@ message Comment {
 message GetBookFromArchiveRequest {
   // The name of the book to retrieve.
   string name = 1;
+
+  // Test map initialization
+  map<string, Comment> comment_map = 2;
 }

--- a/src/test/java/com/google/api/codegen/testdata/library.proto
+++ b/src/test/java/com/google/api/codegen/testdata/library.proto
@@ -110,9 +110,13 @@ service LibraryService {
 
   // Gets a book from an archive.
   rpc GetBookFromArchive(GetBookFromArchiveRequest) returns (Book) {
-    option (google.api.http) = { post: "/v1/{name=archives/**/books/*}" body: "*" };
+    option (google.api.http) = { get: "/v1/{name=archives/**/books/*}"};
   }
 
+  // Updates the index of a book.
+  rpc UpdateBookIndex(UpdateBookIndexRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = { post: "/v1/{name=shelves/*/books/*}/index" body: "*" };
+  }
 }
 
 // A single book in the library.
@@ -371,7 +375,16 @@ message Comment {
 message GetBookFromArchiveRequest {
   // The name of the book to retrieve.
   string name = 1;
+}
 
-  // Test map initialization
-  map<string, Comment> comment_map = 2;
+// Request message for LibraryService.UpdateBookIndex.
+message UpdateBookIndexRequest {
+  // The name of the book to update.
+  string name = 1;
+
+  // The name of the index for the book
+  string index_name = 2;
+
+  // The index to update the book with
+  map<string, string> index_map = 3;
 }

--- a/src/test/java/com/google/api/codegen/testdata/library_config.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/library_config.baseline
@@ -249,3 +249,19 @@ interfaces:
     retry_params_name: default
     field_name_patterns:
       name: book
+  - name: UpdateBookIndex
+    flattening:
+      groups:
+      - parameters:
+        - name
+        - index_name
+        - index_map
+    required_fields:
+    - name
+    - index_name
+    - index_map
+    request_object_method: true
+    retry_codes_name: non_idempotent
+    retry_params_name: default
+    field_name_patterns:
+      name: book_2

--- a/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
@@ -267,5 +267,23 @@ interfaces:
     request_object_method: false
     field_name_patterns:
       name: archived_book
+  - name: UpdateBookIndex
+    flattening:
+      groups:
+      - parameters:
+        - name
+        - index_name
+        - index_map
+    required_fields:
+    - name
+    - index_name
+    - index_map
+    request_object_method: true
+    retry_codes_name: idempotent
+    retry_params_name: default
+    field_name_patterns:
+      name: book
     sample_code_init_fields:
-      - comment_map{"comment_key"}.comment="default comment"
+      - index_name="default index"
+      - index_map{"default_key"}
+      

--- a/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
@@ -267,3 +267,5 @@ interfaces:
     request_object_method: false
     field_name_patterns:
       name: archived_book
+    sample_code_init_fields:
+      - comment_map{"comment_key"}.comment="default comment"

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_json_library.baseline
@@ -89,6 +89,10 @@
         "GetBookFromArchive": {
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
+        },
+        "UpdateBookIndex": {
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
         }
       }
     }

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_main_library.baseline
@@ -156,7 +156,8 @@ function LibraryServiceApi(opts) {
     'moveBook',
     'listStrings',
     'addComments',
-    'getBookFromArchive'
+    'getBookFromArchive',
+    'updateBookIndex'
   ];
   methods.forEach(function(methodName) {
     this['_' + methodName] = Promise.all([defaults, this.stub]).then(function(vars) {
@@ -800,6 +801,44 @@ LibraryServiceApi.prototype.getBookFromArchive = function getBookFromArchive() {
     'name': args.name
   };
   this._getBookFromArchive.then(function(apiCall) {
+    apiCall(req, args.options, args.callback);
+  })['catch'](function(err) {
+    if (args.callback) {
+      args.callback(err);
+    }
+  });
+};
+
+/**
+ * Updates the index of a book.
+ *
+ * @param {String} name
+ *   The name of the book to update.
+ * @param {String} indexName
+ *   The name of the index for the book
+ * @param {Object} indexMap
+ *   The index to update the book with
+ * @param {?gax.CallOptions} options
+ *   Overrides the default settings for this call, e.g, timeout,
+ *   retries, etc.
+ * @param {?EmptyCallback} callback
+ *   The function which will be called with the result of the API call.
+ * @throws an error if the RPC is aborted.
+ */
+LibraryServiceApi.prototype.updateBookIndex = function updateBookIndex() {
+  var args = arguejs({
+    'name': String,
+    'indexName': String,
+    'indexMap': Object,
+    'options': [gax.CallOptions],
+    'callback': [Function]
+  }, arguments);
+  var req = {
+    'name': args.name,
+    'index_name': args.indexName,
+    'index_map': args.indexMap
+  };
+  this._updateBookIndex.then(function(apiCall) {
     apiCall(req, args.options, args.callback);
   })['catch'](function(err) {
     if (args.callback) {

--- a/src/test/java/com/google/api/codegen/testdata/php_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php_json_library.baseline
@@ -89,6 +89,10 @@
         "GetBookFromArchive": {
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
+        },
+        "UpdateBookIndex": {
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
         }
       }
     }

--- a/src/test/java/com/google/api/codegen/testdata/php_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php_main_library.baseline
@@ -54,6 +54,7 @@ use google\example\library\v1\PublishSeriesResponse;
 use google\example\library\v1\Shelf;
 use google\example\library\v1\SomeMessage;
 use google\example\library\v1\StringBuilder;
+use google\example\library\v1\UpdateBookIndexRequest;
 use google\example\library\v1\UpdateBookRequest;
 use google\protobuf\FieldMask;
 
@@ -331,6 +332,7 @@ class LibraryServiceApi
             'listStrings' => $defaultDescriptors,
             'addComments' => $defaultDescriptors,
             'getBookFromArchive' => $defaultDescriptors,
+            'updateBookIndex' => $defaultDescriptors,
         ];
         $pageStreamingDescriptors = self::getPageStreamingDescriptors();
         foreach ($pageStreamingDescriptors as $method => $pageStreamingDescriptor) {
@@ -1186,6 +1188,63 @@ class LibraryServiceApi
             new CallSettings($callSettings));
         $callable = ApiCallable::createApiCall(
             $this->stub, 'GetBookFromArchive', $mergedSettings, $this->descriptors['getBookFromArchive']);
+
+        return $callable(
+            $request,
+            [],
+            ['call_credentials_callback' => $this->createCredentialsCallback()]);
+    }
+
+    /**
+     * Updates the index of a book.
+     *
+     * Sample code:
+     * ```
+     * try {
+     *     $libraryServiceApi = new LibraryServiceApi();
+     *     $formattedName = LibraryServiceApi::formatBookName("[SHELF]", "[BOOK]");
+     *     $indexName = "";
+     *     $indexMapItem = "";
+     *     $indexMap = ["default_key", index_map_item,];
+     *     $libraryServiceApi->updateBookIndex($formattedName, $indexName, $indexMap);
+     * } finally {
+     *     if (isset($libraryServiceApi)) {
+     *         $libraryServiceApi->close();
+     *     }
+     * }
+     * ```
+     *
+     * @param string $name The name of the book to update.
+     * @param string $indexName The name of the index for the book
+     * @param array $indexMap The index to update the book with
+     * @param array $optionalArgs {
+     *     Optional. There are no optional parameters for this method yet;
+     *               this $optionalArgs parameter reserves a spot for future ones.
+     * }
+     * @param array $callSettings {
+     *    Optional.
+     *    @var Google\GAX\RetrySettings $retrySettings
+     *          Retry settings to use for this call. If present, then
+     *          $timeout is ignored.
+     *    @var int $timeoutMillis
+     *          Timeout to use for this call. Only used if $retrySettings
+     *          is not set.
+     * }
+     *
+     * @throws Google\GAX\ApiException if the remote call fails
+     */
+    public function updateBookIndex($name, $indexName, $indexMap, $optionalArgs = [], $callSettings = [])
+    {
+        $request = new UpdateBookIndexRequest();
+        $request->setName($name);
+        $request->setIndexName($indexName);
+        // TODO make this work
+        putAll...
+
+        $mergedSettings = $this->defaultCallSettings['updateBookIndex']->merge(
+            new CallSettings($callSettings));
+        $callable = ApiCallable::createApiCall(
+            $this->stub, 'UpdateBookIndex', $mergedSettings, $this->descriptors['updateBookIndex']);
 
         return $callable(
             $request,

--- a/src/test/java/com/google/api/codegen/testdata/php_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php_main_library.baseline
@@ -55,6 +55,7 @@ use google\example\library\v1\Shelf;
 use google\example\library\v1\SomeMessage;
 use google\example\library\v1\StringBuilder;
 use google\example\library\v1\UpdateBookIndexRequest;
+use google\example\library\v1\UpdateBookIndexRequest\IndexMapEntry;
 use google\example\library\v1\UpdateBookRequest;
 use google\protobuf\FieldMask;
 
@@ -1205,7 +1206,7 @@ class LibraryServiceApi
      *     $formattedName = LibraryServiceApi::formatBookName("[SHELF]", "[BOOK]");
      *     $indexName = "";
      *     $indexMapItem = "";
-     *     $indexMap = ["default_key", index_map_item,];
+     *     $indexMap = ["default_key" => $indexMapItem,];
      *     $libraryServiceApi->updateBookIndex($formattedName, $indexName, $indexMap);
      * } finally {
      *     if (isset($libraryServiceApi)) {
@@ -1238,8 +1239,9 @@ class LibraryServiceApi
         $request = new UpdateBookIndexRequest();
         $request->setName($name);
         $request->setIndexName($indexName);
-        // TODO make this work
-        putAll...
+        foreach ($indexMap as $key => $value) {
+            $request->addIndexMap((new IndexMapEntry())->setKey($key)->setValue($value));
+        }
 
         $mergedSettings = $this->defaultCallSettings['updateBookIndex']->merge(
             new CallSettings($callSettings));

--- a/src/test/java/com/google/api/codegen/testdata/python_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_json_library.baseline
@@ -89,6 +89,10 @@
         "GetBookFromArchive": {
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
+        },
+        "UpdateBookIndex": {
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
         }
       }
     }

--- a/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
@@ -316,6 +316,9 @@ class LibraryServiceApi(object):
         self._get_book_from_archive = api_callable.create_api_call(
             self.stub.GetBookFromArchive,
             settings=defaults['get_book_from_archive'])
+        self._update_book_index = api_callable.create_api_call(
+            self.stub.UpdateBookIndex,
+            settings=defaults['update_book_index'])
 
     # Service calls
     def create_shelf(
@@ -838,4 +841,38 @@ class LibraryServiceApi(object):
         request = library_pb2.GetBookFromArchiveRequest(
             name=name)
         return self._get_book_from_archive(request, options)
+
+    def update_book_index(
+            self,
+            name,
+            index_name,
+            index_map,
+            options=None):
+        """
+        Updates the index of a book.
+
+        Example:
+          >>> from library.library_service_api import LibraryServiceApi
+          >>> api = LibraryServiceApi()
+          >>> name = api.book_path('[SHELF]', '[BOOK]')
+          >>> index_name = ''
+          >>> index_map_item = ''
+          >>> index_map = {'default_key', index_map_item,}
+          >>> api.update_book_index(name, index_name, index_map)
+
+        Args:
+          name (string): The name of the book to update.
+          index_name (string): The name of the index for the book
+          index_map (dict[string -> :class:`google.example.library.v1.library_pb2.UpdateBookIndexRequest.IndexMapEntry`]): The index to update the book with
+          options (:class:`google.gax.CallOptions`): Overrides the default
+            settings for this call, e.g, timeout, retries etc.
+
+        Raises:
+          :exc:`google.gax.errors.GaxError` if the RPC is aborted.
+        """
+        request = library_pb2.UpdateBookIndexRequest(
+            name=name,
+            index_name=index_name,
+            index_map=index_map)
+        self._update_book_index(request, options)
 

--- a/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
@@ -857,7 +857,7 @@ class LibraryServiceApi(object):
           >>> name = api.book_path('[SHELF]', '[BOOK]')
           >>> index_name = ''
           >>> index_map_item = ''
-          >>> index_map = {'default_key', index_map_item,}
+          >>> index_map = {'default_key': index_map_item}
           >>> api.update_book_index(name, index_name, index_map)
 
         Args:

--- a/src/test/java/com/google/api/codegen/testdata/python_message_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_message_library.baseline
@@ -883,3 +883,16 @@ class GetBookFromArchiveRequest(object):
     """
     pass
 
+
+class UpdateBookIndexRequest(object):
+    """
+    Request message for LibraryService.UpdateBookIndex.
+
+    Attributes:
+      name (string): The name of the book to update.
+      index_name (string): The name of the index for the book
+      index_map (dict[string -> :class:`google.example.library.v1.library_pb2.UpdateBookIndexRequest.IndexMapEntry`]): The index to update the book with
+
+    """
+    pass
+

--- a/src/test/java/com/google/api/codegen/testdata/ruby_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_json_library.baseline
@@ -89,6 +89,10 @@
         "GetBookFromArchive": {
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
+        },
+        "UpdateBookIndex": {
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
         }
       }
     }

--- a/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
@@ -592,6 +592,33 @@ module Google
               @stub.method(:get_book_from_archive), settings)
             api_call.call(req, **@headers)
           end
+
+          # Updates the index of a book.
+          #
+          # @param name [String]
+          #   The name of the book to update.
+          # @param index_name [String]
+          #   The name of the index for the book
+          # @param index_map [Hash{String => String}]
+          #   The index to update the book with
+          # @param options [Google::Gax::CallOptions]
+          #   Overrides the default settings for this call, e.g, timeout,
+          #   retries, etc.
+          # @raise [Google::Gax::GaxError] if the RPC is aborted.
+          def update_book_index(
+            name,
+            index_name,
+            index_map,
+            options: nil)
+            req = Google::Example::Library::V1::UpdateBookIndexRequest.new(
+              name: name,
+              index_name: index_name,
+              index_map: index_map)
+            settings = @defaults['update_book_index'].merge(options)
+            api_call = Google::Gax.create_api_call(
+              @stub.method(:update_book_index), settings)
+            api_call.call(req, **@headers)
+          end
         end
       end
     end

--- a/src/test/java/com/google/api/codegen/testdata/ruby_message_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_message_library.baseline
@@ -798,6 +798,18 @@ module Google
         #   @return [String]
         #     The name of the book to retrieve.
         class GetBookFromArchiveRequest; end
+
+        # Request message for LibraryService.UpdateBookIndex.
+        # @!attribute [rw] name
+        #   @return [String]
+        #     The name of the book to update.
+        # @!attribute [rw] index_name
+        #   @return [String]
+        #     The name of the index for the book
+        # @!attribute [rw] index_map
+        #   @return [Hash{String => String}]
+        #     The index to update the book with
+        class UpdateBookIndexRequest; end
       end
     end
   end


### PR DESCRIPTION
Creating this PR to get feedback on the features implemented, and what test strategy to use.

Added support for map fields using {"key"} syntax
Added support for value initialization using ="value" syntax
Added support for "nested" maps and lists using chained syntax e.g.
myobject{"key"}[0].myfield