### PR TITLE
Fix a typo

### DIFF
--- a/src/main/resources/com/google/api/codegen/nodejs/main.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/main.snip
@@ -214,7 +214,7 @@
       ];
       methods.forEach(function(methodName) {
         this['_' + methodName] = Promise.all([defaults, this.stub]).then(function(vars) {
-          var options = vars[0];
+          var options = vars[0][methodName];
           var stub = vars[1];
           return gax.createApiCall(stub[methodName].bind(stub), options);
         }.bind(this));

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_main_library.baseline
@@ -160,7 +160,7 @@ function LibraryServiceApi(opts) {
   ];
   methods.forEach(function(methodName) {
     this['_' + methodName] = Promise.all([defaults, this.stub]).then(function(vars) {
-      var options = vars[0];
+      var options = vars[0][methodName];
       var stub = vars[1];
       return gax.createApiCall(stub[methodName].bind(stub), options);
     }.bind(this));


### PR DESCRIPTION
Without method name, it actually passes the entire mapping
instead of the call settings for a method... :-(