### PR TITLE
Handle streaming grpc in mock service.

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
@@ -308,6 +308,7 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
         .name(methodContext.getNamer().getApiMethodName(method))
         .requestTypeName(requestTypeName)
         .responseTypeName(responseTypeName)
+        .isStreaming(method.getRequestStreaming() || method.getResponseStreaming())
         .build();
   }
 }

--- a/src/main/java/com/google/api/codegen/viewmodel/testing/MockGrpcMethodView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/testing/MockGrpcMethodView.java
@@ -24,6 +24,8 @@ public abstract class MockGrpcMethodView {
 
   public abstract String responseTypeName();
 
+  public abstract boolean isStreaming();
+
   public static Builder newBuilder() {
     return new AutoValue_MockGrpcMethodView.Builder();
   }
@@ -35,6 +37,8 @@ public abstract class MockGrpcMethodView {
     public abstract Builder requestTypeName(String val);
 
     public abstract Builder responseTypeName(String val);
+
+    public abstract Builder isStreaming(boolean val);
 
     public abstract MockGrpcMethodView build();
   }

--- a/src/main/resources/com/google/api/codegen/java/mock_service_impl.snip
+++ b/src/main/resources/com/google/api/codegen/java/mock_service_impl.snip
@@ -41,11 +41,19 @@
 
 @private grpcMethod(method)
   @@Override
-  public void {@method.name}({@method.requestTypeName} request,
-    StreamObserver<{@method.responseTypeName}> responseObserver) {
-    {@method.responseTypeName} response = ({@method.responseTypeName}) responses.remove();
-    requests.add(request);
-    responseObserver.onNext(response);
-    responseObserver.onCompleted();
-  }
+  @if method.isStreaming
+    public StreamObserver<{@method.requestTypeName}> {@method.name}(
+        StreamObserver<{@method.responseTypeName}> responseObserver) {
+      System.err.println("Streaming method is not supported.");
+      return null;
+    }
+  @else
+    public void {@method.name}({@method.requestTypeName} request,
+      StreamObserver<{@method.responseTypeName}> responseObserver) {
+      {@method.responseTypeName} response = ({@method.responseTypeName}) responses.remove();
+      requests.add(request);
+      responseObserver.onNext(response);
+      responseObserver.onCompleted();
+    }
+  @end
 @end

--- a/src/test/java/com/google/api/codegen/testdata/java_mock_service_impl_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_mock_service_impl_library.baseline
@@ -217,12 +217,10 @@ public class MockLibraryServiceImpl implements LibraryService  {
   }
 
   @Override
-  public void streamShelves(ListShelvesRequest request,
-    StreamObserver<ListShelvesResponse> responseObserver) {
-    ListShelvesResponse response = (ListShelvesResponse) responses.remove();
-    requests.add(request);
-    responseObserver.onNext(response);
-    responseObserver.onCompleted();
+  public StreamObserver<ListShelvesRequest> streamShelves(
+      StreamObserver<ListShelvesResponse> responseObserver) {
+    System.err.println("Streaming method is not supported.");
+    return null;
   }
 
   @Override


### PR DESCRIPTION
Create empty streaming grpc stub to avoid compile error.