### PR TITLE
Rename imports to cloud.google.com/go and add import checks

### DIFF
--- a/src/main/resources/com/google/api/codegen/go/doc.snip
+++ b/src/main/resources/com/google/api/codegen/go/doc.snip
@@ -13,7 +13,7 @@
     // {@context.getPackageName} API.
     //
     {@packageCommentSection(service)}
-    package {@context.getPackageName}
+    package {@context.getPackageName} // import "{@context.getApiConfig.getPackageName}"
 @end
 
 @snippet generateBody(service)

--- a/src/test/java/com/google/api/codegen/testdata/go_common_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_common_library.baseline
@@ -1,4 +1,4 @@
-============== file: google.golang.org/cloud/library/apiv1/library.go ==============
+============== file: cloud.google.com/go/library/apiv1/library.go ==============
 // Copyright 2016 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/com/google/api/codegen/testdata/go_doc_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_doc_library.baseline
@@ -1,4 +1,4 @@
-============== file: google.golang.org/cloud/library/apiv1/doc.go ==============
+============== file: cloud.google.com/go/library/apiv1/doc.go ==============
 // Copyright 2016 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,4 +19,4 @@
 // library API.
 //
 // A simple Google Example Library API.
-package library
+package library // import "cloud.google.com/go/library/apiv1"

--- a/src/test/java/com/google/api/codegen/testdata/go_example_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_example_library.baseline
@@ -1,4 +1,4 @@
-============== file: google.golang.org/cloud/library/apiv1/library_client_example_test.go ==============
+============== file: cloud.google.com/go/library/apiv1/library_client_example_test.go ==============
 // Copyright 2016 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,8 +18,8 @@
 package library_test
 
 import (
+    "cloud.google.com/go/library/apiv1"
     "golang.org/x/net/context"
-    "google.golang.org/cloud/library/apiv1"
     google_example_library_v1 "google.golang.org/genproto/googleapis/example/library/v1"
 )
 

--- a/src/test/java/com/google/api/codegen/testdata/go_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_main_library.baseline
@@ -1,4 +1,4 @@
-============== file: google.golang.org/cloud/library/apiv1/library_client.go ==============
+============== file: cloud.google.com/go/library/apiv1/library_client.go ==============
 // Copyright 2016 Google Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/com/google/api/codegen/testdata/library_config.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/library_config.baseline
@@ -6,7 +6,7 @@ language_settings:
   python:
     package_name: google.example.library.v1
   go:
-    package_name: google.golang.org/google/example/library/v1
+    package_name: cloud.google.com/go/example/library/apiv1
   csharp:
     package_name: Google.Example.Library.V1
   ruby:

--- a/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
@@ -6,7 +6,9 @@ language_settings:
   python:
     package_name: library
   go:
-    package_name: google.golang.org/cloud/library/apiv1
+    # Intentionally changed from the gRPC package name.
+    # See: https://github.com/googleapis/toolkit/issues/320
+    package_name: cloud.google.com/go/library/apiv1
   ruby:
     # Note that package_name for ruby is intentionally changed
     # from the gRPC package name of the API to test the generated


### PR DESCRIPTION
This change affects two separate but related workflows.

Firstly, this change adds import check comment to the package
declaration of doc.go files.
The import path is determined by the package_name config in
GAPIC YAML file.
The YAML file used for baseline test is updated to reflect
this new convention.

While the GAPIC YAML file is meant to be edited by humans,
ConfigGenerator is responsible for creating a sensible default,
and therefore:
Secondly, this change modifies default config to also reflect
the new convention.

I still have some questions regarding the generator's behavior
when generating multiple interfaces;
I have reached out to @saicheems and @jba.
If further changes are required, I recommend that they are made
in their own issues and PRs.

Fixes #320. Fixes #321.