### PR TITLE
Use "cloud" in Python package name by default

### DIFF
--- a/src/main/java/com/google/api/codegen/config/LanguageGenerator.java
+++ b/src/main/java/com/google/api/codegen/config/LanguageGenerator.java
@@ -16,7 +16,6 @@ package com.google.api.codegen.config;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
@@ -25,8 +24,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Generator for language settings section. Currently the only language setting is the package
- * name.
+ * Generator for language settings section. Currently the only language setting is the package name.
  */
 public class LanguageGenerator {
 
@@ -41,11 +39,14 @@ public class LanguageGenerator {
         Arrays.asList(
             new RewriteRule("^google", "com.google.cloud"),
             new RewriteRule("(.v[^.]+)$", ".spi$1"));
-    List<RewriteRule> phpRewriteRules = Arrays.asList(new RewriteRule("^google", "google.cloud"));
+    List<RewriteRule> phpRewriteRules =
+        Arrays.asList(new RewriteRule("^google(?!\\.cloud)", "google.cloud"));
+    List<RewriteRule> pythonRewriteRules =
+        Arrays.asList(new RewriteRule("^google(?!\\.cloud)", "google.cloud"));
     LANGUAGE_FORMATTERS =
         ImmutableMap.<String, LanguageFormatter>builder()
             .put("java", new SimpleLanguageFormatter(".", javaRewriteRules, false))
-            .put("python", new SimpleLanguageFormatter(".", null, false))
+            .put("python", new SimpleLanguageFormatter(".", pythonRewriteRules, false))
             .put("go", new GoLanguageFormatter())
             .put("csharp", new SimpleLanguageFormatter(".", null, true))
             .put("ruby", new SimpleLanguageFormatter("::", null, true))

--- a/src/test/java/com/google/api/codegen/ConfigGenerationTest.java
+++ b/src/test/java/com/google/api/codegen/ConfigGenerationTest.java
@@ -17,18 +17,16 @@ package com.google.api.codegen;
 import com.google.api.codegen.config.ConfigGeneratorApi;
 import com.google.api.tools.framework.model.testing.ConfigBaselineTestCase;
 import com.google.api.tools.framework.tools.ToolOptions;
-
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-
 import org.junit.Test;
 
 public class ConfigGenerationTest extends ConfigBaselineTestCase {
   @Override
   protected String baselineFileName() {
-    return "library_config.baseline";
+    return testName.getMethodName() + "_config.baseline";
   }
 
   @Override
@@ -55,5 +53,10 @@ public class ConfigGenerationTest extends ConfigBaselineTestCase {
   @Test
   public void library() throws Exception {
     test("library");
+  }
+
+  @Test
+  public void no_path_templates() throws Exception {
+    test("no_path_templates");
   }
 }

--- a/src/test/java/com/google/api/codegen/testdata/library_config.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/library_config.baseline
@@ -4,7 +4,7 @@ language_settings:
   java:
     package_name: com.google.cloud.example.library.spi.v1
   python:
-    package_name: google.example.library.v1
+    package_name: google.cloud.example.library.v1
   go:
     package_name: cloud.google.com/go/example/library/apiv1
   csharp:

--- a/src/test/java/com/google/api/codegen/testdata/no_path_templates.proto
+++ b/src/test/java/com/google/api/codegen/testdata/no_path_templates.proto
@@ -2,7 +2,7 @@
 
 syntax = "proto3";
 
-package google.example.v1;
+package google.cloud.example.v1;
 
 import "google/api/annotations.proto";
 import "google/protobuf/empty.proto";

--- a/src/test/java/com/google/api/codegen/testdata/no_path_templates.yaml
+++ b/src/test/java/com/google/api/codegen/testdata/no_path_templates.yaml
@@ -5,7 +5,7 @@ title: Google Fake API
 
 # Included protobuf APIs
 apis:
-- name: google.example.v1.NoTemplatesService
+- name: google.cloud.example.v1.NoTemplatesService
 
 # Documentation section
 documentation:

--- a/src/test/java/com/google/api/codegen/testdata/no_path_templates_config.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/no_path_templates_config.baseline
@@ -1,0 +1,41 @@
+type: com.google.api.codegen.ConfigProto
+generate_samples: true
+language_settings:
+  java:
+    package_name: com.google.cloud.cloud.example.spi.v1
+  python:
+    package_name: google.cloud.example.v1
+  go:
+    package_name: cloud.google.com/go/cloud/example/apiv1
+  csharp:
+    package_name: Google.Cloud.Example.V1
+  ruby:
+    package_name: Google::Cloud::Example::V1
+  php:
+    package_name: Google\Cloud\Example\V1
+interfaces:
+- name: google.cloud.example.v1.NoTemplatesService
+  collections: []
+  retry_codes_def:
+  - name: idempotent
+    retry_codes:
+    - UNAVAILABLE
+    - DEADLINE_EXCEEDED
+  - name: non_idempotent
+    retry_codes: []
+  retry_params_def:
+  - name: default
+    initial_retry_delay_millis: 100
+    retry_delay_multiplier: 1.3
+    max_retry_delay_millis: 60000
+    initial_rpc_timeout_millis: 20000
+    rpc_timeout_multiplier: 1
+    max_rpc_timeout_millis: 20000
+    total_timeout_millis: 600000
+  methods:
+  - name: Increment
+    request_object_method: false
+    retry_codes_name: non_idempotent
+    retry_params_name: default
+    timeout_millis: 60000
+

--- a/src/test/java/com/google/api/codegen/testdata/no_path_templates_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testdata/no_path_templates_gapic.yaml
@@ -12,7 +12,7 @@ language_settings:
   nodejs:
     package_name: google-example-no-path-template
 interfaces:
-- name: google.example.v1.NoTemplatesService
+- name: google.cloud.example.v1.NoTemplatesService
   methods:
   - name: Increment
     retry_params_name: default

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_json_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_json_no_path_templates.baseline
@@ -1,7 +1,7 @@
 ============== file: src/no_templates_service_client_config.json ==============
 {
   "interfaces": {
-    "google.example.v1.NoTemplatesService": {
+    "google.cloud.example.v1.NoTemplatesService": {
       "retry_codes": {},
       "retry_params": {},
       "methods": {

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_main_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_main_no_path_templates.baseline
@@ -85,7 +85,7 @@ function NoTemplatesServiceApi(opts) {
   var appName = opts.appName || 'gax';
   var appVersion = opts.appVersion || gax.Version;
 
-  var grpcClient = require('grpc-google-example-v1').client;
+  var grpcClient = require('grpc-google-cloud-example-v1').client;
 
   var googleApiClient = [
     appName + '/' + appVersion,
@@ -93,7 +93,7 @@ function NoTemplatesServiceApi(opts) {
     'nodejs/' + process.version].join(' ');
 
   var defaults = gax.constructSettingsGrpc(
-      'google.example.v1.NoTemplatesService',
+      'google.cloud.example.v1.NoTemplatesService',
       configData,
       clientConfig,
       timeout,
@@ -105,7 +105,7 @@ function NoTemplatesServiceApi(opts) {
   this.stub = gax.createStub(
       servicePath,
       port,
-      grpcClient.google.example.v1.NoTemplatesService,
+      grpcClient.google.cloud.example.v1.NoTemplatesService,
       {'getCredentials': getCredentials,
        'grpc': opts.grpc,
        'sslCreds': sslCreds,

--- a/src/test/java/com/google/api/codegen/testdata/python_json_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_json_no_path_templates.baseline
@@ -1,7 +1,7 @@
 ============== file: example/no_templates_service_client_config.json ==============
 {
   "interfaces": {
-    "google.example.v1.NoTemplatesService": {
+    "google.cloud.example.v1.NoTemplatesService": {
       "retry_codes": {},
       "retry_params": {},
       "methods": {

--- a/src/test/java/com/google/api/codegen/testdata/python_main_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_main_no_path_templates.baseline
@@ -22,7 +22,7 @@
 # The only allowed edits are to method and file documentation. A 3-way
 # merge preserves those additions if the generated source changes.
 
-"""Accesses the google.example.v1 NoTemplatesService API."""
+"""Accesses the google.cloud.example.v1 NoTemplatesService API."""
 
 import json
 import os
@@ -34,7 +34,7 @@ from google.gax import config
 from google.gax import path_template
 import google.gax
 
-from google.example.v1 import no_path_templates_pb2
+from google.cloud.example.v1 import no_path_templates_pb2
 
 
 class NoTemplatesServiceApi(object):
@@ -101,7 +101,7 @@ class NoTemplatesServiceApi(object):
         default_client_config = json.loads(pkg_resources.resource_string(
             __name__, 'no_templates_service_client_config.json'))
         defaults = api_callable.construct_settings(
-            'google.example.v1.NoTemplatesService',
+            'google.cloud.example.v1.NoTemplatesService',
             default_client_config,
             client_config,
             config.STATUS_CODE_NAMES,


### PR DESCRIPTION
Also,
- change regular expressions in the package naming logic so that
  "cloud" will only be added if it is not already present in the
  proto package name
- Modify no_path_templates test to serve as a "cloud" API and add
  as a test for the config generator