### PR TITLE
Go: Properly cast to int32

### DIFF
--- a/src/main/resources/com/google/api/codegen/go/main.snip
+++ b/src/main/resources/com/google/api/codegen/go/main.snip
@@ -375,7 +375,7 @@
                     if pageSize > math.MaxInt32 {
                         pageSize = math.MaxInt32
                     }
-                    it.pageSize = pageSize
+                    it.pageSize = int32(pageSize)
                 }
 
             @end

--- a/src/test/java/com/google/api/codegen/testdata/go_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_main_library.baseline
@@ -609,7 +609,7 @@ func (it *BookIterator) SetPageSize(pageSize int) {
     if pageSize > math.MaxInt32 {
         pageSize = math.MaxInt32
     }
-    it.pageSize = pageSize
+    it.pageSize = int32(pageSize)
 }
 
 // SetPageToken sets the page token for the next call to NextPage, to resume the iteration from
@@ -693,7 +693,7 @@ func (it *StringIterator) SetPageSize(pageSize int) {
     if pageSize > math.MaxInt32 {
         pageSize = math.MaxInt32
     }
-    it.pageSize = pageSize
+    it.pageSize = int32(pageSize)
 }
 
 // SetPageToken sets the page token for the next call to NextPage, to resume the iteration from


### PR DESCRIPTION
This change was missed from #368.
After size-checking the pageSize argument,
we should actually cast the type to int32.