### PR TITLE
Code Gen and Config Gen: using api list from service yaml

### DIFF
--- a/src/main/java/com/google/api/codegen/CodeGeneratorApi.java
+++ b/src/main/java/com/google/api/codegen/CodeGeneratorApi.java
@@ -82,12 +82,7 @@ public class CodeGeneratorApi extends ToolDriverBase {
 
   @Override
   protected void registerAspects() {
-    model.registerConfigAspect(DocumentationConfigAspect.create(model));
-    model.registerConfigAspect(ContextConfigAspect.create(model));
-    model.registerConfigAspect(HttpConfigAspect.create(model));
-    model.registerConfigAspect(VersionConfigAspect.create(model));
-    model.registerConfigAspect(NamingConfigAspect.create(model));
-    model.registerConfigAspect(SystemConfigAspect.create(model));
+    CodegenSetup.registerCodegenConfigAspects(model);
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/CodeGeneratorTool.java
+++ b/src/main/java/com/google/api/codegen/CodeGeneratorTool.java
@@ -22,8 +22,7 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 
-import java.util.ArrayList;
-import java.util.List;
+import com.google.common.collect.Lists;
 
 // Example usage: (assuming environment variable BASE is the base directory of the project
 // containing the YAMLs, descriptor set, and output)
@@ -88,20 +87,11 @@ public class CodeGeneratorTool {
       String[] apiConfigs,
       String[] generatorConfigs,
       String outputDirectory) {
-
     ToolOptions options = ToolOptions.create();
     options.set(ToolOptions.DESCRIPTOR_SET, descriptorSet);
-    List<String> configs = new ArrayList<String>();
-    for (String config : apiConfigs) {
-      configs.add(config);
-    }
-    options.set(ToolOptions.CONFIG_FILES, configs);
+    options.set(ToolOptions.CONFIG_FILES, Lists.newArrayList(apiConfigs));
     options.set(CodeGeneratorApi.OUTPUT_FILE, outputDirectory);
-    List<String> genConfigs = new ArrayList<String>();
-    for (String genConfig : generatorConfigs) {
-      genConfigs.add(genConfig);
-    }
-    options.set(CodeGeneratorApi.GENERATOR_CONFIG_FILES, genConfigs);
+    options.set(CodeGeneratorApi.GENERATOR_CONFIG_FILES, Lists.newArrayList(generatorConfigs));
     CodeGeneratorApi codeGen = new CodeGeneratorApi(options);
     return codeGen.run();
   }

--- a/src/main/java/com/google/api/codegen/CodegenSetup.java
+++ b/src/main/java/com/google/api/codegen/CodegenSetup.java
@@ -1,0 +1,34 @@
+/* Copyright 2016 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen;
+
+import com.google.api.tools.framework.aspects.context.ContextConfigAspect;
+import com.google.api.tools.framework.aspects.documentation.DocumentationConfigAspect;
+import com.google.api.tools.framework.aspects.http.HttpConfigAspect;
+import com.google.api.tools.framework.aspects.naming.NamingConfigAspect;
+import com.google.api.tools.framework.aspects.system.SystemConfigAspect;
+import com.google.api.tools.framework.aspects.versioning.VersionConfigAspect;
+import com.google.api.tools.framework.model.Model;
+
+public class CodegenSetup {
+  public static void registerCodegenConfigAspects(Model model) {
+    model.registerConfigAspect(DocumentationConfigAspect.create(model));
+    model.registerConfigAspect(ContextConfigAspect.create(model));
+    model.registerConfigAspect(HttpConfigAspect.create(model));
+    model.registerConfigAspect(VersionConfigAspect.create(model));
+    model.registerConfigAspect(NamingConfigAspect.create(model));
+    model.registerConfigAspect(SystemConfigAspect.create(model));
+  }
+}

--- a/src/main/java/com/google/api/codegen/InterfaceView.java
+++ b/src/main/java/com/google/api/codegen/InterfaceView.java
@@ -16,6 +16,7 @@ package com.google.api.codegen;
 
 import com.google.api.tools.framework.model.Interface;
 import com.google.api.tools.framework.model.Model;
+import com.google.protobuf.Api;
 
 import java.util.ArrayList;
 
@@ -26,15 +27,13 @@ import java.util.ArrayList;
 public class InterfaceView implements InputElementView<Interface> {
 
   /**
-   * Gets the reachable interfaces of the model.
+   * Gets the interfaces for the apis in the service config.
    */
   @Override
   public Iterable<Interface> getElementIterable(Model model) {
     ArrayList<Interface> interfaces = new ArrayList<>();
-    for (Interface iface : model.getSymbolTable().getInterfaces()) {
-      if (iface.isReachable()) {
-        interfaces.add(iface);
-      }
+    for (Api api : model.getServiceConfig().getApisList()) {
+      interfaces.add(model.getSymbolTable().lookupInterface(api.getName()));
     }
     return interfaces;
   }

--- a/src/main/java/com/google/api/codegen/config/ConfigGeneratorTool.java
+++ b/src/main/java/com/google/api/codegen/config/ConfigGeneratorTool.java
@@ -15,6 +15,7 @@
 package com.google.api.codegen.config;
 
 import com.google.api.tools.framework.tools.ToolOptions;
+import com.google.common.collect.Lists;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
@@ -36,6 +37,14 @@ public class ConfigGeneratorTool {
             .required(true)
             .build());
     options.addOption(
+        Option.builder()
+            .longOpt("service_yaml")
+            .desc("The service YAML configuration file or files.")
+            .hasArg()
+            .argName("SERVICE-YAML")
+            .required(true)
+            .build());
+    options.addOption(
         Option.builder("o")
             .longOpt("output")
             .desc("The directory in which to output the generated config.")
@@ -50,13 +59,17 @@ public class ConfigGeneratorTool {
       formater.printHelp("ConfigGeneratorTool", options);
     }
 
-    generate(cl.getOptionValue("descriptor_set"), cl.getOptionValue("output"));
+    generate(
+        cl.getOptionValue("descriptor_set"),
+        cl.getOptionValues("service_yaml"),
+        cl.getOptionValue("output"));
   }
 
-  private static void generate(String descriptorSet, String outputFile) {
+  private static void generate(String descriptorSet, String[] apiConfigs, String outputFile) {
     ToolOptions options = ToolOptions.create();
     options.set(ConfigGeneratorApi.OUTPUT_FILE, outputFile);
     options.set(ToolOptions.DESCRIPTOR_SET, descriptorSet);
+    options.set(ToolOptions.CONFIG_FILES, Lists.newArrayList(apiConfigs));
     ConfigGeneratorApi configGen = new ConfigGeneratorApi(options);
     configGen.run();
   }

--- a/src/test/java/com/google/api/codegen/ConfigGenerationTest.java
+++ b/src/test/java/com/google/api/codegen/ConfigGenerationTest.java
@@ -17,10 +17,14 @@ package com.google.api.codegen;
 import com.google.api.codegen.config.ConfigGeneratorApi;
 import com.google.api.tools.framework.model.testing.ConfigBaselineTestCase;
 import com.google.api.tools.framework.tools.ToolOptions;
+import com.google.common.collect.Lists;
+
 import java.io.File;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+
 import org.junit.Test;
 
 public class ConfigGenerationTest extends ConfigBaselineTestCase {
@@ -38,10 +42,13 @@ public class ConfigGenerationTest extends ConfigBaselineTestCase {
   @Override
   public Object run() throws Exception {
     String outFile = tempDir.getRoot().getPath() + File.separator + baselineFileName();
+    String serviceConfigPath =
+        getTestDataLocator().findTestData(testName.getMethodName() + ".yaml").getPath();
 
     ToolOptions options = ToolOptions.create();
     options.set(ConfigGeneratorApi.OUTPUT_FILE, outFile);
     options.set(ToolOptions.DESCRIPTOR_SET, testConfig.getDescriptorFile().toString());
+    options.set(ToolOptions.CONFIG_FILES, Lists.newArrayList(serviceConfigPath));
     new ConfigGeneratorApi(options).run();
 
     String outputContent =


### PR DESCRIPTION
This is in preparation for mixin support.

Before this change, any interface discovered in the proto path will have
a corresponding VKit wrapper generated. After this change, only
interfaces in the api list of the service config will have wrappers generated.