### PR TITLE
Made the generated ruby code send Grpc errors to gax-ruby.

### DIFF
--- a/src/main/resources/com/google/api/codegen/ruby/main.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/main.snip
@@ -147,19 +147,21 @@
             @if context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods)
               bundle_descriptors: BUNDLE_DESCRIPTORS,
             @else
-              bundle_descriptors: BUNDLE_DESCRIPTORS)
+              bundle_descriptors: BUNDLE_DESCRIPTORS,
             @end
           @end
           @if context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods)
-            page_descriptors: PAGE_DESCRIPTORS)
+            page_descriptors: PAGE_DESCRIPTORS,
           @end
+          errors: Google::Gax::Grpc::API_ERRORS)
       @else
         Google::Gax.construct_settings(
           '{@service.getFullName}',
           JSON.parse(f.read),
           client_config,
           Google::Gax::Grpc::STATUS_CODE_NAMES,
-          timeout)
+          timeout,
+          errors: Google::Gax::Grpc::API_ERRORS)
       @end
     end
   @end

--- a/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
@@ -209,7 +209,8 @@ module Google
                 Google::Gax::Grpc::STATUS_CODE_NAMES,
                 timeout,
                 bundle_descriptors: BUNDLE_DESCRIPTORS,
-                page_descriptors: PAGE_DESCRIPTORS)
+                page_descriptors: PAGE_DESCRIPTORS,
+                errors: Google::Gax::Grpc::API_ERRORS)
             end
             google_api_client = "#{app_name}/#{app_version} " \
               "#{CODE_GEN_NAME_VERSION} ruby/#{RUBY_VERSION}".freeze


### PR DESCRIPTION
DO NOT MERGE until [gax-ruby/pull/28](https://github.com/googleapis/gax-ruby/issues/26) has been merged.

This was done because we are removing a dependency to GRPC in a file resolving this [gax-ruby issue](https://github.com/googleapis/gax-ruby/issues/26).


