### PR TITLE
Add shadow plugin to generate full JAR

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,10 +15,12 @@ buildscript {
       url 'https://plugins.gradle.org/m2/'
     }
     mavenCentral()
+    jcenter()
   }
   dependencies {
-    classpath 'com.google.protobuf:protobuf-gradle-plugin:0.7.2-SNAPSHOT'
+    classpath "com.google.protobuf:protobuf-gradle-plugin:0.7.2-SNAPSHOT"
     classpath "gradle.plugin.com.github.sherter.google-java-format:google-java-format-gradle-plugin:0.2"
+    classpath "com.github.jengelman.gradle.plugins:shadow:1.2.3"
   }
 }
 
@@ -29,6 +31,7 @@ apply plugin: "idea"
 apply plugin: "eclipse"
 apply plugin: "com.google.protobuf"
 apply plugin: "com.github.sherter.google-java-format"
+apply plugin: "com.github.johnrengelman.shadow"
 
 sourceCompatibility = 1.7
 
@@ -111,6 +114,15 @@ dependencies {
     libraries.mockito,
     libraries.truth,
     libraries.toolsFxTesting
+}
+
+task discoJar(type: com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) {
+  archiveName = "discoGen-${version}.jar"
+  manifest {
+    attributes "Main-Class": "com.google.api.codegen.DiscoveryFragmentGeneratorTool"
+  }
+  from sourceSets.main.output
+  configurations = [ project.configurations.runtime ]
 }
 
 // Source jar


### PR DESCRIPTION
Not much of a change, luckily! The plugin generates a working JAR by a
custom rule (`./gradlew discoJar`) and writes it to
`build/libs/discoGen-${version}.jar`.

Resolves #255 