### PR TITLE
Stage a server-streaming method to library.proto

### DIFF
--- a/src/main/java/com/google/api/codegen/GapicContext.java
+++ b/src/main/java/com/google/api/codegen/GapicContext.java
@@ -17,6 +17,7 @@ package com.google.api.codegen;
 import com.google.api.tools.framework.aspects.documentation.model.DocumentationUtil;
 import com.google.api.tools.framework.model.Field;
 import com.google.api.tools.framework.model.Interface;
+import com.google.api.tools.framework.model.Method;
 import com.google.api.tools.framework.model.Model;
 import com.google.api.tools.framework.model.ProtoElement;
 import com.google.common.base.Preconditions;
@@ -108,5 +109,18 @@ public class GapicContext extends CodegenContext {
       newFields.add(field);
     }
     return newFields;
+  }
+
+  /**
+   * Returns a list of simple RPC methods.
+   */
+  public List<Method> getSimpleRpcMethods(Interface service) {
+    List<Method> simples = new ArrayList<>(service.getMethods().size());
+    for (Method method : service.getMethods()) {
+      if (!method.getRequestStreaming() && !method.getResponseStreaming()) {
+        simples.add(method);
+      }
+    }
+    return simples;
   }
 }

--- a/src/main/java/com/google/api/codegen/GapicContext.java
+++ b/src/main/java/com/google/api/codegen/GapicContext.java
@@ -114,7 +114,7 @@ public class GapicContext extends CodegenContext {
   /**
    * Returns a list of simple RPC methods.
    */
-  public List<Method> getSimpleRpcMethods(Interface service) {
+  public List<Method> getNonStreamingMethods(Interface service) {
     List<Method> simples = new ArrayList<>(service.getMethods().size());
     for (Method method : service.getMethods()) {
       if (!method.getRequestStreaming() && !method.getResponseStreaming()) {

--- a/src/main/java/com/google/api/codegen/csharp/CSharpGapicContext.java
+++ b/src/main/java/com/google/api/codegen/csharp/CSharpGapicContext.java
@@ -545,7 +545,7 @@ public class CSharpGapicContext extends GapicContext implements CSharpContext {
             });
     // TODO: Change back to .from(service.getMethods()) once streaming is implemented.
     //   We ignore streaming for now to not cause test failures.
-    return FluentIterable.from(getSimpleRpcMethods(service))
+    return FluentIterable.from(getNonStreamingMethods(service))
         .transform(
             new Function<Method, MethodInfo>() {
               @Override
@@ -596,7 +596,7 @@ public class CSharpGapicContext extends GapicContext implements CSharpContext {
     final InterfaceConfig interfaceConfig = getApiConfig().getInterfaceConfig(service);
     // TODO: Change back to .from(service.getMethods()) once streaming is implemented.
     //   We ignore streaming for now to not cause test failures.
-    return FluentIterable.from(getSimpleRpcMethods(service))
+    return FluentIterable.from(getNonStreamingMethods(service))
         .transform(
             new Function<Method, PageStreamerInfo>() {
               @Override

--- a/src/main/java/com/google/api/codegen/csharp/CSharpGapicContext.java
+++ b/src/main/java/com/google/api/codegen/csharp/CSharpGapicContext.java
@@ -543,7 +543,9 @@ public class CSharpGapicContext extends GapicContext implements CSharpContext {
                 return value.rawName();
               }
             });
-    return FluentIterable.from(service.getMethods())
+    // TODO: Change back to .from(service.getMethods()) once streaming is implemented.
+    //   We ignore streaming for now to not cause test failures.
+    return FluentIterable.from(getSimpleRpcMethods(service))
         .transform(
             new Function<Method, MethodInfo>() {
               @Override
@@ -592,7 +594,9 @@ public class CSharpGapicContext extends GapicContext implements CSharpContext {
 
   public List<PageStreamerInfo> getPageStreamerInfos(Interface service) {
     final InterfaceConfig interfaceConfig = getApiConfig().getInterfaceConfig(service);
-    return FluentIterable.from(service.getMethods())
+    // TODO: Change back to .from(service.getMethods()) once streaming is implemented.
+    //   We ignore streaming for now to not cause test failures.
+    return FluentIterable.from(getSimpleRpcMethods(service))
         .transform(
             new Function<Method, PageStreamerInfo>() {
               @Override

--- a/src/main/java/com/google/api/codegen/go/GoGapicContext.java
+++ b/src/main/java/com/google/api/codegen/go/GoGapicContext.java
@@ -415,7 +415,7 @@ public class GoGapicContext extends GapicContext implements GoContext {
     TreeSet<GoImport> messageImports = new TreeSet<>();
 
     // Add method request-type imports
-    // TODO(pongad): Change this back to service.getImports() once streaming is implemented.
+    // TODO(pongad): Change this back to service.getMethods() once streaming is implemented.
     //   imports for streaming methods are removed for now to not mess with tests.
     for (Method method : getNonStreamingMethods(service)) {
       MessageType inputMessage = method.getInputMessage();

--- a/src/main/java/com/google/api/codegen/go/GoGapicContext.java
+++ b/src/main/java/com/google/api/codegen/go/GoGapicContext.java
@@ -245,7 +245,7 @@ public class GoGapicContext extends GapicContext implements GoContext {
    */
   public Iterable<PageStreamingConfig> getPageStreamingConfigs(Interface service) {
     Map<String, PageStreamingConfig> streamingConfigs = new LinkedHashMap<>();
-    for (Method method : service.getMethods()) {
+    for (Method method : getSimpleRpcMethods(service)) {
       MethodConfig methodConfig =
           getApiConfig().getInterfaceConfig(service).getMethodConfig(method);
 
@@ -415,7 +415,9 @@ public class GoGapicContext extends GapicContext implements GoContext {
     TreeSet<GoImport> messageImports = new TreeSet<>();
 
     // Add method request-type imports
-    for (Method method : service.getMethods()) {
+    // TODO(pongad): Change this back to service.getImports() once streaming is implemented.
+    //   imports for streaming methods are removed for now to not mess with tests.
+    for (Method method : getSimpleRpcMethods(service)) {
       MessageType inputMessage = method.getInputMessage();
       MessageType outputMessage = method.getOutputMessage();
       MethodConfig methodConfig =

--- a/src/main/java/com/google/api/codegen/go/GoGapicContext.java
+++ b/src/main/java/com/google/api/codegen/go/GoGapicContext.java
@@ -245,7 +245,7 @@ public class GoGapicContext extends GapicContext implements GoContext {
    */
   public Iterable<PageStreamingConfig> getPageStreamingConfigs(Interface service) {
     Map<String, PageStreamingConfig> streamingConfigs = new LinkedHashMap<>();
-    for (Method method : getSimpleRpcMethods(service)) {
+    for (Method method : getNonStreamingMethods(service)) {
       MethodConfig methodConfig =
           getApiConfig().getInterfaceConfig(service).getMethodConfig(method);
 
@@ -417,7 +417,7 @@ public class GoGapicContext extends GapicContext implements GoContext {
     // Add method request-type imports
     // TODO(pongad): Change this back to service.getImports() once streaming is implemented.
     //   imports for streaming methods are removed for now to not mess with tests.
-    for (Method method : getSimpleRpcMethods(service)) {
+    for (Method method : getNonStreamingMethods(service)) {
       MessageType inputMessage = method.getInputMessage();
       MessageType outputMessage = method.getOutputMessage();
       MethodConfig methodConfig =

--- a/src/main/java/com/google/api/codegen/transformer/ApiCallableTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ApiCallableTransformer.java
@@ -36,7 +36,7 @@ public class ApiCallableTransformer {
   public List<ApiCallableView> generateStaticLangApiCallables(SurfaceTransformerContext context) {
     List<ApiCallableView> callableMembers = new ArrayList<>();
 
-    for (Method method : context.getInterface().getMethods()) {
+    for (Method method : context.getNonStreamingMethods()) {
       callableMembers.addAll(generateStaticLangApiCallables(context.asMethodContext(method)));
     }
 
@@ -46,7 +46,7 @@ public class ApiCallableTransformer {
   public List<ApiCallSettingsView> generateCallSettings(SurfaceTransformerContext context) {
     List<ApiCallSettingsView> settingsMembers = new ArrayList<>();
 
-    for (Method method : context.getInterface().getMethods()) {
+    for (Method method : context.getNonStreamingMethods()) {
       settingsMembers.addAll(generateApiCallableSettings(context.asMethodContext(method)));
     }
 

--- a/src/main/java/com/google/api/codegen/transformer/PageStreamingTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/PageStreamingTransformer.java
@@ -33,11 +33,8 @@ public class PageStreamingTransformer {
   public List<PageStreamingDescriptorView> generateDescriptors(SurfaceTransformerContext context) {
     List<PageStreamingDescriptorView> descriptors = new ArrayList<>();
 
-    for (Method method : context.getNonStreamingMethods()) {
+    for (Method method : context.getPageStreamingMethods()) {
       MethodConfig methodConfig = context.getMethodConfig(method);
-      if (!methodConfig.isPageStreaming()) {
-        continue;
-      }
       context.getNamer().addPageStreamingDescriptorImports(context.getTypeTable());
       PageStreamingConfig pageStreaming = methodConfig.getPageStreaming();
 
@@ -59,11 +56,7 @@ public class PageStreamingTransformer {
     List<PageStreamingDescriptorClassView> descriptors = new ArrayList<>();
 
     context.getNamer().addPageStreamingDescriptorImports(context.getTypeTable());
-    for (Method method : context.getInterface().getMethods()) {
-      MethodConfig methodConfig = context.getMethodConfig(method);
-      if (!methodConfig.isPageStreaming()) {
-        continue;
-      }
+    for (Method method : context.getPageStreamingMethods()) {
       descriptors.add(generateDescriptorClass(context.asMethodContext(method)));
     }
 

--- a/src/main/java/com/google/api/codegen/transformer/PageStreamingTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/PageStreamingTransformer.java
@@ -34,6 +34,9 @@ public class PageStreamingTransformer {
     List<PageStreamingDescriptorView> descriptors = new ArrayList<>();
 
     for (Method method : context.getInterface().getMethods()) {
+      if (method.getRequestStreaming() || method.getResponseStreaming()) {
+        continue;
+      }
       MethodConfig methodConfig = context.getMethodConfig(method);
       if (!methodConfig.isPageStreaming()) {
         continue;

--- a/src/main/java/com/google/api/codegen/transformer/PageStreamingTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/PageStreamingTransformer.java
@@ -33,10 +33,7 @@ public class PageStreamingTransformer {
   public List<PageStreamingDescriptorView> generateDescriptors(SurfaceTransformerContext context) {
     List<PageStreamingDescriptorView> descriptors = new ArrayList<>();
 
-    for (Method method : context.getInterface().getMethods()) {
-      if (method.getRequestStreaming() || method.getResponseStreaming()) {
-        continue;
-      }
+    for (Method method : context.getNonStreamingMethods()) {
       MethodConfig methodConfig = context.getMethodConfig(method);
       if (!methodConfig.isPageStreaming()) {
         continue;

--- a/src/main/java/com/google/api/codegen/transformer/SurfaceTransformerContext.java
+++ b/src/main/java/com/google/api/codegen/transformer/SurfaceTransformerContext.java
@@ -20,9 +20,12 @@ import com.google.api.codegen.InterfaceConfig;
 import com.google.api.codegen.MethodConfig;
 import com.google.api.tools.framework.model.Interface;
 import com.google.api.tools.framework.model.Method;
+import com.google.api.tools.framework.model.Method;
 import com.google.auto.value.AutoValue;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 /**
  * The context for transforming a model into a view model for a surface.
@@ -70,5 +73,18 @@ public abstract class SurfaceTransformerContext {
         getNamer(),
         method,
         getMethodConfig(method));
+  }
+
+  /**
+   * Returns a list of simple RPC methods.
+   */
+  public List<Method> getNonStreamingMethods() {
+    List<Method> simples = new ArrayList<>(getInterface().getMethods().size());
+    for (Method method : getInterface().getMethods()) {
+      if (!method.getRequestStreaming() && !method.getResponseStreaming()) {
+        simples.add(method);
+      }
+    }
+    return simples;
   }
 }

--- a/src/main/java/com/google/api/codegen/transformer/SurfaceTransformerContext.java
+++ b/src/main/java/com/google/api/codegen/transformer/SurfaceTransformerContext.java
@@ -79,12 +79,22 @@ public abstract class SurfaceTransformerContext {
    * Returns a list of simple RPC methods.
    */
   public List<Method> getNonStreamingMethods() {
-    List<Method> simples = new ArrayList<>(getInterface().getMethods().size());
+    List<Method> methods = new ArrayList<>(getInterface().getMethods().size());
     for (Method method : getInterface().getMethods()) {
       if (!method.getRequestStreaming() && !method.getResponseStreaming()) {
-        simples.add(method);
+        methods.add(method);
       }
     }
-    return simples;
+    return methods;
+  }
+
+  public List<Method> getPageStreamingMethods() {
+    List<Method> methods = new ArrayList<>();
+    for (Method method : getNonStreamingMethods()) {
+      if (getMethodConfig(method).isPageStreaming()) {
+        methods.add(method);
+      }
+    }
+    return methods;
   }
 }

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTransformer.java
@@ -270,7 +270,7 @@ public class JavaGapicSurfaceTransformer implements ModelToViewTransformer {
   private List<StaticLangApiMethodView> generateApiMethods(SurfaceTransformerContext context) {
     List<StaticLangApiMethodView> apiMethods = new ArrayList<>();
 
-    for (Method method : context.getInterface().getMethods()) {
+    for (Method method : context.getNonStreamingMethods()) {
       MethodConfig methodConfig = context.getMethodConfig(method);
       MethodTransformerContext methodContext = context.asMethodContext(method);
 

--- a/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSurfaceTransformer.java
@@ -143,10 +143,7 @@ public class PhpGapicSurfaceTransformer implements ModelToViewTransformer {
   private List<String> generateMethodKeys(SurfaceTransformerContext context) {
     List<String> methodKeys = new ArrayList<>(context.getInterface().getMethods().size());
 
-    for (Method method : context.getInterface().getMethods()) {
-      if (method.getRequestStreaming() || method.getResponseStreaming()) {
-        continue;
-      }
+    for (Method method : context.getNonStreamingMethods()) {
       methodKeys.add(context.getNamer().getMethodKey(method));
     }
 
@@ -156,10 +153,7 @@ public class PhpGapicSurfaceTransformer implements ModelToViewTransformer {
   private List<ApiMethodView> generateApiMethods(SurfaceTransformerContext context) {
     List<ApiMethodView> apiMethods = new ArrayList<>(context.getInterface().getMethods().size());
 
-    for (Method method : context.getInterface().getMethods()) {
-      if (method.getRequestStreaming() || method.getResponseStreaming()) {
-        continue;
-      }
+    for (Method method : context.getNonStreamingMethods()) {
       apiMethods.add(
           apiMethodTransformer.generateOptionalArrayMethod(context.asMethodContext(method)));
     }

--- a/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSurfaceTransformer.java
@@ -141,9 +141,12 @@ public class PhpGapicSurfaceTransformer implements ModelToViewTransformer {
   }
 
   private List<String> generateMethodKeys(SurfaceTransformerContext context) {
-    List<String> methodKeys = new ArrayList<>();
+    List<String> methodKeys = new ArrayList<>(context.getInterface().getMethods().size());
 
     for (Method method : context.getInterface().getMethods()) {
+      if (method.getRequestStreaming() || method.getResponseStreaming()) {
+        continue;
+      }
       methodKeys.add(context.getNamer().getMethodKey(method));
     }
 
@@ -151,9 +154,12 @@ public class PhpGapicSurfaceTransformer implements ModelToViewTransformer {
   }
 
   private List<ApiMethodView> generateApiMethods(SurfaceTransformerContext context) {
-    List<ApiMethodView> apiMethods = new ArrayList<>();
+    List<ApiMethodView> apiMethods = new ArrayList<>(context.getInterface().getMethods().size());
 
     for (Method method : context.getInterface().getMethods()) {
+      if (method.getRequestStreaming() || method.getResponseStreaming()) {
+        continue;
+      }
       apiMethods.add(
           apiMethodTransformer.generateOptionalArrayMethod(context.asMethodContext(method)));
     }

--- a/src/main/resources/com/google/api/codegen/clientconfig/json.snip
+++ b/src/main/resources/com/google/api/codegen/clientconfig/json.snip
@@ -82,7 +82,7 @@
 @end
 
 @private methodsSection(service)
-    @join method : service.getMethods on ",".add(BREAK)
+    @join method : context.getSimpleRpcMethods(service) on ",".add(BREAK)
         @let methodConfig = context.getApiConfig.getInterfaceConfig(service).getMethodConfig(method), \
                 methodName = context.upperCamelToLowerUnderscore(method.getSimpleName), \
                 isBundling = methodConfig.isBundling, \

--- a/src/main/resources/com/google/api/codegen/clientconfig/json.snip
+++ b/src/main/resources/com/google/api/codegen/clientconfig/json.snip
@@ -82,7 +82,7 @@
 @end
 
 @private methodsSection(service)
-    @join method : context.getSimpleRpcMethods(service) on ",".add(BREAK)
+    @join method : context.getNonStreamingMethods(service) on ",".add(BREAK)
         @let methodConfig = context.getApiConfig.getInterfaceConfig(service).getMethodConfig(method), \
                 methodName = context.upperCamelToLowerUnderscore(method.getSimpleName), \
                 isBundling = methodConfig.isBundling, \

--- a/src/main/resources/com/google/api/codegen/go/example.snip
+++ b/src/main/resources/com/google/api/codegen/go/example.snip
@@ -34,7 +34,7 @@
         // TODO: Use client.
         _ = c
     }
-    @join method : context.getSimpleRpcMethods(service)
+    @join method : context.getNonStreamingMethods(service)
         @let methodName = method.getSimpleName, \
              inTypeName = context.messageTypeName(method.getInputType), \
              outTypeName = context.typeName(method.getOutputType), \

--- a/src/main/resources/com/google/api/codegen/go/example.snip
+++ b/src/main/resources/com/google/api/codegen/go/example.snip
@@ -34,7 +34,7 @@
         // TODO: Use client.
         _ = c
     }
-    @join method : service.getMethods
+    @join method : context.getSimpleRpcMethods(service)
         @let methodName = method.getSimpleName, \
              inTypeName = context.messageTypeName(method.getInputType), \
              outTypeName = context.typeName(method.getOutputType), \

--- a/src/main/resources/com/google/api/codegen/go/main.snip
+++ b/src/main/resources/com/google/api/codegen/go/main.snip
@@ -60,7 +60,7 @@
 
     // {@context.getClientPrefix(service)}CallOptions contains the retry settings for each method of this client.
     type {@context.getClientPrefix(service)}CallOptions struct {
-        @join method : service.getMethods
+        @join method : context.getSimpleRpcMethods(service)
             @let methodName = method.getSimpleName
                 {@methodName} []gax.CallOption
             @end
@@ -98,7 +98,7 @@
             )
         @end
         return &{@context.getClientPrefix(service)}CallOptions{
-            @join method : service.getMethods
+            @join method : context.getSimpleRpcMethods(service)
                 @let methodName = method.getSimpleName, \
                      methodConfig = context.getApiConfig.getInterfaceConfig(service).getMethodConfig(method), \
                      retryParamsName = context.lowerUnderscoreToLowerCamel(methodConfig.getRetrySettingsConfigName), \
@@ -205,7 +205,7 @@
 @end
 
 @private methods(service)
-    @join method : service.getMethods
+    @join method : context.getSimpleRpcMethods(service)
         @let methodName = method.getSimpleName, \
              inTypeName = context.typeName(method.getInputType), \
              outTypeName = context.typeName(method.getOutputType), \

--- a/src/main/resources/com/google/api/codegen/go/main.snip
+++ b/src/main/resources/com/google/api/codegen/go/main.snip
@@ -60,7 +60,7 @@
 
     // {@context.getClientPrefix(service)}CallOptions contains the retry settings for each method of this client.
     type {@context.getClientPrefix(service)}CallOptions struct {
-        @join method : context.getSimpleRpcMethods(service)
+        @join method : context.getNonStreamingMethods(service)
             @let methodName = method.getSimpleName
                 {@methodName} []gax.CallOption
             @end
@@ -98,7 +98,7 @@
             )
         @end
         return &{@context.getClientPrefix(service)}CallOptions{
-            @join method : context.getSimpleRpcMethods(service)
+            @join method : context.getNonStreamingMethods(service)
                 @let methodName = method.getSimpleName, \
                      methodConfig = context.getApiConfig.getInterfaceConfig(service).getMethodConfig(method), \
                      retryParamsName = context.lowerUnderscoreToLowerCamel(methodConfig.getRetrySettingsConfigName), \
@@ -205,7 +205,7 @@
 @end
 
 @private methods(service)
-    @join method : context.getSimpleRpcMethods(service)
+    @join method : context.getNonStreamingMethods(service)
         @let methodName = method.getSimpleName, \
              inTypeName = context.typeName(method.getInputType), \
              outTypeName = context.typeName(method.getOutputType), \

--- a/src/main/resources/com/google/api/codegen/nodejs/main.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/main.snip
@@ -92,10 +92,10 @@
     var CODE_GEN_NAME_VERSION = 'gapic/0.1.0';
 
     var DEFAULT_TIMEOUT = 30;
-    @if context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods)
+    @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getSimpleRpcMethods(service))
 
       var PAGE_DESCRIPTORS = {
-        @join method : context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods) on {@", "}.add(BREAK)
+        @join method : context.messages.filterPageStreamingMethods(ifaceConfig, context.getSimpleRpcMethods(service)) on {@", "}.add(BREAK)
           @let pageStreaming = ifaceConfig.getMethodConfig(method).getPageStreaming(), \
                requestToken = pageStreaming.getRequestTokenField().getSimpleName(), \
                responseToken = pageStreaming.getResponseTokenField().getSimpleName(), \
@@ -108,10 +108,10 @@
         @end
       };
     @end
-    @if context.messages.filterBundlingMethods(ifaceConfig, service.getMethods)
+    @if context.messages.filterBundlingMethods(ifaceConfig, context.getSimpleRpcMethods(service))
 
       var BUNDLE_DESCRIPTORS = {
-        @join method : context.messages.filterBundlingMethods(ifaceConfig, service.getMethods) on {@", "}.add(BREAK)
+        @join method : context.messages.filterBundlingMethods(ifaceConfig, context.getSimpleRpcMethods(service)) on {@", "}.add(BREAK)
           @let bundling = ifaceConfig.getMethodConfig(method).getBundling()
             '{@methodName(method)}': new gax.BundleDescriptor(
                 '{@bundling.getBundledField().getSimpleName()}',
@@ -155,12 +155,12 @@
         clientConfig,
         grpc.status,
         timeout,
-        @if context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods)
+        @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getSimpleRpcMethods(service))
           PAGE_DESCRIPTORS,
         @else
           null,
         @end
-        @if context.messages.filterBundlingMethods(ifaceConfig, service.getMethods)
+        @if context.messages.filterBundlingMethods(ifaceConfig, context.getSimpleRpcMethods(service))
           BUNDLE_DESCRIPTORS,
         @else
           null,
@@ -226,7 +226,7 @@
            'sslCreds': sslCreds,
            'scopes': scopes});
       var methods = [
-        @join method : service.getMethods on {@","}.add(BREAK)
+        @join method : context.getSimpleRpcMethods(service) on {@","}.add(BREAK)
           '{@methodName(method)}'
         @end
       ];
@@ -319,7 +319,7 @@
 
 @private serviceMethodsSection(service)
   // Service calls
-  @join method : service.getMethods
+  @join method : context.getSimpleRpcMethods(service)
 
     {@flattenedMethod(service, method)}
   @end

--- a/src/main/resources/com/google/api/codegen/nodejs/main.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/main.snip
@@ -92,10 +92,10 @@
     var CODE_GEN_NAME_VERSION = 'gapic/0.1.0';
 
     var DEFAULT_TIMEOUT = 30;
-    @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getSimpleRpcMethods(service))
+    @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getNonStreamingMethods(service))
 
       var PAGE_DESCRIPTORS = {
-        @join method : context.messages.filterPageStreamingMethods(ifaceConfig, context.getSimpleRpcMethods(service)) on {@", "}.add(BREAK)
+        @join method : context.messages.filterPageStreamingMethods(ifaceConfig, context.getNonStreamingMethods(service)) on {@", "}.add(BREAK)
           @let pageStreaming = ifaceConfig.getMethodConfig(method).getPageStreaming(), \
                requestToken = pageStreaming.getRequestTokenField().getSimpleName(), \
                responseToken = pageStreaming.getResponseTokenField().getSimpleName(), \
@@ -108,10 +108,10 @@
         @end
       };
     @end
-    @if context.messages.filterBundlingMethods(ifaceConfig, context.getSimpleRpcMethods(service))
+    @if context.messages.filterBundlingMethods(ifaceConfig, context.getNonStreamingMethods(service))
 
       var BUNDLE_DESCRIPTORS = {
-        @join method : context.messages.filterBundlingMethods(ifaceConfig, context.getSimpleRpcMethods(service)) on {@", "}.add(BREAK)
+        @join method : context.messages.filterBundlingMethods(ifaceConfig, context.getNonStreamingMethods(service)) on {@", "}.add(BREAK)
           @let bundling = ifaceConfig.getMethodConfig(method).getBundling()
             '{@methodName(method)}': new gax.BundleDescriptor(
                 '{@bundling.getBundledField().getSimpleName()}',
@@ -155,12 +155,12 @@
         clientConfig,
         grpc.status,
         timeout,
-        @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getSimpleRpcMethods(service))
+        @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getNonStreamingMethods(service))
           PAGE_DESCRIPTORS,
         @else
           null,
         @end
-        @if context.messages.filterBundlingMethods(ifaceConfig, context.getSimpleRpcMethods(service))
+        @if context.messages.filterBundlingMethods(ifaceConfig, context.getNonStreamingMethods(service))
           BUNDLE_DESCRIPTORS,
         @else
           null,
@@ -226,7 +226,7 @@
            'sslCreds': sslCreds,
            'scopes': scopes});
       var methods = [
-        @join method : context.getSimpleRpcMethods(service) on {@","}.add(BREAK)
+        @join method : context.getNonStreamingMethods(service) on {@","}.add(BREAK)
           '{@methodName(method)}'
         @end
       ];
@@ -319,7 +319,7 @@
 
 @private serviceMethodsSection(service)
   // Service calls
-  @join method : context.getSimpleRpcMethods(service)
+  @join method : context.getNonStreamingMethods(service)
 
     {@flattenedMethod(service, method)}
   @end

--- a/src/main/resources/com/google/api/codegen/php/main.snip
+++ b/src/main/resources/com/google/api/codegen/php/main.snip
@@ -404,9 +404,9 @@
     @end
     @if apiMethodDoc.returnTypeName
         {@""} *
-         * @@return {@apiMethodDoc.returnTypeName} 
+         * @@return {@apiMethodDoc.returnTypeName}
     @end
-     * 
+     *
      * @@throws Google\GAX\ApiException if the remote call fails
      */
     {@""}

--- a/src/main/resources/com/google/api/codegen/py/main.snip
+++ b/src/main/resources/com/google/api/codegen/py/main.snip
@@ -61,8 +61,8 @@
 
 @private aliasSection(service)
     @let ifaceConfig = context.getApiConfig.getInterfaceConfig(service), \
-            bundling = context.messages.filterBundlingMethods(ifaceConfig, service.getMethods), \
-            pageStreaming = context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods)
+            bundling = context.messages.filterBundlingMethods(ifaceConfig, context.getSimpleRpcMethods(service)), \
+            pageStreaming = context.messages.filterPageStreamingMethods(ifaceConfig, context.getSimpleRpcMethods(service))
         @if bundling
             _BundleDesc = google.gax.BundleDescriptor
         @end
@@ -109,10 +109,10 @@
         _CODE_GEN_NAME_VERSION = 'gapic/0.1.0'
 
         _GAX_VERSION = pkg_resources.get_distribution('google-gax').version
-        @if context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods)
+        @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getSimpleRpcMethods(service))
 
             _PAGE_DESCRIPTORS = {
-                @join method : context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods) on {@", "}.add(BREAK)
+                @join method : context.messages.filterPageStreamingMethods(ifaceConfig, context.getSimpleRpcMethods(service)) on {@", "}.add(BREAK)
                     @let pageStreaming = ifaceConfig.getMethodConfig(method).getPageStreaming(), \
                             requestToken = pageStreaming.getRequestTokenField().getSimpleName(), \
                             responseToken = pageStreaming.getResponseTokenField().getSimpleName(), \
@@ -126,11 +126,11 @@
                 @end
             }
         @end
-        @if context.messages.filterBundlingMethods(ifaceConfig, service.getMethods)
+        @if context.messages.filterBundlingMethods(ifaceConfig, context.getSimpleRpcMethods(service))
 
             _BUNDLE_DESCRIPTORS = {
                 @let ifaceConfig = context.getApiConfig.getInterfaceConfig(service)
-                    @join method : context.messages.filterBundlingMethods(ifaceConfig, service.getMethods) on {@", "}.add(BREAK)
+                    @join method : context.messages.filterBundlingMethods(ifaceConfig, context.getSimpleRpcMethods(service)) on {@", "}.add(BREAK)
                         @let bundling = ifaceConfig.getMethodConfig(method).getBundling()
                             '{@methodName(method)}': _BundleDesc(
                                 {@bundleDescriptorBody(bundling, method)}
@@ -156,22 +156,22 @@
          jsonBaseName = {@context.upperCamelToLowerUnderscore(service.getSimpleName)}
         default_client_config = json.loads(pkg_resources.resource_string(
             __name__, '{@jsonBaseName}_client_config.json'))
-        @if or(context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods), \
-               context.messages.filterBundlingMethods(ifaceConfig, service.getMethods))
+        @if or(context.messages.filterPageStreamingMethods(ifaceConfig, context.getSimpleRpcMethods(service)), \
+               context.messages.filterBundlingMethods(ifaceConfig, context.getSimpleRpcMethods(service)))
             defaults = api_callable.construct_settings(
                 '{@service.getFullName}',
                 default_client_config,
                 client_config,
                 config.STATUS_CODE_NAMES,
                 kwargs={'metadata': metadata},
-                @if context.messages.filterBundlingMethods(ifaceConfig, service.getMethods)
-                    @if context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods)
+                @if context.messages.filterBundlingMethods(ifaceConfig, context.getSimpleRpcMethods(service))
+                    @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getSimpleRpcMethods(service))
                         bundle_descriptors=self._BUNDLE_DESCRIPTORS,
                     @else
                         bundle_descriptors=self._BUNDLE_DESCRIPTORS)
                     @end
                 @end
-                @if context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods)
+                @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getSimpleRpcMethods(service))
                     page_descriptors=self._PAGE_DESCRIPTORS)
                 @end
         @else
@@ -243,7 +243,7 @@
                 channel=channel,
                 metadata_transformer=metadata_transformer,
                 scopes=scopes)
-            @join method : service.getMethods
+            @join method : context.getSimpleRpcMethods(service)
                 self._{@methodName(method)} = api_callable.create_api_call(
                     self.stub.{@method.getSimpleName()},
                     settings=defaults['{@methodName(method)}'])
@@ -391,7 +391,7 @@
 
 @private serviceMethodsSection(service)
     @# Service calls
-    @join method : service.getMethods on BREAK.add(BREAK)
+    @join method : context.getSimpleRpcMethods(service) on BREAK.add(BREAK)
         {@flattenedMethod(service, method)}
     @end
 @end

--- a/src/main/resources/com/google/api/codegen/py/main.snip
+++ b/src/main/resources/com/google/api/codegen/py/main.snip
@@ -61,8 +61,8 @@
 
 @private aliasSection(service)
     @let ifaceConfig = context.getApiConfig.getInterfaceConfig(service), \
-            bundling = context.messages.filterBundlingMethods(ifaceConfig, context.getSimpleRpcMethods(service)), \
-            pageStreaming = context.messages.filterPageStreamingMethods(ifaceConfig, context.getSimpleRpcMethods(service))
+            bundling = context.messages.filterBundlingMethods(ifaceConfig, context.getNonStreamingMethods(service)), \
+            pageStreaming = context.messages.filterPageStreamingMethods(ifaceConfig, context.getNonStreamingMethods(service))
         @if bundling
             _BundleDesc = google.gax.BundleDescriptor
         @end
@@ -109,10 +109,10 @@
         _CODE_GEN_NAME_VERSION = 'gapic/0.1.0'
 
         _GAX_VERSION = pkg_resources.get_distribution('google-gax').version
-        @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getSimpleRpcMethods(service))
+        @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getNonStreamingMethods(service))
 
             _PAGE_DESCRIPTORS = {
-                @join method : context.messages.filterPageStreamingMethods(ifaceConfig, context.getSimpleRpcMethods(service)) on {@", "}.add(BREAK)
+                @join method : context.messages.filterPageStreamingMethods(ifaceConfig, context.getNonStreamingMethods(service)) on {@", "}.add(BREAK)
                     @let pageStreaming = ifaceConfig.getMethodConfig(method).getPageStreaming(), \
                             requestToken = pageStreaming.getRequestTokenField().getSimpleName(), \
                             responseToken = pageStreaming.getResponseTokenField().getSimpleName(), \
@@ -126,11 +126,11 @@
                 @end
             }
         @end
-        @if context.messages.filterBundlingMethods(ifaceConfig, context.getSimpleRpcMethods(service))
+        @if context.messages.filterBundlingMethods(ifaceConfig, context.getNonStreamingMethods(service))
 
             _BUNDLE_DESCRIPTORS = {
                 @let ifaceConfig = context.getApiConfig.getInterfaceConfig(service)
-                    @join method : context.messages.filterBundlingMethods(ifaceConfig, context.getSimpleRpcMethods(service)) on {@", "}.add(BREAK)
+                    @join method : context.messages.filterBundlingMethods(ifaceConfig, context.getNonStreamingMethods(service)) on {@", "}.add(BREAK)
                         @let bundling = ifaceConfig.getMethodConfig(method).getBundling()
                             '{@methodName(method)}': _BundleDesc(
                                 {@bundleDescriptorBody(bundling, method)}
@@ -156,22 +156,22 @@
          jsonBaseName = {@context.upperCamelToLowerUnderscore(service.getSimpleName)}
         default_client_config = json.loads(pkg_resources.resource_string(
             __name__, '{@jsonBaseName}_client_config.json'))
-        @if or(context.messages.filterPageStreamingMethods(ifaceConfig, context.getSimpleRpcMethods(service)), \
-               context.messages.filterBundlingMethods(ifaceConfig, context.getSimpleRpcMethods(service)))
+        @if or(context.messages.filterPageStreamingMethods(ifaceConfig, context.getNonStreamingMethods(service)), \
+               context.messages.filterBundlingMethods(ifaceConfig, context.getNonStreamingMethods(service)))
             defaults = api_callable.construct_settings(
                 '{@service.getFullName}',
                 default_client_config,
                 client_config,
                 config.STATUS_CODE_NAMES,
                 kwargs={'metadata': metadata},
-                @if context.messages.filterBundlingMethods(ifaceConfig, context.getSimpleRpcMethods(service))
-                    @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getSimpleRpcMethods(service))
+                @if context.messages.filterBundlingMethods(ifaceConfig, context.getNonStreamingMethods(service))
+                    @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getNonStreamingMethods(service))
                         bundle_descriptors=self._BUNDLE_DESCRIPTORS,
                     @else
                         bundle_descriptors=self._BUNDLE_DESCRIPTORS)
                     @end
                 @end
-                @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getSimpleRpcMethods(service))
+                @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getNonStreamingMethods(service))
                     page_descriptors=self._PAGE_DESCRIPTORS)
                 @end
         @else
@@ -243,7 +243,7 @@
                 channel=channel,
                 metadata_transformer=metadata_transformer,
                 scopes=scopes)
-            @join method : context.getSimpleRpcMethods(service)
+            @join method : context.getNonStreamingMethods(service)
                 self._{@methodName(method)} = api_callable.create_api_call(
                     self.stub.{@method.getSimpleName()},
                     settings=defaults['{@methodName(method)}'])
@@ -391,7 +391,7 @@
 
 @private serviceMethodsSection(service)
     @# Service calls
-    @join method : context.getSimpleRpcMethods(service) on BREAK.add(BREAK)
+    @join method : context.getNonStreamingMethods(service) on BREAK.add(BREAK)
         {@flattenedMethod(service, method)}
     @end
 @end

--- a/src/main/resources/com/google/api/codegen/ruby/main.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/main.snip
@@ -88,10 +88,10 @@
     CODE_GEN_NAME_VERSION = 'gapic/0.1.0'.freeze
 
     DEFAULT_TIMEOUT = 30
-    @if context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods)
+    @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getSimpleRpcMethods(service))
 
       PAGE_DESCRIPTORS = {
-        @join method : context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods) on {@", "}.add(BREAK)
+        @join method : context.messages.filterPageStreamingMethods(ifaceConfig, context.getSimpleRpcMethods(service)) on {@", "}.add(BREAK)
           @let pageStreaming = ifaceConfig.getMethodConfig(method).getPageStreaming(), \
                requestToken = pageStreaming.getRequestTokenField().getSimpleName(), \
                responseToken = pageStreaming.getResponseTokenField().getSimpleName(), \
@@ -107,11 +107,11 @@
 
       private_constant :PAGE_DESCRIPTORS
     @end
-    @if context.messages.filterBundlingMethods(ifaceConfig, service.getMethods)
+    @if context.messages.filterBundlingMethods(ifaceConfig, context.getSimpleRpcMethods(service))
 
       BUNDLE_DESCRIPTORS = {
         @let ifaceConfig = context.getApiConfig.getInterfaceConfig(service)
-          @join method : context.messages.filterBundlingMethods(ifaceConfig, service.getMethods) on {@", "}.add(BREAK)
+          @join method : context.messages.filterBundlingMethods(ifaceConfig, context.getSimpleRpcMethods(service)) on {@", "}.add(BREAK)
             @let bundling = ifaceConfig.getMethodConfig(method).getBundling(), \
                  methodName = context.upperCamelToLowerUnderscore(method.getSimpleName)
               '{@methodName}' => Google::Gax::BundleDescriptor.new(
@@ -141,22 +141,22 @@
       '{@jsonBaseName}_client_config.json'
     )
     defaults = client_config_file.open do |f|
-      @if or(context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods), \
-             context.messages.filterBundlingMethods(ifaceConfig, service.getMethods))
+      @if or(context.messages.filterPageStreamingMethods(ifaceConfig, context.getSimpleRpcMethods(service)), \
+             context.messages.filterBundlingMethods(ifaceConfig, context.getSimpleRpcMethods(service)))
         Google::Gax.construct_settings(
           '{@service.getFullName}',
           JSON.parse(f.read),
           client_config,
           Google::Gax::Grpc::STATUS_CODE_NAMES,
           timeout,
-          @if context.messages.filterBundlingMethods(ifaceConfig, service.getMethods)
-            @if context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods)
+          @if context.messages.filterBundlingMethods(ifaceConfig, context.getSimpleRpcMethods(service))
+            @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getSimpleRpcMethods(service))
               bundle_descriptors: BUNDLE_DESCRIPTORS,
             @else
               bundle_descriptors: BUNDLE_DESCRIPTORS,
             @end
           @end
-          @if context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods)
+          @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getSimpleRpcMethods(service))
             page_descriptors: PAGE_DESCRIPTORS,
           @end
           errors: Google::Gax::Grpc::API_ERRORS,
@@ -222,7 +222,7 @@
         &{@context.rubyTypeNameForProtoElement(service)}::Stub.method(:new)
       )
 
-      @join method : service.getMethods
+      @join method : context.getSimpleRpcMethods(service)
         @let methodName = context.upperCamelToLowerUnderscore(method.getSimpleName())
           @@{@methodName} = Google::Gax.create_api_call(
             @@stub.method(:{@methodName}),
@@ -331,7 +331,7 @@
 
 @private serviceMethodsSection(service)
   @# Service calls
-  @join method : service.getMethods
+  @join method : context.getSimpleRpcMethods(service)
 
     {@flattenedMethod(service, method)}
   @end

--- a/src/main/resources/com/google/api/codegen/ruby/main.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/main.snip
@@ -88,10 +88,10 @@
     CODE_GEN_NAME_VERSION = 'gapic/0.1.0'.freeze
 
     DEFAULT_TIMEOUT = 30
-    @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getSimpleRpcMethods(service))
+    @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getNonStreamingMethods(service))
 
       PAGE_DESCRIPTORS = {
-        @join method : context.messages.filterPageStreamingMethods(ifaceConfig, context.getSimpleRpcMethods(service)) on {@", "}.add(BREAK)
+        @join method : context.messages.filterPageStreamingMethods(ifaceConfig, context.getNonStreamingMethods(service)) on {@", "}.add(BREAK)
           @let pageStreaming = ifaceConfig.getMethodConfig(method).getPageStreaming(), \
                requestToken = pageStreaming.getRequestTokenField().getSimpleName(), \
                responseToken = pageStreaming.getResponseTokenField().getSimpleName(), \
@@ -107,11 +107,11 @@
 
       private_constant :PAGE_DESCRIPTORS
     @end
-    @if context.messages.filterBundlingMethods(ifaceConfig, context.getSimpleRpcMethods(service))
+    @if context.messages.filterBundlingMethods(ifaceConfig, context.getNonStreamingMethods(service))
 
       BUNDLE_DESCRIPTORS = {
         @let ifaceConfig = context.getApiConfig.getInterfaceConfig(service)
-          @join method : context.messages.filterBundlingMethods(ifaceConfig, context.getSimpleRpcMethods(service)) on {@", "}.add(BREAK)
+          @join method : context.messages.filterBundlingMethods(ifaceConfig, context.getNonStreamingMethods(service)) on {@", "}.add(BREAK)
             @let bundling = ifaceConfig.getMethodConfig(method).getBundling(), \
                  methodName = context.upperCamelToLowerUnderscore(method.getSimpleName)
               '{@methodName}' => Google::Gax::BundleDescriptor.new(
@@ -141,22 +141,22 @@
       '{@jsonBaseName}_client_config.json'
     )
     defaults = client_config_file.open do |f|
-      @if or(context.messages.filterPageStreamingMethods(ifaceConfig, context.getSimpleRpcMethods(service)), \
-             context.messages.filterBundlingMethods(ifaceConfig, context.getSimpleRpcMethods(service)))
+      @if or(context.messages.filterPageStreamingMethods(ifaceConfig, context.getNonStreamingMethods(service)), \
+             context.messages.filterBundlingMethods(ifaceConfig, context.getNonStreamingMethods(service)))
         Google::Gax.construct_settings(
           '{@service.getFullName}',
           JSON.parse(f.read),
           client_config,
           Google::Gax::Grpc::STATUS_CODE_NAMES,
           timeout,
-          @if context.messages.filterBundlingMethods(ifaceConfig, context.getSimpleRpcMethods(service))
-            @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getSimpleRpcMethods(service))
+          @if context.messages.filterBundlingMethods(ifaceConfig, context.getNonStreamingMethods(service))
+            @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getNonStreamingMethods(service))
               bundle_descriptors: BUNDLE_DESCRIPTORS,
             @else
               bundle_descriptors: BUNDLE_DESCRIPTORS,
             @end
           @end
-          @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getSimpleRpcMethods(service))
+          @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getNonStreamingMethods(service))
             page_descriptors: PAGE_DESCRIPTORS,
           @end
           errors: Google::Gax::Grpc::API_ERRORS,
@@ -222,7 +222,7 @@
         &{@context.rubyTypeNameForProtoElement(service)}::Stub.method(:new)
       )
 
-      @join method : context.getSimpleRpcMethods(service)
+      @join method : context.getNonStreamingMethods(service)
         @let methodName = context.upperCamelToLowerUnderscore(method.getSimpleName())
           @@{@methodName} = Google::Gax.create_api_call(
             @@stub.method(:{@methodName}),
@@ -331,7 +331,7 @@
 
 @private serviceMethodsSection(service)
   @# Service calls
-  @join method : context.getSimpleRpcMethods(service)
+  @join method : context.getNonStreamingMethods(service)
 
     {@flattenedMethod(service, method)}
   @end

--- a/src/test/java/com/google/api/codegen/testdata/library.proto
+++ b/src/test/java/com/google/api/codegen/testdata/library.proto
@@ -117,6 +117,13 @@ service LibraryService {
   rpc UpdateBookIndex(UpdateBookIndexRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = { post: "/v1/{name=bookShelves/*/books/*}/index" body: "*" };
   }
+
+  // Test server streaming
+  rpc StreamShelves(ListShelvesRequest) returns (stream ListShelvesResponse) {
+    // gRPC streaming methods don't have HTTP equivalent and need not have google.api.http option.
+    // TODO(jmuk): Delete option once https://github.com/googleapis/toolkit/pull/325 lands.
+    option (google.api.http) = { get: "/v1/StreamShelves" };
+  }
 }
 
 // A single book in the library.

--- a/src/test/java/com/google/api/codegen/testdata/library_config.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/library_config.baseline
@@ -284,7 +284,7 @@ interfaces:
       name: book_2
     timeout_millis: 60000
   - name: StreamShelves
-    request_object_method: false
+    request_object_method: true
     page_streaming:
       request:
         token_field: page_token
@@ -293,4 +293,5 @@ interfaces:
         resources_field: shelves
     retry_codes_name: idempotent
     retry_params_name: default
-    timeout_millis: 30000
+    timeout_millis: 60000
+

--- a/src/test/java/com/google/api/codegen/testdata/library_config.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/library_config.baseline
@@ -283,4 +283,14 @@ interfaces:
     field_name_patterns:
       name: book_2
     timeout_millis: 60000
-
+  - name: StreamShelves
+    request_object_method: false
+    page_streaming:
+      request:
+        token_field: page_token
+      response:
+        token_field: next_page_token
+        resources_field: shelves
+    retry_codes_name: idempotent
+    retry_params_name: default
+    timeout_millis: 30000

--- a/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
@@ -308,3 +308,14 @@ interfaces:
     sample_code_init_fields:
       - index_name="default index"
       - index_map{"default_key"}
+  - name: StreamShelves
+    request_object_method: false
+    page_streaming:
+      request:
+        token_field: page_token
+      response:
+        token_field: next_page_token
+        resources_field: shelves
+    retry_codes_name: idempotent
+    retry_params_name: default
+    timeout_millis: 30000


### PR DESCRIPTION
This commit adds an example of server streaming gRPC method,
and generators in all languages are instructed to ignore it.
This is done so that streaming needs not be implemented
in every language at once.