### PR TITLE
Ignore streaming methods.

### DIFF
--- a/src/main/java/com/google/api/codegen/ServiceMessages.java
+++ b/src/main/java/com/google/api/codegen/ServiceMessages.java
@@ -14,13 +14,12 @@
  */
 package com.google.api.codegen;
 
+import com.google.api.tools.framework.model.Interface;
 import com.google.api.tools.framework.model.Method;
 import com.google.api.tools.framework.model.TypeRef;
 import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import com.google.protobuf.Empty;
-
-import java.util.List;
 
 /**
  * Utility class with methods to work with service methods.
@@ -43,7 +42,7 @@ public class ServiceMessages {
    * Inputs a list of methods and returns only those which are page streaming.
    */
   public Iterable<Method> filterPageStreamingMethods(
-      final InterfaceConfig config, List<Method> methods) {
+      final InterfaceConfig config, Iterable<Method> methods) {
     Predicate<Method> isPageStreaming =
         new Predicate<Method>() {
           @Override
@@ -59,7 +58,7 @@ public class ServiceMessages {
    * Inputs a list of methods and returns only those which are bundling.
    */
   public Iterable<Method> filterBundlingMethods(
-      final InterfaceConfig config, List<Method> methods) {
+      final InterfaceConfig config, Iterable<Method> methods) {
     Predicate<Method> isBundling =
         new Predicate<Method>() {
           @Override
@@ -69,5 +68,20 @@ public class ServiceMessages {
         };
 
     return Iterables.filter(methods, isBundling);
+  }
+
+  /**
+   * Returns the list of methods in the service. Right now this filters out streaming methods.
+   */
+  public Iterable<Method> getMethods(Interface service) {
+    Predicate<Method> isNonStreaming =
+        new Predicate<Method>() {
+          @Override
+          public boolean apply(Method method) {
+            return !method.getRequestStreaming() && !method.getResponseStreaming();
+          }
+        };
+
+    return Iterables.filter(service.getMethods(), isNonStreaming);
   }
 }

--- a/src/main/java/com/google/api/codegen/config/FieldConfigGenerator.java
+++ b/src/main/java/com/google/api/codegen/config/FieldConfigGenerator.java
@@ -46,6 +46,10 @@ public class FieldConfigGenerator implements MethodConfigGenerator {
 
   @Override
   public Map<String, Object> generate(Method method) {
+    if (method.getRequestStreaming()) {
+      return new LinkedHashMap<String, Object>();
+    }
+
     List<String> ignoredFields = Arrays.asList(PARAMETER_PAGE_TOKEN, PARAMETER_PAGE_SIZE);
 
     List<String> parameterList = new LinkedList<String>();

--- a/src/main/java/com/google/api/codegen/csharp/CSharpGapicContext.java
+++ b/src/main/java/com/google/api/codegen/csharp/CSharpGapicContext.java
@@ -543,7 +543,7 @@ public class CSharpGapicContext extends GapicContext implements CSharpContext {
                 return value.rawName();
               }
             });
-    return FluentIterable.from(service.getMethods())
+    return FluentIterable.from(messages().getMethods(service))
         .transform(
             new Function<Method, MethodInfo>() {
               @Override
@@ -592,7 +592,7 @@ public class CSharpGapicContext extends GapicContext implements CSharpContext {
 
   public List<PageStreamerInfo> getPageStreamerInfos(Interface service) {
     final InterfaceConfig interfaceConfig = getApiConfig().getInterfaceConfig(service);
-    return FluentIterable.from(service.getMethods())
+    return FluentIterable.from(messages().getMethods(service))
         .transform(
             new Function<Method, PageStreamerInfo>() {
               @Override

--- a/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSurfaceTransformer.java
@@ -150,6 +150,9 @@ public class PhpGapicSurfaceTransformer implements ModelToViewTransformer {
     List<String> methodKeys = new ArrayList<>();
 
     for (Method method : context.getInterface().getMethods()) {
+      if (method.getRequestStreaming() || method.getResponseStreaming()) {
+        continue;
+      }
       methodKeys.add(context.getNamer().getMethodKey(method));
     }
 
@@ -160,6 +163,9 @@ public class PhpGapicSurfaceTransformer implements ModelToViewTransformer {
     List<ApiMethodView> apiMethods = new ArrayList<>();
 
     for (Method method : context.getInterface().getMethods()) {
+      if (method.getRequestStreaming() || method.getResponseStreaming()) {
+        continue;
+      }
       apiMethods.add(
           apiMethodTransformer.generateOptionalArrayMethod(context.asMethodContext(method)));
     }

--- a/src/main/resources/com/google/api/codegen/go/example.snip
+++ b/src/main/resources/com/google/api/codegen/go/example.snip
@@ -34,7 +34,7 @@
         // TODO: Use client.
         _ = c
     }
-    @join method : service.getMethods
+    @join method : context.messages.getMethods(service)
         @let methodName = method.getSimpleName, \
              inTypeName = context.messageTypeName(method.getInputType), \
              outTypeName = context.typeName(method.getOutputType), \

--- a/src/main/resources/com/google/api/codegen/go/main.snip
+++ b/src/main/resources/com/google/api/codegen/go/main.snip
@@ -60,7 +60,7 @@
 
     // {@context.getClientPrefix(service)}CallOptions contains the retry settings for each method of this client.
     type {@context.getClientPrefix(service)}CallOptions struct {
-        @join method : service.getMethods
+        @join method : context.messages.getMethods(service)
             @let methodName = method.getSimpleName
                 {@methodName} []gax.CallOption
             @end
@@ -98,7 +98,7 @@
             )
         @end
         return &{@context.getClientPrefix(service)}CallOptions{
-            @join method : service.getMethods
+            @join method : context.messages.getMethods(service)
                 @let methodName = method.getSimpleName, \
                      methodConfig = context.getApiConfig.getInterfaceConfig(service).getMethodConfig(method), \
                      retryParamsName = context.lowerUnderscoreToLowerCamel(methodConfig.getRetrySettingsConfigName), \
@@ -205,7 +205,7 @@
 @end
 
 @private methods(service)
-    @join method : service.getMethods
+    @join method : context.messages.getMethods(service)
         @let methodName = method.getSimpleName, \
              inTypeName = context.typeName(method.getInputType), \
              outTypeName = context.typeName(method.getOutputType), \

--- a/src/main/resources/com/google/api/codegen/java/main.snip
+++ b/src/main/resources/com/google/api/codegen/java/main.snip
@@ -128,7 +128,7 @@
   private final ScheduledExecutorService executor;
   private final List<AutoCloseable> closeables = new ArrayList<>();
 
-  @join method : service.getMethods
+  @join method : context.messages.getMethods(service)
     @let methodName = context.upperCamelToLowerCamel(method.getSimpleName), \
          methodConfig = context.getApiConfig.getInterfaceConfig(service).getMethodConfig(method), \
          inTypeName = context.typeName(method.getInputType), \
@@ -179,7 +179,7 @@
       this.executor = settings.getExecutorProvider().getOrBuildExecutor();
       this.channel = settings.getChannelProvider().getOrBuildChannel(this.executor);
 
-      @join method : service.getMethods
+      @join method : context.messages.getMethods(service)
         @let methodName = context.upperCamelToLowerCamel(method.getSimpleName), \
              methodConfig = context.getApiConfig.getInterfaceConfig(service).getMethodConfig(method), \
              isPageStreaming = methodConfig.isPageStreaming, \
@@ -220,7 +220,7 @@
 @end
 
 @private callables(service)
-  @join method : service.getMethods
+  @join method : context.messages.getMethods(service)
     @let methodName = context.upperCamelToLowerCamel(method.getSimpleName), \
          inTypeName = context.typeName(method.getInputType), \
          outTypeName = context.typeName(method.getOutputType), \

--- a/src/main/resources/com/google/api/codegen/java/settings.snip
+++ b/src/main/resources/com/google/api/codegen/java/settings.snip
@@ -148,7 +148,7 @@
 @end
 
 @private methodMembers(service)
-  @join method : service.getMethods
+  @join method : context.messages.getMethods(service)
     @let methodName = context.upperCamelToLowerCamel(method.getSimpleName), \
          methodConfig = context.getApiConfig.getInterfaceConfig(service).getMethodConfig(method), \
          inTypeName = context.typeName(method.getInputType), \
@@ -178,7 +178,7 @@
 @end
 
 @private methodGetters(service)
-  @join method : service.getMethods
+  @join method : context.messages.getMethods(service)
     @let methodName = context.upperCamelToLowerCamel(method.getSimpleName), \
          methodConfig = context.getApiConfig.getInterfaceConfig(service).getMethodConfig(method), \
          inTypeName = context.typeName(method.getInputType), \
@@ -228,7 +228,7 @@
             settingsBuilder.getClientLibName(),
             settingsBuilder.getClientLibVersion());
 
-      @join method : service.getMethods
+      @join method : context.messages.getMethods(service)
         @let methodName = context.upperCamelToLowerCamel(method.getSimpleName)
           {@methodName}Settings = settingsBuilder.{@methodName}Settings().build();
         @end
@@ -245,7 +245,7 @@
 @private pageStreamingDescriptors(service)
   @let interfaceConfig = context.getApiConfig.getInterfaceConfig(service), \
        dummy = context.addImport("com.google.api.gax.grpc.PageStreamingDescriptor")
-    @join method : context.messages.filterPageStreamingMethods(interfaceConfig, service.getMethods)
+    @join method : context.messages.filterPageStreamingMethods(interfaceConfig, context.messages.getMethods(service))
       @let methodConstant = context.upperCamelToUpperUnderscore(method.getSimpleName), \
            inTypeName = context.typeName(method.getInputType), \
            outTypeName = context.typeName(method.getOutputType), \
@@ -283,7 +283,7 @@
 
 @private bundlingDescriptors(service)
   @let interfaceConfig = context.getApiConfig.getInterfaceConfig(service)
-    @join method : context.messages.filterBundlingMethods(interfaceConfig, service.getMethods)
+    @join method : context.messages.filterBundlingMethods(interfaceConfig, context.messages.getMethods(service))
       @let methodConstant = context.upperCamelToUpperUnderscore(method.getSimpleName), \
            inTypeName = context.typeName(method.getInputType), \
            outTypeName = context.typeName(method.getOutputType), \
@@ -391,7 +391,7 @@
 @end
 
 @private builderMembers(service)
-  @join method : service.getMethods
+  @join method : context.messages.getMethods(service)
     @let methodName = context.upperCamelToLowerCamel(method.getSimpleName), \
          methodConfig = context.getApiConfig.getInterfaceConfig(service).getMethodConfig(method), \
          inTypeName = context.typeName(method.getInputType), \
@@ -470,7 +470,7 @@
     return this;
   }
 
-  @join method : service.getMethods
+  @join method : context.messages.getMethods(service)
     @let methodName = context.upperCamelToLowerCamel(method.getSimpleName), \
          methodConfig = context.getApiConfig.getInterfaceConfig(service).getMethodConfig(method), \
          inTypeName = context.typeName(method.getInputType), \
@@ -561,7 +561,7 @@
 
     @let serviceName = service.getSimpleName, \
          grpcName = context.getGrpcName(service)
-      @join method : service.getMethods
+      @join method : context.messages.getMethods(service)
         @let methodConstant = context.upperCamelToUpperUnderscore(method.getSimpleName), \
              methodName = context.upperCamelToLowerCamel(method.getSimpleName), \
              methodConfig = context.getApiConfig.getInterfaceConfig(service).getMethodConfig(method), \
@@ -603,7 +603,7 @@
     Builder builder = new Builder();
     @let serviceName = service.getSimpleName, \
          grpcName = context.getGrpcName(service)
-      @join method : service.getMethods
+      @join method : context.messages.getMethods(service)
         @let methodConstant = context.upperCamelToUpperUnderscore(method.getSimpleName), \
              methodName = context.upperCamelToLowerCamel(method.getSimpleName), \
              methodConfig = context.getApiConfig.getInterfaceConfig(service).getMethodConfig(method), \
@@ -650,7 +650,7 @@
   private Builder({@settingsClassName(service)} settings) {
     super(settings);
 
-    @join method : service.getMethods
+    @join method : context.messages.getMethods(service)
       @let methodName = context.upperCamelToLowerCamel(method.getSimpleName), \
            methodConfig = context.getApiConfig.getInterfaceConfig(service).getMethodConfig(method), \
            isPageStreaming = methodConfig.isPageStreaming
@@ -665,7 +665,7 @@
 @end
 
 @private settingsList(service)
-  @join method : service.getMethods vertical on ",".add(BREAK)
+  @join method : context.messages.getMethods(service) vertical on ",".add(BREAK)
     @let methodName = context.upperCamelToLowerCamel(method.getSimpleName), \
          methodConfig = context.getApiConfig.getInterfaceConfig(service).getMethodConfig(method), \
          isPageStreaming = methodConfig.isPageStreaming

--- a/src/main/resources/com/google/api/codegen/nodejs/main.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/main.snip
@@ -92,10 +92,10 @@
     var CODE_GEN_NAME_VERSION = 'gapic/0.1.0';
 
     var DEFAULT_TIMEOUT = 30;
-    @if context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods)
+    @if context.messages.filterPageStreamingMethods(ifaceConfig, context.messages.getMethods(service))
 
       var PAGE_DESCRIPTORS = {
-        @join method : context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods) on {@", "}.add(BREAK)
+        @join method : context.messages.filterPageStreamingMethods(ifaceConfig, context.messages.getMethods(service)) on {@", "}.add(BREAK)
           @let pageStreaming = ifaceConfig.getMethodConfig(method).getPageStreaming(), \
                requestToken = pageStreaming.getRequestTokenField().getSimpleName(), \
                responseToken = pageStreaming.getResponseTokenField().getSimpleName(), \
@@ -108,10 +108,10 @@
         @end
       };
     @end
-    @if context.messages.filterBundlingMethods(ifaceConfig, service.getMethods)
+    @if context.messages.filterBundlingMethods(ifaceConfig, context.messages.getMethods(service))
 
       var BUNDLE_DESCRIPTORS = {
-        @join method : context.messages.filterBundlingMethods(ifaceConfig, service.getMethods) on {@", "}.add(BREAK)
+        @join method : context.messages.filterBundlingMethods(ifaceConfig, context.messages.getMethods(service)) on {@", "}.add(BREAK)
           @let bundling = ifaceConfig.getMethodConfig(method).getBundling()
             '{@methodName(method)}': new gax.BundleDescriptor(
                 '{@bundling.getBundledField().getSimpleName()}',
@@ -155,12 +155,12 @@
         clientConfig,
         grpc.status,
         timeout,
-        @if context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods)
+        @if context.messages.filterPageStreamingMethods(ifaceConfig, context.messages.getMethods(service))
           PAGE_DESCRIPTORS,
         @else
           null,
         @end
-        @if context.messages.filterBundlingMethods(ifaceConfig, service.getMethods)
+        @if context.messages.filterBundlingMethods(ifaceConfig, context.messages.getMethods(service))
           BUNDLE_DESCRIPTORS,
         @else
           null,
@@ -226,7 +226,7 @@
            'sslCreds': sslCreds,
            'scopes': scopes});
       var methods = [
-        @join method : service.getMethods on {@","}.add(BREAK)
+        @join method : context.messages.getMethods(service) on {@","}.add(BREAK)
           '{@methodName(method)}'
         @end
       ];
@@ -319,7 +319,7 @@
 
 @private serviceMethodsSection(service)
   // Service calls
-  @join method : service.getMethods
+  @join method : context.messages.getMethods(service)
 
     {@flattenedMethod(service, method)}
   @end

--- a/src/main/resources/com/google/api/codegen/py/main.snip
+++ b/src/main/resources/com/google/api/codegen/py/main.snip
@@ -61,8 +61,8 @@
 
 @private aliasSection(service)
     @let ifaceConfig = context.getApiConfig.getInterfaceConfig(service), \
-            bundling = context.messages.filterBundlingMethods(ifaceConfig, service.getMethods), \
-            pageStreaming = context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods)
+            bundling = context.messages.filterBundlingMethods(ifaceConfig, context.messages.getMethods(service)), \
+            pageStreaming = context.messages.filterPageStreamingMethods(ifaceConfig, context.messages.getMethods(service))
         @if bundling
             _BundleDesc = google.gax.BundleDescriptor
         @end
@@ -109,10 +109,10 @@
         _CODE_GEN_NAME_VERSION = 'gapic/0.1.0'
 
         _GAX_VERSION = pkg_resources.get_distribution('google-gax').version
-        @if context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods)
+        @if context.messages.filterPageStreamingMethods(ifaceConfig, context.messages.getMethods(service))
 
             _PAGE_DESCRIPTORS = {
-                @join method : context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods) on {@", "}.add(BREAK)
+                @join method : context.messages.filterPageStreamingMethods(ifaceConfig, context.messages.getMethods(service)) on {@", "}.add(BREAK)
                     @let pageStreaming = ifaceConfig.getMethodConfig(method).getPageStreaming(), \
                             requestToken = pageStreaming.getRequestTokenField().getSimpleName(), \
                             responseToken = pageStreaming.getResponseTokenField().getSimpleName(), \
@@ -126,11 +126,11 @@
                 @end
             }
         @end
-        @if context.messages.filterBundlingMethods(ifaceConfig, service.getMethods)
+        @if context.messages.filterBundlingMethods(ifaceConfig, context.messages.getMethods(service))
 
             _BUNDLE_DESCRIPTORS = {
                 @let ifaceConfig = context.getApiConfig.getInterfaceConfig(service)
-                    @join method : context.messages.filterBundlingMethods(ifaceConfig, service.getMethods) on {@", "}.add(BREAK)
+                    @join method : context.messages.filterBundlingMethods(ifaceConfig, context.messages.getMethods(service)) on {@", "}.add(BREAK)
                         @let bundling = ifaceConfig.getMethodConfig(method).getBundling()
                             '{@methodName(method)}': _BundleDesc(
                                 {@bundleDescriptorBody(bundling, method)}
@@ -156,22 +156,22 @@
          jsonBaseName = {@context.upperCamelToLowerUnderscore(service.getSimpleName)}
         default_client_config = json.loads(pkg_resources.resource_string(
             __name__, '{@jsonBaseName}_client_config.json'))
-        @if or(context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods), \
-               context.messages.filterBundlingMethods(ifaceConfig, service.getMethods))
+        @if or(context.messages.filterPageStreamingMethods(ifaceConfig, context.messages.getMethods(service)), \
+               context.messages.filterBundlingMethods(ifaceConfig, context.messages.getMethods(service)))
             defaults = api_callable.construct_settings(
                 '{@service.getFullName}',
                 default_client_config,
                 client_config,
                 config.STATUS_CODE_NAMES,
                 kwargs={'metadata': metadata},
-                @if context.messages.filterBundlingMethods(ifaceConfig, service.getMethods)
-                    @if context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods)
+                @if context.messages.filterBundlingMethods(ifaceConfig, context.messages.getMethods(service))
+                    @if context.messages.filterPageStreamingMethods(ifaceConfig, context.messages.getMethods(service))
                         bundle_descriptors=self._BUNDLE_DESCRIPTORS,
                     @else
                         bundle_descriptors=self._BUNDLE_DESCRIPTORS)
                     @end
                 @end
-                @if context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods)
+                @if context.messages.filterPageStreamingMethods(ifaceConfig, context.messages.getMethods(service))
                     page_descriptors=self._PAGE_DESCRIPTORS)
                 @end
         @else
@@ -243,7 +243,7 @@
                 channel=channel,
                 metadata_transformer=metadata_transformer,
                 scopes=scopes)
-            @join method : service.getMethods
+            @join method : context.messages.getMethods(service)
                 self._{@methodName(method)} = api_callable.create_api_call(
                     self.stub.{@method.getSimpleName()},
                     settings=defaults['{@methodName(method)}'])
@@ -391,7 +391,7 @@
 
 @private serviceMethodsSection(service)
     @# Service calls
-    @join method : service.getMethods on BREAK.add(BREAK)
+    @join method : context.messages.getMethods(service) on BREAK.add(BREAK)
         {@flattenedMethod(service, method)}
     @end
 @end

--- a/src/main/resources/com/google/api/codegen/ruby/main.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/main.snip
@@ -88,10 +88,10 @@
     CODE_GEN_NAME_VERSION = 'gapic/0.1.0'.freeze
 
     DEFAULT_TIMEOUT = 30
-    @if context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods)
+    @if context.messages.filterPageStreamingMethods(ifaceConfig, context.messages.getMethods(service))
 
       PAGE_DESCRIPTORS = {
-        @join method : context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods) on {@", "}.add(BREAK)
+        @join method : context.messages.filterPageStreamingMethods(ifaceConfig, context.messages.getMethods(service)) on {@", "}.add(BREAK)
           @let pageStreaming = ifaceConfig.getMethodConfig(method).getPageStreaming(), \
                requestToken = pageStreaming.getRequestTokenField().getSimpleName(), \
                responseToken = pageStreaming.getResponseTokenField().getSimpleName(), \
@@ -107,11 +107,11 @@
 
       private_constant :PAGE_DESCRIPTORS
     @end
-    @if context.messages.filterBundlingMethods(ifaceConfig, service.getMethods)
+    @if context.messages.filterBundlingMethods(ifaceConfig, context.messages.getMethods(service))
 
       BUNDLE_DESCRIPTORS = {
         @let ifaceConfig = context.getApiConfig.getInterfaceConfig(service)
-          @join method : context.messages.filterBundlingMethods(ifaceConfig, service.getMethods) on {@", "}.add(BREAK)
+          @join method : context.messages.filterBundlingMethods(ifaceConfig, context.messages.getMethods(service)) on {@", "}.add(BREAK)
             @let bundling = ifaceConfig.getMethodConfig(method).getBundling(), \
                  methodName = context.upperCamelToLowerUnderscore(method.getSimpleName)
               '{@methodName}' => Google::Gax::BundleDescriptor.new(
@@ -141,22 +141,22 @@
       '{@jsonBaseName}_client_config.json'
     )
     defaults = client_config_file.open do |f|
-      @if or(context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods), \
-             context.messages.filterBundlingMethods(ifaceConfig, service.getMethods))
+      @if or(context.messages.filterPageStreamingMethods(ifaceConfig, context.messages.getMethods(service)), \
+             context.messages.filterBundlingMethods(ifaceConfig, context.messages.getMethods(service)))
         Google::Gax.construct_settings(
           '{@service.getFullName}',
           JSON.parse(f.read),
           client_config,
           Google::Gax::Grpc::STATUS_CODE_NAMES,
           timeout,
-          @if context.messages.filterBundlingMethods(ifaceConfig, service.getMethods)
-            @if context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods)
+          @if context.messages.filterBundlingMethods(ifaceConfig, context.messages.getMethods(service))
+            @if context.messages.filterPageStreamingMethods(ifaceConfig, context.messages.getMethods(service))
               bundle_descriptors: BUNDLE_DESCRIPTORS,
             @else
               bundle_descriptors: BUNDLE_DESCRIPTORS,
             @end
           @end
-          @if context.messages.filterPageStreamingMethods(ifaceConfig, service.getMethods)
+          @if context.messages.filterPageStreamingMethods(ifaceConfig, context.messages.getMethods(service))
             page_descriptors: PAGE_DESCRIPTORS,
           @end
           errors: Google::Gax::Grpc::API_ERRORS,
@@ -222,7 +222,7 @@
         &{@context.rubyTypeNameForProtoElement(service)}::Stub.method(:new)
       )
 
-      @join method : service.getMethods
+      @join method : context.messages.getMethods(service)
         @let methodName = context.upperCamelToLowerUnderscore(method.getSimpleName())
           @@{@methodName} = Google::Gax.create_api_call(
             @@stub.method(:{@methodName}),
@@ -331,7 +331,7 @@
 
 @private serviceMethodsSection(service)
   @# Service calls
-  @join method : service.getMethods
+  @join method : context.messages.getMethods(service)
 
     {@flattenedMethod(service, method)}
   @end

--- a/src/test/java/com/google/api/codegen/testdata/client_config_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/client_config_json_library.baseline
@@ -109,6 +109,14 @@
           "timeout_millis": 10000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
+        },
+        "ListBooksStreaming": {
+          "timeout_millis": 10000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "ChatBook": {
+          "timeout_millis": 10000
         }
       }
     }

--- a/src/test/java/com/google/api/codegen/testdata/library.proto
+++ b/src/test/java/com/google/api/codegen/testdata/library.proto
@@ -117,6 +117,14 @@ service LibraryService {
   rpc UpdateBookIndex(UpdateBookIndexRequest) returns (google.protobuf.Empty) {
     option (google.api.http) = { post: "/v1/{name=bookShelves/*/books/*}/index" body: "*" };
   }
+
+  // Server-side streaming example.
+  rpc ListBooksStreaming(ListBooksStreamingRequest) returns (stream ListBooksStreamingResponse) {
+    option (google.api.http) = { get: "/v1/{name=bookShelves/*}/books:stream" };
+  }
+
+  // Bidi-streaming example.
+  rpc ChatBook(stream BookComment) returns (stream BookComment) {}
 }
 
 // A single book in the library.
@@ -390,4 +398,32 @@ message UpdateBookIndexRequest {
 
   // The index to update the book with
   map<string, string> index_map = 3;
+}
+
+// Request message for LibraryService.ListBooksStreaming.
+message ListBooksStreamingRequest {
+  // The name of the shelf whose books we'd like to list.
+  string name = 1;
+
+  // The last book name already seen. The response will start the next
+  // book.
+  string last_book_name = 2;
+}
+
+// Response message for LibraryService.ListBooksStreamingResponse.
+message ListBooksStreamingResponse {
+  // The list of books.
+  repeated Book books = 1;
+
+  // The name of the last book in this response.
+  string last_book_name = 2;
+}
+
+// The request and response for LibraryService.ChatBook.
+message BookComment {
+  // The name of the book.
+  string name = 1;
+
+  // A comment for the book.
+  string comment = 2;
 }

--- a/src/test/java/com/google/api/codegen/testdata/library_config.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/library_config.baseline
@@ -283,3 +283,22 @@ interfaces:
     field_name_patterns:
       name: book_2
     timeout_millis: 30000
+  - name: ListBooksStreaming
+    flattening:
+      groups:
+      - parameters:
+        - name
+        - last_book_name
+    required_fields:
+    - name
+    - last_book_name
+    request_object_method: true
+    retry_codes_name: idempotent
+    retry_params_name: default
+    field_name_patterns:
+      name: book_shelf
+    timeout_millis: 30000
+  - name: ChatBook
+    retry_codes_name: non_idempotent
+    retry_params_name: default
+    timeout_millis: 30000

--- a/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
@@ -308,3 +308,17 @@ interfaces:
     sample_code_init_fields:
       - index_name="default index"
       - index_map{"default_key"}
+  - name: ListBooksStreaming
+    flattening:
+      groups:
+      - parameters:
+        - name
+    required_fields:
+    - name
+    request_object_method: true
+    retry_codes_name: idempotent
+    retry_params_name: default
+    timeout_millis: 10000
+  - name: ChatBook
+    retry_params_name: default
+    timeout_millis: 10000

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_json_library.baseline
@@ -109,6 +109,14 @@
           "timeout_millis": 10000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
+        },
+        "ListBooksStreaming": {
+          "timeout_millis": 10000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "ChatBook": {
+          "timeout_millis": 10000
         }
       }
     }

--- a/src/test/java/com/google/api/codegen/testdata/php_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php_json_library.baseline
@@ -109,6 +109,14 @@
           "timeout_millis": 10000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
+        },
+        "ListBooksStreaming": {
+          "timeout_millis": 10000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "ChatBook": {
+          "timeout_millis": 10000
         }
       }
     }

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_json_library.baseline
@@ -109,6 +109,14 @@
           "timeout_millis": 10000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
+        },
+        "ListBooksStreaming": {
+          "timeout_millis": 10000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "ChatBook": {
+          "timeout_millis": 10000
         }
       }
     }

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_message_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_message_library.baseline
@@ -897,3 +897,40 @@ class UpdateBookIndexRequest(object):
     """
     pass
 
+
+class ListBooksStreamingRequest(object):
+    """
+    Request message for LibraryService.ListBooksStreaming.
+
+    Attributes:
+      name (string): The name of the shelf whose books we'd like to list.
+      last_book_name (string): The last book name already seen. The response will start the next
+        book.
+
+    """
+    pass
+
+
+class ListBooksStreamingResponse(object):
+    """
+    Response message for LibraryService.ListBooksStreamingResponse.
+
+    Attributes:
+      books (list[:class:`google.example.library.v1.library_pb2.Book`]): The list of books.
+      last_book_name (string): The name of the last book in this response.
+
+    """
+    pass
+
+
+class BookComment(object):
+    """
+    The request and response for LibraryService.ChatBook.
+
+    Attributes:
+      name (string): The name of the book.
+      comment (string): A comment for the book.
+
+    """
+    pass
+

--- a/src/test/java/com/google/api/codegen/testdata/python_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_json_library.baseline
@@ -109,6 +109,14 @@
           "timeout_millis": 10000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
+        },
+        "ListBooksStreaming": {
+          "timeout_millis": 10000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "ChatBook": {
+          "timeout_millis": 10000
         }
       }
     }

--- a/src/test/java/com/google/api/codegen/testdata/ruby_doc_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_doc_json_library.baseline
@@ -109,6 +109,14 @@
           "timeout_millis": 10000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
+        },
+        "ListBooksStreaming": {
+          "timeout_millis": 10000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "ChatBook": {
+          "timeout_millis": 10000
         }
       }
     }

--- a/src/test/java/com/google/api/codegen/testdata/ruby_doc_message_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_doc_message_library.baseline
@@ -813,6 +813,34 @@ module Google
         #   @return [Hash{String => String}]
         #     The index to update the book with
         class UpdateBookIndexRequest; end
+
+        # Request message for LibraryService.ListBooksStreaming.
+        # @!attribute [rw] name
+        #   @return [String]
+        #     The name of the shelf whose books we'd like to list.
+        # @!attribute [rw] last_book_name
+        #   @return [String]
+        #     The last book name already seen. The response will start the next
+        #     book.
+        class ListBooksStreamingRequest; end
+
+        # Response message for LibraryService.ListBooksStreamingResponse.
+        # @!attribute [rw] books
+        #   @return [Array<Google::Example::Library::V1::Book>]
+        #     The list of books.
+        # @!attribute [rw] last_book_name
+        #   @return [String]
+        #     The name of the last book in this response.
+        class ListBooksStreamingResponse; end
+
+        # The request and response for LibraryService.ChatBook.
+        # @!attribute [rw] name
+        #   @return [String]
+        #     The name of the book.
+        # @!attribute [rw] comment
+        #   @return [String]
+        #     A comment for the book.
+        class BookComment; end
       end
     end
   end

--- a/src/test/java/com/google/api/codegen/testdata/ruby_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_json_library.baseline
@@ -109,6 +109,14 @@
           "timeout_millis": 10000,
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
+        },
+        "ListBooksStreaming": {
+          "timeout_millis": 10000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "ChatBook": {
+          "timeout_millis": 10000
         }
       }
     }


### PR DESCRIPTION
Currently Gapic generator does not support gRPC-streaming methods,
we will skip streaming methods for the time being (otherwise
the generated code will behavior incorrectly or lead to compile
errors).

Note that this skip can't be done solely on the configuration
yaml (i.e. not-listing methods in the yaml file), because
many of the generators silently assume the existence of
MethodConfig instances and end up with NullPointerExceptions.

Rather than supporting missing MethodConfig cases, I believe this
special-handling of gRPC-streaming would be better because
anyways this type of special-handling will be necessary when we start
supporting gRPC-streaming methods for a specific language without
affecting other languages.