### PR TITLE
Get rid of '..' path in templates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -273,6 +273,14 @@ if (project.hasProperty('privateOssrhUsername') && project.hasProperty('privateO
     + "your ~/.gradle/gradle.properties file in order to upload archives.")
 }
 
+allprojects {
+  gradle.projectsEvaluated {
+    tasks.withType(JavaCompile) {
+      options.compilerArgs << "-Xlint:unchecked"
+    }
+  }
+}
+
 // Task to run CodeGeneratorTool
 // =============================
 //

--- a/src/main/java/com/google/api/codegen/SnippetSetRunner.java
+++ b/src/main/java/com/google/api/codegen/SnippetSetRunner.java
@@ -30,7 +30,6 @@ public final class SnippetSetRunner {
     /**
      * Runs the code generation.
      */
-    GeneratedResult generate(
-        Element element, String resourceRoot, String snippetFileName, CodegenContext context);
+    GeneratedResult generate(Element element, String snippetFileName, CodegenContext context);
   }
 }

--- a/src/main/java/com/google/api/codegen/SnippetSetRunner.java
+++ b/src/main/java/com/google/api/codegen/SnippetSetRunner.java
@@ -18,10 +18,19 @@ package com.google.api.codegen;
  * A SnippetSetRunner takes the element, snippet file, and context as input and then uses the
  * Snippet Set templating engine to generate an output document.
  */
-public interface SnippetSetRunner<Element> {
+public final class SnippetSetRunner {
 
   /**
-   * Runs the code generation.
+   * The path to the root of snippet resources.
    */
-  GeneratedResult generate(Element element, String snippetFileName, CodegenContext context);
+  public static final String SNIPPET_RESOURCE_ROOT =
+      SnippetSetRunner.class.getPackage().getName().replace('.', '/');
+
+  public interface Generator<Element> {
+    /**
+     * Runs the code generation.
+     */
+    GeneratedResult generate(
+        Element element, String resourceRoot, String snippetFileName, CodegenContext context);
+  }
 }

--- a/src/main/java/com/google/api/codegen/clientconfig/ClientConfigSnippetSetRunner.java
+++ b/src/main/java/com/google/api/codegen/clientconfig/ClientConfigSnippetSetRunner.java
@@ -21,22 +21,17 @@ import com.google.api.tools.framework.snippet.Doc;
 import com.google.api.tools.framework.snippet.SnippetSet;
 import com.google.common.collect.ImmutableMap;
 
-public class ClientConfigSnippetSetRunner<ElementT> implements SnippetSetRunner<ElementT> {
-
-  /**
-   * The path to the root of snippet resources.
-   */
-  private static final String SNIPPET_RESOURCE_ROOT =
-      ClientConfigSnippetSetRunner.class.getPackage().getName().replace('.', '/');
+public class ClientConfigSnippetSetRunner<ElementT>
+    implements SnippetSetRunner.Generator<ElementT> {
 
   @Override
   @SuppressWarnings("unchecked")
   public GeneratedResult generate(
-      ElementT element, String snippetFileName, CodegenContext context) {
+      ElementT element, String resourceRoot, String snippetFileName, CodegenContext context) {
     ClientConfigSnippetSet<ElementT> snippets =
         SnippetSet.createSnippetInterface(
             ClientConfigSnippetSet.class,
-            SNIPPET_RESOURCE_ROOT,
+            resourceRoot,
             snippetFileName,
             ImmutableMap.<String, Object>of("context", context));
 

--- a/src/main/java/com/google/api/codegen/clientconfig/ClientConfigSnippetSetRunner.java
+++ b/src/main/java/com/google/api/codegen/clientconfig/ClientConfigSnippetSetRunner.java
@@ -24,10 +24,16 @@ import com.google.common.collect.ImmutableMap;
 public class ClientConfigSnippetSetRunner<ElementT>
     implements SnippetSetRunner.Generator<ElementT> {
 
+  private final String resourceRoot;
+
+  public ClientConfigSnippetSetRunner(String resourceRoot) {
+    this.resourceRoot = resourceRoot;
+  }
+
   @Override
   @SuppressWarnings("unchecked")
   public GeneratedResult generate(
-      ElementT element, String resourceRoot, String snippetFileName, CodegenContext context) {
+      ElementT element, String snippetFileName, CodegenContext context) {
     ClientConfigSnippetSet<ElementT> snippets =
         SnippetSet.createSnippetInterface(
             ClientConfigSnippetSet.class,

--- a/src/main/java/com/google/api/codegen/csharp/CSharpSnippetSetRunner.java
+++ b/src/main/java/com/google/api/codegen/csharp/CSharpSnippetSetRunner.java
@@ -28,16 +28,16 @@ import java.util.TreeSet;
  */
 public class CSharpSnippetSetRunner<ElementT> implements SnippetSetRunner.Generator<ElementT> {
 
-  /**
-   * The path to the root of snippet resources.
-   */
-  private static final String SNIPPET_RESOURCE_ROOT =
-      CSharpContextCommon.class.getPackage().getName().replace('.', '/');
+  private final String resourceRoot;
+
+  public CSharpSnippetSetRunner(String resourceRoot) {
+    this.resourceRoot = resourceRoot;
+  }
 
   @Override
   @SuppressWarnings("unchecked")
   public GeneratedResult generate(
-      ElementT element, String resourceRoot, String snippetFileName, CodegenContext context) {
+      ElementT element, String snippetFileName, CodegenContext context) {
     CSharpSnippetSet<ElementT> snippets =
         SnippetSet.createSnippetInterface(
             CSharpSnippetSet.class,

--- a/src/main/java/com/google/api/codegen/csharp/CSharpSnippetSetRunner.java
+++ b/src/main/java/com/google/api/codegen/csharp/CSharpSnippetSetRunner.java
@@ -26,7 +26,7 @@ import java.util.TreeSet;
 /**
  * A CSharpProvider provides general CSharp code generation logic.
  */
-public class CSharpSnippetSetRunner<ElementT> implements SnippetSetRunner<ElementT> {
+public class CSharpSnippetSetRunner<ElementT> implements SnippetSetRunner.Generator<ElementT> {
 
   /**
    * The path to the root of snippet resources.
@@ -37,11 +37,11 @@ public class CSharpSnippetSetRunner<ElementT> implements SnippetSetRunner<Elemen
   @Override
   @SuppressWarnings("unchecked")
   public GeneratedResult generate(
-      ElementT element, String snippetFileName, CodegenContext context) {
+      ElementT element, String resourceRoot, String snippetFileName, CodegenContext context) {
     CSharpSnippetSet<ElementT> snippets =
         SnippetSet.createSnippetInterface(
             CSharpSnippetSet.class,
-            SNIPPET_RESOURCE_ROOT,
+            resourceRoot,
             snippetFileName,
             ImmutableMap.<String, Object>of("context", context));
 

--- a/src/main/java/com/google/api/codegen/discovery/CommonDiscoveryProvider.java
+++ b/src/main/java/com/google/api/codegen/discovery/CommonDiscoveryProvider.java
@@ -29,11 +29,13 @@ import java.util.Map;
  */
 public class CommonDiscoveryProvider implements DiscoveryProvider {
   private final DiscoveryContext context;
-  private final SnippetSetRunner<Method> snippetSetRunner;
+  private final SnippetSetRunner.Generator<Method> snippetSetRunner;
   private final String snippetFileName;
 
   public CommonDiscoveryProvider(
-      DiscoveryContext context, SnippetSetRunner<Method> snippetSetRunner, String snippetFileName) {
+      DiscoveryContext context,
+      SnippetSetRunner.Generator<Method> snippetSetRunner,
+      String snippetFileName) {
     this.context = context;
     this.snippetSetRunner = snippetSetRunner;
     this.snippetFileName = snippetFileName;
@@ -41,7 +43,9 @@ public class CommonDiscoveryProvider implements DiscoveryProvider {
 
   @Override
   public Map<String, Doc> generate(Method method) {
-    GeneratedResult result = snippetSetRunner.generate(method, snippetFileName, context);
+    GeneratedResult result =
+        snippetSetRunner.generate(
+            method, SnippetSetRunner.SNIPPET_RESOURCE_ROOT, snippetFileName, context);
 
     Api api = context.getApi();
     String outputRoot =
@@ -62,7 +66,7 @@ public class CommonDiscoveryProvider implements DiscoveryProvider {
 
   public static class Builder {
     private DiscoveryContext context;
-    private SnippetSetRunner<Method> snippetSetRunner;
+    private SnippetSetRunner.Generator<Method> snippetSetRunner;
     private String snippetFileName;
 
     private Builder() {}
@@ -72,7 +76,7 @@ public class CommonDiscoveryProvider implements DiscoveryProvider {
       return this;
     }
 
-    public Builder setSnippetSetRunner(SnippetSetRunner<Method> snippetSetRunner) {
+    public Builder setSnippetSetRunner(SnippetSetRunner.Generator<Method> snippetSetRunner) {
       this.snippetSetRunner = snippetSetRunner;
       return this;
     }

--- a/src/main/java/com/google/api/codegen/discovery/CommonDiscoveryProvider.java
+++ b/src/main/java/com/google/api/codegen/discovery/CommonDiscoveryProvider.java
@@ -29,22 +29,22 @@ import java.util.Map;
  */
 public class CommonDiscoveryProvider implements DiscoveryProvider {
   private final DiscoveryContext context;
-  private final SnippetSetRunner.Generator<Method> snippetSetRunner;
+  private final SnippetSetRunner.Generator<Method> generator;
   private final String snippetFileName;
 
   public CommonDiscoveryProvider(
       DiscoveryContext context,
-      SnippetSetRunner.Generator<Method> snippetSetRunner,
+      SnippetSetRunner.Generator<Method> generator,
       String snippetFileName) {
     this.context = context;
-    this.snippetSetRunner = snippetSetRunner;
+    this.generator = generator;
     this.snippetFileName = snippetFileName;
   }
 
   @Override
   public Map<String, Doc> generate(Method method) {
     GeneratedResult result =
-        snippetSetRunner.generate(
+        generator.generate(
             method, SnippetSetRunner.SNIPPET_RESOURCE_ROOT, snippetFileName, context);
 
     Api api = context.getApi();
@@ -66,7 +66,7 @@ public class CommonDiscoveryProvider implements DiscoveryProvider {
 
   public static class Builder {
     private DiscoveryContext context;
-    private SnippetSetRunner.Generator<Method> snippetSetRunner;
+    private SnippetSetRunner.Generator<Method> generator;
     private String snippetFileName;
 
     private Builder() {}
@@ -76,8 +76,8 @@ public class CommonDiscoveryProvider implements DiscoveryProvider {
       return this;
     }
 
-    public Builder setSnippetSetRunner(SnippetSetRunner.Generator<Method> snippetSetRunner) {
-      this.snippetSetRunner = snippetSetRunner;
+    public Builder setSnippetSetRunner(SnippetSetRunner.Generator<Method> generator) {
+      this.generator = generator;
       return this;
     }
 
@@ -87,7 +87,7 @@ public class CommonDiscoveryProvider implements DiscoveryProvider {
     }
 
     public CommonDiscoveryProvider build() {
-      return new CommonDiscoveryProvider(context, snippetSetRunner, snippetFileName);
+      return new CommonDiscoveryProvider(context, generator, snippetFileName);
     }
   }
 }

--- a/src/main/java/com/google/api/codegen/discovery/CommonDiscoveryProvider.java
+++ b/src/main/java/com/google/api/codegen/discovery/CommonDiscoveryProvider.java
@@ -43,9 +43,7 @@ public class CommonDiscoveryProvider implements DiscoveryProvider {
 
   @Override
   public Map<String, Doc> generate(Method method) {
-    GeneratedResult result =
-        generator.generate(
-            method, SnippetSetRunner.SNIPPET_RESOURCE_ROOT, snippetFileName, context);
+    GeneratedResult result = generator.generate(method, snippetFileName, context);
 
     Api api = context.getApi();
     String outputRoot =

--- a/src/main/java/com/google/api/codegen/discovery/MainDiscoveryProviderFactory.java
+++ b/src/main/java/com/google/api/codegen/discovery/MainDiscoveryProviderFactory.java
@@ -16,6 +16,7 @@ package com.google.api.codegen.discovery;
 
 import com.google.api.Service;
 import com.google.api.codegen.ApiaryConfig;
+import com.google.api.codegen.SnippetSetRunner;
 import com.google.api.codegen.csharp.CSharpDiscoveryContext;
 import com.google.api.codegen.csharp.CSharpSnippetSetRunner;
 import com.google.api.codegen.go.GoDiscoveryContext;
@@ -55,49 +56,57 @@ public class MainDiscoveryProviderFactory implements DiscoveryProviderFactory {
     if (id.equals(CSHARP)) {
       return CommonDiscoveryProvider.newBuilder()
           .setContext(new CSharpDiscoveryContext(service, apiaryConfig))
-          .setSnippetSetRunner(new CSharpSnippetSetRunner<Method>())
+          .setSnippetSetRunner(
+              new CSharpSnippetSetRunner<Method>(SnippetSetRunner.SNIPPET_RESOURCE_ROOT))
           .setSnippetFileName(id + "/" + DEFAULT_SNIPPET_FILE)
           .build();
 
     } else if (id.equals(GO)) {
       return CommonDiscoveryProvider.newBuilder()
           .setContext(new GoDiscoveryContext(service, apiaryConfig))
-          .setSnippetSetRunner(new GoSnippetSetRunner<Method>())
+          .setSnippetSetRunner(
+              new GoSnippetSetRunner<Method>(SnippetSetRunner.SNIPPET_RESOURCE_ROOT))
           .setSnippetFileName(id + "/" + DEFAULT_SNIPPET_FILE)
           .build();
 
     } else if (id.equals(JAVA)) {
       return CommonDiscoveryProvider.newBuilder()
           .setContext(new JavaDiscoveryContext(service, apiaryConfig))
-          .setSnippetSetRunner(new JavaSnippetSetRunner<Method>())
+          .setSnippetSetRunner(
+              new JavaSnippetSetRunner<Method>(SnippetSetRunner.SNIPPET_RESOURCE_ROOT))
           .setSnippetFileName(id + "/" + DEFAULT_SNIPPET_FILE)
           .build();
 
     } else if (id.equals(NODEJS)) {
       return CommonDiscoveryProvider.newBuilder()
           .setContext(new NodeJSDiscoveryContext(service, apiaryConfig))
-          .setSnippetSetRunner(new NodeJSSnippetSetRunner<Method>())
+          .setSnippetSetRunner(
+              new NodeJSSnippetSetRunner<Method>(SnippetSetRunner.SNIPPET_RESOURCE_ROOT))
           .setSnippetFileName(id + "/" + DEFAULT_SNIPPET_FILE)
           .build();
 
     } else if (id.equals(PHP)) {
       return CommonDiscoveryProvider.newBuilder()
           .setContext(new PhpDiscoveryContext(service, apiaryConfig))
-          .setSnippetSetRunner(new PhpSnippetSetRunner<Method>())
+          .setSnippetSetRunner(
+              new PhpSnippetSetRunner<Method>(SnippetSetRunner.SNIPPET_RESOURCE_ROOT))
           .setSnippetFileName(id + "/" + DEFAULT_SNIPPET_FILE)
           .build();
 
     } else if (id.equals(PYTHON)) {
       return CommonDiscoveryProvider.newBuilder()
           .setContext(new PythonDiscoveryContext(service, apiaryConfig))
-          .setSnippetSetRunner(new PythonSnippetSetRunner<Method>(new PythonDiscoveryInitializer()))
+          .setSnippetSetRunner(
+              new PythonSnippetSetRunner<Method>(
+                  new PythonDiscoveryInitializer(), SnippetSetRunner.SNIPPET_RESOURCE_ROOT))
           .setSnippetFileName("py/" + DEFAULT_SNIPPET_FILE)
           .build();
 
     } else if (id.equals(RUBY)) {
       return CommonDiscoveryProvider.newBuilder()
           .setContext(new RubyDiscoveryContext(service, apiaryConfig))
-          .setSnippetSetRunner(new RubySnippetSetRunner<Method>())
+          .setSnippetSetRunner(
+              new RubySnippetSetRunner<Method>(SnippetSetRunner.SNIPPET_RESOURCE_ROOT))
           .setSnippetFileName(id + "/" + DEFAULT_SNIPPET_FILE)
           .build();
 

--- a/src/main/java/com/google/api/codegen/discovery/MainDiscoveryProviderFactory.java
+++ b/src/main/java/com/google/api/codegen/discovery/MainDiscoveryProviderFactory.java
@@ -56,49 +56,49 @@ public class MainDiscoveryProviderFactory implements DiscoveryProviderFactory {
       return CommonDiscoveryProvider.newBuilder()
           .setContext(new CSharpDiscoveryContext(service, apiaryConfig))
           .setSnippetSetRunner(new CSharpSnippetSetRunner<Method>())
-          .setSnippetFileName(DEFAULT_SNIPPET_FILE)
+          .setSnippetFileName(id + "/" + DEFAULT_SNIPPET_FILE)
           .build();
 
     } else if (id.equals(GO)) {
       return CommonDiscoveryProvider.newBuilder()
           .setContext(new GoDiscoveryContext(service, apiaryConfig))
           .setSnippetSetRunner(new GoSnippetSetRunner<Method>())
-          .setSnippetFileName(DEFAULT_SNIPPET_FILE)
+          .setSnippetFileName(id + "/" + DEFAULT_SNIPPET_FILE)
           .build();
 
     } else if (id.equals(JAVA)) {
       return CommonDiscoveryProvider.newBuilder()
           .setContext(new JavaDiscoveryContext(service, apiaryConfig))
           .setSnippetSetRunner(new JavaSnippetSetRunner<Method>())
-          .setSnippetFileName(DEFAULT_SNIPPET_FILE)
+          .setSnippetFileName(id + "/" + DEFAULT_SNIPPET_FILE)
           .build();
 
     } else if (id.equals(NODEJS)) {
       return CommonDiscoveryProvider.newBuilder()
           .setContext(new NodeJSDiscoveryContext(service, apiaryConfig))
           .setSnippetSetRunner(new NodeJSSnippetSetRunner<Method>())
-          .setSnippetFileName(DEFAULT_SNIPPET_FILE)
+          .setSnippetFileName(id + "/" + DEFAULT_SNIPPET_FILE)
           .build();
 
     } else if (id.equals(PHP)) {
       return CommonDiscoveryProvider.newBuilder()
           .setContext(new PhpDiscoveryContext(service, apiaryConfig))
           .setSnippetSetRunner(new PhpSnippetSetRunner<Method>())
-          .setSnippetFileName(DEFAULT_SNIPPET_FILE)
+          .setSnippetFileName(id + "/" + DEFAULT_SNIPPET_FILE)
           .build();
 
     } else if (id.equals(PYTHON)) {
       return CommonDiscoveryProvider.newBuilder()
           .setContext(new PythonDiscoveryContext(service, apiaryConfig))
           .setSnippetSetRunner(new PythonSnippetSetRunner<Method>(new PythonDiscoveryInitializer()))
-          .setSnippetFileName(DEFAULT_SNIPPET_FILE)
+          .setSnippetFileName("py/" + DEFAULT_SNIPPET_FILE)
           .build();
 
     } else if (id.equals(RUBY)) {
       return CommonDiscoveryProvider.newBuilder()
           .setContext(new RubyDiscoveryContext(service, apiaryConfig))
           .setSnippetSetRunner(new RubySnippetSetRunner<Method>())
-          .setSnippetFileName(DEFAULT_SNIPPET_FILE)
+          .setSnippetFileName(id + "/" + DEFAULT_SNIPPET_FILE)
           .build();
 
     } else {

--- a/src/main/java/com/google/api/codegen/gapic/CommonGapicProvider.java
+++ b/src/main/java/com/google/api/codegen/gapic/CommonGapicProvider.java
@@ -99,9 +99,7 @@ public class CommonGapicProvider<ElementT> implements GapicProvider<ElementT> {
     // Run the generator for each service.
     List<GeneratedResult> generated = new ArrayList<>();
     for (ElementT element : view.getElementIterable(model)) {
-      GeneratedResult result =
-          generator.generate(
-              element, SnippetSetRunner.SNIPPET_RESOURCE_ROOT, snippetFileName, context);
+      GeneratedResult result = generator.generate(element, snippetFileName, context);
 
       String subPath;
       // Note on usage of instanceof: there is one case (as of this writing)

--- a/src/main/java/com/google/api/codegen/gapic/CommonGapicProvider.java
+++ b/src/main/java/com/google/api/codegen/gapic/CommonGapicProvider.java
@@ -38,7 +38,7 @@ public class CommonGapicProvider<ElementT> implements GapicProvider<ElementT> {
   private final Model model;
   private final InputElementView<ElementT> view;
   private final GapicContext context;
-  private final SnippetSetRunner.Generator<ElementT> snippetSetRunner;
+  private final SnippetSetRunner.Generator<ElementT> generator;
   private final List<String> snippetFileNames;
   private final GapicCodePathMapper pathMapper;
 
@@ -46,13 +46,13 @@ public class CommonGapicProvider<ElementT> implements GapicProvider<ElementT> {
       Model model,
       InputElementView<ElementT> view,
       GapicContext context,
-      SnippetSetRunner.Generator<ElementT> snippetSetRunner,
+      SnippetSetRunner.Generator<ElementT> generator,
       List<String> snippetFileNames,
       GapicCodePathMapper pathMapper) {
     this.model = model;
     this.view = view;
     this.context = context;
-    this.snippetSetRunner = snippetSetRunner;
+    this.generator = generator;
     this.snippetFileNames = snippetFileNames;
     this.pathMapper = pathMapper;
   }
@@ -100,7 +100,7 @@ public class CommonGapicProvider<ElementT> implements GapicProvider<ElementT> {
     List<GeneratedResult> generated = new ArrayList<>();
     for (ElementT element : view.getElementIterable(model)) {
       GeneratedResult result =
-          snippetSetRunner.generate(
+          generator.generate(
               element, SnippetSetRunner.SNIPPET_RESOURCE_ROOT, snippetFileName, context);
 
       String subPath;
@@ -138,7 +138,7 @@ public class CommonGapicProvider<ElementT> implements GapicProvider<ElementT> {
     private Model model;
     private InputElementView<ElementT> view;
     private GapicContext context;
-    private SnippetSetRunner.Generator<ElementT> snippetSetRunner;
+    private SnippetSetRunner.Generator<ElementT> generator;
     private List<String> snippetFileNames;
     private GapicCodePathMapper pathMapper;
 
@@ -159,9 +159,8 @@ public class CommonGapicProvider<ElementT> implements GapicProvider<ElementT> {
       return this;
     }
 
-    public Builder<ElementT> setSnippetSetRunner(
-        SnippetSetRunner.Generator<ElementT> snippetSetRunner) {
-      this.snippetSetRunner = snippetSetRunner;
+    public Builder<ElementT> setSnippetSetRunner(SnippetSetRunner.Generator<ElementT> generator) {
+      this.generator = generator;
       return this;
     }
 
@@ -177,7 +176,7 @@ public class CommonGapicProvider<ElementT> implements GapicProvider<ElementT> {
 
     public CommonGapicProvider<ElementT> build() {
       return new CommonGapicProvider<ElementT>(
-          model, view, context, snippetSetRunner, snippetFileNames, pathMapper);
+          model, view, context, generator, snippetFileNames, pathMapper);
     }
   }
 }

--- a/src/main/java/com/google/api/codegen/gapic/CommonGapicProvider.java
+++ b/src/main/java/com/google/api/codegen/gapic/CommonGapicProvider.java
@@ -38,7 +38,7 @@ public class CommonGapicProvider<ElementT> implements GapicProvider<ElementT> {
   private final Model model;
   private final InputElementView<ElementT> view;
   private final GapicContext context;
-  private final SnippetSetRunner<ElementT> snippetSetRunner;
+  private final SnippetSetRunner.Generator<ElementT> snippetSetRunner;
   private final List<String> snippetFileNames;
   private final GapicCodePathMapper pathMapper;
 
@@ -46,7 +46,7 @@ public class CommonGapicProvider<ElementT> implements GapicProvider<ElementT> {
       Model model,
       InputElementView<ElementT> view,
       GapicContext context,
-      SnippetSetRunner<ElementT> snippetSetRunner,
+      SnippetSetRunner.Generator<ElementT> snippetSetRunner,
       List<String> snippetFileNames,
       GapicCodePathMapper pathMapper) {
     this.model = model;
@@ -99,7 +99,9 @@ public class CommonGapicProvider<ElementT> implements GapicProvider<ElementT> {
     // Run the generator for each service.
     List<GeneratedResult> generated = new ArrayList<>();
     for (ElementT element : view.getElementIterable(model)) {
-      GeneratedResult result = snippetSetRunner.generate(element, snippetFileName, context);
+      GeneratedResult result =
+          snippetSetRunner.generate(
+              element, SnippetSetRunner.SNIPPET_RESOURCE_ROOT, snippetFileName, context);
 
       String subPath;
       // Note on usage of instanceof: there is one case (as of this writing)
@@ -136,7 +138,7 @@ public class CommonGapicProvider<ElementT> implements GapicProvider<ElementT> {
     private Model model;
     private InputElementView<ElementT> view;
     private GapicContext context;
-    private SnippetSetRunner<ElementT> snippetSetRunner;
+    private SnippetSetRunner.Generator<ElementT> snippetSetRunner;
     private List<String> snippetFileNames;
     private GapicCodePathMapper pathMapper;
 
@@ -157,7 +159,8 @@ public class CommonGapicProvider<ElementT> implements GapicProvider<ElementT> {
       return this;
     }
 
-    public Builder<ElementT> setSnippetSetRunner(SnippetSetRunner<ElementT> snippetSetRunner) {
+    public Builder<ElementT> setSnippetSetRunner(
+        SnippetSetRunner.Generator<ElementT> snippetSetRunner) {
       this.snippetSetRunner = snippetSetRunner;
       return this;
     }

--- a/src/main/java/com/google/api/codegen/gapic/MainGapicProviderFactory.java
+++ b/src/main/java/com/google/api/codegen/gapic/MainGapicProviderFactory.java
@@ -77,7 +77,7 @@ public class MainGapicProviderFactory
               .setView(new InterfaceView())
               .setContext(new ClientConfigGapicContext(model, apiConfig))
               .setSnippetSetRunner(new ClientConfigSnippetSetRunner<Interface>())
-              .setSnippetFileNames(Arrays.asList("json.snip"))
+              .setSnippetFileNames(Arrays.asList("clientconfig/json.snip"))
               .setCodePathMapper(CommonGapicCodePathMapper.defaultInstance())
               .build();
       return Arrays.<GapicProvider<? extends Object>>asList(provider);
@@ -89,7 +89,7 @@ public class MainGapicProviderFactory
               .setView(new InterfaceView())
               .setContext(new CSharpGapicContext(model, apiConfig))
               .setSnippetSetRunner(new CSharpSnippetSetRunner<Interface>())
-              .setSnippetFileNames(Arrays.asList("wrapper.snip"))
+              .setSnippetFileNames(Arrays.asList("csharp/wrapper.snip"))
               .setCodePathMapper(new CSharpCodePathMapper())
               .build();
       return Arrays.<GapicProvider<? extends Object>>asList(provider);
@@ -102,7 +102,7 @@ public class MainGapicProviderFactory
               .setContext(new GoGapicContext(model, apiConfig))
               .setSnippetSetRunner(new GoSnippetSetRunner<Interface>())
               .setSnippetFileNames(
-                  Arrays.asList("main.snip", "example.snip", "doc.snip", "common.snip"))
+                  Arrays.asList("go/main.snip", "go/example.snip", "go/doc.snip", "go/common.snip"))
               .setCodePathMapper(CommonGapicCodePathMapper.defaultInstance())
               .build();
       return Arrays.<GapicProvider<? extends Object>>asList(provider);
@@ -119,7 +119,7 @@ public class MainGapicProviderFactory
               .setView(new InterfaceView())
               .setContext(new JavaGapicContext(model, apiConfig))
               .setSnippetSetRunner(new JavaSnippetSetRunner<Interface>())
-              .setSnippetFileNames(Arrays.asList("main.snip", "settings.snip"))
+              .setSnippetFileNames(Arrays.asList("java/main.snip", "java/settings.snip"))
               .setCodePathMapper(javaPathMapper)
               .build();
       GapicProvider<? extends Object> packageInfoProvider =
@@ -128,7 +128,7 @@ public class MainGapicProviderFactory
               .setView(new InterfaceListView())
               .setContext(new JavaGapicContext(model, apiConfig))
               .setSnippetSetRunner(new JavaIterableSnippetSetRunner<Interface>())
-              .setSnippetFileNames(Arrays.asList("package-info.snip"))
+              .setSnippetFileNames(Arrays.asList("java/package-info.snip"))
               .setCodePathMapper(javaPathMapper)
               .build();
 
@@ -143,7 +143,7 @@ public class MainGapicProviderFactory
               .setView(new InterfaceView())
               .setContext(new NodeJSGapicContext(model, apiConfig))
               .setSnippetSetRunner(new NodeJSSnippetSetRunner<Interface>())
-              .setSnippetFileNames(Arrays.asList("main.snip"))
+              .setSnippetFileNames(Arrays.asList("nodejs/main.snip"))
               .setCodePathMapper(nodeJSPathMapper)
               .build();
       GapicProvider<? extends Object> clientConfigProvider =
@@ -152,7 +152,7 @@ public class MainGapicProviderFactory
               .setView(new InterfaceView())
               .setContext(new ClientConfigGapicContext(model, apiConfig))
               .setSnippetSetRunner(new ClientConfigSnippetSetRunner<Interface>())
-              .setSnippetFileNames(Arrays.asList("json.snip"))
+              .setSnippetFileNames(Arrays.asList("clientconfig/json.snip"))
               .setCodePathMapper(nodeJSPathMapper)
               .build();
 
@@ -167,7 +167,7 @@ public class MainGapicProviderFactory
               .setView(new InterfaceView())
               .setContext(new PhpGapicContext(model, apiConfig))
               .setSnippetSetRunner(new PhpSnippetSetRunner<Interface>())
-              .setSnippetFileNames(Arrays.asList("main.snip"))
+              .setSnippetFileNames(Arrays.asList("php/main.snip"))
               .setCodePathMapper(phpPathMapper)
               .build();
 
@@ -179,7 +179,7 @@ public class MainGapicProviderFactory
               .setView(new InterfaceView())
               .setContext(new ClientConfigGapicContext(model, apiConfig))
               .setSnippetSetRunner(new ClientConfigSnippetSetRunner<Interface>())
-              .setSnippetFileNames(Arrays.asList("json.snip"))
+              .setSnippetFileNames(Arrays.asList("clientconfig/json.snip"))
               .setCodePathMapper(phpClientConfigPathMapper)
               .build();
       return Arrays.<GapicProvider<? extends Object>>asList(provider, clientConfigProvider);
@@ -194,7 +194,7 @@ public class MainGapicProviderFactory
               .setContext(new PythonGapicContext(model, apiConfig))
               .setSnippetSetRunner(
                   new PythonSnippetSetRunner<Interface>(new PythonInterfaceInitializer()))
-              .setSnippetFileNames(Arrays.asList("main.snip"))
+              .setSnippetFileNames(Arrays.asList("py/main.snip"))
               .setCodePathMapper(pythonPathMapper)
               .build();
       GapicProvider<? extends Object> messageProvider =
@@ -204,7 +204,7 @@ public class MainGapicProviderFactory
               .setContext(new PythonGapicContext(model, apiConfig))
               .setSnippetSetRunner(
                   new PythonSnippetSetRunner<ProtoFile>(new PythonProtoFileInitializer()))
-              .setSnippetFileNames(Arrays.asList("message.snip"))
+              .setSnippetFileNames(Arrays.asList("py/message.snip"))
               .setCodePathMapper(CommonGapicCodePathMapper.defaultInstance())
               .build();
       GapicProvider<? extends Object> clientConfigProvider =
@@ -213,7 +213,7 @@ public class MainGapicProviderFactory
               .setView(new InterfaceView())
               .setContext(new ClientConfigGapicContext(model, apiConfig))
               .setSnippetSetRunner(new ClientConfigSnippetSetRunner<Interface>())
-              .setSnippetFileNames(Arrays.asList("json.snip"))
+              .setSnippetFileNames(Arrays.asList("clientconfig/json.snip"))
               .setCodePathMapper(pythonPathMapper)
               .build();
 
@@ -232,7 +232,7 @@ public class MainGapicProviderFactory
               .setView(new InterfaceView())
               .setContext(new RubyGapicContext(model, apiConfig))
               .setSnippetSetRunner(new RubySnippetSetRunner<Interface>())
-              .setSnippetFileNames(Arrays.asList("main.snip"))
+              .setSnippetFileNames(Arrays.asList("ruby/main.snip"))
               .setCodePathMapper(rubyPathMapper)
               .build();
       GapicProvider<? extends Object> messageProvider =
@@ -241,7 +241,7 @@ public class MainGapicProviderFactory
               .setView(new ProtoFileView())
               .setContext(new RubyGapicContext(model, apiConfig))
               .setSnippetSetRunner(new RubySnippetSetRunner<ProtoFile>())
-              .setSnippetFileNames(Arrays.asList("message.snip"))
+              .setSnippetFileNames(Arrays.asList("ruby/message.snip"))
               .setCodePathMapper(rubyPathMapper)
               .build();
       GapicProvider<? extends Object> clientConfigProvider =
@@ -250,7 +250,7 @@ public class MainGapicProviderFactory
               .setView(new InterfaceView())
               .setContext(new ClientConfigGapicContext(model, apiConfig))
               .setSnippetSetRunner(new ClientConfigSnippetSetRunner<Interface>())
-              .setSnippetFileNames(Arrays.asList("json.snip"))
+              .setSnippetFileNames(Arrays.asList("clientconfig/json.snip"))
               .setCodePathMapper(rubyPathMapper)
               .build();
 

--- a/src/main/java/com/google/api/codegen/gapic/MainGapicProviderFactory.java
+++ b/src/main/java/com/google/api/codegen/gapic/MainGapicProviderFactory.java
@@ -15,10 +15,11 @@
 package com.google.api.codegen.gapic;
 
 import com.google.api.codegen.ApiConfig;
+import com.google.api.codegen.clientconfig.ClientConfigGapicContext;
 import com.google.api.codegen.InterfaceListView;
 import com.google.api.codegen.InterfaceView;
 import com.google.api.codegen.ProtoFileView;
-import com.google.api.codegen.clientconfig.ClientConfigGapicContext;
+import com.google.api.codegen.SnippetSetRunner;
 import com.google.api.codegen.clientconfig.ClientConfigSnippetSetRunner;
 import com.google.api.codegen.csharp.CSharpCodePathMapper;
 import com.google.api.codegen.csharp.CSharpGapicContext;
@@ -76,7 +77,9 @@ public class MainGapicProviderFactory
               .setModel(model)
               .setView(new InterfaceView())
               .setContext(new ClientConfigGapicContext(model, apiConfig))
-              .setSnippetSetRunner(new ClientConfigSnippetSetRunner<Interface>())
+              .setSnippetSetRunner(
+                  new ClientConfigSnippetSetRunner<Interface>(
+                      SnippetSetRunner.SNIPPET_RESOURCE_ROOT))
               .setSnippetFileNames(Arrays.asList("clientconfig/json.snip"))
               .setCodePathMapper(CommonGapicCodePathMapper.defaultInstance())
               .build();
@@ -88,7 +91,8 @@ public class MainGapicProviderFactory
               .setModel(model)
               .setView(new InterfaceView())
               .setContext(new CSharpGapicContext(model, apiConfig))
-              .setSnippetSetRunner(new CSharpSnippetSetRunner<Interface>())
+              .setSnippetSetRunner(
+                  new CSharpSnippetSetRunner<Interface>(SnippetSetRunner.SNIPPET_RESOURCE_ROOT))
               .setSnippetFileNames(Arrays.asList("csharp/wrapper.snip"))
               .setCodePathMapper(new CSharpCodePathMapper())
               .build();
@@ -100,7 +104,8 @@ public class MainGapicProviderFactory
               .setModel(model)
               .setView(new InterfaceView())
               .setContext(new GoGapicContext(model, apiConfig))
-              .setSnippetSetRunner(new GoSnippetSetRunner<Interface>())
+              .setSnippetSetRunner(
+                  new GoSnippetSetRunner<Interface>(SnippetSetRunner.SNIPPET_RESOURCE_ROOT))
               .setSnippetFileNames(
                   Arrays.asList("go/main.snip", "go/example.snip", "go/doc.snip", "go/common.snip"))
               .setCodePathMapper(CommonGapicCodePathMapper.defaultInstance())
@@ -118,7 +123,8 @@ public class MainGapicProviderFactory
               .setModel(model)
               .setView(new InterfaceView())
               .setContext(new JavaGapicContext(model, apiConfig))
-              .setSnippetSetRunner(new JavaSnippetSetRunner<Interface>())
+              .setSnippetSetRunner(
+                  new JavaSnippetSetRunner<Interface>(SnippetSetRunner.SNIPPET_RESOURCE_ROOT))
               .setSnippetFileNames(Arrays.asList("java/main.snip", "java/settings.snip"))
               .setCodePathMapper(javaPathMapper)
               .build();
@@ -127,7 +133,9 @@ public class MainGapicProviderFactory
               .setModel(model)
               .setView(new InterfaceListView())
               .setContext(new JavaGapicContext(model, apiConfig))
-              .setSnippetSetRunner(new JavaIterableSnippetSetRunner<Interface>())
+              .setSnippetSetRunner(
+                  new JavaIterableSnippetSetRunner<Interface>(
+                      SnippetSetRunner.SNIPPET_RESOURCE_ROOT))
               .setSnippetFileNames(Arrays.asList("java/package-info.snip"))
               .setCodePathMapper(javaPathMapper)
               .build();
@@ -142,7 +150,8 @@ public class MainGapicProviderFactory
               .setModel(model)
               .setView(new InterfaceView())
               .setContext(new NodeJSGapicContext(model, apiConfig))
-              .setSnippetSetRunner(new NodeJSSnippetSetRunner<Interface>())
+              .setSnippetSetRunner(
+                  new NodeJSSnippetSetRunner<Interface>(SnippetSetRunner.SNIPPET_RESOURCE_ROOT))
               .setSnippetFileNames(Arrays.asList("nodejs/main.snip"))
               .setCodePathMapper(nodeJSPathMapper)
               .build();
@@ -151,7 +160,9 @@ public class MainGapicProviderFactory
               .setModel(model)
               .setView(new InterfaceView())
               .setContext(new ClientConfigGapicContext(model, apiConfig))
-              .setSnippetSetRunner(new ClientConfigSnippetSetRunner<Interface>())
+              .setSnippetSetRunner(
+                  new ClientConfigSnippetSetRunner<Interface>(
+                      SnippetSetRunner.SNIPPET_RESOURCE_ROOT))
               .setSnippetFileNames(Arrays.asList("clientconfig/json.snip"))
               .setCodePathMapper(nodeJSPathMapper)
               .build();
@@ -166,7 +177,8 @@ public class MainGapicProviderFactory
               .setModel(model)
               .setView(new InterfaceView())
               .setContext(new PhpGapicContext(model, apiConfig))
-              .setSnippetSetRunner(new PhpSnippetSetRunner<Interface>())
+              .setSnippetSetRunner(
+                  new PhpSnippetSetRunner<Interface>(SnippetSetRunner.SNIPPET_RESOURCE_ROOT))
               .setSnippetFileNames(Arrays.asList("php/main.snip"))
               .setCodePathMapper(phpPathMapper)
               .build();
@@ -178,7 +190,9 @@ public class MainGapicProviderFactory
               .setModel(model)
               .setView(new InterfaceView())
               .setContext(new ClientConfigGapicContext(model, apiConfig))
-              .setSnippetSetRunner(new ClientConfigSnippetSetRunner<Interface>())
+              .setSnippetSetRunner(
+                  new ClientConfigSnippetSetRunner<Interface>(
+                      SnippetSetRunner.SNIPPET_RESOURCE_ROOT))
               .setSnippetFileNames(Arrays.asList("clientconfig/json.snip"))
               .setCodePathMapper(phpClientConfigPathMapper)
               .build();
@@ -193,7 +207,8 @@ public class MainGapicProviderFactory
               .setView(new InterfaceView())
               .setContext(new PythonGapicContext(model, apiConfig))
               .setSnippetSetRunner(
-                  new PythonSnippetSetRunner<Interface>(new PythonInterfaceInitializer()))
+                  new PythonSnippetSetRunner<Interface>(
+                      new PythonInterfaceInitializer(), SnippetSetRunner.SNIPPET_RESOURCE_ROOT))
               .setSnippetFileNames(Arrays.asList("py/main.snip"))
               .setCodePathMapper(pythonPathMapper)
               .build();
@@ -203,7 +218,8 @@ public class MainGapicProviderFactory
               .setView(new ProtoFileView())
               .setContext(new PythonGapicContext(model, apiConfig))
               .setSnippetSetRunner(
-                  new PythonSnippetSetRunner<ProtoFile>(new PythonProtoFileInitializer()))
+                  new PythonSnippetSetRunner<ProtoFile>(
+                      new PythonProtoFileInitializer(), SnippetSetRunner.SNIPPET_RESOURCE_ROOT))
               .setSnippetFileNames(Arrays.asList("py/message.snip"))
               .setCodePathMapper(CommonGapicCodePathMapper.defaultInstance())
               .build();
@@ -212,7 +228,9 @@ public class MainGapicProviderFactory
               .setModel(model)
               .setView(new InterfaceView())
               .setContext(new ClientConfigGapicContext(model, apiConfig))
-              .setSnippetSetRunner(new ClientConfigSnippetSetRunner<Interface>())
+              .setSnippetSetRunner(
+                  new ClientConfigSnippetSetRunner<Interface>(
+                      SnippetSetRunner.SNIPPET_RESOURCE_ROOT))
               .setSnippetFileNames(Arrays.asList("clientconfig/json.snip"))
               .setCodePathMapper(pythonPathMapper)
               .build();
@@ -231,7 +249,8 @@ public class MainGapicProviderFactory
               .setModel(model)
               .setView(new InterfaceView())
               .setContext(new RubyGapicContext(model, apiConfig))
-              .setSnippetSetRunner(new RubySnippetSetRunner<Interface>())
+              .setSnippetSetRunner(
+                  new RubySnippetSetRunner<Interface>(SnippetSetRunner.SNIPPET_RESOURCE_ROOT))
               .setSnippetFileNames(Arrays.asList("ruby/main.snip"))
               .setCodePathMapper(rubyPathMapper)
               .build();
@@ -240,7 +259,8 @@ public class MainGapicProviderFactory
               .setModel(model)
               .setView(new ProtoFileView())
               .setContext(new RubyGapicContext(model, apiConfig))
-              .setSnippetSetRunner(new RubySnippetSetRunner<ProtoFile>())
+              .setSnippetSetRunner(
+                  new RubySnippetSetRunner<ProtoFile>(SnippetSetRunner.SNIPPET_RESOURCE_ROOT))
               .setSnippetFileNames(Arrays.asList("ruby/message.snip"))
               .setCodePathMapper(rubyPathMapper)
               .build();
@@ -249,7 +269,9 @@ public class MainGapicProviderFactory
               .setModel(model)
               .setView(new InterfaceView())
               .setContext(new ClientConfigGapicContext(model, apiConfig))
-              .setSnippetSetRunner(new ClientConfigSnippetSetRunner<Interface>())
+              .setSnippetSetRunner(
+                  new ClientConfigSnippetSetRunner<Interface>(
+                      SnippetSetRunner.SNIPPET_RESOURCE_ROOT))
               .setSnippetFileNames(Arrays.asList("clientconfig/json.snip"))
               .setCodePathMapper(rubyPathMapper)
               .build();

--- a/src/main/java/com/google/api/codegen/go/GoSnippetSetRunner.java
+++ b/src/main/java/com/google/api/codegen/go/GoSnippetSetRunner.java
@@ -24,22 +24,16 @@ import com.google.common.collect.ImmutableMap;
 /**
  * A GoProvider provides general Go code generation logic.
  */
-public class GoSnippetSetRunner<ElementT> implements SnippetSetRunner<ElementT> {
-
-  /**
-   * The path to the root of snippet resources.
-   */
-  private static final String SNIPPET_RESOURCE_ROOT =
-      GoContextCommon.class.getPackage().getName().replace('.', '/');
+public class GoSnippetSetRunner<ElementT> implements SnippetSetRunner.Generator<ElementT> {
 
   @Override
   @SuppressWarnings("unchecked")
   public GeneratedResult generate(
-      ElementT element, String snippetFileName, CodegenContext context) {
+      ElementT element, String resourceRoot, String snippetFileName, CodegenContext context) {
     GoSnippetSet<ElementT> snippets =
         SnippetSet.createSnippetInterface(
             GoSnippetSet.class,
-            SNIPPET_RESOURCE_ROOT,
+            resourceRoot,
             snippetFileName,
             ImmutableMap.<String, Object>of("context", context));
 

--- a/src/main/java/com/google/api/codegen/go/GoSnippetSetRunner.java
+++ b/src/main/java/com/google/api/codegen/go/GoSnippetSetRunner.java
@@ -26,10 +26,16 @@ import com.google.common.collect.ImmutableMap;
  */
 public class GoSnippetSetRunner<ElementT> implements SnippetSetRunner.Generator<ElementT> {
 
+  private final String resourceRoot;
+
+  public GoSnippetSetRunner(String resourceRoot) {
+    this.resourceRoot = resourceRoot;
+  }
+
   @Override
   @SuppressWarnings("unchecked")
   public GeneratedResult generate(
-      ElementT element, String resourceRoot, String snippetFileName, CodegenContext context) {
+      ElementT element, String snippetFileName, CodegenContext context) {
     GoSnippetSet<ElementT> snippets =
         SnippetSet.createSnippetInterface(
             GoSnippetSet.class,

--- a/src/main/java/com/google/api/codegen/java/JavaIterableSnippetSetRunner.java
+++ b/src/main/java/com/google/api/codegen/java/JavaIterableSnippetSetRunner.java
@@ -32,13 +32,16 @@ import java.util.List;
 public class JavaIterableSnippetSetRunner<ElementT>
     implements SnippetSetRunner.Generator<Iterable<ElementT>> {
 
+  private final String resourceRoot;
+
+  public JavaIterableSnippetSetRunner(String resourceRoot) {
+    this.resourceRoot = resourceRoot;
+  }
+
   @Override
   @SuppressWarnings("unchecked")
   public GeneratedResult generate(
-      Iterable<ElementT> elementList,
-      String resourceRoot,
-      String snippetFileName,
-      CodegenContext context) {
+      Iterable<ElementT> elementList, String snippetFileName, CodegenContext context) {
     JavaIterableSnippetSet<ElementT> snippets =
         SnippetSet.createSnippetInterface(
             JavaIterableSnippetSet.class,

--- a/src/main/java/com/google/api/codegen/java/JavaIterableSnippetSetRunner.java
+++ b/src/main/java/com/google/api/codegen/java/JavaIterableSnippetSetRunner.java
@@ -30,22 +30,19 @@ import java.util.List;
  * subclass of JavaContext.
  */
 public class JavaIterableSnippetSetRunner<ElementT>
-    implements SnippetSetRunner<Iterable<ElementT>> {
-
-  /**
-   * The path to the root of snippet resources.
-   */
-  private final String SNIPPET_RESOURCE_ROOT =
-      JavaContextCommon.class.getPackage().getName().replace('.', '/');
+    implements SnippetSetRunner.Generator<Iterable<ElementT>> {
 
   @Override
   @SuppressWarnings("unchecked")
   public GeneratedResult generate(
-      Iterable<ElementT> elementList, String snippetFileName, CodegenContext context) {
+      Iterable<ElementT> elementList,
+      String resourceRoot,
+      String snippetFileName,
+      CodegenContext context) {
     JavaIterableSnippetSet<ElementT> snippets =
         SnippetSet.createSnippetInterface(
             JavaIterableSnippetSet.class,
-            SNIPPET_RESOURCE_ROOT,
+            resourceRoot,
             snippetFileName,
             ImmutableMap.<String, Object>of("context", context));
 

--- a/src/main/java/com/google/api/codegen/java/JavaSnippetSetRunner.java
+++ b/src/main/java/com/google/api/codegen/java/JavaSnippetSetRunner.java
@@ -28,7 +28,7 @@ import java.util.List;
  * (e.g. Gapic vs Discovery). Behavior that is specific to a use case is provided through a
  * subclass of JavaContext.
  */
-public class JavaSnippetSetRunner<ElementT> implements SnippetSetRunner<ElementT> {
+public class JavaSnippetSetRunner<ElementT> implements SnippetSetRunner.Generator<ElementT> {
 
   /**
    * The path to the root of snippet resources.
@@ -39,11 +39,11 @@ public class JavaSnippetSetRunner<ElementT> implements SnippetSetRunner<ElementT
   @Override
   @SuppressWarnings("unchecked")
   public GeneratedResult generate(
-      ElementT element, String snippetFileName, CodegenContext context) {
+      ElementT element, String resourceRoot, String snippetFileName, CodegenContext context) {
     JavaSnippetSet<ElementT> snippets =
         SnippetSet.createSnippetInterface(
             JavaSnippetSet.class,
-            SNIPPET_RESOURCE_ROOT,
+            resourceRoot,
             snippetFileName,
             ImmutableMap.<String, Object>of("context", context));
 

--- a/src/main/java/com/google/api/codegen/java/JavaSnippetSetRunner.java
+++ b/src/main/java/com/google/api/codegen/java/JavaSnippetSetRunner.java
@@ -30,16 +30,16 @@ import java.util.List;
  */
 public class JavaSnippetSetRunner<ElementT> implements SnippetSetRunner.Generator<ElementT> {
 
-  /**
-   * The path to the root of snippet resources.
-   */
-  private static final String SNIPPET_RESOURCE_ROOT =
-      JavaContextCommon.class.getPackage().getName().replace('.', '/');
+  private final String resourceRoot;
+
+  public JavaSnippetSetRunner(String resourceRoot) {
+    this.resourceRoot = resourceRoot;
+  }
 
   @Override
   @SuppressWarnings("unchecked")
   public GeneratedResult generate(
-      ElementT element, String resourceRoot, String snippetFileName, CodegenContext context) {
+      ElementT element, String snippetFileName, CodegenContext context) {
     JavaSnippetSet<ElementT> snippets =
         SnippetSet.createSnippetInterface(
             JavaSnippetSet.class,

--- a/src/main/java/com/google/api/codegen/nodejs/NodeJSSnippetSetRunner.java
+++ b/src/main/java/com/google/api/codegen/nodejs/NodeJSSnippetSetRunner.java
@@ -26,22 +26,16 @@ import com.google.common.collect.ImmutableMap;
  * (e.g. Gapic vs Discovery). Behavior that is specific to a use case is provided through a
  * subclass of NodeJSContext.
  */
-public class NodeJSSnippetSetRunner<ElementT> implements SnippetSetRunner<ElementT> {
-
-  /**
-   * The path to the root of snippet resources.
-   */
-  private static final String SNIPPET_RESOURCE_ROOT =
-      NodeJSSnippetSetRunner.class.getPackage().getName().replace('.', '/');
+public class NodeJSSnippetSetRunner<ElementT> implements SnippetSetRunner.Generator<ElementT> {
 
   @Override
   @SuppressWarnings("unchecked")
   public GeneratedResult generate(
-      ElementT element, String snippetFileName, CodegenContext context) {
+      ElementT element, String resourceRoot, String snippetFileName, CodegenContext context) {
     NodeJSSnippetSet<ElementT> snippets =
         SnippetSet.createSnippetInterface(
             NodeJSSnippetSet.class,
-            SNIPPET_RESOURCE_ROOT,
+            resourceRoot,
             snippetFileName,
             ImmutableMap.<String, Object>of("context", context));
 

--- a/src/main/java/com/google/api/codegen/nodejs/NodeJSSnippetSetRunner.java
+++ b/src/main/java/com/google/api/codegen/nodejs/NodeJSSnippetSetRunner.java
@@ -28,10 +28,16 @@ import com.google.common.collect.ImmutableMap;
  */
 public class NodeJSSnippetSetRunner<ElementT> implements SnippetSetRunner.Generator<ElementT> {
 
+  private final String resourceRoot;
+
+  public NodeJSSnippetSetRunner(String resourceRoot) {
+    this.resourceRoot = resourceRoot;
+  }
+
   @Override
   @SuppressWarnings("unchecked")
   public GeneratedResult generate(
-      ElementT element, String resourceRoot, String snippetFileName, CodegenContext context) {
+      ElementT element, String snippetFileName, CodegenContext context) {
     NodeJSSnippetSet<ElementT> snippets =
         SnippetSet.createSnippetInterface(
             NodeJSSnippetSet.class,

--- a/src/main/java/com/google/api/codegen/php/PhpSnippetSetRunner.java
+++ b/src/main/java/com/google/api/codegen/php/PhpSnippetSetRunner.java
@@ -30,10 +30,16 @@ import java.util.List;
  */
 public class PhpSnippetSetRunner<ElementT> implements SnippetSetRunner.Generator<ElementT> {
 
+  private final String resourceRoot;
+
+  public PhpSnippetSetRunner(String resourceRoot) {
+    this.resourceRoot = resourceRoot;
+  }
+
   @Override
   @SuppressWarnings("unchecked")
   public GeneratedResult generate(
-      ElementT element, String resourceRoot, String snippetFileName, CodegenContext context) {
+      ElementT element, String snippetFileName, CodegenContext context) {
     PhpSnippetSet<ElementT> snippets =
         SnippetSet.createSnippetInterface(
             PhpSnippetSet.class,

--- a/src/main/java/com/google/api/codegen/php/PhpSnippetSetRunner.java
+++ b/src/main/java/com/google/api/codegen/php/PhpSnippetSetRunner.java
@@ -28,22 +28,16 @@ import java.util.List;
  * Gapic vs Discovery). Behavior that is specific to a use case is provided through a PHP context
  * class (PhpGapicContext vs PhpDiscoveryContext).
  */
-public class PhpSnippetSetRunner<ElementT> implements SnippetSetRunner<ElementT> {
-
-  /**
-   * The path to the root of snippet resources.
-   */
-  private static final String SNIPPET_RESOURCE_ROOT =
-      PhpSnippetSetRunner.class.getPackage().getName().replace('.', '/');
+public class PhpSnippetSetRunner<ElementT> implements SnippetSetRunner.Generator<ElementT> {
 
   @Override
   @SuppressWarnings("unchecked")
   public GeneratedResult generate(
-      ElementT element, String snippetFileName, CodegenContext context) {
+      ElementT element, String resourceRoot, String snippetFileName, CodegenContext context) {
     PhpSnippetSet<ElementT> snippets =
         SnippetSet.createSnippetInterface(
             PhpSnippetSet.class,
-            SNIPPET_RESOURCE_ROOT,
+            resourceRoot,
             snippetFileName,
             ImmutableMap.<String, Object>of("context", context));
 

--- a/src/main/java/com/google/api/codegen/py/PythonSnippetSetRunner.java
+++ b/src/main/java/com/google/api/codegen/py/PythonSnippetSetRunner.java
@@ -29,15 +29,18 @@ import java.util.List;
 public class PythonSnippetSetRunner<ElementT> implements SnippetSetRunner.Generator<ElementT> {
 
   private PythonSnippetSetInputInitializer<ElementT> initializer;
+  private final String resourceRoot;
 
-  public PythonSnippetSetRunner(PythonSnippetSetInputInitializer<ElementT> initializer) {
+  public PythonSnippetSetRunner(
+      PythonSnippetSetInputInitializer<ElementT> initializer, String resourceRoot) {
     this.initializer = initializer;
+    this.resourceRoot = resourceRoot;
   }
 
   @Override
   @SuppressWarnings("unchecked")
   public GeneratedResult generate(
-      ElementT element, String resourceRoot, String snippetFileName, CodegenContext context) {
+      ElementT element, String snippetFileName, CodegenContext context) {
     PythonImportHandler importHandler = initializer.getImportHandler(element);
     ImmutableMap<String, Object> globalMap = initializer.getGlobalMap(element);
     globalMap =

--- a/src/main/java/com/google/api/codegen/py/PythonSnippetSetRunner.java
+++ b/src/main/java/com/google/api/codegen/py/PythonSnippetSetRunner.java
@@ -26,15 +26,9 @@ import java.util.List;
 /**
  * A PythonProvider provides general Python code generation logic.
  */
-public class PythonSnippetSetRunner<ElementT> implements SnippetSetRunner<ElementT> {
+public class PythonSnippetSetRunner<ElementT> implements SnippetSetRunner.Generator<ElementT> {
 
   private PythonSnippetSetInputInitializer<ElementT> initializer;
-
-  /**
-   * The path to the root of snippet resources.
-   */
-  static final String SNIPPET_RESOURCE_ROOT =
-      PythonContextCommon.class.getPackage().getName().replace('.', '/');
 
   public PythonSnippetSetRunner(PythonSnippetSetInputInitializer<ElementT> initializer) {
     this.initializer = initializer;
@@ -43,7 +37,7 @@ public class PythonSnippetSetRunner<ElementT> implements SnippetSetRunner<Elemen
   @Override
   @SuppressWarnings("unchecked")
   public GeneratedResult generate(
-      ElementT element, String snippetFileName, CodegenContext context) {
+      ElementT element, String resourceRoot, String snippetFileName, CodegenContext context) {
     PythonImportHandler importHandler = initializer.getImportHandler(element);
     ImmutableMap<String, Object> globalMap = initializer.getGlobalMap(element);
     globalMap =
@@ -55,7 +49,7 @@ public class PythonSnippetSetRunner<ElementT> implements SnippetSetRunner<Elemen
 
     PythonSnippetSet<ElementT> snippets =
         SnippetSet.createSnippetInterface(
-            PythonSnippetSet.class, SNIPPET_RESOURCE_ROOT, snippetFileName, globalMap);
+            PythonSnippetSet.class, resourceRoot, snippetFileName, globalMap);
 
     Doc body = snippets.generateBody(element);
     List<String> importList = importHandler.calculateImports();

--- a/src/main/java/com/google/api/codegen/ruby/RubyApiaryNameMap.java
+++ b/src/main/java/com/google/api/codegen/ruby/RubyApiaryNameMap.java
@@ -57,11 +57,14 @@ public class RubyApiaryNameMap {
     return NAME_MAP.get(id);
   }
 
+  @SuppressWarnings("unchecked")
   private static ImmutableMap<ResourceId, String> getNameMap() throws IOException {
     String data =
         Resources.toString(
             Resources.getResource(RubyApiaryNameMap.class, "apiary_names.yaml"),
             StandardCharsets.UTF_8);
+
+    // Unchecked cast here.
     Map<String, String> nameData = (Map<String, String>) (new Yaml().load(data));
     ImmutableMap.Builder<ResourceId, String> builder = ImmutableMap.<ResourceId, String>builder();
     for (Map.Entry<String, String> entry : nameData.entrySet()) {

--- a/src/main/java/com/google/api/codegen/ruby/RubySnippetSetRunner.java
+++ b/src/main/java/com/google/api/codegen/ruby/RubySnippetSetRunner.java
@@ -26,10 +26,16 @@ import com.google.common.collect.ImmutableMap;
  */
 public class RubySnippetSetRunner<ElementT> implements SnippetSetRunner.Generator<ElementT> {
 
+  private final String resourceRoot;
+
+  public RubySnippetSetRunner(String resourceRoot) {
+    this.resourceRoot = resourceRoot;
+  }
+
   @Override
   @SuppressWarnings("unchecked")
   public GeneratedResult generate(
-      ElementT element, String resourceRoot, String snippetFileName, CodegenContext context) {
+      ElementT element, String snippetFileName, CodegenContext context) {
     ImmutableMap<String, Object> globalMap =
         ImmutableMap.<String, Object>builder().put("context", context).build();
     RubySnippetSet<ElementT> snippets =

--- a/src/main/java/com/google/api/codegen/ruby/RubySnippetSetRunner.java
+++ b/src/main/java/com/google/api/codegen/ruby/RubySnippetSetRunner.java
@@ -24,23 +24,17 @@ import com.google.common.collect.ImmutableMap;
 /**
  * A RubyProvider provides general Ruby code generation logic.
  */
-public class RubySnippetSetRunner<ElementT> implements SnippetSetRunner<ElementT> {
-
-  /**
-   * The path to the root of snippet resources.
-   */
-  static final String SNIPPET_RESOURCE_ROOT =
-      RubySnippetSetRunner.class.getPackage().getName().replace('.', '/');
+public class RubySnippetSetRunner<ElementT> implements SnippetSetRunner.Generator<ElementT> {
 
   @Override
   @SuppressWarnings("unchecked")
   public GeneratedResult generate(
-      ElementT element, String snippetFileName, CodegenContext context) {
+      ElementT element, String resourceRoot, String snippetFileName, CodegenContext context) {
     ImmutableMap<String, Object> globalMap =
         ImmutableMap.<String, Object>builder().put("context", context).build();
     RubySnippetSet<ElementT> snippets =
         SnippetSet.createSnippetInterface(
-            RubySnippetSet.class, SNIPPET_RESOURCE_ROOT, snippetFileName, globalMap);
+            RubySnippetSet.class, resourceRoot, snippetFileName, globalMap);
 
     Doc filenameDoc = snippets.generateFilename(element);
     String outputFilename = filenameDoc.prettyPrint();

--- a/src/main/java/com/google/api/codegen/util/ClassInstantiator.java
+++ b/src/main/java/com/google/api/codegen/util/ClassInstantiator.java
@@ -30,6 +30,7 @@ public final class ClassInstantiator {
     void error(String message, Object... args);
   }
 
+  @SuppressWarnings("unchecked")
   public static <LP> LP createClass(
       String className,
       Class<LP> coerceType,
@@ -71,6 +72,8 @@ public final class ClassInstantiator {
       return null;
     }
     try {
+      // Unchecked cast here. This is safe though, since we make sure that coerceType is assignable
+      // from classType.
       return (LP) ctor.newInstance(ctorArg);
     } catch (InstantiationException
         | IllegalAccessException

--- a/src/main/resources/com/google/api/codegen/clientconfig/json.snip
+++ b/src/main/resources/com/google/api/codegen/clientconfig/json.snip
@@ -1,4 +1,4 @@
-@extends "../common.snip"
+@extends "common.snip"
 
 @snippet generateFilename(service)
     {@context.upperCamelToLowerUnderscore(service.getSimpleName)}_client_config.json
@@ -76,7 +76,7 @@
               "rpc_timeout_multiplier": {@retryDef.getValue.getRpcTimeoutMultiplier},
               "max_rpc_timeout_millis": {@retryDef.getValue.getMaxRpcTimeout.getMillis()},
               "total_timeout_millis": {@retryDef.getValue.getTotalTimeout.getMillis()}
-            }     
+            }
         @end
     @end
 @end

--- a/src/main/resources/com/google/api/codegen/go/common.snip
+++ b/src/main/resources/com/google/api/codegen/go/common.snip
@@ -1,4 +1,4 @@
-@extends "header.snip"
+@extends "go/header.snip"
 
 @snippet generateFilename(service)
     {@context.getApiConfig.getPackageName}/{@context.getPackageName}.go

--- a/src/main/resources/com/google/api/codegen/go/discovery_fragment.snip
+++ b/src/main/resources/com/google/api/codegen/go/discovery_fragment.snip
@@ -1,4 +1,4 @@
-@extends "../common.snip"
+@extends "common.snip"
 
 @snippet generateFilename(method)
   {@method.getName}.frag.go

--- a/src/main/resources/com/google/api/codegen/go/doc.snip
+++ b/src/main/resources/com/google/api/codegen/go/doc.snip
@@ -1,4 +1,4 @@
-@extends "header.snip"
+@extends "go/header.snip"
 
 @snippet generateFilename(service)
     {@context.getApiConfig.getPackageName}/doc.go

--- a/src/main/resources/com/google/api/codegen/go/example.snip
+++ b/src/main/resources/com/google/api/codegen/go/example.snip
@@ -1,4 +1,4 @@
-@extends "header.snip"
+@extends "go/header.snip"
 
 @snippet generateFilename(service)
     {@context.getApiConfig.getPackageName}/{@context.getReducedServiceName(service)}_client_example_test.go

--- a/src/main/resources/com/google/api/codegen/go/main.snip
+++ b/src/main/resources/com/google/api/codegen/go/main.snip
@@ -1,4 +1,4 @@
-@extends "header.snip"
+@extends "go/header.snip"
 
 @snippet generateFilename(service)
     {@context.getApiConfig.getPackageName}/{@context.getReducedServiceName(service)}_client.go

--- a/src/main/resources/com/google/api/codegen/java/discovery_fragment.snip
+++ b/src/main/resources/com/google/api/codegen/java/discovery_fragment.snip
@@ -1,4 +1,4 @@
-@extends "../common.snip"
+@extends "common.snip"
 
 @snippet generateFilename(method)
   {@method.getName}.frag.java

--- a/src/main/resources/com/google/api/codegen/java/main.snip
+++ b/src/main/resources/com/google/api/codegen/java/main.snip
@@ -1,5 +1,5 @@
-@extends "common.snip"
-@extends "method_sample.snip"
+@extends "java/common.snip"
+@extends "java/method_sample.snip"
 
 @snippet generateFilename(service)
   {@context.getApiWrapperName(service)}.java

--- a/src/main/resources/com/google/api/codegen/java/method_sample.snip
+++ b/src/main/resources/com/google/api/codegen/java/method_sample.snip
@@ -1,4 +1,4 @@
-@extends "common.snip"
+@extends "java/common.snip"
 
 # Generate code samples for method-level documentation.
 @snippet generateMethodSampleCode(docConfig)

--- a/src/main/resources/com/google/api/codegen/java/package-info.snip
+++ b/src/main/resources/com/google/api/codegen/java/package-info.snip
@@ -1,5 +1,5 @@
-@extends "common.snip"
-@extends "main.snip"
+@extends "java/common.snip"
+@extends "java/main.snip"
 
 @snippet generateFilename()
   package-info.java

--- a/src/main/resources/com/google/api/codegen/java/settings.snip
+++ b/src/main/resources/com/google/api/codegen/java/settings.snip
@@ -1,4 +1,4 @@
-@extends "common.snip"
+@extends "java/common.snip"
 
 @snippet generateFilename(service)
   {@settingsClassName(service)}.java

--- a/src/main/resources/com/google/api/codegen/nodejs/discovery_fragment.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/discovery_fragment.snip
@@ -1,4 +1,4 @@
-@extends "../common.snip"
+@extends "common.snip"
 
 @snippet generateFilename(method)
   {@method.getName}.frag.njs

--- a/src/main/resources/com/google/api/codegen/php/main.snip
+++ b/src/main/resources/com/google/api/codegen/php/main.snip
@@ -1,5 +1,5 @@
-@extends "../common.snip"
-@extends "method_sample.snip"
+@extends "common.snip"
+@extends "php/method_sample.snip"
 
 @snippet generateFilename(service)
     {@context.getApiWrapperName(service)}.php

--- a/src/main/resources/com/google/api/codegen/py/common.snip
+++ b/src/main/resources/com/google/api/codegen/py/common.snip
@@ -1,4 +1,4 @@
-@extends "../common.snip"
+@extends "common.snip"
 
 @snippet formatResourceFunctionName(collectionConfig)
   {@collectionConfig.getEntityName}_path

--- a/src/main/resources/com/google/api/codegen/py/discovery_fragment.snip
+++ b/src/main/resources/com/google/api/codegen/py/discovery_fragment.snip
@@ -1,4 +1,4 @@
-@extends "../common.snip"
+@extends "common.snip"
 
 @snippet generateFilename(method)
     {@method.getName}.frag.py

--- a/src/main/resources/com/google/api/codegen/py/main.snip
+++ b/src/main/resources/com/google/api/codegen/py/main.snip
@@ -1,5 +1,5 @@
-@extends "common.snip"
-@extends "method_sample.snip"
+@extends "py/common.snip"
+@extends "py/method_sample.snip"
 
 @snippet generateFilename(service)
     {@context.upperCamelToLowerUnderscore(context.getApiWrapperName(service))}.py
@@ -362,14 +362,14 @@
     @if context.getApiConfig.generateSamples
       @if descriptionComments.isEmpty
       @else
-        
-        
+
+
       @end
       {@methodSample(method)}
       @if signatureComments.isEmpty
       @else
 
-        
+
       @end
     @end
     @join comment : signatureComments
@@ -379,7 +379,7 @@
   @end
 @end
 
-@private methodSample(method) 
+@private methodSample(method)
   @let apiConfig = context.getApiConfig, \
        service = method.getParent, \
        apiName = context.getApiWrapperName(service), \

--- a/src/main/resources/com/google/api/codegen/py/method_sample.snip
+++ b/src/main/resources/com/google/api/codegen/py/method_sample.snip
@@ -1,4 +1,4 @@
-@extends "common.snip"
+@extends "py/common.snip"
 
 # Generate code samples for method-level documentation.
 @snippet generateMethodSampleCode(docConfig)
@@ -13,7 +13,7 @@
         {@prompt} from google.gax import CallOptions, INITIAL_PAGE
       @end
       {@prompt} api = {@ApiName}()
-      @if initCode 
+      @if initCode
         {@initCode}
       @end
       @if docConfig.isIterableResponse
@@ -64,7 +64,7 @@
 @end
 
 # Helper method for initLineStructure()
-@private initLineStructureArgs(line) 
+@private initLineStructureArgs(line)
   @join fieldSetting : line.getFieldSettings on ", "
     {@formattedIdentifier(fieldSetting)}
   @end
@@ -130,7 +130,7 @@
   @end
 @end
 
-# Optionally render the options argument for page streaming 
+# Optionally render the options argument for page streaming
 @private pageStreamingArg(argFields, isPageStreaming)
   @if isPageStreaming
     @if argFields.isEmpty

--- a/src/main/resources/com/google/api/codegen/ruby/common.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/common.snip
@@ -1,4 +1,4 @@
-@extends "../common.snip"
+@extends "common.snip"
 
 @snippet module(moduleNames, content)
   @if moduleNames.hasNext

--- a/src/main/resources/com/google/api/codegen/ruby/discovery_fragment.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/discovery_fragment.snip
@@ -1,4 +1,4 @@
-@extends "../common.snip"
+@extends "common.snip"
 
 @snippet generateFilename(method)
   {@method.getName}.frag.rb

--- a/src/main/resources/com/google/api/codegen/ruby/main.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/main.snip
@@ -1,4 +1,4 @@
-@extends "common.snip"
+@extends "ruby/common.snip"
 
 @snippet generateFilename(service)
   {@context.upperCamelToLowerUnderscore(context.getApiWrapperName(service))}.rb

--- a/src/main/resources/com/google/api/codegen/ruby/message.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/message.snip
@@ -1,4 +1,4 @@
-@extends "common.snip"
+@extends "ruby/common.snip"
 
 @snippet generateFilename(file)
   doc/{@context.getBasename(file)}.rb

--- a/src/test/java/com/google/api/codegen/GapicTestBase.java
+++ b/src/test/java/com/google/api/codegen/GapicTestBase.java
@@ -105,8 +105,8 @@ public abstract class GapicTestBase extends ConfigBaselineTestCase {
     List<Object[]> testArgs = new ArrayList<>();
     for (GapicProvider<? extends Object> provider : providers) {
       for (String snippetFileName : provider.getSnippetFileNames()) {
-        String[] fileNameParts = snippetFileName.split("\\.");
-        String id = idForFactory + "_" + fileNameParts[0];
+        String fileName = snippetFileName.split("\\.")[0].split("/")[1];
+        String id = idForFactory + "_" + fileName;
         testArgs.add(new Object[] {id, idForFactory, gapicConfigFileNames, snippetFileName});
       }
     }


### PR DESCRIPTION
The path '..' is special to UNIX.
When running under non-UNIX-like file systems,

  @extends "../common.snip"

does not work since the directory ".." loses its special meaning.

"Non-UNIX-like file systems" may also appear on UNIX systems.
If the project is packaged into a JAR for distribution,
the '..' directory will still fail, since a JAR is a Zip archive,
and a Zip archive does not have '..' directories.

The '..' was used in the first place to reuse template code stored in
"codegen/common.snip", while the resource root is in subdirectories,
like "codegen/go".

This commit changes the resource root of all template renderings to
"codegen".
In this way, "codegen/common.snip" can simply be used by

  @extends "common.snip"

and files in subdirectories can be used by

  @extends "subdir/foo.snip".

Fixes #260.