### PR TITLE
Update Ruby codegen.

### DIFF
--- a/src/main/java/com/google/api/codegen/ruby/RubyGapicContext.java
+++ b/src/main/java/com/google/api/codegen/ruby/RubyGapicContext.java
@@ -58,7 +58,7 @@ public class RubyGapicContext extends GapicContext implements RubyContext {
    * Returns the Ruby filename which holds the gRPC service definition.
    */
   public String getGrpcFilename(Interface service) {
-    return getBasename(service.getFile()) + "_services";
+    return getBasename(service.getFile()) + "_services_pb";
   }
 
   public String getBasename(ProtoFile protoFile) {

--- a/src/main/resources/com/google/api/codegen/ruby/main.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/main.snip
@@ -9,13 +9,6 @@
 
   {@importSection(service)}
 
-  @# TODO: implement line-wrapping rules and remove this suppression.
-  @# rubocop:disable LineLength
-  @# rubocop:disable MethodLength
-  @# HashSyntax is disabled because {"foo-bar": "baz"} is not allowed before
-  @# Ruby-2.2.
-  @# rubocop:disable HashSyntax
-
   {@serviceClass(service)}
 
 @end

--- a/src/test/java/com/google/api/codegen/testdata/ruby_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_doc_main_library.baseline
@@ -27,14 +27,7 @@ require "json"
 require "pathname"
 
 require "google/gax"
-require "library_services"
-
-# TODO: implement line-wrapping rules and remove this suppression.
-# rubocop:disable LineLength
-# rubocop:disable MethodLength
-# HashSyntax is disabled because {"foo-bar": "baz"} is not allowed before
-# Ruby-2.2.
-# rubocop:disable HashSyntax
+require "library_services_pb"
 
 module Library
   module V1

--- a/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
@@ -27,14 +27,7 @@ require "json"
 require "pathname"
 
 require "google/gax"
-require "library_services"
-
-# TODO: implement line-wrapping rules and remove this suppression.
-# rubocop:disable LineLength
-# rubocop:disable MethodLength
-# HashSyntax is disabled because {"foo-bar": "baz"} is not allowed before
-# Ruby-2.2.
-# rubocop:disable HashSyntax
+require "library_services_pb"
 
 module Library
   module V1


### PR DESCRIPTION
- Remove rubocop disable comments.
  Decided to exclude those generated files from the rubocop target,
  so these comments are not necessary (we still can check the styles
  by manually invoking rubocop).
- Update the require path for ruby.
  The new path (_pb suffix) is the style introduced in protobuf 3.0.
  See googleapis/gax-ruby#37