### PR TITLE
Implement java mock service generator

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
@@ -65,6 +65,11 @@ public class SurfaceNamer extends NameFormatterDelegator {
     return "$ NOT IMPLEMENTED: " + feature + " $";
   }
 
+  /** The full path to the file  */
+  public String getFullFilePath(String path, String name) {
+    return getNotImplementedString("SurfaceNamer.getFullFilePath");
+  }
+
   /** The name of the class that implements a particular proto interface. */
   public String getApiWrapperClassName(Interface interfaze) {
     return className(Name.upperCamel(interfaze.getSimpleName(), "Api"));
@@ -280,6 +285,17 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /**
+   * The type name of the Grpc service class
+   * This needs to match what Grpc generates for the particular language.
+   */
+  public String getGrpcServiceClassName(Interface service) {
+    NamePath namePath = typeNameConverter.getNamePath(modelTypeFormatter.getFullNameFor(service));
+    String grpcContainerName = className(Name.upperCamel(namePath.getHead(), "Grpc"));
+    String serviceClassName = className(Name.upperCamel(service.getSimpleName()));
+    return qualifiedName(namePath.withHead(grpcContainerName).append(serviceClassName));
+  }
+
+  /**
    * The type name of the method constant in the Grpc container class.
    * This needs to match what Grpc generates for the particular language.
    */
@@ -439,7 +455,12 @@ public class SurfaceNamer extends NameFormatterDelegator {
     return className(Name.upperCamel("Mock", service.getSimpleName()));
   }
 
-  /** The class name of the mock gRPC service for the given API service. */
+  /** The class name of the mock gRPC service implementation for the given API service. */
+  public String getMockGrpcServiceImplName(Interface service) {
+    return className(Name.upperCamel("Mock", service.getSimpleName(), "Impl"));
+  }
+
+  /** The method name of getter function call for the given name */
   public String getGetFunctionCallName(Name name) {
     return methodName(Name.from("get").join(name));
   }

--- a/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
@@ -65,9 +65,9 @@ public class SurfaceNamer extends NameFormatterDelegator {
     return "$ NOT IMPLEMENTED: " + feature + " $";
   }
 
-  /** The full path to the file  */
-  public String getFullFilePath(String path, String name) {
-    return getNotImplementedString("SurfaceNamer.getFullFilePath");
+  /** The full path to the source file  */
+  public String getSourceFilePath(String path, String className) {
+    return getNotImplementedString("SurfaceNamer.getSourceFilePath");
   }
 
   /** The name of the class that implements a particular proto interface. */

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
@@ -135,7 +135,7 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
             .name(name)
             .mockServiceClassName(context.getNamer().getMockServiceClassName(service))
             .testCases(createTestCaseViews(context))
-            .outputPath(namer.getFullFilePath(outputPath, name))
+            .outputPath(namer.getSourceFilePath(outputPath, name))
             .templateFileName(TEST_TEMPLATE_FILE)
             // Imports must be done as the last step to catch all imports.
             .imports(context.getTypeTable().getImports())
@@ -204,7 +204,7 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
         .serviceImplClassName(namer.getMockGrpcServiceImplName(context.getInterface()))
         .packageName(context.getApiConfig().getPackageName())
         .grpcContainerName(grpcContainerName)
-        .outputPath(namer.getFullFilePath(outputPath, name))
+        .outputPath(namer.getSourceFilePath(outputPath, name))
         .templateFileName(MOCK_SERVICE_FILE)
         // Imports must be done as the last step to catch all imports.
         .imports(context.getTypeTable().getImports())
@@ -225,7 +225,7 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
         .packageName(context.getApiConfig().getPackageName())
         .grpcMethods(createGrpcMethodViews(context))
         .grpcClassName(grpcClassName)
-        .outputPath(namer.getFullFilePath(outputPath, name))
+        .outputPath(namer.getSourceFilePath(outputPath, name))
         .templateFileName(MOCK_SERVICE_IMPL_FILE)
         // Imports must be done as the last step to catch all imports.
         .imports(context.getTypeTable().getImports())

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceNamer.java
@@ -25,6 +25,7 @@ import com.google.api.codegen.util.java.JavaTypeTable;
 import com.google.api.tools.framework.model.Method;
 import com.google.api.tools.framework.model.TypeRef;
 
+import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 
@@ -38,6 +39,11 @@ public class JavaSurfaceNamer extends SurfaceNamer {
         new JavaNameFormatter(),
         new ModelTypeFormatterImpl(new JavaModelTypeNameConverter()),
         new JavaTypeTable());
+  }
+
+  @Override
+  public String getFullFilePath(String path, String name) {
+    return path + File.separator + name + ".java";
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceNamer.java
@@ -42,8 +42,8 @@ public class JavaSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getFullFilePath(String path, String name) {
-    return path + File.separator + name + ".java";
+  public String getSourceFilePath(String path, String className) {
+    return path + File.separator + className + ".java";
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/util/NamePath.java
+++ b/src/main/java/com/google/api/codegen/util/NamePath.java
@@ -15,6 +15,7 @@
 package com.google.api.codegen.util;
 
 import com.google.common.base.Joiner;
+import com.google.common.collect.Lists;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,7 +25,7 @@ import java.util.List;
  * dots or slashes.
  */
 public class NamePath {
-  private List<String> pathPieces;
+  private ArrayList<String> pathPieces;
 
   /**
    * Create a NamePath that is separated by dots.
@@ -51,7 +52,7 @@ public class NamePath {
   }
 
   private NamePath(List<String> pathPieces) {
-    this.pathPieces = pathPieces;
+    this.pathPieces = Lists.newArrayList(pathPieces);
   }
 
   /**
@@ -63,6 +64,14 @@ public class NamePath {
     newPathPieces.addAll(pathPieces);
     newPathPieces.set(pathPieces.size() - 1, newHead);
     return new NamePath(newPathPieces);
+  }
+
+  /**
+   * Append the given head after the last piece of the path.
+   */
+  public NamePath append(String head) {
+    pathPieces.add(head);
+    return this;
   }
 
   /**

--- a/src/main/java/com/google/api/codegen/viewmodel/testing/MockGrpcMethodView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/testing/MockGrpcMethodView.java
@@ -1,0 +1,41 @@
+/* Copyright 2016 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.viewmodel.testing;
+
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class MockGrpcMethodView {
+  public abstract String name();
+
+  public abstract String requestTypeName();
+
+  public abstract String responseTypeName();
+
+  public static Builder newBuilder() {
+    return new AutoValue_MockGrpcMethodView.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder name(String val);
+
+    public abstract Builder requestTypeName(String val);
+
+    public abstract Builder responseTypeName(String val);
+
+    public abstract MockGrpcMethodView build();
+  }
+}

--- a/src/main/java/com/google/api/codegen/viewmodel/testing/MockServiceImplView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/testing/MockServiceImplView.java
@@ -1,0 +1,69 @@
+/* Copyright 2016 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.viewmodel.testing;
+
+import com.google.api.codegen.SnippetSetRunner;
+import com.google.api.codegen.viewmodel.ViewModel;
+import com.google.auto.value.AutoValue;
+
+import java.util.List;
+
+@AutoValue
+public abstract class MockServiceImplView implements ViewModel {
+
+  public abstract String packageName();
+
+  public abstract String name();
+
+  public abstract String grpcClassName();
+
+  public abstract List<String> imports();
+
+  public abstract List<MockGrpcMethodView> grpcMethods();
+
+  @Override
+  public String resourceRoot() {
+    return SnippetSetRunner.SNIPPET_RESOURCE_ROOT;
+  }
+
+  @Override
+  public abstract String templateFileName();
+
+  @Override
+  public abstract String outputPath();
+
+  public static Builder newBuilder() {
+    return new AutoValue_MockServiceImplView.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder packageName(String val);
+
+    public abstract Builder name(String val);
+
+    public abstract Builder grpcClassName(String val);
+
+    public abstract Builder imports(List<String> val);
+
+    public abstract Builder outputPath(String val);
+
+    public abstract Builder templateFileName(String val);
+
+    public abstract Builder grpcMethods(List<MockGrpcMethodView> val);
+
+    public abstract MockServiceImplView build();
+  }
+}

--- a/src/main/java/com/google/api/codegen/viewmodel/testing/MockServiceView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/testing/MockServiceView.java
@@ -1,0 +1,68 @@
+/* Copyright 2016 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.viewmodel.testing;
+
+import com.google.api.codegen.SnippetSetRunner;
+import com.google.api.codegen.viewmodel.ViewModel;
+import com.google.auto.value.AutoValue;
+
+import java.util.List;
+
+@AutoValue
+public abstract class MockServiceView implements ViewModel {
+  public abstract String packageName();
+
+  public abstract String name();
+
+  public abstract String serviceImplClassName();
+
+  public abstract String grpcContainerName();
+
+  public abstract List<String> imports();
+
+  @Override
+  public String resourceRoot() {
+    return SnippetSetRunner.SNIPPET_RESOURCE_ROOT;
+  }
+
+  @Override
+  public abstract String templateFileName();
+
+  @Override
+  public abstract String outputPath();
+
+  public static Builder newBuilder() {
+    return new AutoValue_MockServiceView.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder packageName(String val);
+
+    public abstract Builder name(String val);
+
+    public abstract Builder serviceImplClassName(String val);
+
+    public abstract Builder grpcContainerName(String val);
+
+    public abstract Builder imports(List<String> val);
+
+    public abstract Builder outputPath(String val);
+
+    public abstract Builder templateFileName(String val);
+
+    public abstract MockServiceView build();
+  }
+}

--- a/src/main/resources/com/google/api/codegen/java/mock_service.snip
+++ b/src/main/resources/com/google/api/codegen/java/mock_service.snip
@@ -1,0 +1,35 @@
+@extends "java/common.snip"
+
+@snippet generate(mockService)
+  {@license()}
+
+  package {@mockService.packageName};
+
+  @join import : mockService.imports
+    import {@import};
+  @end
+
+  @@javax.annotation.Generated("by GAPIC")
+  public class {@mockService.name} implements MockGrpcService  {
+    private {@mockService.serviceImplClassName} serviceImpl;
+
+    public {@mockService.name}() {
+      serviceImpl = new {@mockService.serviceImplClassName}();
+    }
+
+    @@Override
+    public List<GeneratedMessage> getRequests() {
+      return serviceImpl.getRequests();
+    }
+
+    @@Override
+    public ServerServiceDefinition getServiceDefinition() {
+      return {@mockService.grpcContainerName}.bindService(serviceImpl);
+    }
+
+    @@Override
+    public void reset() {
+      serviceImpl.reset();
+    }
+  }
+@end

--- a/src/main/resources/com/google/api/codegen/java/mock_service_impl.snip
+++ b/src/main/resources/com/google/api/codegen/java/mock_service_impl.snip
@@ -1,0 +1,43 @@
+@extends "java/common.snip"
+
+@snippet generate(mockServiceImpl)
+  {@license()}
+
+  package {@mockServiceImpl.packageName};
+
+  @join import : mockServiceImpl.imports
+    import {@import};
+  @end
+
+  @@javax.annotation.Generated("by GAPIC")
+  public class {@mockServiceImpl.name} implements {@mockServiceImpl.grpcClassName}  {
+     private ArrayList<GeneratedMessage> requests;
+
+     public {@mockServiceImpl.name}() {
+       requests = new ArrayList<>();
+     }
+
+     public List<GeneratedMessage> getRequests() {
+       return requests;
+     }
+
+     public void reset() {
+       requests = new ArrayList<>();
+     }
+
+     @join method : mockServiceImpl.grpcMethods
+      {@grpcMethod(method)}
+
+     @end
+  }
+@end
+
+@private grpcMethod(method)
+  @@Override
+  public void {@method.name}({@method.requestTypeName} request,
+      StreamObserver<{@method.responseTypeName}> responseObserver) {
+    requests.add(request);
+    responseObserver.onNext({@method.responseTypeName}.newBuilder().build());
+    responseObserver.onCompleted();
+  }
+@end

--- a/src/test/java/com/google/api/codegen/testdata/java_test_mock_service_impl_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_test_mock_service_impl_library.baseline
@@ -1,0 +1,199 @@
+============== file: src/test/java/com/google/gcloud/pubsub/spi/MockLibraryServiceImpl.java ==============
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.gcloud.pubsub.spi;
+
+import com.google.example.library.v1.AddCommentsRequest;
+import com.google.example.library.v1.Book;
+import com.google.example.library.v1.CreateBookRequest;
+import com.google.example.library.v1.CreateShelfRequest;
+import com.google.example.library.v1.DeleteBookRequest;
+import com.google.example.library.v1.DeleteShelfRequest;
+import com.google.example.library.v1.GetBookFromArchiveRequest;
+import com.google.example.library.v1.GetBookRequest;
+import com.google.example.library.v1.GetShelfRequest;
+import com.google.example.library.v1.LibraryServiceGrpc.LibraryService;
+import com.google.example.library.v1.ListBooksRequest;
+import com.google.example.library.v1.ListBooksResponse;
+import com.google.example.library.v1.ListShelvesRequest;
+import com.google.example.library.v1.ListShelvesResponse;
+import com.google.example.library.v1.ListStringsRequest;
+import com.google.example.library.v1.ListStringsResponse;
+import com.google.example.library.v1.MergeShelvesRequest;
+import com.google.example.library.v1.MoveBookRequest;
+import com.google.example.library.v1.PublishSeriesRequest;
+import com.google.example.library.v1.PublishSeriesResponse;
+import com.google.example.library.v1.Shelf;
+import com.google.example.library.v1.UpdateBookIndexRequest;
+import com.google.example.library.v1.UpdateBookRequest;
+import com.google.protobuf.Empty;
+import com.google.protobuf.GeneratedMessage;
+import io.grpc.stub.StreamObserver;
+import java.util.ArrayList;
+import java.util.List;
+
+@javax.annotation.Generated("by GAPIC")
+public class MockLibraryServiceImpl implements LibraryService  {
+   private ArrayList<GeneratedMessage> requests;
+
+   public MockLibraryServiceImpl() {
+     requests = new ArrayList<>();
+   }
+
+   public List<GeneratedMessage> getRequests() {
+     return requests;
+   }
+
+   public void reset() {
+     requests = new ArrayList<>();
+   }
+
+   @Override
+   public void createShelf(CreateShelfRequest request,
+       StreamObserver<Shelf> responseObserver) {
+     requests.add(request);
+     responseObserver.onNext(Shelf.newBuilder().build());
+     responseObserver.onCompleted();
+   }
+
+   @Override
+   public void getShelf(GetShelfRequest request,
+       StreamObserver<Shelf> responseObserver) {
+     requests.add(request);
+     responseObserver.onNext(Shelf.newBuilder().build());
+     responseObserver.onCompleted();
+   }
+
+   @Override
+   public void listShelves(ListShelvesRequest request,
+       StreamObserver<ListShelvesResponse> responseObserver) {
+     requests.add(request);
+     responseObserver.onNext(ListShelvesResponse.newBuilder().build());
+     responseObserver.onCompleted();
+   }
+
+   @Override
+   public void deleteShelf(DeleteShelfRequest request,
+       StreamObserver<Empty> responseObserver) {
+     requests.add(request);
+     responseObserver.onNext(Empty.newBuilder().build());
+     responseObserver.onCompleted();
+   }
+
+   @Override
+   public void mergeShelves(MergeShelvesRequest request,
+       StreamObserver<Shelf> responseObserver) {
+     requests.add(request);
+     responseObserver.onNext(Shelf.newBuilder().build());
+     responseObserver.onCompleted();
+   }
+
+   @Override
+   public void createBook(CreateBookRequest request,
+       StreamObserver<Book> responseObserver) {
+     requests.add(request);
+     responseObserver.onNext(Book.newBuilder().build());
+     responseObserver.onCompleted();
+   }
+
+   @Override
+   public void publishSeries(PublishSeriesRequest request,
+       StreamObserver<PublishSeriesResponse> responseObserver) {
+     requests.add(request);
+     responseObserver.onNext(PublishSeriesResponse.newBuilder().build());
+     responseObserver.onCompleted();
+   }
+
+   @Override
+   public void getBook(GetBookRequest request,
+       StreamObserver<Book> responseObserver) {
+     requests.add(request);
+     responseObserver.onNext(Book.newBuilder().build());
+     responseObserver.onCompleted();
+   }
+
+   @Override
+   public void listBooks(ListBooksRequest request,
+       StreamObserver<ListBooksResponse> responseObserver) {
+     requests.add(request);
+     responseObserver.onNext(ListBooksResponse.newBuilder().build());
+     responseObserver.onCompleted();
+   }
+
+   @Override
+   public void deleteBook(DeleteBookRequest request,
+       StreamObserver<Empty> responseObserver) {
+     requests.add(request);
+     responseObserver.onNext(Empty.newBuilder().build());
+     responseObserver.onCompleted();
+   }
+
+   @Override
+   public void updateBook(UpdateBookRequest request,
+       StreamObserver<Book> responseObserver) {
+     requests.add(request);
+     responseObserver.onNext(Book.newBuilder().build());
+     responseObserver.onCompleted();
+   }
+
+   @Override
+   public void moveBook(MoveBookRequest request,
+       StreamObserver<Book> responseObserver) {
+     requests.add(request);
+     responseObserver.onNext(Book.newBuilder().build());
+     responseObserver.onCompleted();
+   }
+
+   @Override
+   public void listStrings(ListStringsRequest request,
+       StreamObserver<ListStringsResponse> responseObserver) {
+     requests.add(request);
+     responseObserver.onNext(ListStringsResponse.newBuilder().build());
+     responseObserver.onCompleted();
+   }
+
+   @Override
+   public void addComments(AddCommentsRequest request,
+       StreamObserver<Empty> responseObserver) {
+     requests.add(request);
+     responseObserver.onNext(Empty.newBuilder().build());
+     responseObserver.onCompleted();
+   }
+
+   @Override
+   public void getBookFromArchive(GetBookFromArchiveRequest request,
+       StreamObserver<Book> responseObserver) {
+     requests.add(request);
+     responseObserver.onNext(Book.newBuilder().build());
+     responseObserver.onCompleted();
+   }
+
+   @Override
+   public void updateBookIndex(UpdateBookIndexRequest request,
+       StreamObserver<Empty> responseObserver) {
+     requests.add(request);
+     responseObserver.onNext(Empty.newBuilder().build());
+     responseObserver.onCompleted();
+   }
+
+   @Override
+   public void streamShelves(ListShelvesRequest request,
+       StreamObserver<ListShelvesResponse> responseObserver) {
+     requests.add(request);
+     responseObserver.onNext(ListShelvesResponse.newBuilder().build());
+     responseObserver.onCompleted();
+   }
+
+}

--- a/src/test/java/com/google/api/codegen/testdata/java_test_mock_service_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_test_mock_service_library.baseline
@@ -1,0 +1,46 @@
+============== file: src/test/java/com/google/gcloud/pubsub/spi/MockLibraryService.java ==============
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.gcloud.pubsub.spi;
+
+import com.google.api.gax.testing.MockGrpcService;
+import com.google.example.library.v1.LibraryServiceGrpc;
+import com.google.protobuf.GeneratedMessage;
+import io.grpc.ServerServiceDefinition;
+import java.util.List;
+
+@javax.annotation.Generated("by GAPIC")
+public class MockLibraryService implements MockGrpcService  {
+  private MockLibraryServiceImpl serviceImpl;
+
+  public MockLibraryService() {
+    serviceImpl = new MockLibraryServiceImpl();
+  }
+
+  @Override
+  public List<GeneratedMessage> getRequests() {
+    return serviceImpl.getRequests();
+  }
+
+  @Override
+  public ServerServiceDefinition getServiceDefinition() {
+    return LibraryServiceGrpc.bindService(serviceImpl);
+  }
+
+  @Override
+  public void reset() {
+    serviceImpl.reset();
+  }
+}

--- a/src/test/java/com/google/api/codegen/testdata/java_test_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_test_test_library.baseline
@@ -1,4 +1,4 @@
-============== file: src/test/java/com/google/gcloud/pubsub/spi ==============
+============== file: src/test/java/com/google/gcloud/pubsub/spi/LibraryServiceTest.java ==============
 /*
  * Copyright 2016 Google Inc. All Rights Reserved.
  *


### PR DESCRIPTION
- Implement mock service generator under MVVM
  - View models
     - MockServiceView
     - MockServiceImplView
     - MockGrpcMethodView
  - Views
     - mock_service.snip
     - mock_service_impl.snip

- Fix output file name

- Testing
  - Baseline test
  - Manual sanity test with one API