### PR TITLE
Incremental dependency bump

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,18 +7,13 @@ buildscript {
   repositories {
     mavenLocal()
     maven {
-      // For 0.7.2-SNAPSHOT of protobuf gradle plugin. This should be removed once
-      // this version is releaed.
-      url 'https://oss.sonatype.org/content/repositories/snapshots/'
-    }
-    maven {
       url 'https://plugins.gradle.org/m2/'
     }
     mavenCentral()
     jcenter()
   }
   dependencies {
-    classpath "com.google.protobuf:protobuf-gradle-plugin:0.7.2-SNAPSHOT"
+    classpath "com.google.protobuf:protobuf-gradle-plugin:0.7.3"
     classpath "gradle.plugin.com.github.sherter.google-java-format:google-java-format-gradle-plugin:0.2"
     classpath "com.github.jengelman.gradle.plugins:shadow:1.2.3"
   }
@@ -38,7 +33,7 @@ sourceCompatibility = 1.7
 group = "com.google.api"
 version = "0.0.0-SNAPSHOT"
 // url to the snapshot repository of a private maven repo.
-def privateSnapshotRepo = "http://104.197.230.53:8081/nexus/content/repositories/snapshots/"
+def toolkitSnapshotRepo = "http://104.197.230.53:8081/nexus/content/repositories/snapshots/"
 
 // Dependencies
 // ------------
@@ -68,9 +63,9 @@ ext {
     toolsFxTesting: 'io.gapi:gapi-tools-framework:0.0.0-SNAPSHOT:testing',
 
     // Protobuf
-    protobuf: 'com.google.protobuf:protobuf-java:3.0.0-beta-2',
-    protoc:  'com.google.protobuf:protoc:3.0.0-beta-2',
-    protobufGradlePlugin: 'com.google.protobuf:protobuf-gradle-plugin:0.7.2-SNAPSHOT',
+    protobuf: 'com.google.protobuf:protobuf-java:3.0.0-beta-3',
+    protoc:  'com.google.protobuf:protoc:3.0.0-beta-3',
+    protobufGradlePlugin: 'com.google.protobuf:protobuf-gradle-plugin:0.7.3',
 
     // JSON
     jackson: 'com.fasterxml.jackson.core:jackson-databind:2.7.0',
@@ -84,13 +79,8 @@ repositories {
   mavenLocal()
   mavenCentral()
   maven {
-    // For 0.7.2-SNAPSHOT of protobuf gradle plugin. This should be removed once
-    // this version is releaed.
-    url 'https://oss.sonatype.org/content/repositories/snapshots/'
-  }
-  maven {
-    // Private maven repo.
-    url privateSnapshotRepo
+    // Private maven repo for publishing toolkit snapshots.
+    url toolkitSnapshotRepo
   }
 }
 
@@ -255,12 +245,12 @@ tasks.cleanEclipseJdt {
   }
 }
 
-if (project.hasProperty('privateOssrhUsername') && project.hasProperty('privateOssrhPassword')) {
+if (project.hasProperty('privateToolkitUsername') && project.hasProperty('privateToolkitPassword')) {
   uploadArchives {
     repositories {
       mavenDeployer {
-        snapshotRepository(url: privateSnapshotRepo) {
-          authentication(userName: privateOssrhUsername, password: privateOssrhPassword)
+        snapshotRepository(url: toolkitSnapshotRepo) {
+          authentication(userName: privateToolkitUsername, password: privateToolkitPassword)
         }
 
         pom.project {
@@ -280,8 +270,8 @@ if (project.hasProperty('privateOssrhUsername') && project.hasProperty('privateO
     }
   }
 } else {
-  logger.warn("The uploadArchives task was skipped. The privateOssrhUsername "
-    + "and privateOssrhPassword properties need to be set correctly in "
+  logger.warn("The uploadArchives task was skipped. The privateToolkitUsername "
+    + "and privateToolkitPassword properties need to be set correctly in "
     + "your ~/.gradle/gradle.properties file in order to upload archives.")
 }
 

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_message_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_message_library.baseline
@@ -40,8 +40,36 @@ class FieldMask(object):
 
 class Any(object):
     """
-    ``Any`` contains an arbitrary serialized message along with a URL
-    that describes the type of the serialized message.
+    ``Any`` contains an arbitrary serialized protocol buffer message along with a
+    URL that describes the type of the serialized message.
+
+    Protobuf library provides support to pack/unpack Any values in the form
+    of utility functions or additional generated methods of the Any type.
+
+    Example 1: Pack and unpack a message in C++.
+
+        Foo foo = ...;
+        Any any;
+        any.PackFrom(foo);
+        ...
+        if (any.UnpackTo(&foo)) {
+          ...
+        }
+
+    Example 2: Pack and unpack a message in Java.
+
+        Foo foo = ...;
+        Any any = Any.pack(foo);
+        ...
+        if (any.is(Foo.class)) {
+          foo = any.unpack(Foo.class);
+        }
+
+    The pack methods provided by protobuf library will by default use
+    'type.googleapis.com/full.type.name' as the type URL and the unpack
+    methods only use the fully qualified type name after the last '/'
+    in the type URL, for example "foo.bar.com/x/y.z" will yield type
+    name "y.z".
 
 
     # JSON
@@ -74,7 +102,7 @@ class Any(object):
 
     Attributes:
       type_url (string): A URL/resource name whose content describes the type of the
-        serialized message.
+        serialized protocol buffer message.
 
         For URLs which use the schema ``http``, ``https``, or no schema, the
         following restrictions and interpretations apply:
@@ -82,6 +110,8 @@ class Any(object):
         * If no schema is provided, ``https`` is assumed.
         * The last segment of the URL's path must represent the fully
           qualified name of the type (as in ``path/google.protobuf.Duration``).
+          The name should be in a canonical form (e.g., leading "." is
+          not accepted).
         * An HTTP GET on the URL must yield a ``google.protobuf.Type``
           value in binary format, or produce an error.
         * Applications are allowed to cache lookup results based on the
@@ -92,7 +122,7 @@ class Any(object):
 
         Schemas other than ``http``, ``https`` (or the empty schema) might be
         used with implementation specific semantics.
-      value (bytes): Must be valid serialized data of the above specified type.
+      value (bytes): Must be a valid serialized protocol buffer of the above specified type.
 
     """
     pass
@@ -236,7 +266,7 @@ class FieldMask(object):
     operation applies to all fields (as if a FieldMask of all fields
     had been specified).
 
-    Note that a field mask does not necessarily applies to the
+    Note that a field mask does not necessarily apply to the
     top-level response message. In case of a REST get operation, the
     field mask applies directly to the response, but in case of a REST
     list operation, the mask instead applies to each individual message
@@ -309,6 +339,33 @@ class FieldMask(object):
         {
           mask: "user.displayName,photo"
         }
+
+    # Field Masks and Oneof Fields
+
+    Field masks treat fields in oneofs just as regular fields. Consider the
+    following message:
+
+        message SampleMessage {
+          oneof test_oneof {
+            string name = 4;
+            SubMessage sub_message = 9;
+          }
+        }
+
+    The field mask can be:
+
+        mask {
+          paths: "name"
+        }
+
+    Or:
+
+        mask {
+          paths: "sub_message"
+        }
+
+    Note that oneof type names ("test_oneof" in this case) cannot be used in
+    paths.
 
     Attributes:
       paths (list[string]): The set of field mask paths.

--- a/src/test/java/com/google/api/codegen/testdata/ruby_doc_message_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_doc_message_library.baseline
@@ -53,8 +53,36 @@ end
 
 module Google
   module Protobuf
-    # +Any+ contains an arbitrary serialized message along with a URL
-    # that describes the type of the serialized message.
+    # +Any+ contains an arbitrary serialized protocol buffer message along with a
+    # URL that describes the type of the serialized message.
+    #
+    # Protobuf library provides support to pack/unpack Any values in the form
+    # of utility functions or additional generated methods of the Any type.
+    #
+    # Example 1: Pack and unpack a message in C++.
+    #
+    #     Foo foo = ...;
+    #     Any any;
+    #     any.PackFrom(foo);
+    #     ...
+    #     if (any.UnpackTo(&foo)) {
+    #       ...
+    #     }
+    #
+    # Example 2: Pack and unpack a message in Java.
+    #
+    #     Foo foo = ...;
+    #     Any any = Any.pack(foo);
+    #     ...
+    #     if (any.is(Foo.class)) {
+    #       foo = any.unpack(Foo.class);
+    #     }
+    #
+    # The pack methods provided by protobuf library will by default use
+    # 'type.googleapis.com/full.type.name' as the type URL and the unpack
+    # methods only use the fully qualified type name after the last '/'
+    # in the type URL, for example "foo.bar.com/x/y.z" will yield type
+    # name "y.z".
     #
     #
     # = JSON
@@ -87,7 +115,7 @@ module Google
     # @!attribute [rw] type_url
     #   @return [String]
     #     A URL/resource name whose content describes the type of the
-    #     serialized message.
+    #     serialized protocol buffer message.
     #
     #     For URLs which use the schema +http+, +https+, or no schema, the
     #     following restrictions and interpretations apply:
@@ -95,6 +123,8 @@ module Google
     #     * If no schema is provided, +https+ is assumed.
     #     * The last segment of the URL's path must represent the fully
     #       qualified name of the type (as in +path/google.protobuf.Duration+).
+    #       The name should be in a canonical form (e.g., leading "." is
+    #       not accepted).
     #     * An HTTP GET on the URL must yield a Google::Protobuf::Type
     #       value in binary format, or produce an error.
     #     * Applications are allowed to cache lookup results based on the
@@ -107,7 +137,7 @@ module Google
     #     used with implementation specific semantics.
     # @!attribute [rw] value
     #   @return [String]
-    #     Must be valid serialized data of the above specified type.
+    #     Must be a valid serialized protocol buffer of the above specified type.
     class Any; end
   end
 end
@@ -249,7 +279,7 @@ module Google
     # operation applies to all fields (as if a FieldMask of all fields
     # had been specified).
     #
-    # Note that a field mask does not necessarily applies to the
+    # Note that a field mask does not necessarily apply to the
     # top-level response message. In case of a REST get operation, the
     # field mask applies directly to the response, but in case of a REST
     # list operation, the mask instead applies to each individual message
@@ -322,6 +352,33 @@ module Google
     #     {
     #       mask: "user.displayName,photo"
     #     }
+    #
+    # = Field Masks and Oneof Fields
+    #
+    # Field masks treat fields in oneofs just as regular fields. Consider the
+    # following message:
+    #
+    #     message SampleMessage {
+    #       oneof test_oneof {
+    #         string name = 4;
+    #         SubMessage sub_message = 9;
+    #       }
+    #     }
+    #
+    # The field mask can be:
+    #
+    #     mask {
+    #       paths: "name"
+    #     }
+    #
+    # Or:
+    #
+    #     mask {
+    #       paths: "sub_message"
+    #     }
+    #
+    # Note that oneof type names ("test_oneof" in this case) cannot be used in
+    # paths.
     # @!attribute [rw] paths
     #   @return [Array<String>]
     #     The set of field mask paths.


### PR DESCRIPTION
This is only an incremental bump to limit the scope of changes.

* protobuf-gradle-plugin: 0.7.2-SNAPSHOT to 0.7.3 (getting off of a
  snapshot dependency)
* protobuf/protoc: 3.0.0-beta-2 to 3.0.0-beta-3 (consistent with the
  version we are using in the generated code stack)

Also, renaming "private" snapshot repo references to "toolkit". This
means the username and password entries in each dev's gradle.properties
file need to be updated, if they want to use 'uploadArchives'. The
basic problem is that multiple repos might use the same
keys (e.g. api-compiler), and thus would clash with each other.

* privateOssrhUsername to privateToolkitUsername
* privateOssrhPassword to privateToolkitPassword