### PR TITLE
Modify NodeJS codegen to fit with gcloud-node design.

### DIFF
--- a/src/main/java/com/google/api/codegen/gapic/MainGapicProviderFactory.java
+++ b/src/main/java/com/google/api/codegen/gapic/MainGapicProviderFactory.java
@@ -25,6 +25,7 @@ import com.google.api.codegen.csharp.CSharpGapicContext;
 import com.google.api.codegen.csharp.CSharpSnippetSetRunner;
 import com.google.api.codegen.go.GoGapicContext;
 import com.google.api.codegen.go.GoSnippetSetRunner;
+import com.google.api.codegen.nodejs.NodeJSCodePathMapper;
 import com.google.api.codegen.nodejs.NodeJSGapicContext;
 import com.google.api.codegen.nodejs.NodeJSSnippetSetRunner;
 import com.google.api.codegen.py.PythonGapicContext;
@@ -140,8 +141,7 @@ public class MainGapicProviderFactory
       return Arrays.<GapicProvider<? extends Object>>asList(mainProvider, testProvider);
 
     } else if (id.equals(NODEJS)) {
-      GapicCodePathMapper nodeJSPathMapper =
-          CommonGapicCodePathMapper.newBuilder().setPrefix("src").build();
+      GapicCodePathMapper nodeJSPathMapper = new NodeJSCodePathMapper();
       GapicProvider<? extends Object> mainProvider =
           CommonGapicProvider.<Interface>newBuilder()
               .setModel(model)

--- a/src/main/java/com/google/api/codegen/nodejs/NodeJSCodePathMapper.java
+++ b/src/main/java/com/google/api/codegen/nodejs/NodeJSCodePathMapper.java
@@ -1,0 +1,45 @@
+/* Copyright 2016 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.nodejs;
+
+import com.google.api.codegen.ApiConfig;
+import com.google.api.codegen.gapic.GapicCodePathMapper;
+import com.google.api.tools.framework.model.ProtoElement;
+
+import com.google.common.base.Splitter;
+
+import java.util.List;
+
+public class NodeJSCodePathMapper implements GapicCodePathMapper {
+  @Override
+  public String getOutputPath(ProtoElement element, ApiConfig config) {
+    String apiVersion = "";
+    // For the gcloud package, the generated file would be a sub part of
+    // the package, under the versioned directory. For example, Speech V1 API
+    // would be a part of "@google-cloud/speech" package, and loaded as
+    //    var speechV1 = require("@google-cloud/speech").v1();
+    // To do this, we fetch the version number from the service full name.
+    if (NodeJSUtils.isGcloud(config)) {
+      List<String> packages = Splitter.on(".").splitToList(element.getFullName());
+      if (packages.size() > 2) {
+        String parentName = packages.get(packages.size() - 2);
+        if (parentName.matches("v[0-9]+((alpha|beta)[0-9]+)?")) {
+          apiVersion = parentName;
+        }
+      }
+    }
+    return apiVersion.isEmpty() ? "src" : ("src/" + apiVersion);
+  }
+}

--- a/src/main/java/com/google/api/codegen/nodejs/NodeJSGapicContext.java
+++ b/src/main/java/com/google/api/codegen/nodejs/NodeJSGapicContext.java
@@ -87,21 +87,20 @@ public class NodeJSGapicContext extends GapicContext implements NodeJSContext {
   }
 
   /**
-   * The name for the module for this vkit module.
+   * The name for the module for this vkit module. This assumes that the service's
+   * full name will be in the format of 'google.some.apiname.version.ServiceName',
+   * and extracts the 'apiname' and 'version' part and combine them to lower-camelcased
+   * style (like pubsubV1).
    */
   public String getModuleName(Interface service) {
     List<String> names = Splitter.on(".").splitToList(service.getFullName());
-    if (names.size() >= 3) {
-      return lowerUnderscoreToLowerCamel(
-          names.get(names.size() - 3) + "_" + names.get(names.size() - 2));
-    } else if (names.size() >= 2) {
-      return names.get(names.size() - 2);
-    }
-    return upperCamelToLowerCamel(service.getSimpleName());
+    return names.get(names.size() - 3) + lowerUnderscoreToUpperCamel(names.get(names.size() - 2));
   }
 
   /**
-   * Returns the major version part in the API namespace.
+   * Returns the major version part in the API namespace. This assumes that the service's
+   * full name will be in the format of 'google.some.apiname.version.ServiceName', and
+   * extracts the 'version' part.
    */
   public String getApiVersion(Interface service) {
     List<String> names = Splitter.on(".").splitToList(service.getFullName());

--- a/src/main/java/com/google/api/codegen/nodejs/NodeJSGapicContext.java
+++ b/src/main/java/com/google/api/codegen/nodejs/NodeJSGapicContext.java
@@ -74,8 +74,16 @@ public class NodeJSGapicContext extends GapicContext implements NodeJSContext {
   }
 
   public boolean isGcloud() {
-    String packageName = getApiConfig().getPackageName();
-    return !Strings.isNullOrEmpty(packageName) && packageName.startsWith("@google-cloud/");
+    return NodeJSUtils.isGcloud(getApiConfig());
+  }
+
+  /**
+   * The namespace (full package name) for the service.
+   */
+  public String getNamespace(Interface service) {
+    String fullName = service.getFullName();
+    int slash = fullName.lastIndexOf('.');
+    return fullName.substring(0, slash);
   }
 
   /**
@@ -104,6 +112,7 @@ public class NodeJSGapicContext extends GapicContext implements NodeJSContext {
     String fieldName = wrapIfKeywordOrBuiltIn(lowerUnderscoreToLowerCamel(field.getSimpleName()));
     if (isOptional) {
       fieldName = "otherArgs." + fieldName;
+      commentType = commentType + "=";
     }
     return fieldComment(
         String.format("@param {%s} %s", commentType, fieldName), paramComment, field);
@@ -162,9 +171,9 @@ public class NodeJSGapicContext extends GapicContext implements NodeJSContext {
               + "  a gax.BundleEventEmitter but the API is immediately invoked, so it behaves same\n"
               + "  as a gax.EventEmitter does.";
     }
-    return "@param {?"
+    return "@param {"
         + callbackType
-        + "} callback\n"
+        + "=} callback\n"
         + "  The function which will be called with the result of the API call.\n"
         + returnMessage;
   }
@@ -184,7 +193,7 @@ public class NodeJSGapicContext extends GapicContext implements NodeJSContext {
     }
     Iterable<Field> optionalParams = removePageTokenFromFields(config.getOptionalFields(), config);
     if (optionalParams.iterator().hasNext()) {
-      paramTypesBuilder.append("@param {?Object} otherArgs\n");
+      paramTypesBuilder.append("@param {Object=} otherArgs\n");
       for (Field field : optionalParams) {
         if (config.isPageStreaming()
             && field.equals((config.getPageStreaming().getPageSizeField()))) {
@@ -203,7 +212,7 @@ public class NodeJSGapicContext extends GapicContext implements NodeJSContext {
       }
     }
     paramTypesBuilder.append(
-        "@param {?gax.CallOptions} options\n"
+        "@param {gax.CallOptions=} options\n"
             + "  Overrides the default settings for this call, e.g, timeout,\n"
             + "  retries, etc.");
     String paramTypes = paramTypesBuilder.toString();

--- a/src/main/java/com/google/api/codegen/nodejs/NodeJSGapicContext.java
+++ b/src/main/java/com/google/api/codegen/nodejs/NodeJSGapicContext.java
@@ -87,6 +87,28 @@ public class NodeJSGapicContext extends GapicContext implements NodeJSContext {
   }
 
   /**
+   * The name for the module for this vkit module.
+   */
+  public String getModuleName(Interface service) {
+    List<String> names = Splitter.on(".").splitToList(service.getFullName());
+    if (names.size() >= 3) {
+      return lowerUnderscoreToLowerCamel(
+          names.get(names.size() - 3) + "_" + names.get(names.size() - 2));
+    } else if (names.size() >= 2) {
+      return names.get(names.size() - 2);
+    }
+    return upperCamelToLowerCamel(service.getSimpleName());
+  }
+
+  /**
+   * Returns the major version part in the API namespace.
+   */
+  public String getApiVersion(Interface service) {
+    List<String> names = Splitter.on(".").splitToList(service.getFullName());
+    return names.get(names.size() - 2);
+  }
+
+  /**
    * Returns type information for a field in JSDoc style.
    */
   private String fieldTypeCardinalityComment(Field field) {

--- a/src/main/java/com/google/api/codegen/nodejs/NodeJSUtils.java
+++ b/src/main/java/com/google/api/codegen/nodejs/NodeJSUtils.java
@@ -1,0 +1,30 @@
+/* Copyright 2016 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.nodejs;
+
+import com.google.api.codegen.ApiConfig;
+import com.google.common.base.Strings;
+
+public class NodeJSUtils {
+  /**
+   * Returns true if the current API is a part of gcloud (i.e. cloud API).
+   * This can be known if the package name configuration is in the pattern
+   * of "@google-cloud/(API_NAME)".
+   */
+  public static boolean isGcloud(ApiConfig config) {
+    String packageName = config.getPackageName();
+    return !Strings.isNullOrEmpty(packageName) && packageName.startsWith("@google-cloud/");
+  }
+}

--- a/src/main/resources/com/google/api/codegen/nodejs/main.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/main.snip
@@ -4,6 +4,8 @@
 
 @snippet generateBody(service)
   {@licenseSection(service)}
+  /* TODO: introduce line-wrapping so that it never exceeds the limit. */
+  /* jscs: disable maximumLineLength */
   'use strict';
 
   {@importSection(service)}
@@ -47,12 +49,12 @@
 
 @private serviceClass(service)
   @let path_templates = {@pathTemplateSection(service)}, \
-       documentation = context.defaultComments(service)
+       apiName = context.getApiWrapperName(service)
     {@constantSection(service)}
 
-    {@constructor(documentation, service)}
+    {@constructor(service)}
     @if path_templates
-    
+
       // Path templates
       {@path_templates}
     @end
@@ -75,15 +77,32 @@
      */
 
     {@serviceMethodsSection(service)}
+
+    module.exports = function build(gaxGrpc) {
+      @if context.isGcloud
+        var grpcClient = gaxGrpc.load([{
+          root: require('google-proto-files')('..'),
+          file: '{@service.getFile.getLocation.getDisplayString}'
+        }]);
+      @else
+        var grpcClient = require('{@context.grpcClientName(service)}').client;
+      @end
+      var built = grpcClient.{@context.getNamespace(service)};
+
+      built.{@context.upperCamelToLowerCamel(apiName)} = function(opts) {
+        return new {@apiName}(gaxGrpc, grpcClient, opts);
+      };
+      return built;
+    };
+    module.exports.SERVICE_ADDRESS = SERVICE_ADDRESS;
+    module.exports.ALL_SCOPES = ALL_SCOPES;
   @end
 @end
 
 @private constantSection(service)
   @let ifaceConfig = context.getApiConfig.getInterfaceConfig(service)
-    /** The default address of the service. */
     var SERVICE_ADDRESS = '{@context.getServiceConfig.getServiceAddress(service)}';
 
-    /** The default port of the service. */
     var DEFAULT_SERVICE_PORT = {@context.getServiceConfig.getServicePort()};
 
     var CODE_GEN_NAME_VERSION = 'gapic/0.1.0';
@@ -105,6 +124,28 @@
         @end
       };
     @end
+    @if context.messages.filterBundlingMethods(ifaceConfig, context.getNonStreamingMethods(service))
+
+      var BUNDLE_DESCRIPTORS = {
+        @join method : context.messages.filterBundlingMethods(ifaceConfig, context.getNonStreamingMethods(service)) on {@", "}.add(BREAK)
+          @let bundling = ifaceConfig.getMethodConfig(method).getBundling()
+            '{@methodName(method)}': new gax.BundleDescriptor(
+                '{@bundling.getBundledField().getSimpleName()}',
+                [
+                  @join fieldSelector : bundling.getDiscriminatorFields() on {@", "}.add(BREAK)
+                    '{@fieldSelector.getParamName}'
+                  @end
+                ],
+                @if bundling.hasSubresponseField()
+                  '{@bundling.getSubresponseField().getSimpleName()}',
+                @else
+                  null,
+                @end
+                {@context.getByteLengthFunction(bundling.getBundledField().getType())})
+          @end
+        @end
+      };
+    @end
 
     /**
      * The scopes needed to make gRPC calls to all of the methods defined in
@@ -120,7 +161,7 @@
 
 @private constructDefaults(service)
   @let ifaceConfig = context.getApiConfig.getInterfaceConfig(service)
-    var defaults = gax.constructSettingsGrpc(
+    var defaults = gaxGrpc.constructSettings(
         '{@service.getFullName}',
         configData,
         clientConfig,
@@ -131,90 +172,50 @@
           null,
         @end
         @if context.messages.filterBundlingMethods(ifaceConfig, context.getNonStreamingMethods(service))
-          bundleDescriptors,
+          BUNDLE_DESCRIPTORS,
         @else
           null,
         @end
-        {'x-goog-api-client': googleApiClient},
-        opts.grpc);
+        {'x-goog-api-client': googleApiClient});
   @end
 @end
 
-@private constructor(documentation, service)
+@private constructor(service)
   @let ifaceConfig = context.getApiConfig.getInterfaceConfig(service), \
-       serviceName = context.getApiWrapperName(service)
+       serviceName = context.getApiWrapperName(service), \
+       documentation = context.defaultComments(service)
     /**
      @if documentation
        {@comments(documentation)}
        *
      @end
      * @@class
-     * @@param {?Object} opts - The optional parameters.
-     * @@param {String} opts.servicePath
+     * @@param {Object=} opts - The optional parameters.
+     * @@param {String=} opts.servicePath
      *   The domain name of the API remote host.
-     * @@param {number} opts.port
+     * @@param {number=} opts.port
      *   The port on which to connect to the remote host.
-     * @@param {Function} opts.getCredentials
-     *   Custom function to obtain the credentials.
-     * @@param {grpc.ClientCredentials} opts.sslCreds
+     * @@param {grpc.ClientCredentials=} opts.sslCreds
      *   A ClientCredentials for use with an SSL-enabled channel.
-     * @@param {Object} opts.grpc
-     *   When specified, this is used as the grpc module. Otherwise
-     *   the grpc package will be loaded from the dependency (typically
-     *   the one within 'google-gax' will be loaded). This will be useful
-     *   to share channels among multiple APIs.
-     * @@param {Object} opts.clientConfig
+     * @@param {Object=} opts.clientConfig
      *   The customized config to build the call settings. See
      *   {@@link gax.constructSettings} for the format.
-     * @@param {number} opts.timeout
+     * @@param {number=} opts.timeout
      *   The default timeout, in seconds, for calls made through this client.
-     * @@param {number} opts.appName
+     * @@param {number=} opts.appName
      *   The codename of the calling service.
-     * @@param {String} opts.appVersion
+     * @@param {String=} opts.appVersion
      *   The version of the calling service.
      */
-    function {@serviceName}(opts) {
+    function {@serviceName}(gaxGrpc, grpcClient, opts) {
       opts = opts || {};
       var servicePath = opts.servicePath || SERVICE_ADDRESS;
       var port = opts.port || DEFAULT_SERVICE_PORT;
-      var getCredentials = opts.getCredentials || null;
       var sslCreds = opts.sslCreds || null;
-      var scopes = opts.scopes || ALL_SCOPES;
       var clientConfig = opts.clientConfig || {};
       var timeout = opts.timeout || DEFAULT_TIMEOUT;
       var appName = opts.appName || 'gax';
       var appVersion = opts.appVersion || gax.Version;
-
-      @if context.isGcloud
-        var grpcClient = gax.loadGrpc(opts.grpc, [{
-          root: require('google-proto-files')('..'),
-          file: '{@service.getFile.getLocation.getDisplayString}'
-        }]);
-      @else
-        var grpcClient = require('{@context.grpcClientName(service)}').client;
-      @end
-      @if context.messages.filterBundlingMethods(ifaceConfig, context.getNonStreamingMethods(service))
-
-        var bundleDescriptors = {
-          @join method : context.messages.filterBundlingMethods(ifaceConfig, context.getNonStreamingMethods(service)) on {@", "}.add(BREAK)
-            @let bundling = ifaceConfig.getMethodConfig(method).getBundling()
-              '{@methodName(method)}': new gax.BundleDescriptor(
-                  '{@bundling.getBundledField().getSimpleName()}',
-                  [
-                    @join fieldSelector : bundling.getDiscriminatorFields() on {@", "}.add(BREAK)
-                      '{@fieldSelector.getParamName}'
-                    @end
-                  ],
-                  @if bundling.hasSubresponseField()
-                    '{@bundling.getSubresponseField().getSimpleName()}',
-                  @else
-                    null,
-                  @end
-                  {@context.getByteLengthFunction(bundling.getBundledField().getType())})
-            @end
-          @end
-        };
-      @end
 
       var googleApiClient = [
         appName + '/' + appVersion,
@@ -223,14 +224,11 @@
 
       {@constructDefaults(service)}
 
-      this.stub = gax.createStub(
+      var stub = gaxGrpc.createStub(
           servicePath,
           port,
           grpcClient.{@service.getFullName},
-          {'getCredentials': getCredentials,
-           'grpc': opts.grpc,
-           'sslCreds': sslCreds,
-           'scopes': scopes});
+          {sslCreds: sslCreds});
       var methods = [
         @join method : context.getNonStreamingMethods(service) on {@","}.add(BREAK)
           '{@methodName(method)}'
@@ -238,11 +236,10 @@
       ];
       methods.forEach(function(methodName) {
         this['_' + methodName] = gax.createApiCall(
-            this.stub.then(function(stub) { return stub[methodName].bind(stub); }),
+            stub.then(function(stub) { return stub[methodName].bind(stub); }),
             defaults[methodName]);
       }.bind(this));
-    };
-    exports.{@serviceName} = {@serviceName};
+    }
   @end
 @end
 
@@ -331,12 +328,6 @@
   @end
 @end
 
-@private callableConstructor(method)
-  api_call = Google::Gax.create_api_call(
-    @@stub.method(:{@context.upperCamelToLowerUnderscore(method.getSimpleName())}), settings)
-  api_call.call(req, **@@headers)
-@end
-
 @private methodName(method)
   {@context.upperCamelToLowerCamel(method.getSimpleName())}
 @end
@@ -359,14 +350,14 @@
           {@requiredParameterDefs(requiredParams)},
         @end
         @if optionalParams
-          'otherArgs': [Object, {}],
+          otherArgs: [Object, {}],
         @end
-        'options': [gax.CallOptions],
-        'callback': [Function]
+        options: [gax.CallOptions],
+        callback: [Function]
       }, arguments);
       var req = {
         @join field : requiredParams on ",".add(BREAK)
-          '{@field.getSimpleName}': args.{@fieldParameterName(field)}
+          {@field.getSimpleName}: args.{@fieldParameterName(field)}
         @end
       };
       @join field : optionalParams
@@ -387,6 +378,6 @@
 
 @private requiredParameterDefs(params)
   @join field : params on ",".add(BREAK)
-    '{@fieldParameterName(field)}': {@context.getFieldType(field)}
+    {@fieldParameterName(field)}: {@context.getFieldType(field)}
   @end
 @end

--- a/src/main/resources/com/google/api/codegen/nodejs/main.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/main.snip
@@ -44,6 +44,7 @@
 @private importSection(service)
   var arguejs = require('arguejs');
   var configData = require('./{@context.upperCamelToLowerUnderscore(service.getSimpleName)}_client_config');
+  var extend = require('extend');
   var gax = require('google-gax');
 @end
 
@@ -78,7 +79,11 @@
 
     {@serviceMethodsSection(service)}
 
-    module.exports = function build(gaxGrpc) {
+    function {@apiName}Builder(gaxGrpc) {
+      if (!(this instanceof {@apiName}Builder)) {
+        return new {@apiName}Builder(gaxGrpc);
+      }
+
       @if context.isGcloud
         var grpcClient = gaxGrpc.load([{
           root: require('google-proto-files')('..'),
@@ -87,13 +92,34 @@
       @else
         var grpcClient = require('{@context.grpcClientName(service)}').client;
       @end
-      var built = grpcClient.{@context.getNamespace(service)};
+      extend(this, grpcClient.{@context.getNamespace(service)});
 
-      built.{@context.upperCamelToLowerCamel(apiName)} = function(opts) {
+      /**
+       * Build a new instance of {@@link {@apiName}}.
+       *
+       * @@param {Object=} opts - The optional parameters.
+       * @@param {String=} opts.servicePath
+       *   The domain name of the API remote host.
+       * @@param {number=} opts.port
+       *   The port on which to connect to the remote host.
+       * @@param {grpc.ClientCredentials=} opts.sslCreds
+       *   A ClientCredentials for use with an SSL-enabled channel.
+       * @@param {Object=} opts.clientConfig
+       *   The customized config to build the call settings. See
+       *   {@@link gax.constructSettings} for the format.
+       * @@param {number=} opts.timeout
+       *   The default timeout, in seconds, for calls made through this client.
+       * @@param {number=} opts.appName
+       *   The codename of the calling service.
+       * @@param {String=} opts.appVersion
+       *   The version of the calling service.
+       */
+      this.{@context.upperCamelToLowerCamel(apiName)} = function(opts) {
         return new {@apiName}(gaxGrpc, grpcClient, opts);
       };
-      return built;
+      extend(this.{@context.upperCamelToLowerCamel(apiName)}, {@apiName});
     };
+    module.exports = {@apiName}Builder;
     module.exports.SERVICE_ADDRESS = SERVICE_ADDRESS;
     module.exports.ALL_SCOPES = ALL_SCOPES;
   @end
@@ -180,6 +206,11 @@
   @end
 @end
 
+@private initExplanations(service)
+  This will be created through a builder function within the result of module initialization.
+  See the following examples for the
+@end
+
 @private constructor(service)
   @let ifaceConfig = context.getApiConfig.getInterfaceConfig(service), \
        serviceName = context.getApiWrapperName(service), \
@@ -189,23 +220,26 @@
        {@comments(documentation)}
        *
      @end
+     * This will be created through a builder function which can be obtained by the module.
+     * See the following example of how to initialize the module and how to access to the builder.
+     * @see {@@link {@serviceName}Builder}
+     *
+     * @@example
+     @let moduleName = context.getModuleName(service)
+       @if context.isGcloud
+       *   var {@moduleName} = require('{@context.getApiConfig().getPackageName()}').{@context.getApiVersion(service)}({
+       *     // optional auth parameters.
+       *   });
+       @else
+       *   var {@moduleName} = require('{@context.getApiConfig().getPackageName()}')({
+       *     // optional auth parameters.
+       *   });
+       @end
+
+       *   var api = {@moduleName}.{@context.upperCamelToLowerCamel(serviceName)}();
+     @end
+     *
      * @@class
-     * @@param {Object=} opts - The optional parameters.
-     * @@param {String=} opts.servicePath
-     *   The domain name of the API remote host.
-     * @@param {number=} opts.port
-     *   The port on which to connect to the remote host.
-     * @@param {grpc.ClientCredentials=} opts.sslCreds
-     *   A ClientCredentials for use with an SSL-enabled channel.
-     * @@param {Object=} opts.clientConfig
-     *   The customized config to build the call settings. See
-     *   {@@link gax.constructSettings} for the format.
-     * @@param {number=} opts.timeout
-     *   The default timeout, in seconds, for calls made through this client.
-     * @@param {number=} opts.appName
-     *   The codename of the calling service.
-     * @@param {String=} opts.appVersion
-     *   The version of the calling service.
      */
     function {@serviceName}(gaxGrpc, grpcClient, opts) {
       opts = opts || {};

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_json_library.baseline
@@ -1,4 +1,4 @@
-============== file: src/library_service_client_config.json ==============
+============== file: src/v1/library_service_client_config.json ==============
 {
   "interfaces": {
     "google.example.library.v1.LibraryService": {

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_main_library.baseline
@@ -800,10 +800,10 @@ LibraryServiceApi.prototype.updateBookIndex = function updateBookIndex() {
  *   projects/{project}/zones/{zone}/disks/{disk}.
  * @param {String} tag
  *   REQUIRED: The tag to add.
- * @param {?gax.CallOptions} options
+ * @param {gax.CallOptions=} options
  *   Overrides the default settings for this call, e.g, timeout,
  *   retries, etc.
- * @param {?APICallback<google.tagger.v1.AddTagResponse>} callback
+ * @param {APICallback<google.tagger.v1.AddTagResponse>=} callback
  *   The function which will be called with the result of the API call.
  * @returns {gax.EventEmitter} - the event emitter to handle the call
  *   status.
@@ -811,14 +811,14 @@ LibraryServiceApi.prototype.updateBookIndex = function updateBookIndex() {
  */
 LibraryServiceApi.prototype.addTag = function addTag() {
   var args = arguejs({
-    'resource': String,
-    'tag': String,
-    'options': [gax.CallOptions],
-    'callback': [Function]
+    resource: String,
+    tag: String,
+    options: [gax.CallOptions],
+    callback: [Function]
   }, arguments);
   var req = {
-    'resource': args.resource,
-    'tag': args.tag
+    resource: args.resource,
+    tag: args.tag
   };
   return this._addTag(req, args.options, args.callback);
 };
@@ -834,6 +834,6 @@ module.exports = function build(gaxGrpc) {
     return new LibraryServiceApi(gaxGrpc, grpcClient, opts);
   };
   return built;
-}
+};
 module.exports.SERVICE_ADDRESS = SERVICE_ADDRESS;
 module.exports.ALL_SCOPES = ALL_SCOPES;

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_main_library.baseline
@@ -30,6 +30,7 @@
 
 var arguejs = require('arguejs');
 var configData = require('./library_service_client_config');
+var extend = require('extend');
 var gax = require('google-gax');
 
 var SERVICE_ADDRESS = 'library-example.googleapis.com';
@@ -89,23 +90,17 @@ var ALL_SCOPES = [
  * Check out [cloud docs!](https://cloud.google.com/library/example/link).
  * This is [not a cloud link](http://www.google.com).
  *
+ * This will be created through a builder function which can be obtained by the module.
+ * See the following example of how to initialize the module and how to access to the builder.
+ * @ee {@link LibraryServiceApiBuilder}
+ *
+ * @example
+ *   var libraryV1 = require('@google-cloud/library').v1({
+ *     // optional auth parameters.
+ *   });
+ *   var api = libraryV1.libraryServiceApi();
+ *
  * @class
- * @param {Object=} opts - The optional parameters.
- * @param {String=} opts.servicePath
- *   The domain name of the API remote host.
- * @param {number=} opts.port
- *   The port on which to connect to the remote host.
- * @param {grpc.ClientCredentials=} opts.sslCreds
- *   A ClientCredentials for use with an SSL-enabled channel.
- * @param {Object=} opts.clientConfig
- *   The customized config to build the call settings. See
- *   {@link gax.constructSettings} for the format.
- * @param {number=} opts.timeout
- *   The default timeout, in seconds, for calls made through this client.
- * @param {number=} opts.appName
- *   The codename of the calling service.
- * @param {String=} opts.appVersion
- *   The version of the calling service.
  */
 function LibraryServiceApi(gaxGrpc, grpcClient, opts) {
   opts = opts || {};
@@ -823,17 +818,42 @@ LibraryServiceApi.prototype.addTag = function addTag() {
   return this._addTag(req, args.options, args.callback);
 };
 
-module.exports = function build(gaxGrpc) {
+function LibraryServiceApiBuilder(gaxGrpc) {
+  if (!(this instanceof LibraryServiceApiBuilder)) {
+    return new LibraryServiceApiBuilder(gaxGrpc);
+  }
+
   var grpcClient = gaxGrpc.load([{
     root: require('google-proto-files')('..'),
     file: 'library.proto'
   }]);
-  var built = grpcClient.google.example.library.v1;
+  extend(this, grpcClient.google.example.library.v1);
 
-  built.libraryServiceApi = function(opts) {
+  /**
+   * Build a new instance of {@link LibraryServiceApi}.
+   *
+   * @param {Object=} opts - The optional parameters.
+   * @param {String=} opts.servicePath
+   *   The domain name of the API remote host.
+   * @param {number=} opts.port
+   *   The port on which to connect to the remote host.
+   * @param {grpc.ClientCredentials=} opts.sslCreds
+   *   A ClientCredentials for use with an SSL-enabled channel.
+   * @param {Object=} opts.clientConfig
+   *   The customized config to build the call settings. See
+   *   {@link gax.constructSettings} for the format.
+   * @param {number=} opts.timeout
+   *   The default timeout, in seconds, for calls made through this client.
+   * @param {number=} opts.appName
+   *   The codename of the calling service.
+   * @param {String=} opts.appVersion
+   *   The version of the calling service.
+   */
+  this.libraryServiceApi = function(opts) {
     return new LibraryServiceApi(gaxGrpc, grpcClient, opts);
   };
-  return built;
+  extend(this.libraryServiceApi, LibraryServiceApi);
 };
+module.exports = LibraryServiceApiBuilder;
 module.exports.SERVICE_ADDRESS = SERVICE_ADDRESS;
 module.exports.ALL_SCOPES = ALL_SCOPES;

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_main_library.baseline
@@ -1,4 +1,4 @@
-============== file: src/library_service_api.js ==============
+============== file: src/v1/library_service_api.js ==============
 /*
  * Copyright 2016 Google Inc. All rights reserved.
  *
@@ -24,16 +24,16 @@
  * The only allowed edits are to method and file documentation. A 3-way
  * merge preserves those additions if the generated source changes.
  */
+/* TODO: introduce line-wrapping so that it never exceeds the limit. */
+/* jscs: disable maximumLineLength */
 'use strict';
 
 var arguejs = require('arguejs');
 var configData = require('./library_service_client_config');
 var gax = require('google-gax');
 
-/** The default address of the service. */
 var SERVICE_ADDRESS = 'library-example.googleapis.com';
 
-/** The default port of the service. */
 var DEFAULT_SERVICE_PORT = 443;
 
 var CODE_GEN_NAME_VERSION = 'gapic/0.1.0';
@@ -53,6 +53,17 @@ var PAGE_DESCRIPTORS = {
       'page_token',
       'next_page_token',
       'strings')
+};
+
+var BUNDLE_DESCRIPTORS = {
+  'publishSeries': new gax.BundleDescriptor(
+      'books',
+      [
+        'edition',
+        'shelf.name'
+      ],
+      'book_names',
+      gax.createByteLengthFunction(grpcClient.google.example.library.v1.Book))
 };
 
 /**
@@ -79,81 +90,52 @@ var ALL_SCOPES = [
  * This is [not a cloud link](http://www.google.com).
  *
  * @class
- * @param {?Object} opts - The optional parameters.
- * @param {String} opts.servicePath
+ * @param {Object=} opts - The optional parameters.
+ * @param {String=} opts.servicePath
  *   The domain name of the API remote host.
- * @param {number} opts.port
+ * @param {number=} opts.port
  *   The port on which to connect to the remote host.
- * @param {Function} opts.getCredentials
- *   Custom function to obtain the credentials.
- * @param {grpc.ClientCredentials} opts.sslCreds
+ * @param {grpc.ClientCredentials=} opts.sslCreds
  *   A ClientCredentials for use with an SSL-enabled channel.
- * @param {Object} opts.grpc
- *   When specified, this is used as the grpc module. Otherwise
- *   the grpc package will be loaded from the dependency (typically
- *   the one within 'google-gax' will be loaded). This will be useful
- *   to share channels among multiple APIs.
- * @param {Object} opts.clientConfig
+ * @param {Object=} opts.clientConfig
  *   The customized config to build the call settings. See
  *   {@link gax.constructSettings} for the format.
- * @param {number} opts.timeout
+ * @param {number=} opts.timeout
  *   The default timeout, in seconds, for calls made through this client.
- * @param {number} opts.appName
+ * @param {number=} opts.appName
  *   The codename of the calling service.
- * @param {String} opts.appVersion
+ * @param {String=} opts.appVersion
  *   The version of the calling service.
  */
-function LibraryServiceApi(opts) {
+function LibraryServiceApi(gaxGrpc, grpcClient, opts) {
   opts = opts || {};
   var servicePath = opts.servicePath || SERVICE_ADDRESS;
   var port = opts.port || DEFAULT_SERVICE_PORT;
-  var getCredentials = opts.getCredentials || null;
   var sslCreds = opts.sslCreds || null;
-  var scopes = opts.scopes || ALL_SCOPES;
   var clientConfig = opts.clientConfig || {};
   var timeout = opts.timeout || DEFAULT_TIMEOUT;
   var appName = opts.appName || 'gax';
   var appVersion = opts.appVersion || gax.Version;
-
-  var grpcClient = gax.loadGrpc(opts.grpc, [{
-    root: require('google-proto-files')('..'),
-    file: 'library.proto'
-  }]);
-
-  var bundleDescriptors = {
-    'publishSeries': new gax.BundleDescriptor(
-        'books',
-        [
-          'edition',
-          'shelf.name'
-        ],
-        'book_names',
-        gax.createByteLengthFunction(grpcClient.google.example.library.v1.Book))
-  };
 
   var googleApiClient = [
     appName + '/' + appVersion,
     CODE_GEN_NAME_VERSION,
     'nodejs/' + process.version].join(' ');
 
-  var defaults = gax.constructSettingsGrpc(
+  var defaults = gaxGrpc.constructSettings(
       'google.example.library.v1.LibraryService',
       configData,
       clientConfig,
       timeout,
       PAGE_DESCRIPTORS,
-      bundleDescriptors,
-      {'x-goog-api-client': googleApiClient},
-      opts.grpc);
+      BUNDLE_DESCRIPTORS,
+      {'x-goog-api-client': googleApiClient});
 
-  this.stub = gax.createStub(
+  var stub = gaxGrpc.createStub(
       servicePath,
       port,
       grpcClient.google.example.library.v1.LibraryService,
-      {'getCredentials': getCredentials,
-       'grpc': opts.grpc,
-       'sslCreds': sslCreds,
-       'scopes': scopes});
+      {sslCreds: sslCreds});
   var methods = [
     'createShelf',
     'getShelf',
@@ -175,11 +157,10 @@ function LibraryServiceApi(opts) {
   ];
   methods.forEach(function(methodName) {
     this['_' + methodName] = gax.createApiCall(
-        this.stub.then(function(stub) { return stub[methodName].bind(stub); }),
+        stub.then(function(stub) { return stub[methodName].bind(stub); }),
         defaults[methodName]);
   }.bind(this));
-};
-exports.LibraryServiceApi = LibraryServiceApi;
+}
 
 // Path templates
 
@@ -308,10 +289,10 @@ LibraryServiceApi.matchBookFromArchivedBookName =
  *
  * @param {google.example.library.v1.Shelf} shelf
  *   The shelf to create.
- * @param {?gax.CallOptions} options
+ * @param {gax.CallOptions=} options
  *   Overrides the default settings for this call, e.g, timeout,
  *   retries, etc.
- * @param {?APICallback<google.example.library.v1.Shelf>} callback
+ * @param {APICallback<google.example.library.v1.Shelf>=} callback
  *   The function which will be called with the result of the API call.
  * @returns {gax.EventEmitter} - the event emitter to handle the call
  *   status.
@@ -319,12 +300,12 @@ LibraryServiceApi.matchBookFromArchivedBookName =
  */
 LibraryServiceApi.prototype.createShelf = function createShelf() {
   var args = arguejs({
-    'shelf': Object,
-    'options': [gax.CallOptions],
-    'callback': [Function]
+    shelf: Object,
+    options: [gax.CallOptions],
+    callback: [Function]
   }, arguments);
   var req = {
-    'shelf': args.shelf
+    shelf: args.shelf
   };
   return this._createShelf(req, args.options, args.callback);
 };
@@ -336,14 +317,14 @@ LibraryServiceApi.prototype.createShelf = function createShelf() {
  *   The name of the shelf to retrieve.
  * @param {String} options_
  *   To test 'options' parameter name conflict.
- * @param {?Object} otherArgs
- * @param {google.example.library.v1.SomeMessage} otherArgs.message
+ * @param {Object=} otherArgs
+ * @param {google.example.library.v1.SomeMessage=} otherArgs.message
  *   Field to verify that message-type query parameter gets flattened.
- * @param {google.example.library.v1.StringBuilder} otherArgs.stringBuilder
- * @param {?gax.CallOptions} options
+ * @param {google.example.library.v1.StringBuilder=} otherArgs.stringBuilder
+ * @param {gax.CallOptions=} options
  *   Overrides the default settings for this call, e.g, timeout,
  *   retries, etc.
- * @param {?APICallback<google.example.library.v1.Shelf>} callback
+ * @param {APICallback<google.example.library.v1.Shelf>=} callback
  *   The function which will be called with the result of the API call.
  * @returns {gax.EventEmitter} - the event emitter to handle the call
  *   status.
@@ -351,15 +332,15 @@ LibraryServiceApi.prototype.createShelf = function createShelf() {
  */
 LibraryServiceApi.prototype.getShelf = function getShelf() {
   var args = arguejs({
-    'name': String,
-    'options_': String,
-    'otherArgs': [Object, {}],
-    'options': [gax.CallOptions],
-    'callback': [Function]
+    name: String,
+    options_: String,
+    otherArgs: [Object, {}],
+    options: [gax.CallOptions],
+    callback: [Function]
   }, arguments);
   var req = {
-    'name': args.name,
-    'options': args.options_
+    name: args.name,
+    options: args.options_
   };
   if ('message' in args.otherArgs) {
     req.message = args.otherArgs.message;
@@ -373,7 +354,7 @@ LibraryServiceApi.prototype.getShelf = function getShelf() {
 /**
  * Lists shelves.
  *
- * @param {?gax.CallOptions} options
+ * @param {gax.CallOptions=} options
  *   Overrides the default settings for this call, e.g, timeout,
  *   retries, etc.
  * @returns {Stream<google.example.library.v1.Shelf>}
@@ -384,8 +365,8 @@ LibraryServiceApi.prototype.getShelf = function getShelf() {
  */
 LibraryServiceApi.prototype.listShelves = function listShelves() {
   var args = arguejs({
-    'options': [gax.CallOptions],
-    'callback': [Function]
+    options: [gax.CallOptions],
+    callback: [Function]
   }, arguments);
   var req = {
   };
@@ -397,10 +378,10 @@ LibraryServiceApi.prototype.listShelves = function listShelves() {
  *
  * @param {String} name
  *   The name of the shelf to delete.
- * @param {?gax.CallOptions} options
+ * @param {gax.CallOptions=} options
  *   Overrides the default settings for this call, e.g, timeout,
  *   retries, etc.
- * @param {?EmptyCallback} callback
+ * @param {EmptyCallback=} callback
  *   The function which will be called with the result of the API call.
  * @returns {gax.EventEmitter} - the event emitter to handle the call
  *   status.
@@ -408,12 +389,12 @@ LibraryServiceApi.prototype.listShelves = function listShelves() {
  */
 LibraryServiceApi.prototype.deleteShelf = function deleteShelf() {
   var args = arguejs({
-    'name': String,
-    'options': [gax.CallOptions],
-    'callback': [Function]
+    name: String,
+    options: [gax.CallOptions],
+    callback: [Function]
   }, arguments);
   var req = {
-    'name': args.name
+    name: args.name
   };
   return this._deleteShelf(req, args.options, args.callback);
 };
@@ -427,10 +408,10 @@ LibraryServiceApi.prototype.deleteShelf = function deleteShelf() {
  *   The name of the shelf we're adding books to.
  * @param {String} otherShelfName
  *   The name of the shelf we're removing books from and deleting.
- * @param {?gax.CallOptions} options
+ * @param {gax.CallOptions=} options
  *   Overrides the default settings for this call, e.g, timeout,
  *   retries, etc.
- * @param {?APICallback<google.example.library.v1.Shelf>} callback
+ * @param {APICallback<google.example.library.v1.Shelf>=} callback
  *   The function which will be called with the result of the API call.
  * @returns {gax.EventEmitter} - the event emitter to handle the call
  *   status.
@@ -438,14 +419,14 @@ LibraryServiceApi.prototype.deleteShelf = function deleteShelf() {
  */
 LibraryServiceApi.prototype.mergeShelves = function mergeShelves() {
   var args = arguejs({
-    'name': String,
-    'otherShelfName': String,
-    'options': [gax.CallOptions],
-    'callback': [Function]
+    name: String,
+    otherShelfName: String,
+    options: [gax.CallOptions],
+    callback: [Function]
   }, arguments);
   var req = {
-    'name': args.name,
-    'other_shelf_name': args.otherShelfName
+    name: args.name,
+    other_shelf_name: args.otherShelfName
   };
   return this._mergeShelves(req, args.options, args.callback);
 };
@@ -457,10 +438,10 @@ LibraryServiceApi.prototype.mergeShelves = function mergeShelves() {
  *   The name of the shelf in which the book is created.
  * @param {google.example.library.v1.Book} book
  *   The book to create.
- * @param {?gax.CallOptions} options
+ * @param {gax.CallOptions=} options
  *   Overrides the default settings for this call, e.g, timeout,
  *   retries, etc.
- * @param {?APICallback<google.example.library.v1.Book>} callback
+ * @param {APICallback<google.example.library.v1.Book>=} callback
  *   The function which will be called with the result of the API call.
  * @returns {gax.EventEmitter} - the event emitter to handle the call
  *   status.
@@ -468,14 +449,14 @@ LibraryServiceApi.prototype.mergeShelves = function mergeShelves() {
  */
 LibraryServiceApi.prototype.createBook = function createBook() {
   var args = arguejs({
-    'name': String,
-    'book': Object,
-    'options': [gax.CallOptions],
-    'callback': [Function]
+    name: String,
+    book: Object,
+    options: [gax.CallOptions],
+    callback: [Function]
   }, arguments);
   var req = {
-    'name': args.name,
-    'book': args.book
+    name: args.name,
+    book: args.book
   };
   return this._createBook(req, args.options, args.callback);
 };
@@ -487,13 +468,13 @@ LibraryServiceApi.prototype.createBook = function createBook() {
  *   The shelf in which the series is created.
  * @param {google.example.library.v1.Book[]} books
  *   The books to publish in the series.
- * @param {?Object} otherArgs
- * @param {number} otherArgs.edition
+ * @param {Object=} otherArgs
+ * @param {number=} otherArgs.edition
  *   The edition of the series
- * @param {?gax.CallOptions} options
+ * @param {gax.CallOptions=} options
  *   Overrides the default settings for this call, e.g, timeout,
  *   retries, etc.
- * @param {?APICallback<google.example.library.v1.PublishSeriesResponse>} callback
+ * @param {APICallback<google.example.library.v1.PublishSeriesResponse>=} callback
  *   The function which will be called with the result of the API call.
  * @returns {gax.BundleEventEmitter} - the event emitter to handle the call
  *   status. When isBundling: false is specified in the options, it still returns
@@ -503,15 +484,15 @@ LibraryServiceApi.prototype.createBook = function createBook() {
  */
 LibraryServiceApi.prototype.publishSeries = function publishSeries() {
   var args = arguejs({
-    'shelf': Object,
-    'books': Array,
-    'otherArgs': [Object, {}],
-    'options': [gax.CallOptions],
-    'callback': [Function]
+    shelf: Object,
+    books: Array,
+    otherArgs: [Object, {}],
+    options: [gax.CallOptions],
+    callback: [Function]
   }, arguments);
   var req = {
-    'shelf': args.shelf,
-    'books': args.books
+    shelf: args.shelf,
+    books: args.books
   };
   if ('edition' in args.otherArgs) {
     req.edition = args.otherArgs.edition;
@@ -524,10 +505,10 @@ LibraryServiceApi.prototype.publishSeries = function publishSeries() {
  *
  * @param {String} name
  *   The name of the book to retrieve.
- * @param {?gax.CallOptions} options
+ * @param {gax.CallOptions=} options
  *   Overrides the default settings for this call, e.g, timeout,
  *   retries, etc.
- * @param {?APICallback<google.example.library.v1.Book>} callback
+ * @param {APICallback<google.example.library.v1.Book>=} callback
  *   The function which will be called with the result of the API call.
  * @returns {gax.EventEmitter} - the event emitter to handle the call
  *   status.
@@ -535,12 +516,12 @@ LibraryServiceApi.prototype.publishSeries = function publishSeries() {
  */
 LibraryServiceApi.prototype.getBook = function getBook() {
   var args = arguejs({
-    'name': String,
-    'options': [gax.CallOptions],
-    'callback': [Function]
+    name: String,
+    options: [gax.CallOptions],
+    callback: [Function]
   }, arguments);
   var req = {
-    'name': args.name
+    name: args.name
   };
   return this._getBook(req, args.options, args.callback);
 };
@@ -550,16 +531,16 @@ LibraryServiceApi.prototype.getBook = function getBook() {
  *
  * @param {String} name
  *   The name of the shelf whose books we'd like to list.
- * @param {?Object} otherArgs
- * @param {number} otherArgs.pageSize
+ * @param {Object=} otherArgs
+ * @param {number=} otherArgs.pageSize
  *   The maximum number of resources contained in the underlying API
  *   response. If page streaming is performed per-resource, this
  *   parameter does not affect the return value. If page streaming is
  *   performed per-page, this determines the maximum number of
  *   resources in a page.
- * @param {String} otherArgs.filter
+ * @param {String=} otherArgs.filter
  *   To test python built-in wrapping.
- * @param {?gax.CallOptions} options
+ * @param {gax.CallOptions=} options
  *   Overrides the default settings for this call, e.g, timeout,
  *   retries, etc.
  * @returns {Stream<google.example.library.v1.Book>}
@@ -570,13 +551,13 @@ LibraryServiceApi.prototype.getBook = function getBook() {
  */
 LibraryServiceApi.prototype.listBooks = function listBooks() {
   var args = arguejs({
-    'name': String,
-    'otherArgs': [Object, {}],
-    'options': [gax.CallOptions],
-    'callback': [Function]
+    name: String,
+    otherArgs: [Object, {}],
+    options: [gax.CallOptions],
+    callback: [Function]
   }, arguments);
   var req = {
-    'name': args.name
+    name: args.name
   };
   if ('pageSize' in args.otherArgs) {
     req.page_size = args.otherArgs.pageSize;
@@ -592,10 +573,10 @@ LibraryServiceApi.prototype.listBooks = function listBooks() {
  *
  * @param {String} name
  *   The name of the book to delete.
- * @param {?gax.CallOptions} options
+ * @param {gax.CallOptions=} options
  *   Overrides the default settings for this call, e.g, timeout,
  *   retries, etc.
- * @param {?EmptyCallback} callback
+ * @param {EmptyCallback=} callback
  *   The function which will be called with the result of the API call.
  * @returns {gax.EventEmitter} - the event emitter to handle the call
  *   status.
@@ -603,12 +584,12 @@ LibraryServiceApi.prototype.listBooks = function listBooks() {
  */
 LibraryServiceApi.prototype.deleteBook = function deleteBook() {
   var args = arguejs({
-    'name': String,
-    'options': [gax.CallOptions],
-    'callback': [Function]
+    name: String,
+    options: [gax.CallOptions],
+    callback: [Function]
   }, arguments);
   var req = {
-    'name': args.name
+    name: args.name
   };
   return this._deleteBook(req, args.options, args.callback);
 };
@@ -620,15 +601,15 @@ LibraryServiceApi.prototype.deleteBook = function deleteBook() {
  *   The name of the book to update.
  * @param {google.example.library.v1.Book} book
  *   The book to update with.
- * @param {?Object} otherArgs
- * @param {google.protobuf.FieldMask} otherArgs.updateMask
+ * @param {Object=} otherArgs
+ * @param {google.protobuf.FieldMask=} otherArgs.updateMask
  *   A field mask to apply, rendered as an HTTP parameter.
- * @param {google.example.library.v1.FieldMask} otherArgs.physicalMask
+ * @param {google.example.library.v1.FieldMask=} otherArgs.physicalMask
  *   To test Python import clash resolution.
- * @param {?gax.CallOptions} options
+ * @param {gax.CallOptions=} options
  *   Overrides the default settings for this call, e.g, timeout,
  *   retries, etc.
- * @param {?APICallback<google.example.library.v1.Book>} callback
+ * @param {APICallback<google.example.library.v1.Book>=} callback
  *   The function which will be called with the result of the API call.
  * @returns {gax.EventEmitter} - the event emitter to handle the call
  *   status.
@@ -636,15 +617,15 @@ LibraryServiceApi.prototype.deleteBook = function deleteBook() {
  */
 LibraryServiceApi.prototype.updateBook = function updateBook() {
   var args = arguejs({
-    'name': String,
-    'book': Object,
-    'otherArgs': [Object, {}],
-    'options': [gax.CallOptions],
-    'callback': [Function]
+    name: String,
+    book: Object,
+    otherArgs: [Object, {}],
+    options: [gax.CallOptions],
+    callback: [Function]
   }, arguments);
   var req = {
-    'name': args.name,
-    'book': args.book
+    name: args.name,
+    book: args.book
   };
   if ('updateMask' in args.otherArgs) {
     req.update_mask = args.otherArgs.updateMask;
@@ -662,10 +643,10 @@ LibraryServiceApi.prototype.updateBook = function updateBook() {
  *   The name of the book to move.
  * @param {String} otherShelfName
  *   The name of the destination shelf.
- * @param {?gax.CallOptions} options
+ * @param {gax.CallOptions=} options
  *   Overrides the default settings for this call, e.g, timeout,
  *   retries, etc.
- * @param {?APICallback<google.example.library.v1.Book>} callback
+ * @param {APICallback<google.example.library.v1.Book>=} callback
  *   The function which will be called with the result of the API call.
  * @returns {gax.EventEmitter} - the event emitter to handle the call
  *   status.
@@ -673,14 +654,14 @@ LibraryServiceApi.prototype.updateBook = function updateBook() {
  */
 LibraryServiceApi.prototype.moveBook = function moveBook() {
   var args = arguejs({
-    'name': String,
-    'otherShelfName': String,
-    'options': [gax.CallOptions],
-    'callback': [Function]
+    name: String,
+    otherShelfName: String,
+    options: [gax.CallOptions],
+    callback: [Function]
   }, arguments);
   var req = {
-    'name': args.name,
-    'other_shelf_name': args.otherShelfName
+    name: args.name,
+    other_shelf_name: args.otherShelfName
   };
   return this._moveBook(req, args.options, args.callback);
 };
@@ -688,15 +669,15 @@ LibraryServiceApi.prototype.moveBook = function moveBook() {
 /**
  * Lists a primitive resource. To test go page streaming.
  *
- * @param {?Object} otherArgs
- * @param {String} otherArgs.name
- * @param {number} otherArgs.pageSize
+ * @param {Object=} otherArgs
+ * @param {String=} otherArgs.name
+ * @param {number=} otherArgs.pageSize
  *   The maximum number of resources contained in the underlying API
  *   response. If page streaming is performed per-resource, this
  *   parameter does not affect the return value. If page streaming is
  *   performed per-page, this determines the maximum number of
  *   resources in a page.
- * @param {?gax.CallOptions} options
+ * @param {gax.CallOptions=} options
  *   Overrides the default settings for this call, e.g, timeout,
  *   retries, etc.
  * @returns {Stream<String>}
@@ -707,9 +688,9 @@ LibraryServiceApi.prototype.moveBook = function moveBook() {
  */
 LibraryServiceApi.prototype.listStrings = function listStrings() {
   var args = arguejs({
-    'otherArgs': [Object, {}],
-    'options': [gax.CallOptions],
-    'callback': [Function]
+    otherArgs: [Object, {}],
+    options: [gax.CallOptions],
+    callback: [Function]
   }, arguments);
   var req = {
   };
@@ -727,10 +708,10 @@ LibraryServiceApi.prototype.listStrings = function listStrings() {
  *
  * @param {String} name
  * @param {google.example.library.v1.Comment[]} comments
- * @param {?gax.CallOptions} options
+ * @param {gax.CallOptions=} options
  *   Overrides the default settings for this call, e.g, timeout,
  *   retries, etc.
- * @param {?EmptyCallback} callback
+ * @param {EmptyCallback=} callback
  *   The function which will be called with the result of the API call.
  * @returns {gax.EventEmitter} - the event emitter to handle the call
  *   status.
@@ -738,14 +719,14 @@ LibraryServiceApi.prototype.listStrings = function listStrings() {
  */
 LibraryServiceApi.prototype.addComments = function addComments() {
   var args = arguejs({
-    'name': String,
-    'comments': Array,
-    'options': [gax.CallOptions],
-    'callback': [Function]
+    name: String,
+    comments: Array,
+    options: [gax.CallOptions],
+    callback: [Function]
   }, arguments);
   var req = {
-    'name': args.name,
-    'comments': args.comments
+    name: args.name,
+    comments: args.comments
   };
   return this._addComments(req, args.options, args.callback);
 };
@@ -755,10 +736,10 @@ LibraryServiceApi.prototype.addComments = function addComments() {
  *
  * @param {String} name
  *   The name of the book to retrieve.
- * @param {?gax.CallOptions} options
+ * @param {gax.CallOptions=} options
  *   Overrides the default settings for this call, e.g, timeout,
  *   retries, etc.
- * @param {?APICallback<google.example.library.v1.Book>} callback
+ * @param {APICallback<google.example.library.v1.Book>=} callback
  *   The function which will be called with the result of the API call.
  * @returns {gax.EventEmitter} - the event emitter to handle the call
  *   status.
@@ -766,12 +747,12 @@ LibraryServiceApi.prototype.addComments = function addComments() {
  */
 LibraryServiceApi.prototype.getBookFromArchive = function getBookFromArchive() {
   var args = arguejs({
-    'name': String,
-    'options': [gax.CallOptions],
-    'callback': [Function]
+    name: String,
+    options: [gax.CallOptions],
+    callback: [Function]
   }, arguments);
   var req = {
-    'name': args.name
+    name: args.name
   };
   return this._getBookFromArchive(req, args.options, args.callback);
 };
@@ -785,10 +766,10 @@ LibraryServiceApi.prototype.getBookFromArchive = function getBookFromArchive() {
  *   The name of the index for the book
  * @param {Object} indexMap
  *   The index to update the book with
- * @param {?gax.CallOptions} options
+ * @param {gax.CallOptions=} options
  *   Overrides the default settings for this call, e.g, timeout,
  *   retries, etc.
- * @param {?EmptyCallback} callback
+ * @param {EmptyCallback=} callback
  *   The function which will be called with the result of the API call.
  * @returns {gax.EventEmitter} - the event emitter to handle the call
  *   status.
@@ -796,16 +777,16 @@ LibraryServiceApi.prototype.getBookFromArchive = function getBookFromArchive() {
  */
 LibraryServiceApi.prototype.updateBookIndex = function updateBookIndex() {
   var args = arguejs({
-    'name': String,
-    'indexName': String,
-    'indexMap': Object,
-    'options': [gax.CallOptions],
-    'callback': [Function]
+    name: String,
+    indexName: String,
+    indexMap: Object,
+    options: [gax.CallOptions],
+    callback: [Function]
   }, arguments);
   var req = {
-    'name': args.name,
-    'index_name': args.indexName,
-    'index_map': args.indexMap
+    name: args.name,
+    index_name: args.indexName,
+    index_map: args.indexMap
   };
   return this._updateBookIndex(req, args.options, args.callback);
 };
@@ -841,3 +822,18 @@ LibraryServiceApi.prototype.addTag = function addTag() {
   };
   return this._addTag(req, args.options, args.callback);
 };
+
+module.exports = function build(gaxGrpc) {
+  var grpcClient = gaxGrpc.load([{
+    root: require('google-proto-files')('..'),
+    file: 'library.proto'
+  }]);
+  var built = grpcClient.google.example.library.v1;
+
+  built.libraryServiceApi = function(opts) {
+    return new LibraryServiceApi(gaxGrpc, grpcClient, opts);
+  };
+  return built;
+}
+module.exports.SERVICE_ADDRESS = SERVICE_ADDRESS;
+module.exports.ALL_SCOPES = ALL_SCOPES;

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_main_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_main_no_path_templates.baseline
@@ -24,16 +24,16 @@
  * The only allowed edits are to method and file documentation. A 3-way
  * merge preserves those additions if the generated source changes.
  */
+/* TODO: introduce line-wrapping so that it never exceeds the limit. */
+/* jscs: disable maximumLineLength */
 'use strict';
 
 var arguejs = require('arguejs');
 var configData = require('./no_templates_service_client_config');
 var gax = require('google-gax');
 
-/** The default address of the service. */
 var SERVICE_ADDRESS = 'no-path-templates.googleapis.com';
 
-/** The default port of the service. */
 var DEFAULT_SERVICE_PORT = 443;
 
 var CODE_GEN_NAME_VERSION = 'gapic/0.1.0';
@@ -49,77 +49,61 @@ var ALL_SCOPES = [
 
 /**
  * @class
- * @param {?Object} opts - The optional parameters.
- * @param {String} opts.servicePath
+ * @param {Object=} opts - The optional parameters.
+ * @param {String=} opts.servicePath
  *   The domain name of the API remote host.
- * @param {number} opts.port
+ * @param {number=} opts.port
  *   The port on which to connect to the remote host.
- * @param {Function} opts.getCredentials
- *   Custom function to obtain the credentials.
- * @param {grpc.ClientCredentials} opts.sslCreds
+ * @param {grpc.ClientCredentials=} opts.sslCreds
  *   A ClientCredentials for use with an SSL-enabled channel.
- * @param {Object} opts.grpc
- *   When specified, this is used as the grpc module. Otherwise
- *   the grpc package will be loaded from the dependency (typically
- *   the one within 'google-gax' will be loaded). This will be useful
- *   to share channels among multiple APIs.
- * @param {Object} opts.clientConfig
+ * @param {Object=} opts.clientConfig
  *   The customized config to build the call settings. See
  *   {@link gax.constructSettings} for the format.
- * @param {number} opts.timeout
+ * @param {number=} opts.timeout
  *   The default timeout, in seconds, for calls made through this client.
- * @param {number} opts.appName
+ * @param {number=} opts.appName
  *   The codename of the calling service.
- * @param {String} opts.appVersion
+ * @param {String=} opts.appVersion
  *   The version of the calling service.
  */
-function NoTemplatesServiceApi(opts) {
+function NoTemplatesServiceApi(gaxGrpc, grpcClient, opts) {
   opts = opts || {};
   var servicePath = opts.servicePath || SERVICE_ADDRESS;
   var port = opts.port || DEFAULT_SERVICE_PORT;
-  var getCredentials = opts.getCredentials || null;
   var sslCreds = opts.sslCreds || null;
-  var scopes = opts.scopes || ALL_SCOPES;
   var clientConfig = opts.clientConfig || {};
   var timeout = opts.timeout || DEFAULT_TIMEOUT;
   var appName = opts.appName || 'gax';
   var appVersion = opts.appVersion || gax.Version;
-
-  var grpcClient = require('grpc-google-cloud-example-v1').client;
 
   var googleApiClient = [
     appName + '/' + appVersion,
     CODE_GEN_NAME_VERSION,
     'nodejs/' + process.version].join(' ');
 
-  var defaults = gax.constructSettingsGrpc(
+  var defaults = gaxGrpc.constructSettings(
       'google.cloud.example.v1.NoTemplatesService',
       configData,
       clientConfig,
       timeout,
       null,
       null,
-      {'x-goog-api-client': googleApiClient},
-      opts.grpc);
+      {'x-goog-api-client': googleApiClient});
 
-  this.stub = gax.createStub(
+  var stub = gaxGrpc.createStub(
       servicePath,
       port,
       grpcClient.google.cloud.example.v1.NoTemplatesService,
-      {'getCredentials': getCredentials,
-       'grpc': opts.grpc,
-       'sslCreds': sslCreds,
-       'scopes': scopes});
+      {sslCreds: sslCreds});
   var methods = [
     'increment'
   ];
   methods.forEach(function(methodName) {
     this['_' + methodName] = gax.createApiCall(
-        this.stub.then(function(stub) { return stub[methodName].bind(stub); }),
+        stub.then(function(stub) { return stub[methodName].bind(stub); }),
         defaults[methodName]);
   }.bind(this));
-};
-exports.NoTemplatesServiceApi = NoTemplatesServiceApi;
+}
 
 // Callback types
 
@@ -148,10 +132,10 @@ exports.NoTemplatesServiceApi = NoTemplatesServiceApi;
  *         and trailing
  *    whitespace.
  *
- * @param {?gax.CallOptions} options
+ * @param {gax.CallOptions=} options
  *   Overrides the default settings for this call, e.g, timeout,
  *   retries, etc.
- * @param {?EmptyCallback} callback
+ * @param {EmptyCallback=} callback
  *   The function which will be called with the result of the API call.
  * @returns {gax.EventEmitter} - the event emitter to handle the call
  *   status.
@@ -159,10 +143,22 @@ exports.NoTemplatesServiceApi = NoTemplatesServiceApi;
  */
 NoTemplatesServiceApi.prototype.increment = function increment() {
   var args = arguejs({
-    'options': [gax.CallOptions],
-    'callback': [Function]
+    options: [gax.CallOptions],
+    callback: [Function]
   }, arguments);
   var req = {
   };
   return this._increment(req, args.options, args.callback);
 };
+
+module.exports = function build(gaxGrpc) {
+  var grpcClient = require('grpc-google-cloud-example-v1').client;
+  var built = grpcClient.google.cloud.example.v1;
+
+  built.noTemplatesServiceApi = function(opts) {
+    return new NoTemplatesServiceApi(gaxGrpc, grpcClient, opts);
+  };
+  return built;
+}
+module.exports.SERVICE_ADDRESS = SERVICE_ADDRESS;
+module.exports.ALL_SCOPES = ALL_SCOPES;

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_main_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_main_no_path_templates.baseline
@@ -30,6 +30,7 @@
 
 var arguejs = require('arguejs');
 var configData = require('./no_templates_service_client_config');
+var extend = require('extend');
 var gax = require('google-gax');
 
 var SERVICE_ADDRESS = 'no-path-templates.googleapis.com';
@@ -48,23 +49,17 @@ var ALL_SCOPES = [
 ];
 
 /**
+ * This will be created through a builder function which can be obtained by the module.
+ * See the following example of how to initialize the module and how to access to the builder.
+ * @ee {@link NoTemplatesServiceApiBuilder}
+ *
+ * @example
+ *   var exampleV1 = require('google-example-no-path-template')({
+ *     // optional auth parameters.
+ *   });
+ *   var api = exampleV1.noTemplatesServiceApi();
+ *
  * @class
- * @param {Object=} opts - The optional parameters.
- * @param {String=} opts.servicePath
- *   The domain name of the API remote host.
- * @param {number=} opts.port
- *   The port on which to connect to the remote host.
- * @param {grpc.ClientCredentials=} opts.sslCreds
- *   A ClientCredentials for use with an SSL-enabled channel.
- * @param {Object=} opts.clientConfig
- *   The customized config to build the call settings. See
- *   {@link gax.constructSettings} for the format.
- * @param {number=} opts.timeout
- *   The default timeout, in seconds, for calls made through this client.
- * @param {number=} opts.appName
- *   The codename of the calling service.
- * @param {String=} opts.appVersion
- *   The version of the calling service.
  */
 function NoTemplatesServiceApi(gaxGrpc, grpcClient, opts) {
   opts = opts || {};
@@ -151,14 +146,39 @@ NoTemplatesServiceApi.prototype.increment = function increment() {
   return this._increment(req, args.options, args.callback);
 };
 
-module.exports = function build(gaxGrpc) {
-  var grpcClient = require('grpc-google-cloud-example-v1').client;
-  var built = grpcClient.google.cloud.example.v1;
+function NoTemplatesServiceApiBuilder(gaxGrpc) {
+  if (!(this instanceof NoTemplatesServiceApiBuilder)) {
+    return new NoTemplatesServiceApiBuilder(gaxGrpc);
+  }
 
-  built.noTemplatesServiceApi = function(opts) {
+  var grpcClient = require('grpc-google-cloud-example-v1').client;
+  extend(this, grpcClient.google.cloud.example.v1);
+
+  /**
+   * Build a new instance of {@link NoTemplatesServiceApi}.
+   *
+   * @param {Object=} opts - The optional parameters.
+   * @param {String=} opts.servicePath
+   *   The domain name of the API remote host.
+   * @param {number=} opts.port
+   *   The port on which to connect to the remote host.
+   * @param {grpc.ClientCredentials=} opts.sslCreds
+   *   A ClientCredentials for use with an SSL-enabled channel.
+   * @param {Object=} opts.clientConfig
+   *   The customized config to build the call settings. See
+   *   {@link gax.constructSettings} for the format.
+   * @param {number=} opts.timeout
+   *   The default timeout, in seconds, for calls made through this client.
+   * @param {number=} opts.appName
+   *   The codename of the calling service.
+   * @param {String=} opts.appVersion
+   *   The version of the calling service.
+   */
+  this.noTemplatesServiceApi = function(opts) {
     return new NoTemplatesServiceApi(gaxGrpc, grpcClient, opts);
   };
-  return built;
+  extend(this.noTemplatesServiceApi, NoTemplatesServiceApi);
 };
+module.exports = NoTemplatesServiceApiBuilder;
 module.exports.SERVICE_ADDRESS = SERVICE_ADDRESS;
 module.exports.ALL_SCOPES = ALL_SCOPES;

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_main_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_main_no_path_templates.baseline
@@ -159,6 +159,6 @@ module.exports = function build(gaxGrpc) {
     return new NoTemplatesServiceApi(gaxGrpc, grpcClient, opts);
   };
   return built;
-}
+};
 module.exports.SERVICE_ADDRESS = SERVICE_ADDRESS;
 module.exports.ALL_SCOPES = ALL_SCOPES;


### PR DESCRIPTION
- The new style exports a function instead of the class. The
  exported function will take the auth context as a parameter
  and returns builder function.
- Files will be under a sub directory with versioned name,
  so that it can be exposed as a sub package of the API package.
- A few misc changes and style changes made to pass lint
  checker in gcloud.