### PR TITLE
Fix issues in java test generation.

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
@@ -43,7 +43,6 @@ import com.google.api.tools.framework.model.Field;
 import com.google.api.tools.framework.model.TypeRef;
 import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -101,7 +100,9 @@ public class InitCodeTransformer {
               .expectedValueIdentifier(
                   namer.getVariableName(
                       fieldSetting.getIdentifier(), fieldSetting.getInitValueConfig()))
-              .actualValueGetter(namer.getGetFunctionCallName(fieldSetting.getIdentifier()))
+              .actualValueGetter(
+                  namer.getGetFunctionCallName(
+                      fieldSetting.getIdentifier(), fieldSetting.getType()))
               .build();
       assertViews.add(assertView);
     }

--- a/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
@@ -447,9 +447,17 @@ public class SurfaceNamer extends NameFormatterDelegator {
     return getNotImplementedString("SurfaceNamer.getAndSavePagedResponseTypeName");
   }
 
-  /** The test case name for the given method. */
-  public String getTestCaseName(Method method) {
-    return methodName(Name.upperCamel(method.getSimpleName(), "Test"));
+  /**
+   * The test case name for the given method.
+   * Use the given count value to produce unique test case names if there are multiple tests
+   * for each method
+   */
+  public String getTestCaseName(Method method, Integer count) {
+    if (count > 1) {
+      return methodName(Name.upperCamel(method.getSimpleName(), "Test" + Integer.toString(count)));
+    } else {
+      return methodName(Name.upperCamel(method.getSimpleName(), "Test"));
+    }
   }
 
   /** The test class name for the given API service. */
@@ -468,7 +476,11 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** The method name of getter function call for the given name */
-  public String getGetFunctionCallName(Name name) {
-    return methodName(Name.from("get").join(name));
+  public String getGetFunctionCallName(Name name, TypeRef type) {
+    if (type.isRepeated() && !type.isMap()) {
+      return methodName(Name.from("get").join(name).join("list"));
+    } else {
+      return methodName(Name.from("get").join(name));
+    }
   }
 }

--- a/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
@@ -449,8 +449,9 @@ public class SurfaceNamer extends NameFormatterDelegator {
 
   /**
    * The test case name for the given method.
+   *
    * Use the given count value to produce unique test case names if there are multiple tests
-   * for each method
+   * for one method.
    */
   public String getTestCaseName(Method method, Integer count) {
     if (count > 1) {

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
@@ -54,7 +54,8 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
 
   private GapicCodePathMapper pathMapper;
 
-  // TODO(shinfan): Reuse this logic with InitCodeGenerator
+  // TODO: Reuse this logic with InitCodeGenerator
+  // Github issue: https://github.com/googleapis/toolkit/issues/395
   private class TestCaseNameTable {
     private HashMap<String, Integer> nameCount;
 
@@ -180,9 +181,10 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
           testCaseViews.add(createTestCaseView(methodContext, paramFields, nameTable));
         }
       } else {
-        // TODO(shinfan): Add support of non-flattening method
+        // TODO: Add support of non-flattening method
+        // Github issue: https://github.com/googleapis/toolkit/issues/393
         System.err.println(
-            "Non-flatenning method test is not supported yet for " + method.getSimpleName());
+            "Non-flattening method test is not supported yet for " + method.getSimpleName());
       }
     }
     return testCaseViews;

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
@@ -54,6 +54,7 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
 
   private GapicCodePathMapper pathMapper;
 
+  // TODO(shinfan): Reuse this logic with InitCodeGenerator
   private class TestCaseNameTable {
     private HashMap<String, Integer> nameCount;
 
@@ -180,6 +181,8 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
         }
       } else {
         // TODO(shinfan): Add support of non-flattening method
+        System.err.println(
+            "Non-flatenning method test is not supported yet for " + method.getSimpleName());
       }
     }
     return testCaseViews;

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
@@ -17,6 +17,7 @@ package com.google.api.codegen.transformer.java;
 import com.google.api.codegen.ApiConfig;
 import com.google.api.codegen.InterfaceView;
 import com.google.api.codegen.MethodConfig;
+import com.google.api.codegen.ServiceMessages;
 import com.google.api.codegen.gapic.GapicCodePathMapper;
 import com.google.api.codegen.transformer.InitCodeTransformer;
 import com.google.api.codegen.transformer.MethodTransformerContext;
@@ -35,11 +36,13 @@ import com.google.api.codegen.viewmodel.testing.MockGrpcMethodView;
 import com.google.api.codegen.viewmodel.testing.MockGrpcResponseView;
 import com.google.api.codegen.viewmodel.testing.MockServiceImplView;
 import com.google.api.codegen.viewmodel.testing.MockServiceView;
+import com.google.api.tools.framework.model.Field;
 import com.google.api.tools.framework.model.Interface;
 import com.google.api.tools.framework.model.Method;
 import com.google.api.tools.framework.model.Model;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 /** A subclass of ModelToViewTransformer which translates model into API tests in Java. */
@@ -50,6 +53,24 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
   private static String MOCK_SERVICE_IMPL_FILE = "java/mock_service_impl.snip";
 
   private GapicCodePathMapper pathMapper;
+
+  private class TestCaseNameTable {
+    private HashMap<String, Integer> nameCount;
+
+    public TestCaseNameTable() {
+      nameCount = new HashMap<>();
+    }
+
+    public String getTestName(SurfaceNamer namer, Method method) {
+      String testedMethodName = method.getSimpleName();
+      Integer count = 1;
+      if (nameCount.containsKey(testedMethodName)) {
+        count = nameCount.get(testedMethodName) + 1;
+      }
+      nameCount.put(testedMethodName, count);
+      return namer.getTestCaseName(method, count);
+    }
+  }
 
   public JavaGapicSurfaceTestTransformer(GapicCodePathMapper javaPathMapper) {
     this.pathMapper = javaPathMapper;
@@ -106,8 +127,10 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
 
   private void addMockServiceImplImports(SurfaceTransformerContext context) {
     ModelTypeTable typeTable = context.getTypeTable();
-    typeTable.saveNicknameFor("java.util.List");
     typeTable.saveNicknameFor("java.util.ArrayList");
+    typeTable.saveNicknameFor("java.util.List");
+    typeTable.saveNicknameFor("java.util.LinkedList");
+    typeTable.saveNicknameFor("java.util.Queue");
     typeTable.saveNicknameFor("com.google.common.collect.Lists");
     typeTable.saveNicknameFor("com.google.protobuf.GeneratedMessage");
     typeTable.saveNicknameFor("io.grpc.stub.StreamObserver");
@@ -147,21 +170,32 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
 
   private List<GapicSurfaceTestCaseView> createTestCaseViews(SurfaceTransformerContext context) {
     ArrayList<GapicSurfaceTestCaseView> testCaseViews = new ArrayList<>();
+    TestCaseNameTable nameTable = new TestCaseNameTable();
     for (Method method : context.getNonStreamingMethods()) {
       MethodTransformerContext methodContext = context.asMethodContext(method);
-      testCaseViews.add(createTestCaseView(methodContext));
+      MethodConfig methodConfig = methodContext.getMethodConfig();
+      if (methodConfig.isFlattening()) {
+        for (List<Field> paramFields : methodConfig.getFlattening().getFlatteningGroups()) {
+          testCaseViews.add(createTestCaseView(methodContext, paramFields, nameTable));
+        }
+      } else {
+        // TODO(shinfan): Add support of non-flattening method
+      }
     }
     return testCaseViews;
   }
 
-  private GapicSurfaceTestCaseView createTestCaseView(MethodTransformerContext methodContext) {
+  private GapicSurfaceTestCaseView createTestCaseView(
+      MethodTransformerContext methodContext,
+      List<Field> paramFields,
+      TestCaseNameTable nameTable) {
     MethodConfig methodConfig = methodContext.getMethodConfig();
+    Method method = methodContext.getMethod();
     InitCodeTransformer initCodeTransformer = new InitCodeTransformer();
-    InitCodeView initCodeView =
-        initCodeTransformer.generateInitCode(methodContext, methodConfig.getRequiredFields());
+
+    InitCodeView initCodeView = initCodeTransformer.generateInitCode(methodContext, paramFields);
     List<GapicSurfaceTestAssertView> assertViews =
-        initCodeTransformer.generateTestAssertViews(
-            methodContext, methodConfig.getRequiredFields());
+        initCodeTransformer.generateTestAssertViews(methodContext, paramFields);
 
     String resourceTypeName = "";
     ApiMethodType type = ApiMethodType.FlattenedMethod;
@@ -176,19 +210,16 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
     }
 
     String requestTypeName =
-        methodContext
-            .getTypeTable()
-            .getAndSaveNicknameFor(methodContext.getMethod().getInputType());
+        methodContext.getTypeTable().getAndSaveNicknameFor(method.getInputType());
 
     String responseTypeName =
-        methodContext
-            .getTypeTable()
-            .getAndSaveNicknameFor(methodContext.getMethod().getOutputType());
+        methodContext.getTypeTable().getAndSaveNicknameFor(method.getOutputType());
 
     SurfaceNamer namer = methodContext.getNamer();
     return GapicSurfaceTestCaseView.newBuilder()
-        .name(namer.getTestCaseName(methodContext.getMethod()))
-        .surfaceMethodName(namer.getApiMethodName(methodContext.getMethod()))
+        .name(nameTable.getTestName(namer, method))
+        .surfaceMethodName(namer.getApiMethodName(method))
+        .hasReturnValue(!ServiceMessages.s_isEmptyType(method.getOutputType()))
         .requestTypeName(requestTypeName)
         .responseTypeName(responseTypeName)
         .initCode(initCodeView)

--- a/src/main/java/com/google/api/codegen/viewmodel/testing/GapicSurfaceTestCaseView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/testing/GapicSurfaceTestCaseView.java
@@ -26,6 +26,8 @@ public abstract class GapicSurfaceTestCaseView {
 
   public abstract String surfaceMethodName();
 
+  public abstract boolean hasReturnValue();
+
   public abstract String requestTypeName();
 
   public abstract String responseTypeName();
@@ -49,6 +51,8 @@ public abstract class GapicSurfaceTestCaseView {
     public abstract Builder surfaceMethodName(String val);
 
     public abstract Builder name(String val);
+
+    public abstract Builder hasReturnValue(boolean val);
 
     public abstract Builder requestTypeName(String val);
 

--- a/src/main/resources/com/google/api/codegen/java/mock_service_impl.snip
+++ b/src/main/resources/com/google/api/codegen/java/mock_service_impl.snip
@@ -43,14 +43,13 @@
   @@Override
   public void {@method.name}({@method.requestTypeName} request,
       StreamObserver<{@method.responseTypeName}> responseObserver) {
-    if (responses != null && !responses.isEmpty()) {
-      {@method.responseTypeName} response = ({@method.responseTypeName}) responses.poll();
+    try {
+      {@method.responseTypeName} response = ({@method.responseTypeName}) responses.remove();
       requests.add(request);
       responseObserver.onNext(response);
       responseObserver.onCompleted();
-    } else {
-      responseObserver.onError(
-          new Exception("No response is set for gRPC method {@method.name}."));
+    } catch (Exception e) {
+      responseObserver.onError(e);
     }
   }
 @end

--- a/src/main/resources/com/google/api/codegen/java/mock_service_impl.snip
+++ b/src/main/resources/com/google/api/codegen/java/mock_service_impl.snip
@@ -42,14 +42,10 @@
 @private grpcMethod(method)
   @@Override
   public void {@method.name}({@method.requestTypeName} request,
-      StreamObserver<{@method.responseTypeName}> responseObserver) {
-    try {
-      {@method.responseTypeName} response = ({@method.responseTypeName}) responses.remove();
-      requests.add(request);
-      responseObserver.onNext(response);
-      responseObserver.onCompleted();
-    } catch (Exception e) {
-      responseObserver.onError(e);
-    }
+    StreamObserver<{@method.responseTypeName}> responseObserver) {
+    {@method.responseTypeName} response = ({@method.responseTypeName}) responses.remove();
+    requests.add(request);
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
   }
 @end

--- a/src/main/resources/com/google/api/codegen/java/mock_service_impl.snip
+++ b/src/main/resources/com/google/api/codegen/java/mock_service_impl.snip
@@ -12,11 +12,11 @@
   @@javax.annotation.Generated("by GAPIC")
   public class {@mockServiceImpl.name} implements {@mockServiceImpl.grpcClassName}  {
     private ArrayList<GeneratedMessage> requests;
-    private ArrayList<GeneratedMessage> responses;
+    private Queue<GeneratedMessage> responses;
 
     public {@mockServiceImpl.name}() {
       requests = new ArrayList<>();
-      responses = new ArrayList<>();
+      responses = new LinkedList<>();
     }
 
     public List<GeneratedMessage> getRequests() {
@@ -24,12 +24,12 @@
     }
 
     public void setResponses(List<GeneratedMessage> responses) {
-      this.responses = Lists.newArrayList(responses);
+      this.responses = Lists.newLinkedList(responses);
     }
 
     public void reset() {
       requests = new ArrayList<>();
-      responses = new ArrayList<>();
+      responses = new LinkedList<>();
     }
 
     @join method : mockServiceImpl.grpcMethods
@@ -44,8 +44,7 @@
   public void {@method.name}({@method.requestTypeName} request,
       StreamObserver<{@method.responseTypeName}> responseObserver) {
     if (responses != null && !responses.isEmpty()) {
-      {@method.responseTypeName} response = ({@method.responseTypeName}) responses.get(0);
-      responses.remove(0);
+      {@method.responseTypeName} response = ({@method.responseTypeName}) responses.poll();
       requests.add(request);
       responseObserver.onNext(response);
       responseObserver.onCompleted();

--- a/src/main/resources/com/google/api/codegen/java/test.snip
+++ b/src/main/resources/com/google/api/codegen/java/test.snip
@@ -57,12 +57,12 @@
     {@initCode(test.initCode)}
     {@methodCall(test)}
 
-    List<GeneratedMessage> requests = serviceHelper.getService().getRequests();
-    Assert.assertEquals(1, requests.size());
-    {@test.requestTypeName} request = ({@test.requestTypeName})requests.get(0);
+    List<GeneratedMessage> actualRequests = serviceHelper.getService().getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    {@test.requestTypeName} actualRequest = ({@test.requestTypeName})actualRequests.get(0);
 
     @join assert : test.asserts
-      Assert.assertEquals(request.{@assert.actualValueGetter}(), {@assert.expectedValueIdentifier});
+      Assert.assertEquals(actualRequest.{@assert.actualValueGetter}(), {@assert.expectedValueIdentifier});
     @end
   }
 @end
@@ -85,10 +85,15 @@
     List<{@test.resourceTypeName}> resources = Lists.newArrayList(pageAccessor.getPageValues());
     Assert.assertEquals(0, resources.size());
   @case "FlattenedMethod"
-    {@test.responseTypeName} actualResponse =
-        api.{@test.surfaceMethodName}(\
-        {@sampleMethodCallArgList(test.initCode.fieldSettings)});
-    Assert.assertEquals(expectedResponse, actualResponse);
+    @if test.hasReturnValue
+      {@test.responseTypeName} actualResponse =
+          api.{@test.surfaceMethodName}(\
+          {@sampleMethodCallArgList(test.initCode.fieldSettings)});
+      Assert.assertEquals(expectedResponse, actualResponse);
+    @else
+      api.{@test.surfaceMethodName}(\
+            {@sampleMethodCallArgList(test.initCode.fieldSettings)});
+    @end
   @default
     $unhandledCase: {@test.type}$
   @end

--- a/src/test/java/com/google/api/codegen/testdata/java_mock_service_impl_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_mock_service_impl_library.baseline
@@ -72,223 +72,155 @@ public class MockLibraryServiceImpl implements LibraryService  {
 
   @Override
   public void createShelf(CreateShelfRequest request,
-      StreamObserver<Shelf> responseObserver) {
-    try {
-      Shelf response = (Shelf) responses.remove();
-      requests.add(request);
-      responseObserver.onNext(response);
-      responseObserver.onCompleted();
-    } catch (Exception e) {
-      responseObserver.onError(e);
-    }
+    StreamObserver<Shelf> responseObserver) {
+    Shelf response = (Shelf) responses.remove();
+    requests.add(request);
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
   }
 
   @Override
   public void getShelf(GetShelfRequest request,
-      StreamObserver<Shelf> responseObserver) {
-    try {
-      Shelf response = (Shelf) responses.remove();
-      requests.add(request);
-      responseObserver.onNext(response);
-      responseObserver.onCompleted();
-    } catch (Exception e) {
-      responseObserver.onError(e);
-    }
+    StreamObserver<Shelf> responseObserver) {
+    Shelf response = (Shelf) responses.remove();
+    requests.add(request);
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
   }
 
   @Override
   public void listShelves(ListShelvesRequest request,
-      StreamObserver<ListShelvesResponse> responseObserver) {
-    try {
-      ListShelvesResponse response = (ListShelvesResponse) responses.remove();
-      requests.add(request);
-      responseObserver.onNext(response);
-      responseObserver.onCompleted();
-    } catch (Exception e) {
-      responseObserver.onError(e);
-    }
+    StreamObserver<ListShelvesResponse> responseObserver) {
+    ListShelvesResponse response = (ListShelvesResponse) responses.remove();
+    requests.add(request);
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
   }
 
   @Override
   public void deleteShelf(DeleteShelfRequest request,
-      StreamObserver<Empty> responseObserver) {
-    try {
-      Empty response = (Empty) responses.remove();
-      requests.add(request);
-      responseObserver.onNext(response);
-      responseObserver.onCompleted();
-    } catch (Exception e) {
-      responseObserver.onError(e);
-    }
+    StreamObserver<Empty> responseObserver) {
+    Empty response = (Empty) responses.remove();
+    requests.add(request);
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
   }
 
   @Override
   public void mergeShelves(MergeShelvesRequest request,
-      StreamObserver<Shelf> responseObserver) {
-    try {
-      Shelf response = (Shelf) responses.remove();
-      requests.add(request);
-      responseObserver.onNext(response);
-      responseObserver.onCompleted();
-    } catch (Exception e) {
-      responseObserver.onError(e);
-    }
+    StreamObserver<Shelf> responseObserver) {
+    Shelf response = (Shelf) responses.remove();
+    requests.add(request);
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
   }
 
   @Override
   public void createBook(CreateBookRequest request,
-      StreamObserver<Book> responseObserver) {
-    try {
-      Book response = (Book) responses.remove();
-      requests.add(request);
-      responseObserver.onNext(response);
-      responseObserver.onCompleted();
-    } catch (Exception e) {
-      responseObserver.onError(e);
-    }
+    StreamObserver<Book> responseObserver) {
+    Book response = (Book) responses.remove();
+    requests.add(request);
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
   }
 
   @Override
   public void publishSeries(PublishSeriesRequest request,
-      StreamObserver<PublishSeriesResponse> responseObserver) {
-    try {
-      PublishSeriesResponse response = (PublishSeriesResponse) responses.remove();
-      requests.add(request);
-      responseObserver.onNext(response);
-      responseObserver.onCompleted();
-    } catch (Exception e) {
-      responseObserver.onError(e);
-    }
+    StreamObserver<PublishSeriesResponse> responseObserver) {
+    PublishSeriesResponse response = (PublishSeriesResponse) responses.remove();
+    requests.add(request);
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
   }
 
   @Override
   public void getBook(GetBookRequest request,
-      StreamObserver<Book> responseObserver) {
-    try {
-      Book response = (Book) responses.remove();
-      requests.add(request);
-      responseObserver.onNext(response);
-      responseObserver.onCompleted();
-    } catch (Exception e) {
-      responseObserver.onError(e);
-    }
+    StreamObserver<Book> responseObserver) {
+    Book response = (Book) responses.remove();
+    requests.add(request);
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
   }
 
   @Override
   public void listBooks(ListBooksRequest request,
-      StreamObserver<ListBooksResponse> responseObserver) {
-    try {
-      ListBooksResponse response = (ListBooksResponse) responses.remove();
-      requests.add(request);
-      responseObserver.onNext(response);
-      responseObserver.onCompleted();
-    } catch (Exception e) {
-      responseObserver.onError(e);
-    }
+    StreamObserver<ListBooksResponse> responseObserver) {
+    ListBooksResponse response = (ListBooksResponse) responses.remove();
+    requests.add(request);
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
   }
 
   @Override
   public void deleteBook(DeleteBookRequest request,
-      StreamObserver<Empty> responseObserver) {
-    try {
-      Empty response = (Empty) responses.remove();
-      requests.add(request);
-      responseObserver.onNext(response);
-      responseObserver.onCompleted();
-    } catch (Exception e) {
-      responseObserver.onError(e);
-    }
+    StreamObserver<Empty> responseObserver) {
+    Empty response = (Empty) responses.remove();
+    requests.add(request);
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
   }
 
   @Override
   public void updateBook(UpdateBookRequest request,
-      StreamObserver<Book> responseObserver) {
-    try {
-      Book response = (Book) responses.remove();
-      requests.add(request);
-      responseObserver.onNext(response);
-      responseObserver.onCompleted();
-    } catch (Exception e) {
-      responseObserver.onError(e);
-    }
+    StreamObserver<Book> responseObserver) {
+    Book response = (Book) responses.remove();
+    requests.add(request);
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
   }
 
   @Override
   public void moveBook(MoveBookRequest request,
-      StreamObserver<Book> responseObserver) {
-    try {
-      Book response = (Book) responses.remove();
-      requests.add(request);
-      responseObserver.onNext(response);
-      responseObserver.onCompleted();
-    } catch (Exception e) {
-      responseObserver.onError(e);
-    }
+    StreamObserver<Book> responseObserver) {
+    Book response = (Book) responses.remove();
+    requests.add(request);
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
   }
 
   @Override
   public void listStrings(ListStringsRequest request,
-      StreamObserver<ListStringsResponse> responseObserver) {
-    try {
-      ListStringsResponse response = (ListStringsResponse) responses.remove();
-      requests.add(request);
-      responseObserver.onNext(response);
-      responseObserver.onCompleted();
-    } catch (Exception e) {
-      responseObserver.onError(e);
-    }
+    StreamObserver<ListStringsResponse> responseObserver) {
+    ListStringsResponse response = (ListStringsResponse) responses.remove();
+    requests.add(request);
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
   }
 
   @Override
   public void addComments(AddCommentsRequest request,
-      StreamObserver<Empty> responseObserver) {
-    try {
-      Empty response = (Empty) responses.remove();
-      requests.add(request);
-      responseObserver.onNext(response);
-      responseObserver.onCompleted();
-    } catch (Exception e) {
-      responseObserver.onError(e);
-    }
+    StreamObserver<Empty> responseObserver) {
+    Empty response = (Empty) responses.remove();
+    requests.add(request);
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
   }
 
   @Override
   public void getBookFromArchive(GetBookFromArchiveRequest request,
-      StreamObserver<Book> responseObserver) {
-    try {
-      Book response = (Book) responses.remove();
-      requests.add(request);
-      responseObserver.onNext(response);
-      responseObserver.onCompleted();
-    } catch (Exception e) {
-      responseObserver.onError(e);
-    }
+    StreamObserver<Book> responseObserver) {
+    Book response = (Book) responses.remove();
+    requests.add(request);
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
   }
 
   @Override
   public void updateBookIndex(UpdateBookIndexRequest request,
-      StreamObserver<Empty> responseObserver) {
-    try {
-      Empty response = (Empty) responses.remove();
-      requests.add(request);
-      responseObserver.onNext(response);
-      responseObserver.onCompleted();
-    } catch (Exception e) {
-      responseObserver.onError(e);
-    }
+    StreamObserver<Empty> responseObserver) {
+    Empty response = (Empty) responses.remove();
+    requests.add(request);
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
   }
 
   @Override
   public void streamShelves(ListShelvesRequest request,
-      StreamObserver<ListShelvesResponse> responseObserver) {
-    try {
-      ListShelvesResponse response = (ListShelvesResponse) responses.remove();
-      requests.add(request);
-      responseObserver.onNext(response);
-      responseObserver.onCompleted();
-    } catch (Exception e) {
-      responseObserver.onError(e);
-    }
+    StreamObserver<ListShelvesResponse> responseObserver) {
+    ListShelvesResponse response = (ListShelvesResponse) responses.remove();
+    requests.add(request);
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
   }
 
 }

--- a/src/test/java/com/google/api/codegen/testdata/java_mock_service_impl_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_mock_service_impl_library.baseline
@@ -73,238 +73,221 @@ public class MockLibraryServiceImpl implements LibraryService  {
   @Override
   public void createShelf(CreateShelfRequest request,
       StreamObserver<Shelf> responseObserver) {
-    if (responses != null && !responses.isEmpty()) {
-      Shelf response = (Shelf) responses.poll();
+    try {
+      Shelf response = (Shelf) responses.remove();
       requests.add(request);
       responseObserver.onNext(response);
       responseObserver.onCompleted();
-    } else {
-      responseObserver.onError(
-          new Exception("No response is set for gRPC method createShelf."));
+    } catch (Exception e) {
+      responseObserver.onError(e);
     }
   }
 
   @Override
   public void getShelf(GetShelfRequest request,
       StreamObserver<Shelf> responseObserver) {
-    if (responses != null && !responses.isEmpty()) {
-      Shelf response = (Shelf) responses.poll();
+    try {
+      Shelf response = (Shelf) responses.remove();
       requests.add(request);
       responseObserver.onNext(response);
       responseObserver.onCompleted();
-    } else {
-      responseObserver.onError(
-          new Exception("No response is set for gRPC method getShelf."));
+    } catch (Exception e) {
+      responseObserver.onError(e);
     }
   }
 
   @Override
   public void listShelves(ListShelvesRequest request,
       StreamObserver<ListShelvesResponse> responseObserver) {
-    if (responses != null && !responses.isEmpty()) {
-      ListShelvesResponse response = (ListShelvesResponse) responses.poll();
+    try {
+      ListShelvesResponse response = (ListShelvesResponse) responses.remove();
       requests.add(request);
       responseObserver.onNext(response);
       responseObserver.onCompleted();
-    } else {
-      responseObserver.onError(
-          new Exception("No response is set for gRPC method listShelves."));
+    } catch (Exception e) {
+      responseObserver.onError(e);
     }
   }
 
   @Override
   public void deleteShelf(DeleteShelfRequest request,
       StreamObserver<Empty> responseObserver) {
-    if (responses != null && !responses.isEmpty()) {
-      Empty response = (Empty) responses.poll();
+    try {
+      Empty response = (Empty) responses.remove();
       requests.add(request);
       responseObserver.onNext(response);
       responseObserver.onCompleted();
-    } else {
-      responseObserver.onError(
-          new Exception("No response is set for gRPC method deleteShelf."));
+    } catch (Exception e) {
+      responseObserver.onError(e);
     }
   }
 
   @Override
   public void mergeShelves(MergeShelvesRequest request,
       StreamObserver<Shelf> responseObserver) {
-    if (responses != null && !responses.isEmpty()) {
-      Shelf response = (Shelf) responses.poll();
+    try {
+      Shelf response = (Shelf) responses.remove();
       requests.add(request);
       responseObserver.onNext(response);
       responseObserver.onCompleted();
-    } else {
-      responseObserver.onError(
-          new Exception("No response is set for gRPC method mergeShelves."));
+    } catch (Exception e) {
+      responseObserver.onError(e);
     }
   }
 
   @Override
   public void createBook(CreateBookRequest request,
       StreamObserver<Book> responseObserver) {
-    if (responses != null && !responses.isEmpty()) {
-      Book response = (Book) responses.poll();
+    try {
+      Book response = (Book) responses.remove();
       requests.add(request);
       responseObserver.onNext(response);
       responseObserver.onCompleted();
-    } else {
-      responseObserver.onError(
-          new Exception("No response is set for gRPC method createBook."));
+    } catch (Exception e) {
+      responseObserver.onError(e);
     }
   }
 
   @Override
   public void publishSeries(PublishSeriesRequest request,
       StreamObserver<PublishSeriesResponse> responseObserver) {
-    if (responses != null && !responses.isEmpty()) {
-      PublishSeriesResponse response = (PublishSeriesResponse) responses.poll();
+    try {
+      PublishSeriesResponse response = (PublishSeriesResponse) responses.remove();
       requests.add(request);
       responseObserver.onNext(response);
       responseObserver.onCompleted();
-    } else {
-      responseObserver.onError(
-          new Exception("No response is set for gRPC method publishSeries."));
+    } catch (Exception e) {
+      responseObserver.onError(e);
     }
   }
 
   @Override
   public void getBook(GetBookRequest request,
       StreamObserver<Book> responseObserver) {
-    if (responses != null && !responses.isEmpty()) {
-      Book response = (Book) responses.poll();
+    try {
+      Book response = (Book) responses.remove();
       requests.add(request);
       responseObserver.onNext(response);
       responseObserver.onCompleted();
-    } else {
-      responseObserver.onError(
-          new Exception("No response is set for gRPC method getBook."));
+    } catch (Exception e) {
+      responseObserver.onError(e);
     }
   }
 
   @Override
   public void listBooks(ListBooksRequest request,
       StreamObserver<ListBooksResponse> responseObserver) {
-    if (responses != null && !responses.isEmpty()) {
-      ListBooksResponse response = (ListBooksResponse) responses.poll();
+    try {
+      ListBooksResponse response = (ListBooksResponse) responses.remove();
       requests.add(request);
       responseObserver.onNext(response);
       responseObserver.onCompleted();
-    } else {
-      responseObserver.onError(
-          new Exception("No response is set for gRPC method listBooks."));
+    } catch (Exception e) {
+      responseObserver.onError(e);
     }
   }
 
   @Override
   public void deleteBook(DeleteBookRequest request,
       StreamObserver<Empty> responseObserver) {
-    if (responses != null && !responses.isEmpty()) {
-      Empty response = (Empty) responses.poll();
+    try {
+      Empty response = (Empty) responses.remove();
       requests.add(request);
       responseObserver.onNext(response);
       responseObserver.onCompleted();
-    } else {
-      responseObserver.onError(
-          new Exception("No response is set for gRPC method deleteBook."));
+    } catch (Exception e) {
+      responseObserver.onError(e);
     }
   }
 
   @Override
   public void updateBook(UpdateBookRequest request,
       StreamObserver<Book> responseObserver) {
-    if (responses != null && !responses.isEmpty()) {
-      Book response = (Book) responses.poll();
+    try {
+      Book response = (Book) responses.remove();
       requests.add(request);
       responseObserver.onNext(response);
       responseObserver.onCompleted();
-    } else {
-      responseObserver.onError(
-          new Exception("No response is set for gRPC method updateBook."));
+    } catch (Exception e) {
+      responseObserver.onError(e);
     }
   }
 
   @Override
   public void moveBook(MoveBookRequest request,
       StreamObserver<Book> responseObserver) {
-    if (responses != null && !responses.isEmpty()) {
-      Book response = (Book) responses.poll();
+    try {
+      Book response = (Book) responses.remove();
       requests.add(request);
       responseObserver.onNext(response);
       responseObserver.onCompleted();
-    } else {
-      responseObserver.onError(
-          new Exception("No response is set for gRPC method moveBook."));
+    } catch (Exception e) {
+      responseObserver.onError(e);
     }
   }
 
   @Override
   public void listStrings(ListStringsRequest request,
       StreamObserver<ListStringsResponse> responseObserver) {
-    if (responses != null && !responses.isEmpty()) {
-      ListStringsResponse response = (ListStringsResponse) responses.poll();
+    try {
+      ListStringsResponse response = (ListStringsResponse) responses.remove();
       requests.add(request);
       responseObserver.onNext(response);
       responseObserver.onCompleted();
-    } else {
-      responseObserver.onError(
-          new Exception("No response is set for gRPC method listStrings."));
+    } catch (Exception e) {
+      responseObserver.onError(e);
     }
   }
 
   @Override
   public void addComments(AddCommentsRequest request,
       StreamObserver<Empty> responseObserver) {
-    if (responses != null && !responses.isEmpty()) {
-      Empty response = (Empty) responses.poll();
+    try {
+      Empty response = (Empty) responses.remove();
       requests.add(request);
       responseObserver.onNext(response);
       responseObserver.onCompleted();
-    } else {
-      responseObserver.onError(
-          new Exception("No response is set for gRPC method addComments."));
+    } catch (Exception e) {
+      responseObserver.onError(e);
     }
   }
 
   @Override
   public void getBookFromArchive(GetBookFromArchiveRequest request,
       StreamObserver<Book> responseObserver) {
-    if (responses != null && !responses.isEmpty()) {
-      Book response = (Book) responses.poll();
+    try {
+      Book response = (Book) responses.remove();
       requests.add(request);
       responseObserver.onNext(response);
       responseObserver.onCompleted();
-    } else {
-      responseObserver.onError(
-          new Exception("No response is set for gRPC method getBookFromArchive."));
+    } catch (Exception e) {
+      responseObserver.onError(e);
     }
   }
 
   @Override
   public void updateBookIndex(UpdateBookIndexRequest request,
       StreamObserver<Empty> responseObserver) {
-    if (responses != null && !responses.isEmpty()) {
-      Empty response = (Empty) responses.poll();
+    try {
+      Empty response = (Empty) responses.remove();
       requests.add(request);
       responseObserver.onNext(response);
       responseObserver.onCompleted();
-    } else {
-      responseObserver.onError(
-          new Exception("No response is set for gRPC method updateBookIndex."));
+    } catch (Exception e) {
+      responseObserver.onError(e);
     }
   }
 
   @Override
   public void streamShelves(ListShelvesRequest request,
       StreamObserver<ListShelvesResponse> responseObserver) {
-    if (responses != null && !responses.isEmpty()) {
-      ListShelvesResponse response = (ListShelvesResponse) responses.poll();
+    try {
+      ListShelvesResponse response = (ListShelvesResponse) responses.remove();
       requests.add(request);
       responseObserver.onNext(response);
       responseObserver.onCompleted();
-    } else {
-      responseObserver.onError(
-          new Exception("No response is set for gRPC method streamShelves."));
+    } catch (Exception e) {
+      responseObserver.onError(e);
     }
   }
 

--- a/src/test/java/com/google/api/codegen/testdata/java_mock_service_impl_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_mock_service_impl_library.baseline
@@ -43,16 +43,18 @@ import com.google.protobuf.Empty;
 import com.google.protobuf.GeneratedMessage;
 import io.grpc.stub.StreamObserver;
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Queue;
 
 @javax.annotation.Generated("by GAPIC")
 public class MockLibraryServiceImpl implements LibraryService  {
   private ArrayList<GeneratedMessage> requests;
-  private ArrayList<GeneratedMessage> responses;
+  private Queue<GeneratedMessage> responses;
 
   public MockLibraryServiceImpl() {
     requests = new ArrayList<>();
-    responses = new ArrayList<>();
+    responses = new LinkedList<>();
   }
 
   public List<GeneratedMessage> getRequests() {
@@ -60,20 +62,19 @@ public class MockLibraryServiceImpl implements LibraryService  {
   }
 
   public void setResponses(List<GeneratedMessage> responses) {
-    this.responses = Lists.newArrayList(responses);
+    this.responses = Lists.newLinkedList(responses);
   }
 
   public void reset() {
     requests = new ArrayList<>();
-    responses = new ArrayList<>();
+    responses = new LinkedList<>();
   }
 
   @Override
   public void createShelf(CreateShelfRequest request,
       StreamObserver<Shelf> responseObserver) {
     if (responses != null && !responses.isEmpty()) {
-      Shelf response = (Shelf) responses.get(0);
-      responses.remove(0);
+      Shelf response = (Shelf) responses.poll();
       requests.add(request);
       responseObserver.onNext(response);
       responseObserver.onCompleted();
@@ -87,8 +88,7 @@ public class MockLibraryServiceImpl implements LibraryService  {
   public void getShelf(GetShelfRequest request,
       StreamObserver<Shelf> responseObserver) {
     if (responses != null && !responses.isEmpty()) {
-      Shelf response = (Shelf) responses.get(0);
-      responses.remove(0);
+      Shelf response = (Shelf) responses.poll();
       requests.add(request);
       responseObserver.onNext(response);
       responseObserver.onCompleted();
@@ -102,8 +102,7 @@ public class MockLibraryServiceImpl implements LibraryService  {
   public void listShelves(ListShelvesRequest request,
       StreamObserver<ListShelvesResponse> responseObserver) {
     if (responses != null && !responses.isEmpty()) {
-      ListShelvesResponse response = (ListShelvesResponse) responses.get(0);
-      responses.remove(0);
+      ListShelvesResponse response = (ListShelvesResponse) responses.poll();
       requests.add(request);
       responseObserver.onNext(response);
       responseObserver.onCompleted();
@@ -117,8 +116,7 @@ public class MockLibraryServiceImpl implements LibraryService  {
   public void deleteShelf(DeleteShelfRequest request,
       StreamObserver<Empty> responseObserver) {
     if (responses != null && !responses.isEmpty()) {
-      Empty response = (Empty) responses.get(0);
-      responses.remove(0);
+      Empty response = (Empty) responses.poll();
       requests.add(request);
       responseObserver.onNext(response);
       responseObserver.onCompleted();
@@ -132,8 +130,7 @@ public class MockLibraryServiceImpl implements LibraryService  {
   public void mergeShelves(MergeShelvesRequest request,
       StreamObserver<Shelf> responseObserver) {
     if (responses != null && !responses.isEmpty()) {
-      Shelf response = (Shelf) responses.get(0);
-      responses.remove(0);
+      Shelf response = (Shelf) responses.poll();
       requests.add(request);
       responseObserver.onNext(response);
       responseObserver.onCompleted();
@@ -147,8 +144,7 @@ public class MockLibraryServiceImpl implements LibraryService  {
   public void createBook(CreateBookRequest request,
       StreamObserver<Book> responseObserver) {
     if (responses != null && !responses.isEmpty()) {
-      Book response = (Book) responses.get(0);
-      responses.remove(0);
+      Book response = (Book) responses.poll();
       requests.add(request);
       responseObserver.onNext(response);
       responseObserver.onCompleted();
@@ -162,8 +158,7 @@ public class MockLibraryServiceImpl implements LibraryService  {
   public void publishSeries(PublishSeriesRequest request,
       StreamObserver<PublishSeriesResponse> responseObserver) {
     if (responses != null && !responses.isEmpty()) {
-      PublishSeriesResponse response = (PublishSeriesResponse) responses.get(0);
-      responses.remove(0);
+      PublishSeriesResponse response = (PublishSeriesResponse) responses.poll();
       requests.add(request);
       responseObserver.onNext(response);
       responseObserver.onCompleted();
@@ -177,8 +172,7 @@ public class MockLibraryServiceImpl implements LibraryService  {
   public void getBook(GetBookRequest request,
       StreamObserver<Book> responseObserver) {
     if (responses != null && !responses.isEmpty()) {
-      Book response = (Book) responses.get(0);
-      responses.remove(0);
+      Book response = (Book) responses.poll();
       requests.add(request);
       responseObserver.onNext(response);
       responseObserver.onCompleted();
@@ -192,8 +186,7 @@ public class MockLibraryServiceImpl implements LibraryService  {
   public void listBooks(ListBooksRequest request,
       StreamObserver<ListBooksResponse> responseObserver) {
     if (responses != null && !responses.isEmpty()) {
-      ListBooksResponse response = (ListBooksResponse) responses.get(0);
-      responses.remove(0);
+      ListBooksResponse response = (ListBooksResponse) responses.poll();
       requests.add(request);
       responseObserver.onNext(response);
       responseObserver.onCompleted();
@@ -207,8 +200,7 @@ public class MockLibraryServiceImpl implements LibraryService  {
   public void deleteBook(DeleteBookRequest request,
       StreamObserver<Empty> responseObserver) {
     if (responses != null && !responses.isEmpty()) {
-      Empty response = (Empty) responses.get(0);
-      responses.remove(0);
+      Empty response = (Empty) responses.poll();
       requests.add(request);
       responseObserver.onNext(response);
       responseObserver.onCompleted();
@@ -222,8 +214,7 @@ public class MockLibraryServiceImpl implements LibraryService  {
   public void updateBook(UpdateBookRequest request,
       StreamObserver<Book> responseObserver) {
     if (responses != null && !responses.isEmpty()) {
-      Book response = (Book) responses.get(0);
-      responses.remove(0);
+      Book response = (Book) responses.poll();
       requests.add(request);
       responseObserver.onNext(response);
       responseObserver.onCompleted();
@@ -237,8 +228,7 @@ public class MockLibraryServiceImpl implements LibraryService  {
   public void moveBook(MoveBookRequest request,
       StreamObserver<Book> responseObserver) {
     if (responses != null && !responses.isEmpty()) {
-      Book response = (Book) responses.get(0);
-      responses.remove(0);
+      Book response = (Book) responses.poll();
       requests.add(request);
       responseObserver.onNext(response);
       responseObserver.onCompleted();
@@ -252,8 +242,7 @@ public class MockLibraryServiceImpl implements LibraryService  {
   public void listStrings(ListStringsRequest request,
       StreamObserver<ListStringsResponse> responseObserver) {
     if (responses != null && !responses.isEmpty()) {
-      ListStringsResponse response = (ListStringsResponse) responses.get(0);
-      responses.remove(0);
+      ListStringsResponse response = (ListStringsResponse) responses.poll();
       requests.add(request);
       responseObserver.onNext(response);
       responseObserver.onCompleted();
@@ -267,8 +256,7 @@ public class MockLibraryServiceImpl implements LibraryService  {
   public void addComments(AddCommentsRequest request,
       StreamObserver<Empty> responseObserver) {
     if (responses != null && !responses.isEmpty()) {
-      Empty response = (Empty) responses.get(0);
-      responses.remove(0);
+      Empty response = (Empty) responses.poll();
       requests.add(request);
       responseObserver.onNext(response);
       responseObserver.onCompleted();
@@ -282,8 +270,7 @@ public class MockLibraryServiceImpl implements LibraryService  {
   public void getBookFromArchive(GetBookFromArchiveRequest request,
       StreamObserver<Book> responseObserver) {
     if (responses != null && !responses.isEmpty()) {
-      Book response = (Book) responses.get(0);
-      responses.remove(0);
+      Book response = (Book) responses.poll();
       requests.add(request);
       responseObserver.onNext(response);
       responseObserver.onCompleted();
@@ -297,8 +284,7 @@ public class MockLibraryServiceImpl implements LibraryService  {
   public void updateBookIndex(UpdateBookIndexRequest request,
       StreamObserver<Empty> responseObserver) {
     if (responses != null && !responses.isEmpty()) {
-      Empty response = (Empty) responses.get(0);
-      responses.remove(0);
+      Empty response = (Empty) responses.poll();
       requests.add(request);
       responseObserver.onNext(response);
       responseObserver.onCompleted();
@@ -312,8 +298,7 @@ public class MockLibraryServiceImpl implements LibraryService  {
   public void streamShelves(ListShelvesRequest request,
       StreamObserver<ListShelvesResponse> responseObserver) {
     if (responses != null && !responses.isEmpty()) {
-      ListShelvesResponse response = (ListShelvesResponse) responses.get(0);
-      responses.remove(0);
+      ListShelvesResponse response = (ListShelvesResponse) responses.poll();
       requests.add(request);
       responseObserver.onNext(response);
       responseObserver.onCompleted();

--- a/src/test/java/com/google/api/codegen/testdata/java_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_test_library.baseline
@@ -40,10 +40,12 @@ import com.google.example.library.v1.MoveBookRequest;
 import com.google.example.library.v1.PublishSeriesRequest;
 import com.google.example.library.v1.PublishSeriesResponse;
 import com.google.example.library.v1.Shelf;
+import com.google.example.library.v1.SomeMessage;
 import com.google.example.library.v1.UpdateBookIndexRequest;
 import com.google.example.library.v1.UpdateBookRequest;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Empty;
+import com.google.protobuf.FieldMask;
 import com.google.protobuf.GeneratedMessage;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -100,11 +102,11 @@ public class LibraryServiceTest {
         api.createShelf(shelf);
     Assert.assertEquals(expectedResponse, actualResponse);
 
-    List<GeneratedMessage> requests = serviceHelper.getService().getRequests();
-    Assert.assertEquals(1, requests.size());
-    CreateShelfRequest request = (CreateShelfRequest)requests.get(0);
+    List<GeneratedMessage> actualRequests = serviceHelper.getService().getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    CreateShelfRequest actualRequest = (CreateShelfRequest)actualRequests.get(0);
 
-    Assert.assertEquals(request.getShelf(), shelf);
+    Assert.assertEquals(actualRequest.getShelf(), shelf);
   }
 
   @Test
@@ -117,17 +119,63 @@ public class LibraryServiceTest {
     serviceHelper.getService().setResponses(expectedResponses);
 
     String formattedName = LibraryServiceApi.formatShelfName("[SHELF]");
-    String options = "";
     Shelf actualResponse =
-        api.getShelf(formattedName, options);
+        api.getShelf(formattedName);
     Assert.assertEquals(expectedResponse, actualResponse);
 
-    List<GeneratedMessage> requests = serviceHelper.getService().getRequests();
-    Assert.assertEquals(1, requests.size());
-    GetShelfRequest request = (GetShelfRequest)requests.get(0);
+    List<GeneratedMessage> actualRequests = serviceHelper.getService().getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    GetShelfRequest actualRequest = (GetShelfRequest)actualRequests.get(0);
 
-    Assert.assertEquals(request.getName(), formattedName);
-    Assert.assertEquals(request.getOptions(), options);
+    Assert.assertEquals(actualRequest.getName(), formattedName);
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void getShelfTest2() {
+    Shelf expectedResponse = Shelf.newBuilder()
+      .build();
+    List<GeneratedMessage> expectedResponses = new ArrayList<>();
+    expectedResponses.add(expectedResponse);
+    serviceHelper.getService().setResponses(expectedResponses);
+
+    String formattedName = LibraryServiceApi.formatShelfName("[SHELF]");
+    SomeMessage message = SomeMessage.newBuilder().build();
+    Shelf actualResponse =
+        api.getShelf(formattedName, message);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<GeneratedMessage> actualRequests = serviceHelper.getService().getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    GetShelfRequest actualRequest = (GetShelfRequest)actualRequests.get(0);
+
+    Assert.assertEquals(actualRequest.getName(), formattedName);
+    Assert.assertEquals(actualRequest.getMessage(), message);
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void getShelfTest3() {
+    Shelf expectedResponse = Shelf.newBuilder()
+      .build();
+    List<GeneratedMessage> expectedResponses = new ArrayList<>();
+    expectedResponses.add(expectedResponse);
+    serviceHelper.getService().setResponses(expectedResponses);
+
+    String formattedName = LibraryServiceApi.formatShelfName("[SHELF]");
+    SomeMessage message = SomeMessage.newBuilder().build();
+    com.google.example.library.v1.StringBuilder stringBuilder = com.google.example.library.v1.StringBuilder.newBuilder().build();
+    Shelf actualResponse =
+        api.getShelf(formattedName, message, stringBuilder);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<GeneratedMessage> actualRequests = serviceHelper.getService().getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    GetShelfRequest actualRequest = (GetShelfRequest)actualRequests.get(0);
+
+    Assert.assertEquals(actualRequest.getName(), formattedName);
+    Assert.assertEquals(actualRequest.getMessage(), message);
+    Assert.assertEquals(actualRequest.getStringBuilder(), stringBuilder);
   }
 
   @Test
@@ -147,9 +195,9 @@ public class LibraryServiceTest {
     List<Shelf> resources = Lists.newArrayList(pageAccessor.getPageValues());
     Assert.assertEquals(0, resources.size());
 
-    List<GeneratedMessage> requests = serviceHelper.getService().getRequests();
-    Assert.assertEquals(1, requests.size());
-    ListShelvesRequest request = (ListShelvesRequest)requests.get(0);
+    List<GeneratedMessage> actualRequests = serviceHelper.getService().getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    ListShelvesRequest actualRequest = (ListShelvesRequest)actualRequests.get(0);
 
   }
 
@@ -163,15 +211,13 @@ public class LibraryServiceTest {
     serviceHelper.getService().setResponses(expectedResponses);
 
     String formattedName = LibraryServiceApi.formatShelfName("[SHELF]");
-    Empty actualResponse =
-        api.deleteShelf(formattedName);
-    Assert.assertEquals(expectedResponse, actualResponse);
+    api.deleteShelf(formattedName);
 
-    List<GeneratedMessage> requests = serviceHelper.getService().getRequests();
-    Assert.assertEquals(1, requests.size());
-    DeleteShelfRequest request = (DeleteShelfRequest)requests.get(0);
+    List<GeneratedMessage> actualRequests = serviceHelper.getService().getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    DeleteShelfRequest actualRequest = (DeleteShelfRequest)actualRequests.get(0);
 
-    Assert.assertEquals(request.getName(), formattedName);
+    Assert.assertEquals(actualRequest.getName(), formattedName);
   }
 
   @Test
@@ -189,12 +235,12 @@ public class LibraryServiceTest {
         api.mergeShelves(formattedName, formattedOtherShelfName);
     Assert.assertEquals(expectedResponse, actualResponse);
 
-    List<GeneratedMessage> requests = serviceHelper.getService().getRequests();
-    Assert.assertEquals(1, requests.size());
-    MergeShelvesRequest request = (MergeShelvesRequest)requests.get(0);
+    List<GeneratedMessage> actualRequests = serviceHelper.getService().getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    MergeShelvesRequest actualRequest = (MergeShelvesRequest)actualRequests.get(0);
 
-    Assert.assertEquals(request.getName(), formattedName);
-    Assert.assertEquals(request.getOtherShelfName(), formattedOtherShelfName);
+    Assert.assertEquals(actualRequest.getName(), formattedName);
+    Assert.assertEquals(actualRequest.getOtherShelfName(), formattedOtherShelfName);
   }
 
   @Test
@@ -212,12 +258,12 @@ public class LibraryServiceTest {
         api.createBook(formattedName, book);
     Assert.assertEquals(expectedResponse, actualResponse);
 
-    List<GeneratedMessage> requests = serviceHelper.getService().getRequests();
-    Assert.assertEquals(1, requests.size());
-    CreateBookRequest request = (CreateBookRequest)requests.get(0);
+    List<GeneratedMessage> actualRequests = serviceHelper.getService().getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    CreateBookRequest actualRequest = (CreateBookRequest)actualRequests.get(0);
 
-    Assert.assertEquals(request.getName(), formattedName);
-    Assert.assertEquals(request.getBook(), book);
+    Assert.assertEquals(actualRequest.getName(), formattedName);
+    Assert.assertEquals(actualRequest.getBook(), book);
   }
 
   @Test
@@ -231,16 +277,18 @@ public class LibraryServiceTest {
 
     Shelf shelf = Shelf.newBuilder().build();
     List<Book> books = new ArrayList<>();
+    int edition = 0;
     PublishSeriesResponse actualResponse =
-        api.publishSeries(shelf, books);
+        api.publishSeries(shelf, books, edition);
     Assert.assertEquals(expectedResponse, actualResponse);
 
-    List<GeneratedMessage> requests = serviceHelper.getService().getRequests();
-    Assert.assertEquals(1, requests.size());
-    PublishSeriesRequest request = (PublishSeriesRequest)requests.get(0);
+    List<GeneratedMessage> actualRequests = serviceHelper.getService().getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    PublishSeriesRequest actualRequest = (PublishSeriesRequest)actualRequests.get(0);
 
-    Assert.assertEquals(request.getShelf(), shelf);
-    Assert.assertEquals(request.getBooks(), books);
+    Assert.assertEquals(actualRequest.getShelf(), shelf);
+    Assert.assertEquals(actualRequest.getBooksList(), books);
+    Assert.assertEquals(actualRequest.getEdition(), edition);
   }
 
   @Test
@@ -257,11 +305,11 @@ public class LibraryServiceTest {
         api.getBook(formattedName);
     Assert.assertEquals(expectedResponse, actualResponse);
 
-    List<GeneratedMessage> requests = serviceHelper.getService().getRequests();
-    Assert.assertEquals(1, requests.size());
-    GetBookRequest request = (GetBookRequest)requests.get(0);
+    List<GeneratedMessage> actualRequests = serviceHelper.getService().getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    GetBookRequest actualRequest = (GetBookRequest)actualRequests.get(0);
 
-    Assert.assertEquals(request.getName(), formattedName);
+    Assert.assertEquals(actualRequest.getName(), formattedName);
   }
 
   @Test
@@ -274,18 +322,20 @@ public class LibraryServiceTest {
     serviceHelper.getService().setResponses(expectedResponses);
 
     String formattedName = LibraryServiceApi.formatShelfName("[SHELF]");
-    PageAccessor<Book> pageAccessor = api.listBooks(formattedName);
+    String filter = "";
+    PageAccessor<Book> pageAccessor = api.listBooks(formattedName, filter);
 
     // PageAccessor will not make actual request until it is being used.
     // Add all the pages here in order to make grpc requests.
     List<Book> resources = Lists.newArrayList(pageAccessor.getPageValues());
     Assert.assertEquals(0, resources.size());
 
-    List<GeneratedMessage> requests = serviceHelper.getService().getRequests();
-    Assert.assertEquals(1, requests.size());
-    ListBooksRequest request = (ListBooksRequest)requests.get(0);
+    List<GeneratedMessage> actualRequests = serviceHelper.getService().getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    ListBooksRequest actualRequest = (ListBooksRequest)actualRequests.get(0);
 
-    Assert.assertEquals(request.getName(), formattedName);
+    Assert.assertEquals(actualRequest.getName(), formattedName);
+    Assert.assertEquals(actualRequest.getFilter(), filter);
   }
 
   @Test
@@ -298,15 +348,13 @@ public class LibraryServiceTest {
     serviceHelper.getService().setResponses(expectedResponses);
 
     String formattedName = LibraryServiceApi.formatBookName("[SHELF]", "[BOOK]");
-    Empty actualResponse =
-        api.deleteBook(formattedName);
-    Assert.assertEquals(expectedResponse, actualResponse);
+    api.deleteBook(formattedName);
 
-    List<GeneratedMessage> requests = serviceHelper.getService().getRequests();
-    Assert.assertEquals(1, requests.size());
-    DeleteBookRequest request = (DeleteBookRequest)requests.get(0);
+    List<GeneratedMessage> actualRequests = serviceHelper.getService().getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    DeleteBookRequest actualRequest = (DeleteBookRequest)actualRequests.get(0);
 
-    Assert.assertEquals(request.getName(), formattedName);
+    Assert.assertEquals(actualRequest.getName(), formattedName);
   }
 
   @Test
@@ -324,12 +372,39 @@ public class LibraryServiceTest {
         api.updateBook(formattedName, book);
     Assert.assertEquals(expectedResponse, actualResponse);
 
-    List<GeneratedMessage> requests = serviceHelper.getService().getRequests();
-    Assert.assertEquals(1, requests.size());
-    UpdateBookRequest request = (UpdateBookRequest)requests.get(0);
+    List<GeneratedMessage> actualRequests = serviceHelper.getService().getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    UpdateBookRequest actualRequest = (UpdateBookRequest)actualRequests.get(0);
 
-    Assert.assertEquals(request.getName(), formattedName);
-    Assert.assertEquals(request.getBook(), book);
+    Assert.assertEquals(actualRequest.getName(), formattedName);
+    Assert.assertEquals(actualRequest.getBook(), book);
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void updateBookTest2() {
+    Book expectedResponse = Book.newBuilder()
+      .build();
+    List<GeneratedMessage> expectedResponses = new ArrayList<>();
+    expectedResponses.add(expectedResponse);
+    serviceHelper.getService().setResponses(expectedResponses);
+
+    String formattedName = LibraryServiceApi.formatBookName("[SHELF]", "[BOOK]");
+    Book book = Book.newBuilder().build();
+    FieldMask updateMask = FieldMask.newBuilder().build();
+    com.google.example.library.v1.FieldMask physicalMask = com.google.example.library.v1.FieldMask.newBuilder().build();
+    Book actualResponse =
+        api.updateBook(formattedName, book, updateMask, physicalMask);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<GeneratedMessage> actualRequests = serviceHelper.getService().getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    UpdateBookRequest actualRequest = (UpdateBookRequest)actualRequests.get(0);
+
+    Assert.assertEquals(actualRequest.getName(), formattedName);
+    Assert.assertEquals(actualRequest.getBook(), book);
+    Assert.assertEquals(actualRequest.getUpdateMask(), updateMask);
+    Assert.assertEquals(actualRequest.getPhysicalMask(), physicalMask);
   }
 
   @Test
@@ -347,12 +422,12 @@ public class LibraryServiceTest {
         api.moveBook(formattedName, formattedOtherShelfName);
     Assert.assertEquals(expectedResponse, actualResponse);
 
-    List<GeneratedMessage> requests = serviceHelper.getService().getRequests();
-    Assert.assertEquals(1, requests.size());
-    MoveBookRequest request = (MoveBookRequest)requests.get(0);
+    List<GeneratedMessage> actualRequests = serviceHelper.getService().getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    MoveBookRequest actualRequest = (MoveBookRequest)actualRequests.get(0);
 
-    Assert.assertEquals(request.getName(), formattedName);
-    Assert.assertEquals(request.getOtherShelfName(), formattedOtherShelfName);
+    Assert.assertEquals(actualRequest.getName(), formattedName);
+    Assert.assertEquals(actualRequest.getOtherShelfName(), formattedOtherShelfName);
   }
 
   @Test
@@ -372,9 +447,9 @@ public class LibraryServiceTest {
     List<String> resources = Lists.newArrayList(pageAccessor.getPageValues());
     Assert.assertEquals(0, resources.size());
 
-    List<GeneratedMessage> requests = serviceHelper.getService().getRequests();
-    Assert.assertEquals(1, requests.size());
-    ListStringsRequest request = (ListStringsRequest)requests.get(0);
+    List<GeneratedMessage> actualRequests = serviceHelper.getService().getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    ListStringsRequest actualRequest = (ListStringsRequest)actualRequests.get(0);
 
   }
 
@@ -393,16 +468,14 @@ public class LibraryServiceTest {
       .setComment(comment)
       .build();
     List<Comment> comments = Arrays.asList(commentsElement);
-    Empty actualResponse =
-        api.addComments(formattedName, comments);
-    Assert.assertEquals(expectedResponse, actualResponse);
+    api.addComments(formattedName, comments);
 
-    List<GeneratedMessage> requests = serviceHelper.getService().getRequests();
-    Assert.assertEquals(1, requests.size());
-    AddCommentsRequest request = (AddCommentsRequest)requests.get(0);
+    List<GeneratedMessage> actualRequests = serviceHelper.getService().getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    AddCommentsRequest actualRequest = (AddCommentsRequest)actualRequests.get(0);
 
-    Assert.assertEquals(request.getName(), formattedName);
-    Assert.assertEquals(request.getComments(), comments);
+    Assert.assertEquals(actualRequest.getName(), formattedName);
+    Assert.assertEquals(actualRequest.getCommentsList(), comments);
   }
 
   @Test
@@ -419,11 +492,11 @@ public class LibraryServiceTest {
         api.getBookFromArchive(formattedName);
     Assert.assertEquals(expectedResponse, actualResponse);
 
-    List<GeneratedMessage> requests = serviceHelper.getService().getRequests();
-    Assert.assertEquals(1, requests.size());
-    GetBookFromArchiveRequest request = (GetBookFromArchiveRequest)requests.get(0);
+    List<GeneratedMessage> actualRequests = serviceHelper.getService().getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    GetBookFromArchiveRequest actualRequest = (GetBookFromArchiveRequest)actualRequests.get(0);
 
-    Assert.assertEquals(request.getName(), formattedName);
+    Assert.assertEquals(actualRequest.getName(), formattedName);
   }
 
   @Test
@@ -440,17 +513,15 @@ public class LibraryServiceTest {
     String indexMapItem = "";
     Map<String, String> indexMap = new HashMap<>();
     indexMap.put("default_key", indexMapItem);
-    Empty actualResponse =
-        api.updateBookIndex(formattedName, indexName, indexMap);
-    Assert.assertEquals(expectedResponse, actualResponse);
+    api.updateBookIndex(formattedName, indexName, indexMap);
 
-    List<GeneratedMessage> requests = serviceHelper.getService().getRequests();
-    Assert.assertEquals(1, requests.size());
-    UpdateBookIndexRequest request = (UpdateBookIndexRequest)requests.get(0);
+    List<GeneratedMessage> actualRequests = serviceHelper.getService().getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    UpdateBookIndexRequest actualRequest = (UpdateBookIndexRequest)actualRequests.get(0);
 
-    Assert.assertEquals(request.getName(), formattedName);
-    Assert.assertEquals(request.getIndexName(), indexName);
-    Assert.assertEquals(request.getIndexMap(), indexMap);
+    Assert.assertEquals(actualRequest.getName(), formattedName);
+    Assert.assertEquals(actualRequest.getIndexName(), indexName);
+    Assert.assertEquals(actualRequest.getIndexMap(), indexMap);
   }
 
 }


### PR DESCRIPTION
- Fix names
  - Handle duplicate test case name since we may have more than one test for each method.
  - requests -> actualRequests
  - list field getter: getXXXX() -> getXXXList()
- Use LinkedList to store mock requests for efficiency.
- In the initialization stage, initialize all the flattened fields instead of required fields.
- Ignore the response if the grpc method has no return value.
