### PR TITLE
Broaden the prereq comment in the go fragments

### DIFF
--- a/src/main/resources/com/google/api/codegen/go/discovery_fragment.snip
+++ b/src/main/resources/com/google/api/codegen/go/discovery_fragment.snip
@@ -19,8 +19,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/{@context.getApi.getName}/{@context.getApiVersion}
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_adexchangebuyer.v1.4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_adexchangebuyer.v1.4.json.baseline
@@ -9,8 +9,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/adexchangebuyer/v1.4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -50,8 +50,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/adexchangebuyer/v1.4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -90,8 +90,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/adexchangebuyer/v1.4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -133,8 +133,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/adexchangebuyer/v1.4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -176,8 +176,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/adexchangebuyer/v1.4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -217,8 +217,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/adexchangebuyer/v1.4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -257,8 +257,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/adexchangebuyer/v1.4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -301,8 +301,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/adexchangebuyer/v1.4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -347,8 +347,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/adexchangebuyer/v1.4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -393,8 +393,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/adexchangebuyer/v1.4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -437,8 +437,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/adexchangebuyer/v1.4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -481,8 +481,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/adexchangebuyer/v1.4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -523,8 +523,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/adexchangebuyer/v1.4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -568,8 +568,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/adexchangebuyer/v1.4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -612,8 +612,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/adexchangebuyer/v1.4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -655,8 +655,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/adexchangebuyer/v1.4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -698,8 +698,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/adexchangebuyer/v1.4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -740,8 +740,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/adexchangebuyer/v1.4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -783,8 +783,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/adexchangebuyer/v1.4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -826,8 +826,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/adexchangebuyer/v1.4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -867,8 +867,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/adexchangebuyer/v1.4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -908,8 +908,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/adexchangebuyer/v1.4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -955,8 +955,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/adexchangebuyer/v1.4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -996,8 +996,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/adexchangebuyer/v1.4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1040,8 +1040,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/adexchangebuyer/v1.4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1083,8 +1083,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/adexchangebuyer/v1.4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1124,8 +1124,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/adexchangebuyer/v1.4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1170,8 +1170,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/adexchangebuyer/v1.4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1216,8 +1216,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/adexchangebuyer/v1.4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1257,8 +1257,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/adexchangebuyer/v1.4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1297,8 +1297,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/adexchangebuyer/v1.4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1338,8 +1338,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/adexchangebuyer/v1.4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1380,8 +1380,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/adexchangebuyer/v1.4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1431,8 +1431,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/adexchangebuyer/v1.4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1471,8 +1471,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/adexchangebuyer/v1.4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1509,8 +1509,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/adexchangebuyer/v1.4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1560,8 +1560,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/adexchangebuyer/v1.4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_appengine.v1beta5.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_appengine.v1beta5.json.baseline
@@ -9,8 +9,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/appengine/v1beta5
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -50,8 +50,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/appengine/v1beta5
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -94,8 +94,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/appengine/v1beta5
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -140,8 +140,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/appengine/v1beta5
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -184,8 +184,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/appengine/v1beta5
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -228,8 +228,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/appengine/v1beta5
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -274,8 +274,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/appengine/v1beta5
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -320,8 +320,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/appengine/v1beta5
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -366,8 +366,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/appengine/v1beta5
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -414,8 +414,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/appengine/v1beta5
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -462,8 +462,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/appengine/v1beta5
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -515,8 +515,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/appengine/v1beta5
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -564,8 +564,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/appengine/v1beta5
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_autoscaler.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_autoscaler.v1beta2.json.baseline
@@ -9,8 +9,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/autoscaler/v1beta2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -56,8 +56,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/autoscaler/v1beta2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -103,8 +103,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/autoscaler/v1beta2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -149,8 +149,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/autoscaler/v1beta2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -198,8 +198,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/autoscaler/v1beta2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -247,8 +247,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/autoscaler/v1beta2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -296,8 +296,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/autoscaler/v1beta2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -340,8 +340,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/autoscaler/v1beta2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -387,8 +387,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/autoscaler/v1beta2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -436,8 +436,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/autoscaler/v1beta2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_bigquery.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_bigquery.v2.json.baseline
@@ -9,8 +9,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/bigquery/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -50,8 +50,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/bigquery/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -94,8 +94,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/bigquery/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -137,8 +137,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/bigquery/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -183,8 +183,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/bigquery/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -229,8 +229,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/bigquery/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -275,8 +275,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/bigquery/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -319,8 +319,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/bigquery/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -363,8 +363,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/bigquery/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -407,8 +407,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/bigquery/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -450,8 +450,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/bigquery/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -496,8 +496,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/bigquery/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -539,8 +539,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/bigquery/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -584,8 +584,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/bigquery/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -633,8 +633,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/bigquery/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -680,8 +680,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/bigquery/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -724,8 +724,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/bigquery/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -771,8 +771,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/bigquery/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -817,8 +817,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/bigquery/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -866,8 +866,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/bigquery/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -915,8 +915,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/bigquery/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudbilling.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudbilling.v1.json.baseline
@@ -9,8 +9,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/cloudbilling/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -51,8 +51,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/cloudbilling/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -96,8 +96,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/cloudbilling/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -143,8 +143,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/cloudbilling/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -185,8 +185,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/cloudbilling/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_clouddebugger.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_clouddebugger.v2.json.baseline
@@ -9,8 +9,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/clouddebugger/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -50,8 +50,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/clouddebugger/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -96,8 +96,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/clouddebugger/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -138,8 +138,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/clouddebugger/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -182,8 +182,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/clouddebugger/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -226,8 +226,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/clouddebugger/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -267,8 +267,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/clouddebugger/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -310,8 +310,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/clouddebugger/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudmonitoring.v2beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudmonitoring.v2beta2.json.baseline
@@ -9,8 +9,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/cloudmonitoring/v2beta2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -52,8 +52,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/cloudmonitoring/v2beta2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -96,8 +96,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/cloudmonitoring/v2beta2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -139,8 +139,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/cloudmonitoring/v2beta2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -190,8 +190,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/cloudmonitoring/v2beta2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -233,8 +233,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/cloudmonitoring/v2beta2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudresourcemanager.v1beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudresourcemanager.v1beta1.json.baseline
@@ -9,8 +9,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/cloudresourcemanager/v1beta1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -50,8 +50,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/cloudresourcemanager/v1beta1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -95,8 +95,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/cloudresourcemanager/v1beta1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -140,8 +140,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/cloudresourcemanager/v1beta1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -185,8 +185,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/cloudresourcemanager/v1beta1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -231,8 +231,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/cloudresourcemanager/v1beta1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -275,8 +275,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/cloudresourcemanager/v1beta1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -317,8 +317,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/cloudresourcemanager/v1beta1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -358,8 +358,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/cloudresourcemanager/v1beta1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -399,8 +399,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/cloudresourcemanager/v1beta1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -444,8 +444,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/cloudresourcemanager/v1beta1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -489,8 +489,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/cloudresourcemanager/v1beta1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -534,8 +534,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/cloudresourcemanager/v1beta1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -580,8 +580,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/cloudresourcemanager/v1beta1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -623,8 +623,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/cloudresourcemanager/v1beta1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudtrace.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudtrace.v1.json.baseline
@@ -9,8 +9,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/cloudtrace/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -52,8 +52,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/cloudtrace/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -96,8 +96,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/cloudtrace/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_clouduseraccounts.beta.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_clouduseraccounts.beta.json.baseline
@@ -9,8 +9,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/clouduseraccounts/v0.beta
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -50,8 +50,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/clouduseraccounts/v0.beta
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -94,8 +94,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/clouduseraccounts/v0.beta
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -140,8 +140,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/clouduseraccounts/v0.beta
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -186,8 +186,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/clouduseraccounts/v0.beta
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -230,8 +230,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/clouduseraccounts/v0.beta
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -274,8 +274,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/clouduseraccounts/v0.beta
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -317,8 +317,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/clouduseraccounts/v0.beta
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -363,8 +363,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/clouduseraccounts/v0.beta
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -409,8 +409,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/clouduseraccounts/v0.beta
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -459,8 +459,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/clouduseraccounts/v0.beta
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -506,8 +506,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/clouduseraccounts/v0.beta
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -552,8 +552,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/clouduseraccounts/v0.beta
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -596,8 +596,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/clouduseraccounts/v0.beta
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -640,8 +640,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/clouduseraccounts/v0.beta
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -683,8 +683,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/clouduseraccounts/v0.beta
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -729,8 +729,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/clouduseraccounts/v0.beta
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_compute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_compute.v1.json.baseline
@@ -9,8 +9,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -55,8 +55,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -102,8 +102,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -149,8 +149,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -195,8 +195,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -244,8 +244,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -290,8 +290,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -337,8 +337,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -384,8 +384,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -430,8 +430,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -479,8 +479,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -528,8 +528,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -574,8 +574,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -618,8 +618,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -662,8 +662,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -708,8 +708,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -751,8 +751,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -797,8 +797,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -843,8 +843,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -889,8 +889,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -935,8 +935,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -982,8 +982,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1031,8 +1031,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1077,8 +1077,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1126,8 +1126,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1173,8 +1173,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1220,8 +1220,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1266,8 +1266,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1315,8 +1315,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1359,8 +1359,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1403,8 +1403,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1446,8 +1446,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1492,8 +1492,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1538,8 +1538,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1584,8 +1584,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1630,8 +1630,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1677,8 +1677,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1724,8 +1724,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1770,8 +1770,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1819,8 +1819,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1868,8 +1868,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1912,8 +1912,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1956,8 +1956,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1999,8 +1999,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -2045,8 +2045,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -2089,8 +2089,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -2133,8 +2133,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -2176,8 +2176,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -2222,8 +2222,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -2268,8 +2268,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -2314,8 +2314,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -2355,8 +2355,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -2399,8 +2399,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -2445,8 +2445,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -2489,8 +2489,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -2533,8 +2533,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -2576,8 +2576,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -2622,8 +2622,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -2668,8 +2668,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -2714,8 +2714,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -2758,8 +2758,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -2802,8 +2802,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -2845,8 +2845,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -2891,8 +2891,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -2937,8 +2937,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -2983,8 +2983,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -3027,8 +3027,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -3073,8 +3073,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -3117,8 +3117,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -3160,8 +3160,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -3206,8 +3206,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -3255,8 +3255,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -3301,8 +3301,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -3348,8 +3348,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -3397,8 +3397,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -3444,8 +3444,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -3490,8 +3490,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -3539,8 +3539,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -3586,8 +3586,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -3635,8 +3635,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -3687,8 +3687,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -3736,8 +3736,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -3785,8 +3785,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -3834,8 +3834,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -3880,8 +3880,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -3927,8 +3927,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -3974,8 +3974,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -4020,8 +4020,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -4069,8 +4069,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -4118,8 +4118,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -4167,8 +4167,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -4216,8 +4216,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -4260,8 +4260,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -4304,8 +4304,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -4347,8 +4347,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -4393,8 +4393,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -4445,8 +4445,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -4491,8 +4491,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -4540,8 +4540,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -4587,8 +4587,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -4640,8 +4640,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -4690,8 +4690,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -4737,8 +4737,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -4784,8 +4784,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -4830,8 +4830,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -4879,8 +4879,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -4926,8 +4926,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -4979,8 +4979,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -5028,8 +5028,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -5077,8 +5077,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -5126,8 +5126,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -5175,8 +5175,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -5222,8 +5222,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -5269,8 +5269,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -5313,8 +5313,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -5359,8 +5359,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -5406,8 +5406,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -5455,8 +5455,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -5499,8 +5499,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -5543,8 +5543,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -5586,8 +5586,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -5632,8 +5632,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -5673,8 +5673,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -5716,8 +5716,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -5759,8 +5759,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -5802,8 +5802,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -5845,8 +5845,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -5889,8 +5889,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -5936,8 +5936,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -5985,8 +5985,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -6029,8 +6029,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -6075,8 +6075,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -6119,8 +6119,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -6163,8 +6163,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -6206,8 +6206,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -6252,8 +6252,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -6296,8 +6296,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -6340,8 +6340,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -6386,8 +6386,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -6430,8 +6430,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -6474,8 +6474,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -6517,8 +6517,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -6563,8 +6563,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -6609,8 +6609,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -6656,8 +6656,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -6703,8 +6703,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -6749,8 +6749,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -6798,8 +6798,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -6842,8 +6842,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -6886,8 +6886,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -6929,8 +6929,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -6975,8 +6975,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -7021,8 +7021,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -7065,8 +7065,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -7109,8 +7109,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -7152,8 +7152,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -7198,8 +7198,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -7244,8 +7244,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -7290,8 +7290,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -7336,8 +7336,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -7383,8 +7383,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -7430,8 +7430,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -7476,8 +7476,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -7525,8 +7525,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -7574,8 +7574,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -7623,8 +7623,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -7669,8 +7669,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -7716,8 +7716,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -7763,8 +7763,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -7812,8 +7812,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -7858,8 +7858,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -7907,8 +7907,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -7956,8 +7956,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -8005,8 +8005,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -8054,8 +8054,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -8100,8 +8100,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -8147,8 +8147,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -8194,8 +8194,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -8240,8 +8240,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -8289,8 +8289,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -8333,8 +8333,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -8377,8 +8377,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -8420,8 +8420,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -8466,8 +8466,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -8512,8 +8512,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -8558,8 +8558,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -8604,8 +8604,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -8650,8 +8650,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -8697,8 +8697,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -8744,8 +8744,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -8790,8 +8790,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -8839,8 +8839,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -8883,8 +8883,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -8930,8 +8930,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -8979,8 +8979,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -9023,8 +9023,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/compute/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_container.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_container.v1.json.baseline
@@ -9,8 +9,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/container/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -57,8 +57,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/container/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -106,8 +106,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/container/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -155,8 +155,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/container/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -201,8 +201,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/container/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -252,8 +252,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/container/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -298,8 +298,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/container/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -347,8 +347,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/container/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_dataflow.v1b3.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_dataflow.v1b3.json.baseline
@@ -9,8 +9,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/dataflow/v1b3
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -52,8 +52,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/dataflow/v1b3
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -96,8 +96,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/dataflow/v1b3
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -140,8 +140,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/dataflow/v1b3
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -186,8 +186,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/dataflow/v1b3
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -235,8 +235,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/dataflow/v1b3
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -281,8 +281,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/dataflow/v1b3
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -327,8 +327,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/dataflow/v1b3
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -373,8 +373,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/dataflow/v1b3
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_dataproc.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_dataproc.v1.json.baseline
@@ -9,8 +9,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/dataproc/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -55,8 +55,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/dataproc/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -102,8 +102,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/dataproc/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -151,8 +151,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/dataproc/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -198,8 +198,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/dataproc/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -247,8 +247,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/dataproc/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -296,8 +296,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/dataproc/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -345,8 +345,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/dataproc/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -392,8 +392,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/dataproc/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -439,8 +439,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/dataproc/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -488,8 +488,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/dataproc/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -534,8 +534,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/dataproc/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -575,8 +575,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/dataproc/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -616,8 +616,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/dataproc/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -657,8 +657,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/dataproc/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_datastore.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_datastore.v1beta2.json.baseline
@@ -9,8 +9,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/datastore/v1beta2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -52,8 +52,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/datastore/v1beta2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -95,8 +95,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/datastore/v1beta2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -138,8 +138,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/datastore/v1beta2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -181,8 +181,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/datastore/v1beta2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -224,8 +224,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/datastore/v1beta2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_deploymentmanager.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_deploymentmanager.v2.json.baseline
@@ -9,8 +9,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/deploymentmanager/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -55,8 +55,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/deploymentmanager/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -99,8 +99,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/deploymentmanager/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -143,8 +143,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/deploymentmanager/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -186,8 +186,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/deploymentmanager/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -232,8 +232,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/deploymentmanager/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -278,8 +278,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/deploymentmanager/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -324,8 +324,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/deploymentmanager/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -370,8 +370,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/deploymentmanager/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -417,8 +417,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/deploymentmanager/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -466,8 +466,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/deploymentmanager/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -510,8 +510,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/deploymentmanager/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -556,8 +556,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/deploymentmanager/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -603,8 +603,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/deploymentmanager/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -652,8 +652,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/deploymentmanager/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_dns.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_dns.v1.json.baseline
@@ -9,8 +9,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/dns/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -55,8 +55,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/dns/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -102,8 +102,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/dns/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -151,8 +151,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/dns/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -194,8 +194,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/dns/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -235,8 +235,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/dns/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -279,8 +279,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/dns/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -325,8 +325,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/dns/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -366,8 +366,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/dns/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_logging.v2beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_logging.v2beta1.json.baseline
@@ -9,8 +9,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/logging/v2beta1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -51,8 +51,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/logging/v2beta1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -93,8 +93,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/logging/v2beta1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -138,8 +138,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/logging/v2beta1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -179,8 +179,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/logging/v2beta1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -223,8 +223,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/logging/v2beta1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -264,8 +264,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/logging/v2beta1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -305,8 +305,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/logging/v2beta1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -352,8 +352,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/logging/v2beta1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -397,8 +397,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/logging/v2beta1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -441,8 +441,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/logging/v2beta1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -482,8 +482,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/logging/v2beta1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -523,8 +523,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/logging/v2beta1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -570,8 +570,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/logging/v2beta1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_prediction.v1.6.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_prediction.v1.6.json.baseline
@@ -9,8 +9,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/prediction/v1.6
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -55,8 +55,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/prediction/v1.6
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -99,8 +99,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/prediction/v1.6
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -140,8 +140,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/prediction/v1.6
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -184,8 +184,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/prediction/v1.6
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -227,8 +227,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/prediction/v1.6
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -273,8 +273,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/prediction/v1.6
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -319,8 +319,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/prediction/v1.6
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_pubsub.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_pubsub.v1.json.baseline
@@ -9,8 +9,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/pubsub/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -52,8 +52,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/pubsub/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -99,8 +99,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/pubsub/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -140,8 +140,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/pubsub/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -181,8 +181,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/pubsub/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -225,8 +225,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/pubsub/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -271,8 +271,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/pubsub/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -314,8 +314,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/pubsub/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -357,8 +357,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/pubsub/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -400,8 +400,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/pubsub/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -446,8 +446,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/pubsub/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -492,8 +492,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/pubsub/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -538,8 +538,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/pubsub/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -579,8 +579,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/pubsub/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -620,8 +620,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/pubsub/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -664,8 +664,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/pubsub/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -710,8 +710,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/pubsub/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -753,8 +753,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/pubsub/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -799,8 +799,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/pubsub/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -845,8 +845,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/pubsub/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_replicapoolupdater.v1beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_replicapoolupdater.v1beta1.json.baseline
@@ -9,8 +9,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/replicapoolupdater/v1beta1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -56,8 +56,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/replicapoolupdater/v1beta1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -103,8 +103,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/replicapoolupdater/v1beta1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -149,8 +149,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/replicapoolupdater/v1beta1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -198,8 +198,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/replicapoolupdater/v1beta1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -250,8 +250,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/replicapoolupdater/v1beta1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -297,8 +297,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/replicapoolupdater/v1beta1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -344,8 +344,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/replicapoolupdater/v1beta1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -391,8 +391,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/replicapoolupdater/v1beta1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -438,8 +438,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/replicapoolupdater/v1beta1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_sqladmin.v1beta4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_sqladmin.v1beta4.json.baseline
@@ -9,8 +9,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/sqladmin/v1beta4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -56,8 +56,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/sqladmin/v1beta4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -103,8 +103,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/sqladmin/v1beta4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -152,8 +152,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/sqladmin/v1beta4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -199,8 +199,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/sqladmin/v1beta4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -246,8 +246,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/sqladmin/v1beta4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -292,8 +292,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/sqladmin/v1beta4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -336,8 +336,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/sqladmin/v1beta4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -385,8 +385,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/sqladmin/v1beta4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -434,8 +434,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/sqladmin/v1beta4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -474,8 +474,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/sqladmin/v1beta4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -520,8 +520,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/sqladmin/v1beta4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -564,8 +564,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/sqladmin/v1beta4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -610,8 +610,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/sqladmin/v1beta4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -656,8 +656,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/sqladmin/v1beta4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -700,8 +700,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/sqladmin/v1beta4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -746,8 +746,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/sqladmin/v1beta4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -789,8 +789,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/sqladmin/v1beta4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -835,8 +835,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/sqladmin/v1beta4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -881,8 +881,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/sqladmin/v1beta4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -925,8 +925,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/sqladmin/v1beta4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -969,8 +969,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/sqladmin/v1beta4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1013,8 +1013,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/sqladmin/v1beta4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1059,8 +1059,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/sqladmin/v1beta4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1103,8 +1103,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/sqladmin/v1beta4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1147,8 +1147,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/sqladmin/v1beta4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1193,8 +1193,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/sqladmin/v1beta4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1237,8 +1237,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/sqladmin/v1beta4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1286,8 +1286,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/sqladmin/v1beta4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1332,8 +1332,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/sqladmin/v1beta4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1379,8 +1379,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/sqladmin/v1beta4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1426,8 +1426,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/sqladmin/v1beta4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1472,8 +1472,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/sqladmin/v1beta4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1516,8 +1516,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/sqladmin/v1beta4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1557,8 +1557,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/sqladmin/v1beta4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1607,8 +1607,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/sqladmin/v1beta4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1653,8 +1653,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/sqladmin/v1beta4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1697,8 +1697,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/sqladmin/v1beta4
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_storage.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_storage.v1.json.baseline
@@ -9,8 +9,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storage/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -51,8 +51,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storage/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -96,8 +96,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storage/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -139,8 +139,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storage/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -180,8 +180,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storage/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -227,8 +227,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storage/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -274,8 +274,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storage/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -312,8 +312,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storage/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -353,8 +353,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storage/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -396,8 +396,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storage/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -442,8 +442,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storage/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -485,8 +485,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storage/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -528,8 +528,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storage/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -568,8 +568,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storage/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -610,8 +610,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storage/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -655,8 +655,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storage/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -698,8 +698,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storage/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -739,8 +739,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storage/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -786,8 +786,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storage/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -833,8 +833,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storage/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -879,8 +879,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storage/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -928,8 +928,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storage/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -975,8 +975,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storage/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1020,8 +1020,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storage/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1071,8 +1071,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storage/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1122,8 +1122,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storage/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1169,8 +1169,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storage/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1225,8 +1225,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storage/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1267,8 +1267,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storage/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1312,8 +1312,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storage/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1356,8 +1356,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storage/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1402,8 +1402,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storage/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1449,8 +1449,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storage/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1505,8 +1505,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storage/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -1552,8 +1552,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storage/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_storagetransfer.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_storagetransfer.v1.json.baseline
@@ -9,8 +9,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storagetransfer/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -49,8 +49,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storagetransfer/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -91,8 +91,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storagetransfer/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -133,8 +133,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storagetransfer/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -174,8 +174,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storagetransfer/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -219,8 +219,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storagetransfer/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -262,8 +262,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storagetransfer/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -303,8 +303,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storagetransfer/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -344,8 +344,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storagetransfer/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -385,8 +385,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storagetransfer/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -431,8 +431,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storagetransfer/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -474,8 +474,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/storagetransfer/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_taskqueue.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_taskqueue.v1beta2.json.baseline
@@ -9,8 +9,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/taskqueue/v1beta2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -53,8 +53,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/taskqueue/v1beta2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -97,8 +97,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/taskqueue/v1beta2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -144,8 +144,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/taskqueue/v1beta2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -190,8 +190,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/taskqueue/v1beta2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -240,8 +240,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/taskqueue/v1beta2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -284,8 +284,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/taskqueue/v1beta2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -336,8 +336,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/taskqueue/v1beta2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_translate.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_translate.v2.json.baseline
@@ -9,8 +9,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/translate/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -50,8 +50,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/translate/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"
@@ -90,8 +90,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/translate/v2
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_vision.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_vision.v1.json.baseline
@@ -9,8 +9,8 @@ package main
 // 2. This sample uses Application Default Credentials for authentication. If
 //    not already done, install the gcloud CLI from https://cloud.google.com/sdk/
 //    and run 'gcloud auth application-default login'
-// 3. To install the client library, run:
-//    go get -u google.golang.org/api/vision/v1
+// 3. To install and update dependencies run 'go get -u' in the project
+//    directory.
 
 import (
   "golang.org/x/net/context"


### PR DESCRIPTION
Followup to #282

Based on feedback that we weren't listing all of the necessary dependencies to install to run a sample. I feel that telling the user to call `go get -u` is more idiomatic than saying: call `go get github.com/...` and `go get github.com/...`

Let me know if there's a better way.