### PR TITLE
Redirect Go core proto path to google.golang.org/genproto/googleapis

### DIFF
--- a/src/main/java/com/google/api/codegen/go/GoGapicContext.java
+++ b/src/main/java/com/google/api/codegen/go/GoGapicContext.java
@@ -79,7 +79,7 @@ public class GoGapicContext extends GapicContext implements GoContext {
   /**
    * The import path for generated pb.go files for core-proto files.
    */
-  private static final String CORE_PROTO_BASE = "github.com/googleapis/proto-client-go";
+  private static final String CORE_PROTO_BASE = "google.golang.org/genproto/googleapis";
 
   /**
    * The set of the core protobuf packages.

--- a/src/test/java/com/google/api/codegen/testdata/go_example_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_example_library.baseline
@@ -18,9 +18,9 @@
 package library_test
 
 import (
-    google_example_library_v1 "github.com/googleapis/proto-client-go/library/v1"
     "golang.org/x/net/context"
     "google.golang.org/cloud/library/apiv1"
+    google_example_library_v1 "google.golang.org/genproto/googleapis/example/library/v1"
 )
 
 func ExampleNewClient() {

--- a/src/test/java/com/google/api/codegen/testdata/go_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_main_library.baseline
@@ -23,10 +23,10 @@ import (
     "time"
 
     gax "github.com/googleapis/gax-go"
-    google_example_library_v1 "github.com/googleapis/proto-client-go/library/v1"
     "golang.org/x/net/context"
     "google.golang.org/api/option"
     "google.golang.org/api/transport"
+    google_example_library_v1 "google.golang.org/genproto/googleapis/example/library/v1"
     "google.golang.org/grpc"
     "google.golang.org/grpc/codes"
     "google.golang.org/grpc/metadata"

--- a/src/test/java/com/google/api/codegen/testdata/library.proto
+++ b/src/test/java/com/google/api/codegen/testdata/library.proto
@@ -19,7 +19,7 @@ import "google/protobuf/field_mask.proto";
 option java_multiple_files = true;
 option java_outer_classname = "LibraryProto";
 option java_package = "com.google.example.library.v1";
-option go_package = "github.com/googleapis/proto-client-go/library/v1";
+option go_package = "google.golang.org/genproto/googleapis/example/library/v1";
 
 // This API represents a simple digital library.  It lets you manage Shelf
 // resources and Book resources in the library. It defines the following


### PR DESCRIPTION
Go generation logic reads the import path of proto-generated types
from the protobuf file's go_package attribute.
If one doesn't exist, it falls back to a default.

This commit changes the default
and the go_package attribute of the baseline test
to reflect the new convention.