### PR TITLE
Go: Properly use zeroValue

### DIFF
--- a/src/main/resources/com/google/api/codegen/go/main.snip
+++ b/src/main/resources/com/google/api/codegen/go/main.snip
@@ -353,7 +353,7 @@
             func (it *{@iteratorTypeName}) Next() ({@resourceFieldTypeName}, error) {
                 for it.currentIndex >= len(it.items) {
                     if it.atLastPage {
-                        return nil, Done
+                        return {@context.zeroValue(resourceFieldType)}, Done
                     }
                     if err := it.apiCall(); err != nil {
                         return {@context.zeroValue(resourceFieldType)}, err

--- a/src/test/java/com/google/api/codegen/testdata/go_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_main_library.baseline
@@ -671,7 +671,7 @@ func (it *StringIterator) NextPage() ([]string, error) {
 func (it *StringIterator) Next() (string, error) {
     for it.currentIndex >= len(it.items) {
         if it.atLastPage {
-            return nil, Done
+            return "", Done
         }
         if err := it.apiCall(); err != nil {
             return "", err


### PR DESCRIPTION
StringIterator.Next() tries to return nil instead of "".
This commit makes it properly return "".

This change also applies to iterator over other non-ref types.