### PR TITLE
Per-method timeout configuration

### DIFF
--- a/src/main/java/com/google/api/codegen/MethodConfig.java
+++ b/src/main/java/com/google/api/codegen/MethodConfig.java
@@ -1,16 +1,15 @@
-/* Copyright 2016 Google Inc
+/*
+ * Copyright 2016 Google Inc
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.google.api.codegen;
 
@@ -56,12 +55,9 @@ public class MethodConfig {
    * method. On errors, null will be returned, and diagnostics are reported to the diag collector.
    */
   @Nullable
-  public static MethodConfig createMethodConfig(
-      DiagCollector diagCollector,
-      final MethodConfigProto methodConfigProto,
-      Method method,
-      ImmutableSet<String> retryCodesConfigNames,
-      ImmutableSet<String> retryParamsConfigNames) {
+  public static MethodConfig createMethodConfig(DiagCollector diagCollector,
+      final MethodConfigProto methodConfigProto, Method method,
+      ImmutableSet<String> retryCodesConfigNames, ImmutableSet<String> retryParamsConfigNames) {
 
     boolean error = false;
 
@@ -70,9 +66,8 @@ public class MethodConfig {
         .equals(methodConfigProto.getPageStreaming())) {
       pageStreaming = null;
     } else {
-      pageStreaming =
-          PageStreamingConfig.createPageStreaming(
-              diagCollector, methodConfigProto.getPageStreaming(), method);
+      pageStreaming = PageStreamingConfig.createPageStreaming(diagCollector,
+          methodConfigProto.getPageStreaming(), method);
       if (pageStreaming == null) {
         error = true;
       }
@@ -82,9 +77,8 @@ public class MethodConfig {
     if (FlatteningConfigProto.getDefaultInstance().equals(methodConfigProto.getFlattening())) {
       flattening = null;
     } else {
-      flattening =
-          FlatteningConfig.createFlattening(
-              diagCollector, methodConfigProto.getFlattening(), method);
+      flattening = FlatteningConfig.createFlattening(diagCollector,
+          methodConfigProto.getFlattening(), method);
       if (flattening == null) {
         error = true;
       }
@@ -103,33 +97,24 @@ public class MethodConfig {
 
     String retryCodesName = methodConfigProto.getRetryCodesName();
     if (!retryCodesName.isEmpty() && !retryCodesConfigNames.contains(retryCodesName)) {
-      diagCollector.addDiag(
-          Diag.error(
-              SimpleLocation.TOPLEVEL,
-              "Retry codes config used but not defined: '%s' (in method %s)",
-              retryCodesName,
-              method.getFullName()));
+      diagCollector.addDiag(Diag.error(SimpleLocation.TOPLEVEL,
+          "Retry codes config used but not defined: '%s' (in method %s)", retryCodesName,
+          method.getFullName()));
       error = true;
     }
 
     String retryParamsName = methodConfigProto.getRetryParamsName();
     if (!retryParamsConfigNames.isEmpty() && !retryParamsConfigNames.contains(retryParamsName)) {
-      diagCollector.addDiag(
-          Diag.error(
-              SimpleLocation.TOPLEVEL,
-              "Retry parameters config used but not defined: %s (in method %s)",
-              retryParamsName,
-              method.getFullName()));
+      diagCollector.addDiag(Diag.error(SimpleLocation.TOPLEVEL,
+          "Retry parameters config used but not defined: %s (in method %s)", retryParamsName,
+          method.getFullName()));
       error = true;
     }
 
     Duration timeout = Duration.millis(methodConfigProto.getTimeoutMillis());
     if (timeout.getMillis() <= 0) {
-      diagCollector.addDiag(
-          Diag.error(
-              SimpleLocation.TOPLEVEL,
-              "Default timeout not found or has invalid value (in method %s)",
-              method.getFullName()));
+      diagCollector.addDiag(Diag.error(SimpleLocation.TOPLEVEL,
+          "Default timeout not found or has invalid value (in method %s)", method.getFullName()));
       error = true;
     }
 
@@ -142,25 +127,20 @@ public class MethodConfig {
       if (requiredField != null) {
         builder.add(requiredField);
       } else {
-        Diag.error(
-            SimpleLocation.TOPLEVEL,
-            "Required field '%s' not found (in method %s)",
-            fieldName,
-            method.getFullName());
+        Diag.error(SimpleLocation.TOPLEVEL, "Required field '%s' not found (in method %s)",
+            fieldName, method.getFullName());
         error = true;
       }
     }
     Set<Field> requiredFields = builder.build();
 
-    Iterable<Field> optionalFields =
-        Iterables.filter(
-            new ServiceMessages().flattenedFields(method.getInputType()),
-            new Predicate<Field>() {
-              @Override
-              public boolean apply(Field input) {
-                return !(methodConfigProto.getRequiredFieldsList().contains(input.getSimpleName()));
-              }
-            });
+    Iterable<Field> optionalFields = Iterables.filter(
+        new ServiceMessages().flattenedFields(method.getInputType()), new Predicate<Field>() {
+          @Override
+          public boolean apply(Field input) {
+            return !(methodConfigProto.getRequiredFieldsList().contains(input.getSimpleName()));
+          }
+        });
 
     ImmutableMap<String, String> fieldNamePatterns =
         ImmutableMap.copyOf(methodConfigProto.getFieldNamePatterns());
@@ -172,32 +152,16 @@ public class MethodConfig {
     if (error) {
       return null;
     } else {
-      return new MethodConfig(
-          pageStreaming,
-          flattening,
-          retryCodesName,
-          retryParamsName,
-          timeout,
-          bundling,
-          hasRequestObjectMethod,
-          requiredFields,
-          optionalFields,
-          fieldNamePatterns,
+      return new MethodConfig(pageStreaming, flattening, retryCodesName, retryParamsName, timeout,
+          bundling, hasRequestObjectMethod, requiredFields, optionalFields, fieldNamePatterns,
           sampleCodeInitFields);
     }
   }
 
-  private MethodConfig(
-      PageStreamingConfig pageStreaming,
-      FlatteningConfig flattening,
-      String retryCodesConfigName,
-      String retrySettingsConfigName,
-      Duration timeout,
-      BundlingConfig bundling,
-      boolean hasRequestObjectMethod,
-      Iterable<Field> requiredFields,
-      Iterable<Field> optionalFields,
-      ImmutableMap<String, String> fieldNamePatterns,
+  private MethodConfig(PageStreamingConfig pageStreaming, FlatteningConfig flattening,
+      String retryCodesConfigName, String retrySettingsConfigName, Duration timeout,
+      BundlingConfig bundling, boolean hasRequestObjectMethod, Iterable<Field> requiredFields,
+      Iterable<Field> optionalFields, ImmutableMap<String, String> fieldNamePatterns,
       List<String> sampleCodeInitFields) {
     this.pageStreaming = pageStreaming;
     this.flattening = flattening;
@@ -212,72 +176,100 @@ public class MethodConfig {
     this.sampleCodeInitFields = sampleCodeInitFields;
   }
 
-  /** Returns true if this method has page streaming configured. */
+  /**
+   * Returns true if this method has page streaming configured.
+   */
   public boolean isPageStreaming() {
     return pageStreaming != null;
   }
 
-  /** Returns the page streaming configuration of the method. */
+  /**
+   * Returns the page streaming configuration of the method.
+   */
   public PageStreamingConfig getPageStreaming() {
     return pageStreaming;
   }
 
-  /** Returns true if this method has flattening configured. */
+  /**
+   * Returns true if this method has flattening configured.
+   */
   public boolean isFlattening() {
     return flattening != null;
   }
 
-  /** Returns the flattening configuration of the method. */
+  /**
+   * Returns the flattening configuration of the method.
+   */
   public FlatteningConfig getFlattening() {
     return flattening;
   }
 
-  /** Returns the name of the retry codes config this method uses. */
+  /**
+   * Returns the name of the retry codes config this method uses.
+   */
   public String getRetryCodesConfigName() {
     return retryCodesConfigName;
   }
 
-  /** Returns the name of the retry params config this method uses. */
+  /**
+   * Returns the name of the retry params config this method uses.
+   */
   public String getRetrySettingsConfigName() {
     return retrySettingsConfigName;
   }
 
-  /** Returns the default, non-retrying timeout for the method. */
+  /**
+   * Returns the default, non-retrying timeout for the method.
+   */
   public Duration getTimeout() {
     return timeout;
   }
 
-  /** Returns true if this method has bundling configured. */
+  /**
+   * Returns true if this method has bundling configured.
+   */
   public boolean isBundling() {
     return bundling != null;
   }
 
-  /** Returns the bundling configuration of the method. */
+  /**
+   * Returns the bundling configuration of the method.
+   */
   public BundlingConfig getBundling() {
     return bundling;
   }
 
-  /** Returns whether the generation of the method taking a request object is turned on. */
+  /**
+   * Returns whether the generation of the method taking a request object is turned on.
+   */
   public boolean hasRequestObjectMethod() {
     return hasRequestObjectMethod;
   }
 
-  /** Returns the set of fields of the method that are always required. */
+  /**
+   * Returns the set of fields of the method that are always required.
+   */
   public Iterable<Field> getRequiredFields() {
     return requiredFields;
   }
 
-  /** Returns the set of fields of the method that are not always required. */
+  /**
+   * Returns the set of fields of the method that are not always required.
+   */
   public Iterable<Field> getOptionalFields() {
     return optionalFields;
   }
 
-  /** Returns a map of fields to entity_name elements. */
+  /**
+   * Returns a map of fields to entity_name elements.
+   */
   public ImmutableMap<String, String> getFieldNamePatterns() {
     return fieldNamePatterns;
   }
 
-  /** Returns the field structure of fields that needs to be initialized in sample code. */
+  /**
+   * Returns the field structure of fields that needs to be initialized in sample code.
+   */
   public List<String> getSampleCodeInitFields() {
     return sampleCodeInitFields;
   }

--- a/src/main/java/com/google/api/codegen/MethodConfig.java
+++ b/src/main/java/com/google/api/codegen/MethodConfig.java
@@ -1,15 +1,16 @@
-/*
- * Copyright 2016 Google Inc
+/* Copyright 2016 Google Inc
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.google.api.codegen;
 
@@ -55,9 +56,12 @@ public class MethodConfig {
    * method. On errors, null will be returned, and diagnostics are reported to the diag collector.
    */
   @Nullable
-  public static MethodConfig createMethodConfig(DiagCollector diagCollector,
-      final MethodConfigProto methodConfigProto, Method method,
-      ImmutableSet<String> retryCodesConfigNames, ImmutableSet<String> retryParamsConfigNames) {
+  public static MethodConfig createMethodConfig(
+      DiagCollector diagCollector,
+      final MethodConfigProto methodConfigProto,
+      Method method,
+      ImmutableSet<String> retryCodesConfigNames,
+      ImmutableSet<String> retryParamsConfigNames) {
 
     boolean error = false;
 
@@ -66,8 +70,9 @@ public class MethodConfig {
         .equals(methodConfigProto.getPageStreaming())) {
       pageStreaming = null;
     } else {
-      pageStreaming = PageStreamingConfig.createPageStreaming(diagCollector,
-          methodConfigProto.getPageStreaming(), method);
+      pageStreaming =
+          PageStreamingConfig.createPageStreaming(
+              diagCollector, methodConfigProto.getPageStreaming(), method);
       if (pageStreaming == null) {
         error = true;
       }
@@ -77,8 +82,9 @@ public class MethodConfig {
     if (FlatteningConfigProto.getDefaultInstance().equals(methodConfigProto.getFlattening())) {
       flattening = null;
     } else {
-      flattening = FlatteningConfig.createFlattening(diagCollector,
-          methodConfigProto.getFlattening(), method);
+      flattening =
+          FlatteningConfig.createFlattening(
+              diagCollector, methodConfigProto.getFlattening(), method);
       if (flattening == null) {
         error = true;
       }
@@ -97,24 +103,33 @@ public class MethodConfig {
 
     String retryCodesName = methodConfigProto.getRetryCodesName();
     if (!retryCodesName.isEmpty() && !retryCodesConfigNames.contains(retryCodesName)) {
-      diagCollector.addDiag(Diag.error(SimpleLocation.TOPLEVEL,
-          "Retry codes config used but not defined: '%s' (in method %s)", retryCodesName,
-          method.getFullName()));
+      diagCollector.addDiag(
+          Diag.error(
+              SimpleLocation.TOPLEVEL,
+              "Retry codes config used but not defined: '%s' (in method %s)",
+              retryCodesName,
+              method.getFullName()));
       error = true;
     }
 
     String retryParamsName = methodConfigProto.getRetryParamsName();
     if (!retryParamsConfigNames.isEmpty() && !retryParamsConfigNames.contains(retryParamsName)) {
-      diagCollector.addDiag(Diag.error(SimpleLocation.TOPLEVEL,
-          "Retry parameters config used but not defined: %s (in method %s)", retryParamsName,
-          method.getFullName()));
+      diagCollector.addDiag(
+          Diag.error(
+              SimpleLocation.TOPLEVEL,
+              "Retry parameters config used but not defined: %s (in method %s)",
+              retryParamsName,
+              method.getFullName()));
       error = true;
     }
 
     Duration timeout = Duration.millis(methodConfigProto.getTimeoutMillis());
     if (timeout.getMillis() <= 0) {
-      diagCollector.addDiag(Diag.error(SimpleLocation.TOPLEVEL,
-          "Default timeout not found or has invalid value (in method %s)", method.getFullName()));
+      diagCollector.addDiag(
+          Diag.error(
+              SimpleLocation.TOPLEVEL,
+              "Default timeout not found or has invalid value (in method %s)",
+              method.getFullName()));
       error = true;
     }
 
@@ -127,20 +142,25 @@ public class MethodConfig {
       if (requiredField != null) {
         builder.add(requiredField);
       } else {
-        Diag.error(SimpleLocation.TOPLEVEL, "Required field '%s' not found (in method %s)",
-            fieldName, method.getFullName());
+        Diag.error(
+            SimpleLocation.TOPLEVEL,
+            "Required field '%s' not found (in method %s)",
+            fieldName,
+            method.getFullName());
         error = true;
       }
     }
     Set<Field> requiredFields = builder.build();
 
-    Iterable<Field> optionalFields = Iterables.filter(
-        new ServiceMessages().flattenedFields(method.getInputType()), new Predicate<Field>() {
-          @Override
-          public boolean apply(Field input) {
-            return !(methodConfigProto.getRequiredFieldsList().contains(input.getSimpleName()));
-          }
-        });
+    Iterable<Field> optionalFields =
+        Iterables.filter(
+            new ServiceMessages().flattenedFields(method.getInputType()),
+            new Predicate<Field>() {
+              @Override
+              public boolean apply(Field input) {
+                return !(methodConfigProto.getRequiredFieldsList().contains(input.getSimpleName()));
+              }
+            });
 
     ImmutableMap<String, String> fieldNamePatterns =
         ImmutableMap.copyOf(methodConfigProto.getFieldNamePatterns());
@@ -152,16 +172,32 @@ public class MethodConfig {
     if (error) {
       return null;
     } else {
-      return new MethodConfig(pageStreaming, flattening, retryCodesName, retryParamsName, timeout,
-          bundling, hasRequestObjectMethod, requiredFields, optionalFields, fieldNamePatterns,
+      return new MethodConfig(
+          pageStreaming,
+          flattening,
+          retryCodesName,
+          retryParamsName,
+          timeout,
+          bundling,
+          hasRequestObjectMethod,
+          requiredFields,
+          optionalFields,
+          fieldNamePatterns,
           sampleCodeInitFields);
     }
   }
 
-  private MethodConfig(PageStreamingConfig pageStreaming, FlatteningConfig flattening,
-      String retryCodesConfigName, String retrySettingsConfigName, Duration timeout,
-      BundlingConfig bundling, boolean hasRequestObjectMethod, Iterable<Field> requiredFields,
-      Iterable<Field> optionalFields, ImmutableMap<String, String> fieldNamePatterns,
+  private MethodConfig(
+      PageStreamingConfig pageStreaming,
+      FlatteningConfig flattening,
+      String retryCodesConfigName,
+      String retrySettingsConfigName,
+      Duration timeout,
+      BundlingConfig bundling,
+      boolean hasRequestObjectMethod,
+      Iterable<Field> requiredFields,
+      Iterable<Field> optionalFields,
+      ImmutableMap<String, String> fieldNamePatterns,
       List<String> sampleCodeInitFields) {
     this.pageStreaming = pageStreaming;
     this.flattening = flattening;
@@ -176,100 +212,72 @@ public class MethodConfig {
     this.sampleCodeInitFields = sampleCodeInitFields;
   }
 
-  /**
-   * Returns true if this method has page streaming configured.
-   */
+  /** Returns true if this method has page streaming configured. */
   public boolean isPageStreaming() {
     return pageStreaming != null;
   }
 
-  /**
-   * Returns the page streaming configuration of the method.
-   */
+  /** Returns the page streaming configuration of the method. */
   public PageStreamingConfig getPageStreaming() {
     return pageStreaming;
   }
 
-  /**
-   * Returns true if this method has flattening configured.
-   */
+  /** Returns true if this method has flattening configured. */
   public boolean isFlattening() {
     return flattening != null;
   }
 
-  /**
-   * Returns the flattening configuration of the method.
-   */
+  /** Returns the flattening configuration of the method. */
   public FlatteningConfig getFlattening() {
     return flattening;
   }
 
-  /**
-   * Returns the name of the retry codes config this method uses.
-   */
+  /** Returns the name of the retry codes config this method uses. */
   public String getRetryCodesConfigName() {
     return retryCodesConfigName;
   }
 
-  /**
-   * Returns the name of the retry params config this method uses.
-   */
+  /** Returns the name of the retry params config this method uses. */
   public String getRetrySettingsConfigName() {
     return retrySettingsConfigName;
   }
 
-  /**
-   * Returns the default, non-retrying timeout for the method.
-   */
+  /** Returns the default, non-retrying timeout for the method. */
   public Duration getTimeout() {
     return timeout;
   }
 
-  /**
-   * Returns true if this method has bundling configured.
-   */
+  /** Returns true if this method has bundling configured. */
   public boolean isBundling() {
     return bundling != null;
   }
 
-  /**
-   * Returns the bundling configuration of the method.
-   */
+  /** Returns the bundling configuration of the method. */
   public BundlingConfig getBundling() {
     return bundling;
   }
 
-  /**
-   * Returns whether the generation of the method taking a request object is turned on.
-   */
+  /** Returns whether the generation of the method taking a request object is turned on. */
   public boolean hasRequestObjectMethod() {
     return hasRequestObjectMethod;
   }
 
-  /**
-   * Returns the set of fields of the method that are always required.
-   */
+  /** Returns the set of fields of the method that are always required. */
   public Iterable<Field> getRequiredFields() {
     return requiredFields;
   }
 
-  /**
-   * Returns the set of fields of the method that are not always required.
-   */
+  /** Returns the set of fields of the method that are not always required. */
   public Iterable<Field> getOptionalFields() {
     return optionalFields;
   }
 
-  /**
-   * Returns a map of fields to entity_name elements.
-   */
+  /** Returns a map of fields to entity_name elements. */
   public ImmutableMap<String, String> getFieldNamePatterns() {
     return fieldNamePatterns;
   }
 
-  /**
-   * Returns the field structure of fields that needs to be initialized in sample code.
-   */
+  /** Returns the field structure of fields that needs to be initialized in sample code. */
   public List<String> getSampleCodeInitFields() {
     return sampleCodeInitFields;
   }

--- a/src/main/java/com/google/api/codegen/config/ConfigGeneratorApi.java
+++ b/src/main/java/com/google/api/codegen/config/ConfigGeneratorApi.java
@@ -128,7 +128,7 @@ public class ConfigGeneratorApi extends ToolDriverBase {
       Map<String, Object> methodConfig = new LinkedHashMap<String, Object>();
       methodConfig.put(CONFIG_KEY_METHOD_NAME, method.getSimpleName());
       for (MethodConfigGenerator generator : methodConfigGenerators) {
-        Map<String, ? extends Object> config = generator.generate(method);
+        Map<String, Object> config = generator.generate(method);
         if (config != null) {
           methodConfig.putAll(config);
         }

--- a/src/main/java/com/google/api/codegen/config/ConfigGeneratorApi.java
+++ b/src/main/java/com/google/api/codegen/config/ConfigGeneratorApi.java
@@ -67,6 +67,8 @@ public class ConfigGeneratorApi extends ToolDriverBase {
 
   private static final String CONFIG_PROTO_TYPE = ConfigProto.getDescriptor().getFullName();
 
+  private static final String DEFAULT_TIMEOUT = "30000";
+
   /** Constructs a config generator api based on given options. */
   public ConfigGeneratorApi(ToolOptions options) {
     super(options);
@@ -120,7 +122,7 @@ public class ConfigGeneratorApi extends ToolDriverBase {
             new MethodConfigGenerator() {
               @Override
               public Map<String, Object> generate(Method method) {
-                return ImmutableMap.of("timeout_millis", (Object) 30000);
+                return ImmutableMap.of("timeout_millis", (Object) DEFAULT_TIMEOUT);
               }
             });
     List<Object> methods = new LinkedList<Object>();

--- a/src/main/java/com/google/api/codegen/config/ConfigGeneratorApi.java
+++ b/src/main/java/com/google/api/codegen/config/ConfigGeneratorApi.java
@@ -45,9 +45,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 
-/**
- * Main class for the config generator.
- */
+/** Main class for the config generator. */
 public class ConfigGeneratorApi extends ToolDriverBase {
 
   public static final Option<String> OUTPUT_FILE =
@@ -69,9 +67,7 @@ public class ConfigGeneratorApi extends ToolDriverBase {
 
   private static final String CONFIG_PROTO_TYPE = ConfigProto.getDescriptor().getFullName();
 
-  /**
-   * Constructs a config generator api based on given options.
-   */
+  /** Constructs a config generator api based on given options. */
   public ConfigGeneratorApi(ToolOptions options) {
     super(options);
   }
@@ -101,9 +97,7 @@ public class ConfigGeneratorApi extends ToolDriverBase {
     dump(output);
   }
 
-  /**
-   * Generates a collection configurations section.
-   */
+  /** Generates a collection configurations section. */
   private static List<Object> generateCollectionConfigs(Map<String, String> nameMap) {
     List<Object> output = new LinkedList<Object>();
     for (String resourceNameString : nameMap.keySet()) {
@@ -122,13 +116,19 @@ public class ConfigGeneratorApi extends ToolDriverBase {
             new FieldConfigGenerator(),
             new PageStreamingConfigGenerator(),
             new RetryGenerator(),
-            new FieldNamePatternConfigGenerator(collectionConfigNameMap));
+            new FieldNamePatternConfigGenerator(collectionConfigNameMap),
+            new MethodConfigGenerator() {
+              @Override
+              public Map<String, Object> generate(Method method) {
+                return ImmutableMap.of("timeout_millis", (Object) 30000);
+              }
+            });
     List<Object> methods = new LinkedList<Object>();
     for (Method method : service.getMethods()) {
       Map<String, Object> methodConfig = new LinkedHashMap<String, Object>();
       methodConfig.put(CONFIG_KEY_METHOD_NAME, method.getSimpleName());
       for (MethodConfigGenerator generator : methodConfigGenerators) {
-        Map<String, Object> config = generator.generate(method);
+        Map<String, ? extends Object> config = generator.generate(method);
         if (config != null) {
           methodConfig.putAll(config);
         }

--- a/src/main/java/com/google/api/codegen/config/ConfigGeneratorApi.java
+++ b/src/main/java/com/google/api/codegen/config/ConfigGeneratorApi.java
@@ -67,7 +67,8 @@ public class ConfigGeneratorApi extends ToolDriverBase {
 
   private static final String CONFIG_PROTO_TYPE = ConfigProto.getDescriptor().getFullName();
 
-  private static final String DEFAULT_TIMEOUT = "30000";
+  private static final String CONFIG_KEY_TIMEOUT = "timeout_millis";
+  private static final int CONFIG_VALUE_DEFAULT_TIMEOUT = 30000;
 
   /** Constructs a config generator api based on given options. */
   public ConfigGeneratorApi(ToolOptions options) {
@@ -122,7 +123,7 @@ public class ConfigGeneratorApi extends ToolDriverBase {
             new MethodConfigGenerator() {
               @Override
               public Map<String, Object> generate(Method method) {
-                return ImmutableMap.of("timeout_millis", (Object) DEFAULT_TIMEOUT);
+                return ImmutableMap.of(CONFIG_KEY_TIMEOUT, (Object) CONFIG_VALUE_DEFAULT_TIMEOUT);
               }
             });
     List<Object> methods = new LinkedList<Object>();

--- a/src/main/java/com/google/api/codegen/py/PythonGapicContext.java
+++ b/src/main/java/com/google/api/codegen/py/PythonGapicContext.java
@@ -41,14 +41,10 @@ import java.util.Map;
 
 import javax.annotation.Nullable;
 
-/**
- * A GapicContext specialized for Python.
- */
+/** A GapicContext specialized for Python. */
 public class PythonGapicContext extends GapicContext {
 
-  /**
-   * A map from primitive types to its default value.
-   */
+  /** A map from primitive types to its default value. */
   private static final ImmutableMap<Type, String> DEFAULT_VALUE_MAP =
       ImmutableMap.<Type, String>builder()
           .put(Type.TYPE_BOOL, "False")
@@ -68,9 +64,7 @@ public class PythonGapicContext extends GapicContext {
           .put(Type.TYPE_BYTES, "\'\'")
           .build();
 
-  /**
-   * A map from primitive types to their names in Python.
-   */
+  /** A map from primitive types to their names in Python. */
   private static final Map<Type, String> PRIMITIVE_TYPE_NAMES =
       ImmutableMap.<Type, String>builder()
           .put(Type.TYPE_DOUBLE, "float")
@@ -108,9 +102,7 @@ public class PythonGapicContext extends GapicContext {
     return file.getSimpleName().replace(".proto", "_pb2.py");
   }
 
-  /**
-   * Return comments lines for a given proto element, extracted directly from the proto doc
-   */
+  /** Return comments lines for a given proto element, extracted directly from the proto doc */
   public List<String> defaultComments(ProtoElement element) {
     if (!element.hasAttribute(ElementDocumentationAttribute.KEY)) {
       return ImmutableList.<String>of("");
@@ -118,9 +110,7 @@ public class PythonGapicContext extends GapicContext {
     return pythonCommon.convertToCommentedBlock(getSphinxifiedScopedDescription(element));
   }
 
-  /**
-   * Returns type information for a field in Sphinx docstring style.
-   */
+  /** Returns type information for a field in Sphinx docstring style. */
   private String fieldTypeCardinalityComment(Field field, PythonImportHandler importHandler) {
     return typeCardinalityComment(field.getType(), importHandler);
   }
@@ -143,9 +133,7 @@ public class PythonGapicContext extends GapicContext {
     return String.format("%s%s%s", prefix, typeComment, closingBrace ? "]" : "");
   }
 
-  /**
-   * Returns type information for a field in Sphinx docstring style.
-   */
+  /** Returns type information for a field in Sphinx docstring style. */
   private String fieldTypeComment(Field field, PythonImportHandler importHandler) {
     return typeComment(field.getType(), importHandler);
   }
@@ -165,9 +153,7 @@ public class PythonGapicContext extends GapicContext {
     }
   }
 
-  /**
-   * Returns a comment string for field, consisting of type information and proto comment.
-   */
+  /** Returns a comment string for field, consisting of type information and proto comment. */
   private String fieldComment(Field field, PythonImportHandler importHandler, String paramComment) {
     String comment =
         String.format(
@@ -241,9 +227,7 @@ public class PythonGapicContext extends GapicContext {
     return PythonDocConfig.newBuilder();
   }
 
-  /**
-   * Generate comments lines for a given method's description.
-   */
+  /** Generate comments lines for a given method's description. */
   public List<String> methodDescriptionComments(Method method) {
     String description = "";
     if (method.hasAttribute(ElementDocumentationAttribute.KEY)) {
@@ -299,18 +283,14 @@ public class PythonGapicContext extends GapicContext {
     return Splitter.on("\n").splitToList(contentBuilder.toString());
   }
 
-  /**
-   * Get required (non-optional) fields.
-   */
+  /** Get required (non-optional) fields. */
   public List<Field> getRequiredFields(Method method) {
     Interface service = (Interface) method.getParent();
     MethodConfig methodConfig = getApiConfig().getInterfaceConfig(service).getMethodConfig(method);
     return Lists.newArrayList(methodConfig.getRequiredFields());
   }
 
-  /**
-   * Get return type string, or an empty string if there is no return type.
-   */
+  /** Get return type string, or an empty string if there is no return type. */
   public String returnTypeOrEmpty(Method method, PythonImportHandler importHandler) {
     TypeRef returnType = method.getOutputType();
     return messages().isEmptyType(returnType)
@@ -318,16 +298,12 @@ public class PythonGapicContext extends GapicContext {
         : typeCardinalityComment(returnType, importHandler);
   }
 
-  /**
-   * Return the default value for the given field. Return null if there is no default value.
-   */
+  /** Return the default value for the given field. Return null if there is no default value. */
   public String defaultValue(Field field, PythonImportHandler importHandler) {
     return defaultValue(field.getType(), importHandler);
   }
 
-  /**
-   * Return the default value for the given type. Return null if there is no default value.
-   */
+  /** Return the default value for the given type. Return null if there is no default value. */
   public String defaultValue(TypeRef type, PythonImportHandler importHandler) {
     // Return empty array if the type is repeated.
     if (type.getCardinality() == Cardinality.REPEATED) {
@@ -348,9 +324,7 @@ public class PythonGapicContext extends GapicContext {
     }
   }
 
-  /**
-   * Return whether the given field's default value is mutable in python.
-   */
+  /** Return whether the given field's default value is mutable in python. */
   public boolean isDefaultValueMutable(Field field) {
     TypeRef type = field.getType();
     if (type.getCardinality() == Cardinality.REPEATED) {

--- a/src/main/proto/com/google/api/codegen/config.proto
+++ b/src/main/proto/com/google/api/codegen/config.proto
@@ -150,6 +150,10 @@ message MethodConfigProto {
   // The name must be defined in InterfaceConfigProto::retry_params_def.
   string retry_params_name = 5;
 
+  // Specifies the default timeout for a non-retrying call. If the call is
+  // retrying, refer to `retry_params_name` instead.
+  uint64 timeout_millis = 11;
+
   // Specifies the configuration for bundling.
   BundlingConfigProto bundling = 6;
 

--- a/src/main/resources/com/google/api/codegen/clientconfig/json.snip
+++ b/src/main/resources/com/google/api/codegen/clientconfig/json.snip
@@ -86,9 +86,15 @@
         @let methodConfig = context.getApiConfig.getInterfaceConfig(service).getMethodConfig(method), \
                 methodName = context.upperCamelToLowerUnderscore(method.getSimpleName), \
                 isBundling = methodConfig.isBundling, \
+                timeout = methodConfig.getTimeout.getMillis, \
                 retryCodesName = methodConfig.getRetryCodesConfigName, \
                 retryParamsName = methodConfig.getRetrySettingsConfigName
             "{@method.getSimpleName}": {
+              @if or(and(retryCodesName, retryParamsName), isBundling)
+                "timeout_millis": {@timeout},
+              @else
+                "timeout_millis": {@timeout}
+              @end
               @if and(retryCodesName, retryParamsName)
                   "retry_codes_name": "{@retryCodesName}",
                   @if isBundling

--- a/src/main/resources/com/google/api/codegen/py/main.snip
+++ b/src/main/resources/com/google/api/codegen/py/main.snip
@@ -109,8 +109,6 @@
         _CODE_GEN_NAME_VERSION = 'gapic/0.1.0'
 
         _GAX_VERSION = pkg_resources.get_distribution('google-gax').version
-
-        _DEFAULT_TIMEOUT = 30
         @if context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods)
 
             _PAGE_DESCRIPTORS = {
@@ -165,7 +163,6 @@
                 default_client_config,
                 client_config,
                 config.STATUS_CODE_NAMES,
-                timeout,
                 kwargs={'metadata': metadata},
                 @if context.messages.filterBundlingMethods(ifaceConfig, service.getMethods)
                     @if context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods)
@@ -183,7 +180,6 @@
                 default_client_config,
                 client_config,
                 config.STATUS_CODE_NAMES,
-                timeout,
                 kwargs={'metadata': metadata})
         @end
     @end
@@ -202,7 +198,6 @@
                 ssl_creds=None,
                 scopes=None,
                 client_config=None,
-                timeout=_DEFAULT_TIMEOUT,
                 app_name='gax',
                 app_version=_GAX_VERSION):
             """Constructor.
@@ -221,8 +216,6 @@
                 or the specified config is missing data points.
               metadata_transformer (Callable[[], list]): A function that creates
                  the metadata for requests.
-              timeout (int): The default timeout, in seconds, for calls made
-                through this client
               app_name (string): The codename of the calling service.
               app_version (string): The version of the calling service.
 

--- a/src/test/java/com/google/api/codegen/GapicTestBase.java
+++ b/src/test/java/com/google/api/codegen/GapicTestBase.java
@@ -29,9 +29,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-/**
- * Base class for code generator baseline tests.
- */
+/** Base class for code generator baseline tests. */
 public abstract class GapicTestBase extends ConfigBaselineTestCase {
 
   // example: library[ruby_message]
@@ -58,7 +56,6 @@ public abstract class GapicTestBase extends ConfigBaselineTestCase {
   @Override
   protected void setupModel() {
     super.setupModel();
-
     config =
         CodegenTestUtil.readConfig(
             model.getDiagCollector(), getTestDataLocator(), gapicConfigFileNames);
@@ -125,6 +122,9 @@ public abstract class GapicTestBase extends ConfigBaselineTestCase {
 
     ApiConfig apiConfig = ApiConfig.createApiConfig(model, config);
     if (apiConfig == null) {
+      for (Diag diag : model.getDiagCollector().getDiags()) {
+        System.err.println(diag.toString());
+      }
       return null;
     }
 

--- a/src/test/java/com/google/api/codegen/testdata/client_config_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/client_config_json_library.baseline
@@ -106,6 +106,7 @@
           "retry_params_name": "default"
         },
         "UpdateBookIndex": {
+          "timeout_millis": 10000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         }

--- a/src/test/java/com/google/api/codegen/testdata/client_config_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/client_config_json_library.baseline
@@ -24,30 +24,37 @@
       },
       "methods": {
         "CreateShelf": {
+          "timeout_millis": 1000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
         "GetShelf": {
+          "timeout_millis": 2000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "ListShelves": {
+          "timeout_millis": 3000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "DeleteShelf": {
+          "timeout_millis": 4000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "MergeShelves": {
+          "timeout_millis": 5000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
         "CreateBook": {
+          "timeout_millis": 6000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
         "PublishSeries": {
+          "timeout_millis": 7000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default",
           "bundling": {
@@ -59,34 +66,42 @@
           }
         },
         "GetBook": {
+          "timeout_millis": 8000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "ListBooks": {
+          "timeout_millis": 10000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "DeleteBook": {
+          "timeout_millis": 10000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "UpdateBook": {
+          "timeout_millis": 10000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "MoveBook": {
+          "timeout_millis": 10000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
         "ListStrings": {
+          "timeout_millis": 10000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "AddComments": {
+          "timeout_millis": 10000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
         "GetBookFromArchive": {
+          "timeout_millis": 10000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },

--- a/src/test/java/com/google/api/codegen/testdata/library_config.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/library_config.baseline
@@ -49,6 +49,7 @@ interfaces:
     request_object_method: false
     retry_codes_name: non_idempotent
     retry_params_name: default
+    timeout_millis: 30000
   - name: GetShelf
     flattening:
       groups:
@@ -65,6 +66,7 @@ interfaces:
     retry_params_name: default
     field_name_patterns:
       name: book_shelf
+    timeout_millis: 30000
   - name: ListShelves
     request_object_method: false
     page_streaming:
@@ -75,6 +77,7 @@ interfaces:
         resources_field: shelves
     retry_codes_name: idempotent
     retry_params_name: default
+    timeout_millis: 30000
   - name: DeleteShelf
     flattening:
       groups:
@@ -87,6 +90,7 @@ interfaces:
     retry_params_name: default
     field_name_patterns:
       name: book_shelf
+    timeout_millis: 30000
   - name: MergeShelves
     flattening:
       groups:
@@ -101,6 +105,7 @@ interfaces:
     retry_params_name: default
     field_name_patterns:
       name: book_shelf
+    timeout_millis: 30000
   - name: CreateBook
     flattening:
       groups:
@@ -115,6 +120,7 @@ interfaces:
     retry_params_name: default
     field_name_patterns:
       name: book_shelf
+    timeout_millis: 30000
   - name: PublishSeries
     flattening:
       groups:
@@ -129,6 +135,7 @@ interfaces:
     request_object_method: true
     retry_codes_name: non_idempotent
     retry_params_name: default
+    timeout_millis: 30000
   - name: GetBook
     flattening:
       groups:
@@ -141,6 +148,7 @@ interfaces:
     retry_params_name: default
     field_name_patterns:
       name: book_2
+    timeout_millis: 30000
   - name: ListBooks
     flattening:
       groups:
@@ -162,6 +170,7 @@ interfaces:
     retry_params_name: default
     field_name_patterns:
       name: book_shelf
+    timeout_millis: 30000
   - name: DeleteBook
     flattening:
       groups:
@@ -174,6 +183,7 @@ interfaces:
     retry_params_name: default
     field_name_patterns:
       name: book_2
+    timeout_millis: 30000
   - name: UpdateBook
     flattening:
       groups:
@@ -192,6 +202,7 @@ interfaces:
     retry_params_name: default
     field_name_patterns:
       name: book_2
+    timeout_millis: 30000
   - name: MoveBook
     flattening:
       groups:
@@ -206,6 +217,7 @@ interfaces:
     retry_params_name: default
     field_name_patterns:
       name: book_2
+    timeout_millis: 30000
   - name: ListStrings
     flattening:
       groups:
@@ -223,6 +235,7 @@ interfaces:
         resources_field: strings
     retry_codes_name: idempotent
     retry_params_name: default
+    timeout_millis: 30000
   - name: AddComments
     flattening:
       groups:
@@ -237,6 +250,7 @@ interfaces:
     retry_params_name: default
     field_name_patterns:
       name: book_shelf
+    timeout_millis: 30000
   - name: GetBookFromArchive
     flattening:
       groups:
@@ -249,6 +263,7 @@ interfaces:
     retry_params_name: default
     field_name_patterns:
       name: book
+    timeout_millis: 30000
   - name: UpdateBookIndex
     flattening:
       groups:
@@ -265,3 +280,4 @@ interfaces:
     retry_params_name: default
     field_name_patterns:
       name: book_2
+    timeout_millis: 30000

--- a/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
@@ -293,6 +293,7 @@ interfaces:
     - name
     - index_name
     - index_map
+    timeout_millis: 10000
     request_object_method: true
     retry_codes_name: idempotent
     retry_params_name: default

--- a/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
@@ -293,7 +293,6 @@ interfaces:
     - name
     - index_name
     - index_map
-    timeout_millis: 10000
     request_object_method: true
     retry_codes_name: idempotent
     retry_params_name: default

--- a/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
@@ -46,6 +46,7 @@ interfaces:
       - shelf
     retry_codes_name: non_idempotent
     retry_params_name: default
+    timeout_millis: 1000
     request_object_method: false
   - name: GetShelf
     flattening:
@@ -63,6 +64,7 @@ interfaces:
       - name
     retry_codes_name: idempotent
     retry_params_name: default
+    timeout_millis: 2000
     request_object_method: true
     field_name_patterns:
       name: shelf
@@ -78,6 +80,7 @@ interfaces:
         resources_field: shelves
     retry_codes_name: idempotent
     retry_params_name: default
+    timeout_millis: 3000
     request_object_method: false
   - name: DeleteShelf
     flattening:
@@ -88,6 +91,7 @@ interfaces:
       - name
     retry_codes_name: idempotent
     retry_params_name: default
+    timeout_millis: 4000
     request_object_method: false
     field_name_patterns:
       name: shelf
@@ -102,6 +106,7 @@ interfaces:
       - other_shelf_name
     retry_codes_name: non_idempotent
     retry_params_name: default
+    timeout_millis: 5000
     request_object_method: true
     field_name_patterns:
       name: shelf
@@ -117,6 +122,7 @@ interfaces:
       - book
     retry_codes_name: non_idempotent
     retry_params_name: default
+    timeout_millis: 6000
     request_object_method: true
     field_name_patterns:
       name: shelf
@@ -132,6 +138,7 @@ interfaces:
       - books
     retry_codes_name: non_idempotent
     retry_params_name: default
+    timeout_millis: 7000
     bundling:
       thresholds:
         element_count_threshold: 6
@@ -155,6 +162,7 @@ interfaces:
       - name
     retry_codes_name: idempotent
     retry_params_name: default
+    timeout_millis: 8000
     request_object_method: false
     field_name_patterns:
       name: book
@@ -175,6 +183,7 @@ interfaces:
         resources_field: books
     retry_codes_name: idempotent
     retry_params_name: default
+    timeout_millis: 10000
     request_object_method: true
     field_name_patterns:
       name: shelf
@@ -187,6 +196,7 @@ interfaces:
       - name
     retry_codes_name: idempotent
     retry_params_name: default
+    timeout_millis: 10000
     # leaving commented out to test the default
     #request_object_method: false
     field_name_patterns:
@@ -207,6 +217,7 @@ interfaces:
       - book
     retry_codes_name: idempotent
     retry_params_name: default
+    timeout_millis: 10000
     request_object_method: true
     field_name_patterns:
       name: book
@@ -221,6 +232,7 @@ interfaces:
       - other_shelf_name
     retry_codes_name: non_idempotent
     retry_params_name: default
+    timeout_millis: 10000
     request_object_method: true
     field_name_patterns:
       name: book
@@ -238,6 +250,7 @@ interfaces:
         resources_field: strings
     retry_codes_name: idempotent
     retry_params_name: default
+    timeout_millis: 10000
     request_object_method: false
   - name: AddComments
     flattening:
@@ -250,6 +263,7 @@ interfaces:
       - comments
     retry_codes_name: non_idempotent
     retry_params_name: default
+    timeout_millis: 10000
     request_object_method: true
     field_name_patterns:
       name: book
@@ -264,6 +278,7 @@ interfaces:
       - name
     retry_codes_name: idempotent
     retry_params_name: default
+    timeout_millis: 10000
     request_object_method: false
     field_name_patterns:
       name: archived_book

--- a/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
@@ -296,6 +296,7 @@ interfaces:
     request_object_method: true
     retry_codes_name: idempotent
     retry_params_name: default
+    timeout_millis: 10000
     field_name_patterns:
       name: book
     sample_code_init_fields:

--- a/src/test/java/com/google/api/codegen/testdata/no_path_templates_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testdata/no_path_templates_gapic.yaml
@@ -14,3 +14,4 @@ interfaces:
   methods:
   - name: Increment
     retry_params_name: default
+    timeout_millis: 10000

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_json_library.baseline
@@ -106,6 +106,7 @@
           "retry_params_name": "default"
         },
         "UpdateBookIndex": {
+          "timeout_millis": 10000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         }

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_json_library.baseline
@@ -24,30 +24,37 @@
       },
       "methods": {
         "CreateShelf": {
+          "timeout_millis": 1000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
         "GetShelf": {
+          "timeout_millis": 2000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "ListShelves": {
+          "timeout_millis": 3000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "DeleteShelf": {
+          "timeout_millis": 4000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "MergeShelves": {
+          "timeout_millis": 5000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
         "CreateBook": {
+          "timeout_millis": 6000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
         "PublishSeries": {
+          "timeout_millis": 7000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default",
           "bundling": {
@@ -59,34 +66,42 @@
           }
         },
         "GetBook": {
+          "timeout_millis": 8000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "ListBooks": {
+          "timeout_millis": 10000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "DeleteBook": {
+          "timeout_millis": 10000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "UpdateBook": {
+          "timeout_millis": 10000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "MoveBook": {
+          "timeout_millis": 10000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
         "ListStrings": {
+          "timeout_millis": 10000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "AddComments": {
+          "timeout_millis": 10000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
         "GetBookFromArchive": {
+          "timeout_millis": 10000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },

--- a/src/test/java/com/google/api/codegen/testdata/php_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php_json_library.baseline
@@ -106,6 +106,7 @@
           "retry_params_name": "default"
         },
         "UpdateBookIndex": {
+          "timeout_millis": 10000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         }

--- a/src/test/java/com/google/api/codegen/testdata/php_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php_json_library.baseline
@@ -24,30 +24,37 @@
       },
       "methods": {
         "CreateShelf": {
+          "timeout_millis": 1000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
         "GetShelf": {
+          "timeout_millis": 2000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "ListShelves": {
+          "timeout_millis": 3000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "DeleteShelf": {
+          "timeout_millis": 4000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "MergeShelves": {
+          "timeout_millis": 5000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
         "CreateBook": {
+          "timeout_millis": 6000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
         "PublishSeries": {
+          "timeout_millis": 7000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default",
           "bundling": {
@@ -59,34 +66,42 @@
           }
         },
         "GetBook": {
+          "timeout_millis": 8000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "ListBooks": {
+          "timeout_millis": 10000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "DeleteBook": {
+          "timeout_millis": 10000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "UpdateBook": {
+          "timeout_millis": 10000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "MoveBook": {
+          "timeout_millis": 10000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
         "ListStrings": {
+          "timeout_millis": 10000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "AddComments": {
+          "timeout_millis": 10000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
         "GetBookFromArchive": {
+          "timeout_millis": 10000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },

--- a/src/test/java/com/google/api/codegen/testdata/python_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_json_library.baseline
@@ -106,6 +106,7 @@
           "retry_params_name": "default"
         },
         "UpdateBookIndex": {
+          "timeout_millis": 10000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         }

--- a/src/test/java/com/google/api/codegen/testdata/python_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_json_library.baseline
@@ -24,30 +24,37 @@
       },
       "methods": {
         "CreateShelf": {
+          "timeout_millis": 1000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
         "GetShelf": {
+          "timeout_millis": 2000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "ListShelves": {
+          "timeout_millis": 3000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "DeleteShelf": {
+          "timeout_millis": 4000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "MergeShelves": {
+          "timeout_millis": 5000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
         "CreateBook": {
+          "timeout_millis": 6000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
         "PublishSeries": {
+          "timeout_millis": 7000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default",
           "bundling": {
@@ -59,34 +66,42 @@
           }
         },
         "GetBook": {
+          "timeout_millis": 8000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "ListBooks": {
+          "timeout_millis": 10000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "DeleteBook": {
+          "timeout_millis": 10000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "UpdateBook": {
+          "timeout_millis": 10000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "MoveBook": {
+          "timeout_millis": 10000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
         "ListStrings": {
+          "timeout_millis": 10000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "AddComments": {
+          "timeout_millis": 10000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
         "GetBookFromArchive": {
+          "timeout_millis": 10000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },

--- a/src/test/java/com/google/api/codegen/testdata/python_json_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_json_no_path_templates.baseline
@@ -6,6 +6,7 @@
       "retry_params": {},
       "methods": {
         "Increment": {
+          "timeout_millis": 10000
         }
       }
     }

--- a/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
@@ -71,8 +71,6 @@ class LibraryServiceApi(object):
 
     _GAX_VERSION = pkg_resources.get_distribution('google-gax').version
 
-    _DEFAULT_TIMEOUT = 30
-
     _PAGE_DESCRIPTORS = {
         'list_shelves': _PageDesc(
             'page_token',
@@ -213,7 +211,6 @@ class LibraryServiceApi(object):
             ssl_creds=None,
             scopes=None,
             client_config=None,
-            timeout=_DEFAULT_TIMEOUT,
             app_name='gax',
             app_version=_GAX_VERSION):
         """Constructor.
@@ -232,8 +229,6 @@ class LibraryServiceApi(object):
             or the specified config is missing data points.
           metadata_transformer (Callable[[], list]): A function that creates
              the metadata for requests.
-          timeout (int): The default timeout, in seconds, for calls made
-            through this client
           app_name (string): The codename of the calling service.
           app_version (string): The version of the calling service.
 
@@ -259,7 +254,6 @@ class LibraryServiceApi(object):
             default_client_config,
             client_config,
             config.STATUS_CODE_NAMES,
-            timeout,
             kwargs={'metadata': metadata},
             bundle_descriptors=self._BUNDLE_DESCRIPTORS,
             page_descriptors=self._PAGE_DESCRIPTORS)

--- a/src/test/java/com/google/api/codegen/testdata/python_main_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_main_no_path_templates.baseline
@@ -48,8 +48,6 @@ class NoTemplatesServiceApi(object):
 
     _GAX_VERSION = pkg_resources.get_distribution('google-gax').version
 
-    _DEFAULT_TIMEOUT = 30
-
     # The scopes needed to make gRPC calls to all of the methods defined in
     # this service
     _ALL_SCOPES = (
@@ -64,7 +62,6 @@ class NoTemplatesServiceApi(object):
             ssl_creds=None,
             scopes=None,
             client_config=None,
-            timeout=_DEFAULT_TIMEOUT,
             app_name='gax',
             app_version=_GAX_VERSION):
         """Constructor.
@@ -83,8 +80,6 @@ class NoTemplatesServiceApi(object):
             or the specified config is missing data points.
           metadata_transformer (Callable[[], list]): A function that creates
              the metadata for requests.
-          timeout (int): The default timeout, in seconds, for calls made
-            through this client
           app_name (string): The codename of the calling service.
           app_version (string): The version of the calling service.
 
@@ -110,7 +105,6 @@ class NoTemplatesServiceApi(object):
             default_client_config,
             client_config,
             config.STATUS_CODE_NAMES,
-            timeout,
             kwargs={'metadata': metadata})
         self.stub = config.create_stub(
             no_path_templates_pb2.beta_create_NoTemplatesService_stub,

--- a/src/test/java/com/google/api/codegen/testdata/ruby_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_json_library.baseline
@@ -106,6 +106,7 @@
           "retry_params_name": "default"
         },
         "UpdateBookIndex": {
+          "timeout_millis": 10000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         }

--- a/src/test/java/com/google/api/codegen/testdata/ruby_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_json_library.baseline
@@ -24,30 +24,37 @@
       },
       "methods": {
         "CreateShelf": {
+          "timeout_millis": 1000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
         "GetShelf": {
+          "timeout_millis": 2000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "ListShelves": {
+          "timeout_millis": 3000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "DeleteShelf": {
+          "timeout_millis": 4000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "MergeShelves": {
+          "timeout_millis": 5000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
         "CreateBook": {
+          "timeout_millis": 6000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
         "PublishSeries": {
+          "timeout_millis": 7000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default",
           "bundling": {
@@ -59,34 +66,42 @@
           }
         },
         "GetBook": {
+          "timeout_millis": 8000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "ListBooks": {
+          "timeout_millis": 10000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "DeleteBook": {
+          "timeout_millis": 10000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "UpdateBook": {
+          "timeout_millis": 10000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "MoveBook": {
+          "timeout_millis": 10000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
         "ListStrings": {
+          "timeout_millis": 10000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
         "AddComments": {
+          "timeout_millis": 10000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
         },
         "GetBookFromArchive": {
+          "timeout_millis": 10000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },


### PR DESCRIPTION
This change permits API producers to configure default timeouts for all methods on a per-method basis. Previously, this was only possible for retrying methods.

Since this PR does not break any current codegen, we can update languages individually. Python GAPIC is updated here to demonstrate the impact; [a corresponding change to Python GAX](https://github.com/googleapis/gax-python/pull/116) will be submitted alongside this one.

cc: @jmuk 

Fixes #127