### PR TITLE
Python 3 compatibility fix

### DIFF
--- a/src/main/resources/com/google/api/codegen/py/main.snip
+++ b/src/main/resources/com/google/api/codegen/py/main.snip
@@ -155,7 +155,7 @@
     @let ifaceConfig = context.getApiConfig.getInterfaceConfig(service), \
          jsonBaseName = {@context.upperCamelToLowerUnderscore(service.getSimpleName)}
         default_client_config = json.loads(pkg_resources.resource_string(
-            __name__, '{@jsonBaseName}_client_config.json'))
+            __name__, '{@jsonBaseName}_client_config.json').decode())
         @if or(context.messages.filterPageStreamingMethods(ifaceConfig, context.getNonStreamingMethods(service)), \
                context.messages.filterBundlingMethods(ifaceConfig, context.getNonStreamingMethods(service)))
             defaults = api_callable.construct_settings(

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
@@ -248,7 +248,7 @@ class LibraryServiceApi(object):
         )
         metadata = [('x-goog-api-client', goog_api_client)]
         default_client_config = json.loads(pkg_resources.resource_string(
-            __name__, 'library_service_client_config.json'))
+            __name__, 'library_service_client_config.json').decode())
         defaults = api_callable.construct_settings(
             'google.example.library.v1.LibraryService',
             default_client_config,

--- a/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
@@ -248,7 +248,7 @@ class LibraryServiceApi(object):
         )
         metadata = [('x-goog-api-client', goog_api_client)]
         default_client_config = json.loads(pkg_resources.resource_string(
-            __name__, 'library_service_client_config.json'))
+            __name__, 'library_service_client_config.json').decode())
         defaults = api_callable.construct_settings(
             'google.example.library.v1.LibraryService',
             default_client_config,

--- a/src/test/java/com/google/api/codegen/testdata/python_main_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_main_no_path_templates.baseline
@@ -99,7 +99,7 @@ class NoTemplatesServiceApi(object):
         )
         metadata = [('x-goog-api-client', goog_api_client)]
         default_client_config = json.loads(pkg_resources.resource_string(
-            __name__, 'no_templates_service_client_config.json'))
+            __name__, 'no_templates_service_client_config.json').decode())
         defaults = api_callable.construct_settings(
             'google.example.v1.NoTemplatesService',
             default_client_config,


### PR DESCRIPTION
In Python 3, the json library distinguishes between string and bytes
types. Ensure that we are passing in string to the json loading
function.

This addresses https://github.com/GoogleCloudPlatform/gcloud-python/issues/1944