### PR TITLE
Create Python wrappers from Proto enums

### DIFF
--- a/src/main/java/com/google/api/codegen/gapic/CommonGapicProvider.java
+++ b/src/main/java/com/google/api/codegen/gapic/CommonGapicProvider.java
@@ -23,17 +23,13 @@ import com.google.api.tools.framework.model.ProtoElement;
 import com.google.api.tools.framework.model.stages.Merged;
 import com.google.api.tools.framework.snippet.Doc;
 import com.google.common.base.Strings;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-
 import javax.annotation.Nullable;
 
-/**
- * Common GapicProvider which runs code generation.
- */
+/** Common GapicProvider which runs code generation. */
 public class CommonGapicProvider<ElementT> implements GapicProvider<ElementT> {
   private final Model model;
   private final InputElementView<ElementT> view;
@@ -83,7 +79,9 @@ public class CommonGapicProvider<ElementT> implements GapicProvider<ElementT> {
       return docs;
     }
     for (GeneratedResult result : generatedOutput) {
-      docs.put(result.getFilename(), result.getDoc());
+      if (!result.getDoc().isWhitespace()) {
+        docs.put(result.getFilename(), result.getDoc());
+      }
     }
     return docs;
   }

--- a/src/main/java/com/google/api/codegen/gapic/MainGapicProviderFactory.java
+++ b/src/main/java/com/google/api/codegen/gapic/MainGapicProviderFactory.java
@@ -45,11 +45,9 @@ import com.google.api.codegen.util.ruby.RubyNameFormatter;
 import com.google.api.tools.framework.model.Interface;
 import com.google.api.tools.framework.model.Model;
 import com.google.api.tools.framework.model.ProtoFile;
-
-import org.apache.commons.lang3.NotImplementedException;
-
 import java.util.Arrays;
 import java.util.List;
+import org.apache.commons.lang3.NotImplementedException;
 
 /** MainGapicProviderFactory creates GapicProvider instances based on an id. */
 public class MainGapicProviderFactory
@@ -225,6 +223,18 @@ public class MainGapicProviderFactory
               .setSnippetFileNames(Arrays.asList("py/main.snip"))
               .setCodePathMapper(pythonPathMapper)
               .build();
+      // Note: enumProvider implementation doesn't care about the InputElementT view.
+      GapicProvider<? extends Object> enumProvider =
+          CommonGapicProvider.<Interface>newBuilder()
+              .setModel(model)
+              .setView(new InterfaceView())
+              .setContext(new PythonGapicContext(model, apiConfig))
+              .setSnippetSetRunner(
+                  new PythonSnippetSetRunner<Interface>(
+                      new PythonInterfaceInitializer(), SnippetSetRunner.SNIPPET_RESOURCE_ROOT))
+              .setSnippetFileNames(Arrays.asList("py/enum.snip"))
+              .setCodePathMapper(pythonPathMapper)
+              .build();
       GapicProvider<? extends Object> clientConfigProvider =
           CommonGapicProvider.<Interface>newBuilder()
               .setModel(model)
@@ -238,7 +248,8 @@ public class MainGapicProviderFactory
               .build();
 
       if (id.equals(PYTHON)) {
-        return Arrays.<GapicProvider<? extends Object>>asList(mainProvider, clientConfigProvider);
+        return Arrays.<GapicProvider<? extends Object>>asList(
+            mainProvider, enumProvider, clientConfigProvider);
       }
 
       GapicProvider<? extends Object> messageProvider =
@@ -253,7 +264,7 @@ public class MainGapicProviderFactory
               .setCodePathMapper(CommonGapicCodePathMapper.defaultInstance())
               .build();
       return Arrays.<GapicProvider<? extends Object>>asList(
-          mainProvider, messageProvider, clientConfigProvider);
+          mainProvider, messageProvider, enumProvider, clientConfigProvider);
 
     } else if (id.equals(RUBY) || id.equals(RUBY_DOC)) {
       GapicCodePathMapper rubyPathMapper =

--- a/src/main/java/com/google/api/codegen/gapic/MainGapicProviderFactory.java
+++ b/src/main/java/com/google/api/codegen/gapic/MainGapicProviderFactory.java
@@ -231,7 +231,8 @@ public class MainGapicProviderFactory
               .setContext(new PythonGapicContext(model, apiConfig))
               .setSnippetSetRunner(
                   new PythonSnippetSetRunner<Interface>(
-                      new PythonInterfaceInitializer(), SnippetSetRunner.SNIPPET_RESOURCE_ROOT))
+                      new PythonInterfaceInitializer(apiConfig),
+                      SnippetSetRunner.SNIPPET_RESOURCE_ROOT))
               .setSnippetFileNames(Arrays.asList("py/enum.snip"))
               .setCodePathMapper(pythonPathMapper)
               .build();

--- a/src/main/java/com/google/api/codegen/py/PythonContextCommon.java
+++ b/src/main/java/com/google/api/codegen/py/PythonContextCommon.java
@@ -14,11 +14,14 @@
  */
 package com.google.api.codegen.py;
 
+import com.google.api.tools.framework.model.Model;
+import com.google.api.tools.framework.model.TypeRef;
+import com.google.common.base.Predicate;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-
+import com.google.common.collect.Iterables;
 import java.util.List;
 
 /**
@@ -30,14 +33,23 @@ public class PythonContextCommon {
   // Snippet Helpers
   // ===============
 
-  /**
-   * Return a non-conflicting safe name if name is a python built-in.
-   */
+  /** Return a non-conflicting safe name if name is a python built-in. */
   public String wrapIfKeywordOrBuiltIn(String name) {
     if (KEYWORD_BUILT_IN_SET.contains(name)) {
       return name + "_";
     }
     return name;
+  }
+
+  public Iterable<TypeRef> getEnumTypes(Model model) {
+    return Iterables.filter(
+        model.getSymbolTable().getDeclaredTypes(),
+        new Predicate<TypeRef>() {
+          @Override
+          public boolean apply(TypeRef type) {
+            return type.isEnum() && type.getEnumType().isReachable();
+          }
+        });
   }
 
   /*

--- a/src/main/java/com/google/api/codegen/py/PythonDocConfig.java
+++ b/src/main/java/com/google/api/codegen/py/PythonDocConfig.java
@@ -29,15 +29,12 @@ import com.google.api.tools.framework.model.Method;
 import com.google.api.tools.framework.model.TypeRef;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 
-/**
- * Represents the Python documentation settings for an Api method.
- */
+/** Represents the Python documentation settings for an Api method. */
 @AutoValue
 abstract class PythonDocConfig extends DocConfig {
   public static PythonDocConfig.Builder newBuilder() {
@@ -57,9 +54,7 @@ abstract class PythonDocConfig extends DocConfig {
     return LanguageUtil.upperCamelToLowerUnderscore(getMethod().getSimpleName());
   }
 
-  /**
-   * Does this method return an iterable response?
-   */
+  /** Does this method return an iterable response? */
   public boolean isPageStreaming() {
     Method method = getMethod();
     MethodConfig methodConfig =
@@ -67,23 +62,17 @@ abstract class PythonDocConfig extends DocConfig {
     return methodConfig.isPageStreaming();
   }
 
-  /**
-   * Is this method gRPC-response streaming?
-   */
+  /** Is this method gRPC-response streaming? */
   public boolean isResponseGrpcStreaming() {
     return getMethod().getResponseStreaming();
   }
 
-  /**
-   * Is this method gRPC-request streaming?
-   */
+  /** Is this method gRPC-request streaming? */
   public boolean isRequestGrpcStreaming() {
     return getMethod().getRequestStreaming();
   }
 
-  /**
-   * Get list of import statements for this method's code sample.
-   */
+  /** Get list of import statements for this method's code sample. */
   public List<String> getAppImports() {
     List<String> importStrings = new ArrayList<>();
     importStrings.add(apiImport(getApiName()));
@@ -112,8 +101,17 @@ abstract class PythonDocConfig extends DocConfig {
           // nothing to do
       }
 
-      if (lineType != null && lineType.isMessage()) {
-        protoImports.add(getImportHandler().fileToImport(lineType.getMessageType().getFile()));
+      if (lineType != null) {
+        if (lineType.isMessage()) {
+          // TODO: What if a file is not imported in the main GAPIC codegen, but is needed for
+          // samplegen? For example, subfields of request messages.
+          protoImports.add(getImportHandler().fileToImport(lineType.getMessageType().getFile()));
+        } else if (lineType.isEnum()) {
+          protoImports.add(
+              (PythonImport.create(
+                      PythonImport.ImportType.APP, getApiConfig().getPackageName(), "enums"))
+                  .importString());
+        }
       }
     }
     importStrings.addAll(protoImports);

--- a/src/main/java/com/google/api/codegen/py/PythonGapicContext.java
+++ b/src/main/java/com/google/api/codegen/py/PythonGapicContext.java
@@ -151,7 +151,7 @@ public class PythonGapicContext extends GapicContext {
       case TYPE_MESSAGE:
         return ":class:`" + importHandler.elementPath(type.getMessageType(), true) + "`";
       case TYPE_ENUM:
-        return "enum from :class:`"
+        return "enum :class:`"
             + getApiConfig().getPackageName()
             + ".enums."
             + pythonCommon.wrapIfKeywordOrBuiltIn(type.getEnumType().getSimpleName())

--- a/src/main/java/com/google/api/codegen/py/PythonGapicContext.java
+++ b/src/main/java/com/google/api/codegen/py/PythonGapicContext.java
@@ -151,7 +151,11 @@ public class PythonGapicContext extends GapicContext {
       case TYPE_MESSAGE:
         return ":class:`" + importHandler.elementPath(type.getMessageType(), true) + "`";
       case TYPE_ENUM:
-        return ":class:`" + importHandler.elementPath(type.getEnumType(), true) + "`";
+        return "enum from :class:`"
+            + getApiConfig().getPackageName()
+            + ".enums."
+            + pythonCommon.wrapIfKeywordOrBuiltIn(type.getEnumType().getSimpleName())
+            + "`";
       default:
         if (type.isPrimitive()) {
           return PRIMITIVE_TYPE_NAMES.get(type.getKind());
@@ -162,8 +166,8 @@ public class PythonGapicContext extends GapicContext {
   }
 
   /** Returns a comment string for field, consisting of type information and proto comment. */
-  private String fieldComment(String name, String cardinality, String paramComment) {
-    String comment = String.format("  %s (%s)", name, cardinality);
+  private String fieldComment(String name, String type, String paramComment) {
+    String comment = String.format("  %s (%s)", name, type);
     if (!Strings.isNullOrEmpty(paramComment)) {
       if (paramComment.charAt(paramComment.length() - 1) == '\n') {
         paramComment = paramComment.substring(0, paramComment.length() - 1);

--- a/src/main/java/com/google/api/codegen/py/PythonGapicContext.java
+++ b/src/main/java/com/google/api/codegen/py/PythonGapicContext.java
@@ -20,6 +20,7 @@ import com.google.api.codegen.InterfaceConfig;
 import com.google.api.codegen.MethodConfig;
 import com.google.api.tools.framework.aspects.documentation.model.DocumentationUtil;
 import com.google.api.tools.framework.aspects.documentation.model.ElementDocumentationAttribute;
+import com.google.api.tools.framework.model.EnumType;
 import com.google.api.tools.framework.model.EnumValue;
 import com.google.api.tools.framework.model.Field;
 import com.google.api.tools.framework.model.Interface;
@@ -146,6 +147,10 @@ public class PythonGapicContext extends GapicContext {
     return typeComment(field.getType(), importHandler);
   }
 
+  private String enumClassName(EnumType enumType) {
+    return "enums." + pythonCommon.wrapIfKeywordOrBuiltIn(enumType.getSimpleName());
+  }
+
   private String typeComment(TypeRef type, PythonImportHandler importHandler) {
     switch (type.getKind()) {
       case TYPE_MESSAGE:
@@ -153,8 +158,8 @@ public class PythonGapicContext extends GapicContext {
       case TYPE_ENUM:
         return "enum :class:`"
             + getApiConfig().getPackageName()
-            + ".enums."
-            + pythonCommon.wrapIfKeywordOrBuiltIn(type.getEnumType().getSimpleName())
+            + "."
+            + enumClassName(type.getEnumType())
             + "`";
       default:
         if (type.isPrimitive()) {
@@ -359,7 +364,11 @@ public class PythonGapicContext extends GapicContext {
       case TYPE_ENUM:
         Preconditions.checkArgument(
             type.getEnumType().getValues().size() > 0, "enum must have a value");
-        return importHandler.elementPath(type.getEnumType().getValues().get(0), false);
+        // TODO:multiple enums of same name?
+        return "enums."
+            + type.getEnumType().getSimpleName()
+            + "."
+            + type.getEnumType().getValues().get(0).getSimpleName();
       default:
         if (type.isPrimitive()) {
           return DEFAULT_VALUE_MAP.get(type.getKind());

--- a/src/main/java/com/google/api/codegen/py/PythonSphinxCommentFixer.java
+++ b/src/main/java/com/google/api/codegen/py/PythonSphinxCommentFixer.java
@@ -26,7 +26,7 @@ public class PythonSphinxCommentFixer {
     comment = comment.replace("\"", "\\\"");
     comment = sphinxifyProtoMarkdownLinks(comment);
     comment = sphinxifyAbsoluteMarkdownLinks(comment);
-    return sphinxifyCloudMarkdownLinks(comment);
+    return sphinxifyCloudMarkdownLinks(comment).trim();
   }
 
   /** Returns a string with all proto markdown links formatted to Sphinx style. */

--- a/src/main/resources/com/google/api/codegen/py/enum.snip
+++ b/src/main/resources/com/google/api/codegen/py/enum.snip
@@ -43,6 +43,10 @@
 @end
 
 @private shouldGenerateEnum(element)
+    # Note: cannot use and(element.isEnum, element.getEnumType.isReachable)
+    # because template language evaluates function arguments eagerly, which
+    # can cause an exception to be thrown at element.getEnumType if element is
+    # not an enum.
     @if element.isEnum
         @if element.getEnumType.isReachable
             TRUE

--- a/src/main/resources/com/google/api/codegen/py/enum.snip
+++ b/src/main/resources/com/google/api/codegen/py/enum.snip
@@ -1,0 +1,84 @@
+@snippet generateFilename(service)
+    enums.py
+@end
+
+@snippet generateBody(service)
+@end
+
+@snippet generateMethodSampleCode(docConfig)
+@end
+
+@snippet generateModule(_, __, ___)
+    @let enums = enumConstants()
+        @if enums
+            {@licenseSection()}
+        
+            {@moduleDocstring()}
+        
+        
+            {@enums}
+
+        @end
+    @end
+@end
+
+@private licenseSection()
+    @# Copyright 2016 Google Inc. All rights reserved.
+    @#
+    @# Licensed under the Apache License, Version 2.0 (the "License");
+    @# you may not use this file except in compliance with the License.
+    @# You may obtain a copy of the License at
+    @#
+    @# http://www.apache.org/licenses/LICENSE-2.0
+    @#
+    @# Unless required by applicable law or agreed to in writing, software
+    @# distributed under the License is distributed on an "AS IS" BASIS,
+    @# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    @# See the License for the specific language governing permissions and
+    @# limitations under the License.
+@end
+
+@private moduleDocstring()
+    """Wrappers for protocol buffer enum types."""
+@end
+
+@private shouldGenerateEnum(element)
+    @if element.isEnum
+        @if element.getEnumType.isReachable
+            TRUE
+        @end
+    @end
+@end
+
+@private enumComments(enum)
+    @let overview = context.getSphinxifiedScopedDescription(enum)
+        """
+        @if overview
+            @join line : context.splitToLines(overview)
+                {@line}
+            @end
+        {@BREAK}
+        @end
+        Attributes:
+        @join value : enum.getValues()
+            @join line : {@context.enumValueComment(value)} if line
+                {@line}
+            @end
+        @end
+        """
+    @end
+@end
+
+@private enumSection(enum)
+    class {@context.python.wrapIfKeywordOrBuiltIn(enum.getSimpleName)}(object):
+        {@enumComments(enum)}
+        @join value : enum.getValues
+            {@context.python.wrapIfKeywordOrBuiltIn(value.getSimpleName)} = {@value.getNumber}
+        @end
+@end
+
+@private enumConstants()
+    @join type : context.getModel.getSymbolTable.getDeclaredTypes if shouldGenerateEnum(type) on BREAK.add(BREAK).add(BREAK)
+        {@enumSection(type.getEnumType)}
+    @end
+@end

--- a/src/main/resources/com/google/api/codegen/py/enum.snip
+++ b/src/main/resources/com/google/api/codegen/py/enum.snip
@@ -42,18 +42,6 @@
     """Wrappers for protocol buffer enum types."""
 @end
 
-@private shouldGenerateEnum(element)
-    # Note: cannot use and(element.isEnum, element.getEnumType.isReachable)
-    # because template language evaluates function arguments eagerly, which
-    # can cause an exception to be thrown at element.getEnumType if element is
-    # not an enum.
-    @if element.isEnum
-        @if element.getEnumType.isReachable
-            TRUE
-        @end
-    @end
-@end
-
 @private enumComments(enum)
     @let overview = context.getSphinxifiedScopedDescription(enum)
         """
@@ -82,7 +70,7 @@
 @end
 
 @private enumConstants()
-    @join type : context.getModel.getSymbolTable.getDeclaredTypes if shouldGenerateEnum(type) on BREAK.add(BREAK).add(BREAK)
+    @join type : context.python.getEnumTypes(context.getModel) on BREAK.add(BREAK).add(BREAK)
         {@enumSection(type.getEnumType)}
     @end
 @end

--- a/src/main/resources/com/google/api/codegen/py/main.snip
+++ b/src/main/resources/com/google/api/codegen/py/main.snip
@@ -98,50 +98,8 @@
     @end
 @end
 
-@private enumComments(enum)
-    @let overview = context.getSphinxifiedScopedDescription(enum)
-        """
-        @if overview
-            @join line : context.splitToLines(overview)
-                {@line}
-            @end
-        {@BREAK}
-        @end
-        Attributes:
-        @join value : enum.getValues()
-            @join line : {@context.enumValueComment(value)} if line
-                {@line}
-            @end
-        @end
-        """
-    @end
-@end
-
-@private enumSection(enum)
-    class {@context.python.wrapIfKeywordOrBuiltIn(enum.getSimpleName)}(object):
-        {@enumComments(enum)}
-        @join value : enum.getValues
-            {@context.python.wrapIfKeywordOrBuiltIn(value.getSimpleName)} = {@value.getNumber}
-        @end
-@end
-
-@private shouldGenerateEnum(element)
-    @if element.isEnum
-        @if element.getEnumType.isReachable
-            TRUE
-        @end
-    @end
-@end
-
-@private enumConstants(service)
-    @join type : context.getModel.getSymbolTable.getDeclaredTypes if shouldGenerateEnum(type) on BREAK.add(BREAK)
-        {@enumSection(type.getEnumType)}
-    @end
-@end
-
 @private constantSection(service)
-    @let ifaceConfig = context.getApiConfig.getInterfaceConfig(service), \
-            enums = enumConstants(service)
+    @let ifaceConfig = context.getApiConfig.getInterfaceConfig(service)
         SERVICE_ADDRESS = '{@context.getServiceConfig.getServiceAddress(service)}'
         """The default address of the service."""
 
@@ -190,10 +148,6 @@
                 '{@auth_scope}',
             @end
         )
-        @if enums
-
-            {@enums}
-        @end
     @end
 @end
 

--- a/src/main/resources/com/google/api/codegen/py/main.snip
+++ b/src/main/resources/com/google/api/codegen/py/main.snip
@@ -98,8 +98,50 @@
     @end
 @end
 
+@private enumComments(enum)
+    @let overview = context.getSphinxifiedScopedDescription(enum)
+        """
+        @if overview
+            @join line : context.splitToLines(overview)
+                {@line}
+            @end
+        {@BREAK}
+        @end
+        Attributes:
+        @join value : enum.getValues()
+            @join line : {@context.enumValueComment(value)} if line
+                {@line}
+            @end
+        @end
+        """
+    @end
+@end
+
+@private enumSection(enum)
+    class {@context.python.wrapIfKeywordOrBuiltIn(enum.getSimpleName)}(object):
+        {@enumComments(enum)}
+        @join value : enum.getValues
+            {@context.python.wrapIfKeywordOrBuiltIn(value.getSimpleName)} = {@value.getNumber}
+        @end
+@end
+
+@private shouldGenerateEnum(element)
+    @if element.isEnum
+        @if element.getEnumType.isReachable
+            TRUE
+        @end
+    @end
+@end
+
+@private enumConstants(service)
+    @join type : context.getModel.getSymbolTable.getDeclaredTypes if shouldGenerateEnum(type) on BREAK.add(BREAK)
+        {@enumSection(type.getEnumType)}
+    @end
+@end
+
 @private constantSection(service)
-    @let ifaceConfig = context.getApiConfig.getInterfaceConfig(service)
+    @let ifaceConfig = context.getApiConfig.getInterfaceConfig(service), \
+            enums = enumConstants(service)
         SERVICE_ADDRESS = '{@context.getServiceConfig.getServiceAddress(service)}'
         """The default address of the service."""
 
@@ -148,6 +190,10 @@
                 '{@auth_scope}',
             @end
         )
+        @if enums
+
+            {@enums}
+        @end
     @end
 @end
 

--- a/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
@@ -3,7 +3,7 @@ language_settings:
   java:
     package_name: com.google.gcloud.pubsub.spi
   python:
-    package_name: google.example.library.v1
+    package_name: google.cloud.gapic.example.library.v1
   go:
     # Intentionally changed from the gRPC package name.
     # See: https://github.com/googleapis/toolkit/issues/320

--- a/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
@@ -3,7 +3,7 @@ language_settings:
   java:
     package_name: com.google.gcloud.pubsub.spi
   python:
-    package_name: library
+    package_name: google.example.library.v1
   go:
     # Intentionally changed from the gRPC package name.
     # See: https://github.com/googleapis/toolkit/issues/320

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_enum_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_enum_library.baseline
@@ -54,3 +54,17 @@ class Rating(object):
     GOOD = 0
     BAD = 1
 
+
+class Stage(object):
+    """
+    Attributes:
+      UNSET (int)
+      DRAFT (int)
+      PUBLISHED (int)
+      DELETED (int)
+    """
+    UNSET = 0
+    DRAFT = 1
+    PUBLISHED = 2
+    DELETED = 3
+

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_enum_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_enum_library.baseline
@@ -1,4 +1,4 @@
-============== file: google/example/library/v1/enums.py ==============
+============== file: google/cloud/gapic/example/library/v1/enums.py ==============
 # Copyright 2016 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_enum_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_enum_library.baseline
@@ -1,0 +1,56 @@
+============== file: google/example/library/v1/enums.py ==============
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Wrappers for protocol buffer enum types."""
+
+
+class Material(object):
+    """
+    Attributes:
+      PAPIER_MACHE (int)
+      WOOD (int)
+      PORCELAIN (int)
+      SEQUINS (int)
+      CARDBOARD (int)
+    """
+    PAPIER_MACHE = 0
+    WOOD = 1
+    PORCELAIN = 2
+    SEQUINS = 3
+    CARDBOARD = 4
+
+
+class NullValue(object):
+    """
+    ``NullValue`` is a singleton enumeration to represent the null value for the
+    ``Value`` type union.
+
+     The JSON representation for ``NullValue`` is JSON ``null``.
+
+    Attributes:
+      NULL_VALUE (int): Null value.
+    """
+    NULL_VALUE = 0
+
+
+class Rating(object):
+    """
+    Attributes:
+      GOOD (int): GOOD enum description
+      BAD (int)
+    """
+    GOOD = 0
+    BAD = 1
+

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_json_library.baseline
@@ -1,4 +1,4 @@
-============== file: google/example/library/v1/library_service_client_config.json ==============
+============== file: google/cloud/gapic/example/library/v1/library_service_client_config.json ==============
 {
   "interfaces": {
     "google.example.library.v1.LibraryService": {

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_json_library.baseline
@@ -1,4 +1,4 @@
-============== file: library/library_service_client_config.json ==============
+============== file: google/example/library/v1/library_service_client_config.json ==============
 {
   "interfaces": {
     "google.example.library.v1.LibraryService": {

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
@@ -34,6 +34,7 @@ from google.gax import config
 from google.gax import path_template
 import google.gax
 
+from google.example.library.v1 import enums
 from google.example.library.v1 import field_mask_pb2 as v1_field_mask_pb2
 from google.example.library.v1 import library_pb2
 from google.protobuf import field_mask_pb2 as protobuf_field_mask_pb2
@@ -828,11 +829,12 @@ class LibraryServiceApi(object):
 
         Example:
           >>> from google.cloud.gapic.example.library.v1.library_service_api import LibraryServiceApi
+          >>> from google.cloud.gapic.example.library.v1 import enums
           >>> from google.example.library.v1 import library_pb2
           >>> api = LibraryServiceApi()
           >>> name = api.book_path('[SHELF]', '[BOOK]')
           >>> comment = ''
-          >>> stage = library_pb2.Comment.Stage.UNSET
+          >>> stage = enums.Stage.UNSET
           >>> comments_element = library_pb2.Comment(comment, stage)
           >>> comments = [comments_element]
           >>> api.add_comments(name, comments)
@@ -924,7 +926,7 @@ class LibraryServiceApi(object):
         gRPC streaming methods don't have HTTP equivalent and need not have google.api.http option.
 
         Example:
-          >>> from library.library_service_api import LibraryServiceApi
+          >>> from google.cloud.gapic.example.library.v1.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
           >>> for element in api.stream_shelves():
           >>>   # process element
@@ -952,7 +954,7 @@ class LibraryServiceApi(object):
         gRPC streaming methods don't have HTTP equivalent and need not have google.api.http option.
 
         Example:
-          >>> from library.library_service_api import LibraryServiceApi
+          >>> from google.cloud.gapic.example.library.v1.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
           >>> name = ''
           >>> for element in api.stream_books(name):
@@ -986,7 +988,7 @@ class LibraryServiceApi(object):
         EXPERIMENTAL: This method interface might change in the future.
 
         Example:
-          >>> from library.library_service_api import LibraryServiceApi
+          >>> from google.cloud.gapic.example.library.v1.library_service_api import LibraryServiceApi
           >>> from google.example.library.v1 import library_pb2
           >>> api = LibraryServiceApi()
           >>> request = library_pb2.DiscussBookRequest()
@@ -1050,7 +1052,7 @@ class LibraryServiceApi(object):
         Adds a label to the entity.
 
         Example:
-          >>> from library.library_service_api import LibraryServiceApi
+          >>> from google.cloud.gapic.example.library.v1.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
           >>> resource = api.book_path('[SHELF]', '[BOOK]')
           >>> label = ''

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
@@ -1,4 +1,4 @@
-============== file: library/library_service_api.py ==============
+============== file: google/example/library/v1/library_service_api.py ==============
 # Copyright 2016 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -107,42 +107,6 @@ class LibraryServiceApi(object):
         'https://www.googleapis.com/auth/cloud-platform',
         'https://www.googleapis.com/auth/library',
     )
-
-    class Material(object):
-        """
-        Attributes:
-          PAPIER_MACHE (int)
-          WOOD (int)
-          PORCELAIN (int)
-          SEQUINS (int)
-          CARDBOARD (int)
-        """
-        PAPIER_MACHE = 0
-        WOOD = 1
-        PORCELAIN = 2
-        SEQUINS = 3
-        CARDBOARD = 4
-
-    class NullValue(object):
-        """
-        ``NullValue`` is a singleton enumeration to represent the null value for the
-        ``Value`` type union.
-
-         The JSON representation for ``NullValue`` is JSON ``null``.
-
-        Attributes:
-          NULL_VALUE (int): Null value.
-        """
-        NULL_VALUE = 0
-
-    class Rating(object):
-        """
-        Attributes:
-          GOOD (int): GOOD enum description
-          BAD (int)
-        """
-        GOOD = 0
-        BAD = 1
 
     _SHELF_PATH_TEMPLATE = path_template.PathTemplate(
         'shelves/{shelf}')
@@ -385,7 +349,7 @@ class LibraryServiceApi(object):
         Creates a shelf, and returns the new Shelf.
 
         Example:
-          >>> from library.library_service_api import LibraryServiceApi
+          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
           >>> from google.example.library.v1 import library_pb2
           >>> api = LibraryServiceApi()
           >>> shelf = library_pb2.Shelf()
@@ -418,7 +382,7 @@ class LibraryServiceApi(object):
         Gets a shelf.
 
         Example:
-          >>> from library.library_service_api import LibraryServiceApi
+          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
           >>> name = api.shelf_path('[SHELF]')
           >>> options_ = ''
@@ -457,7 +421,7 @@ class LibraryServiceApi(object):
         Lists shelves.
 
         Example:
-          >>> from library.library_service_api import LibraryServiceApi
+          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
           >>> from google.gax import CallOptions, INITIAL_PAGE
           >>> api = LibraryServiceApi()
           >>>
@@ -496,7 +460,7 @@ class LibraryServiceApi(object):
         Deletes a shelf.
 
         Example:
-          >>> from library.library_service_api import LibraryServiceApi
+          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
           >>> name = api.shelf_path('[SHELF]')
           >>> api.delete_shelf(name)
@@ -525,7 +489,7 @@ class LibraryServiceApi(object):
         ``other_shelf_name``. Returns the updated shelf.
 
         Example:
-          >>> from library.library_service_api import LibraryServiceApi
+          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
           >>> name = api.shelf_path('[SHELF]')
           >>> other_shelf_name = api.shelf_path('[SHELF]')
@@ -558,7 +522,7 @@ class LibraryServiceApi(object):
         Creates a book.
 
         Example:
-          >>> from library.library_service_api import LibraryServiceApi
+          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
           >>> from google.example.library.v1 import library_pb2
           >>> api = LibraryServiceApi()
           >>> name = api.shelf_path('[SHELF]')
@@ -593,7 +557,7 @@ class LibraryServiceApi(object):
         Creates a series of books.
 
         Example:
-          >>> from library.library_service_api import LibraryServiceApi
+          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
           >>> from google.example.library.v1 import library_pb2
           >>> api = LibraryServiceApi()
           >>> shelf = library_pb2.Shelf()
@@ -628,7 +592,7 @@ class LibraryServiceApi(object):
         Gets a book.
 
         Example:
-          >>> from library.library_service_api import LibraryServiceApi
+          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
           >>> name = api.book_path('[SHELF]', '[BOOK]')
           >>> response = api.get_book(name)
@@ -659,7 +623,7 @@ class LibraryServiceApi(object):
         Lists books in a shelf.
 
         Example:
-          >>> from library.library_service_api import LibraryServiceApi
+          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
           >>> from google.gax import CallOptions, INITIAL_PAGE
           >>> api = LibraryServiceApi()
           >>> name = api.shelf_path('[SHELF]')
@@ -710,7 +674,7 @@ class LibraryServiceApi(object):
         Deletes a book.
 
         Example:
-          >>> from library.library_service_api import LibraryServiceApi
+          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
           >>> name = api.book_path('[SHELF]', '[BOOK]')
           >>> api.delete_book(name)
@@ -739,7 +703,7 @@ class LibraryServiceApi(object):
         Updates a book.
 
         Example:
-          >>> from library.library_service_api import LibraryServiceApi
+          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
           >>> from google.example.library.v1 import library_pb2
           >>> api = LibraryServiceApi()
           >>> name = api.book_path('[SHELF]', '[BOOK]')
@@ -781,7 +745,7 @@ class LibraryServiceApi(object):
         Moves a book to another shelf, and returns the new book.
 
         Example:
-          >>> from library.library_service_api import LibraryServiceApi
+          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
           >>> name = api.book_path('[SHELF]', '[BOOK]')
           >>> other_shelf_name = api.shelf_path('[SHELF]')
@@ -814,7 +778,7 @@ class LibraryServiceApi(object):
         Lists a primitive resource. To test go page streaming.
 
         Example:
-          >>> from library.library_service_api import LibraryServiceApi
+          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
           >>> from google.gax import CallOptions, INITIAL_PAGE
           >>> api = LibraryServiceApi()
           >>>
@@ -863,7 +827,7 @@ class LibraryServiceApi(object):
         Adds comments to a book
 
         Example:
-          >>> from library.library_service_api import LibraryServiceApi
+          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
           >>> from google.example.library.v1 import library_pb2
           >>> api = LibraryServiceApi()
           >>> name = api.book_path('[SHELF]', '[BOOK]')
@@ -896,7 +860,7 @@ class LibraryServiceApi(object):
         Gets a book from an archive.
 
         Example:
-          >>> from library.library_service_api import LibraryServiceApi
+          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
           >>> name = api.archived_book_path('[ARCHIVE_PATH]', '[BOOK]')
           >>> response = api.get_book_from_archive(name)
@@ -927,7 +891,7 @@ class LibraryServiceApi(object):
         Updates the index of a book.
 
         Example:
-          >>> from library.library_service_api import LibraryServiceApi
+          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
           >>> name = api.book_path('[SHELF]', '[BOOK]')
           >>> index_name = ''
@@ -1054,7 +1018,7 @@ class LibraryServiceApi(object):
         Adds a tag to the book. This RPC is a mixin.
 
         Example:
-          >>> from library.library_service_api import LibraryServiceApi
+          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
           >>> resource = api.book_path('[SHELF]', '[BOOK]')
           >>> tag = ''

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
@@ -1,4 +1,4 @@
-============== file: google/example/library/v1/library_service_api.py ==============
+============== file: google/cloud/gapic/example/library/v1/library_service_api.py ==============
 # Copyright 2016 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -349,7 +349,7 @@ class LibraryServiceApi(object):
         Creates a shelf, and returns the new Shelf.
 
         Example:
-          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
+          >>> from google.cloud.gapic.example.library.v1.library_service_api import LibraryServiceApi
           >>> from google.example.library.v1 import library_pb2
           >>> api = LibraryServiceApi()
           >>> shelf = library_pb2.Shelf()
@@ -382,7 +382,7 @@ class LibraryServiceApi(object):
         Gets a shelf.
 
         Example:
-          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
+          >>> from google.cloud.gapic.example.library.v1.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
           >>> name = api.shelf_path('[SHELF]')
           >>> options_ = ''
@@ -421,7 +421,7 @@ class LibraryServiceApi(object):
         Lists shelves.
 
         Example:
-          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
+          >>> from google.cloud.gapic.example.library.v1.library_service_api import LibraryServiceApi
           >>> from google.gax import CallOptions, INITIAL_PAGE
           >>> api = LibraryServiceApi()
           >>>
@@ -460,7 +460,7 @@ class LibraryServiceApi(object):
         Deletes a shelf.
 
         Example:
-          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
+          >>> from google.cloud.gapic.example.library.v1.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
           >>> name = api.shelf_path('[SHELF]')
           >>> api.delete_shelf(name)
@@ -489,7 +489,7 @@ class LibraryServiceApi(object):
         ``other_shelf_name``. Returns the updated shelf.
 
         Example:
-          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
+          >>> from google.cloud.gapic.example.library.v1.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
           >>> name = api.shelf_path('[SHELF]')
           >>> other_shelf_name = api.shelf_path('[SHELF]')
@@ -522,7 +522,7 @@ class LibraryServiceApi(object):
         Creates a book.
 
         Example:
-          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
+          >>> from google.cloud.gapic.example.library.v1.library_service_api import LibraryServiceApi
           >>> from google.example.library.v1 import library_pb2
           >>> api = LibraryServiceApi()
           >>> name = api.shelf_path('[SHELF]')
@@ -557,7 +557,7 @@ class LibraryServiceApi(object):
         Creates a series of books.
 
         Example:
-          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
+          >>> from google.cloud.gapic.example.library.v1.library_service_api import LibraryServiceApi
           >>> from google.example.library.v1 import library_pb2
           >>> api = LibraryServiceApi()
           >>> shelf = library_pb2.Shelf()
@@ -592,7 +592,7 @@ class LibraryServiceApi(object):
         Gets a book.
 
         Example:
-          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
+          >>> from google.cloud.gapic.example.library.v1.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
           >>> name = api.book_path('[SHELF]', '[BOOK]')
           >>> response = api.get_book(name)
@@ -623,7 +623,7 @@ class LibraryServiceApi(object):
         Lists books in a shelf.
 
         Example:
-          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
+          >>> from google.cloud.gapic.example.library.v1.library_service_api import LibraryServiceApi
           >>> from google.gax import CallOptions, INITIAL_PAGE
           >>> api = LibraryServiceApi()
           >>> name = api.shelf_path('[SHELF]')
@@ -674,7 +674,7 @@ class LibraryServiceApi(object):
         Deletes a book.
 
         Example:
-          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
+          >>> from google.cloud.gapic.example.library.v1.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
           >>> name = api.book_path('[SHELF]', '[BOOK]')
           >>> api.delete_book(name)
@@ -703,7 +703,7 @@ class LibraryServiceApi(object):
         Updates a book.
 
         Example:
-          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
+          >>> from google.cloud.gapic.example.library.v1.library_service_api import LibraryServiceApi
           >>> from google.example.library.v1 import library_pb2
           >>> api = LibraryServiceApi()
           >>> name = api.book_path('[SHELF]', '[BOOK]')
@@ -745,7 +745,7 @@ class LibraryServiceApi(object):
         Moves a book to another shelf, and returns the new book.
 
         Example:
-          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
+          >>> from google.cloud.gapic.example.library.v1.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
           >>> name = api.book_path('[SHELF]', '[BOOK]')
           >>> other_shelf_name = api.shelf_path('[SHELF]')
@@ -778,7 +778,7 @@ class LibraryServiceApi(object):
         Lists a primitive resource. To test go page streaming.
 
         Example:
-          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
+          >>> from google.cloud.gapic.example.library.v1.library_service_api import LibraryServiceApi
           >>> from google.gax import CallOptions, INITIAL_PAGE
           >>> api = LibraryServiceApi()
           >>>
@@ -827,7 +827,7 @@ class LibraryServiceApi(object):
         Adds comments to a book
 
         Example:
-          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
+          >>> from google.cloud.gapic.example.library.v1.library_service_api import LibraryServiceApi
           >>> from google.example.library.v1 import library_pb2
           >>> api = LibraryServiceApi()
           >>> name = api.book_path('[SHELF]', '[BOOK]')
@@ -860,7 +860,7 @@ class LibraryServiceApi(object):
         Gets a book from an archive.
 
         Example:
-          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
+          >>> from google.cloud.gapic.example.library.v1.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
           >>> name = api.archived_book_path('[ARCHIVE_PATH]', '[BOOK]')
           >>> response = api.get_book_from_archive(name)
@@ -891,7 +891,7 @@ class LibraryServiceApi(object):
         Updates the index of a book.
 
         Example:
-          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
+          >>> from google.cloud.gapic.example.library.v1.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
           >>> name = api.book_path('[SHELF]', '[BOOK]')
           >>> index_name = ''
@@ -1018,7 +1018,7 @@ class LibraryServiceApi(object):
         Adds a tag to the book. This RPC is a mixin.
 
         Example:
-          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
+          >>> from google.cloud.gapic.example.library.v1.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
           >>> resource = api.book_path('[SHELF]', '[BOOK]')
           >>> tag = ''

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
@@ -108,6 +108,42 @@ class LibraryServiceApi(object):
         'https://www.googleapis.com/auth/library',
     )
 
+    class Material(object):
+        """
+        Attributes:
+          PAPIER_MACHE (int)
+          WOOD (int)
+          PORCELAIN (int)
+          SEQUINS (int)
+          CARDBOARD (int)
+        """
+        PAPIER_MACHE = 0
+        WOOD = 1
+        PORCELAIN = 2
+        SEQUINS = 3
+        CARDBOARD = 4
+
+    class NullValue(object):
+        """
+        ``NullValue`` is a singleton enumeration to represent the null value for the
+        ``Value`` type union.
+
+         The JSON representation for ``NullValue`` is JSON ``null``.
+
+        Attributes:
+          NULL_VALUE (int): Null value.
+        """
+        NULL_VALUE = 0
+
+    class Rating(object):
+        """
+        Attributes:
+          GOOD (int): GOOD enum description
+          BAD (int)
+        """
+        GOOD = 0
+        BAD = 1
+
     _SHELF_PATH_TEMPLATE = path_template.PathTemplate(
         'shelves/{shelf}')
     _BOOK_PATH_TEMPLATE = path_template.PathTemplate(

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_message_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_message_library.baseline
@@ -17,7 +17,7 @@
 class FieldMask(object):
     """
     Attributes:
-      materials (list[:class:`google.example.library.v1.field_mask_pb2.FieldMask.Material`])
+      materials (list[enum from :class:`google.example.library.v1.enums.Material`])
 
     """
     pass
@@ -623,7 +623,7 @@ class Book(object):
       author (string): The name of the book author.
       title (string): The title of the book.
       read (bool): Value indicating whether the book has been read.
-      rating (:class:`google.example.library.v1.library_pb2.Book.Rating`): For testing enums.
+      rating (enum from :class:`google.example.library.v1.enums.Rating`): For testing enums.
       any_value (:class:`google.protobuf.any_pb2.Any`): For testing all well-known types.
       struct_value (:class:`google.protobuf.struct_pb2.Struct`)
       value_value (:class:`google.protobuf.struct_pb2.Value`)

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_message_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_message_library.baseline
@@ -17,7 +17,7 @@
 class FieldMask(object):
     """
     Attributes:
-      materials (list[enum from :class:`google.example.library.v1.enums.Material`])
+      materials (list[enum :class:`google.cloud.gapic.example.library.v1.enums.Material`])
 
     """
     pass
@@ -623,7 +623,7 @@ class Book(object):
       author (string): The name of the book author.
       title (string): The title of the book.
       read (bool): Value indicating whether the book has been read.
-      rating (enum from :class:`google.example.library.v1.enums.Rating`): For testing enums.
+      rating (enum :class:`google.cloud.gapic.example.library.v1.enums.Rating`): For testing enums.
       any_value (:class:`google.protobuf.any_pb2.Any`): For testing all well-known types.
       struct_value (:class:`google.protobuf.struct_pb2.Struct`)
       value_value (:class:`google.protobuf.struct_pb2.Value`)
@@ -958,7 +958,7 @@ class Comment(object):
     Attributes:
       user_name (string): won't be filled in by the sample generator
       comment (bytes): should be filled in by the sample generator
-      stage (enum from :class:`google.example.library.v1.enums.Stage`): should be filled in by the sample generator
+      stage (enum :class:`google.cloud.gapic.example.library.v1.enums.Stage`): should be filled in by the sample generator
 
     """
     pass

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_message_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_message_library.baseline
@@ -958,7 +958,7 @@ class Comment(object):
     Attributes:
       user_name (string): won't be filled in by the sample generator
       comment (bytes): should be filled in by the sample generator
-      stage (:class:`google.example.library.v1.library_pb2.Comment.Stage`): should be filled in by the sample generator
+      stage (enum from :class:`google.example.library.v1.enums.Stage`): should be filled in by the sample generator
 
     """
     pass

--- a/src/test/java/com/google/api/codegen/testdata/python_enum_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_enum_library.baseline
@@ -54,3 +54,17 @@ class Rating(object):
     GOOD = 0
     BAD = 1
 
+
+class Stage(object):
+    """
+    Attributes:
+      UNSET (int)
+      DRAFT (int)
+      PUBLISHED (int)
+      DELETED (int)
+    """
+    UNSET = 0
+    DRAFT = 1
+    PUBLISHED = 2
+    DELETED = 3
+

--- a/src/test/java/com/google/api/codegen/testdata/python_enum_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_enum_library.baseline
@@ -1,4 +1,4 @@
-============== file: google/example/library/v1/enums.py ==============
+============== file: google/cloud/gapic/example/library/v1/enums.py ==============
 # Copyright 2016 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/com/google/api/codegen/testdata/python_enum_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_enum_library.baseline
@@ -1,0 +1,56 @@
+============== file: google/example/library/v1/enums.py ==============
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Wrappers for protocol buffer enum types."""
+
+
+class Material(object):
+    """
+    Attributes:
+      PAPIER_MACHE (int)
+      WOOD (int)
+      PORCELAIN (int)
+      SEQUINS (int)
+      CARDBOARD (int)
+    """
+    PAPIER_MACHE = 0
+    WOOD = 1
+    PORCELAIN = 2
+    SEQUINS = 3
+    CARDBOARD = 4
+
+
+class NullValue(object):
+    """
+    ``NullValue`` is a singleton enumeration to represent the null value for the
+    ``Value`` type union.
+
+     The JSON representation for ``NullValue`` is JSON ``null``.
+
+    Attributes:
+      NULL_VALUE (int): Null value.
+    """
+    NULL_VALUE = 0
+
+
+class Rating(object):
+    """
+    Attributes:
+      GOOD (int): GOOD enum description
+      BAD (int)
+    """
+    GOOD = 0
+    BAD = 1
+

--- a/src/test/java/com/google/api/codegen/testdata/python_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_json_library.baseline
@@ -1,4 +1,4 @@
-============== file: google/example/library/v1/library_service_client_config.json ==============
+============== file: google/cloud/gapic/example/library/v1/library_service_client_config.json ==============
 {
   "interfaces": {
     "google.example.library.v1.LibraryService": {

--- a/src/test/java/com/google/api/codegen/testdata/python_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_json_library.baseline
@@ -1,4 +1,4 @@
-============== file: library/library_service_client_config.json ==============
+============== file: google/example/library/v1/library_service_client_config.json ==============
 {
   "interfaces": {
     "google.example.library.v1.LibraryService": {

--- a/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
@@ -34,6 +34,7 @@ from google.gax import config
 from google.gax import path_template
 import google.gax
 
+from google.example.library.v1 import enums
 from google.example.library.v1 import field_mask_pb2 as v1_field_mask_pb2
 from google.example.library.v1 import library_pb2
 from google.protobuf import field_mask_pb2 as protobuf_field_mask_pb2
@@ -828,11 +829,12 @@ class LibraryServiceApi(object):
 
         Example:
           >>> from google.cloud.gapic.example.library.v1.library_service_api import LibraryServiceApi
+          >>> from google.cloud.gapic.example.library.v1 import enums
           >>> from google.example.library.v1 import library_pb2
           >>> api = LibraryServiceApi()
           >>> name = api.book_path('[SHELF]', '[BOOK]')
           >>> comment = ''
-          >>> stage = library_pb2.Comment.Stage.UNSET
+          >>> stage = enums.Stage.UNSET
           >>> comments_element = library_pb2.Comment(comment, stage)
           >>> comments = [comments_element]
           >>> api.add_comments(name, comments)
@@ -924,7 +926,7 @@ class LibraryServiceApi(object):
         gRPC streaming methods don't have HTTP equivalent and need not have google.api.http option.
 
         Example:
-          >>> from library.library_service_api import LibraryServiceApi
+          >>> from google.cloud.gapic.example.library.v1.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
           >>> for element in api.stream_shelves():
           >>>   # process element
@@ -952,7 +954,7 @@ class LibraryServiceApi(object):
         gRPC streaming methods don't have HTTP equivalent and need not have google.api.http option.
 
         Example:
-          >>> from library.library_service_api import LibraryServiceApi
+          >>> from google.cloud.gapic.example.library.v1.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
           >>> name = ''
           >>> for element in api.stream_books(name):
@@ -986,7 +988,7 @@ class LibraryServiceApi(object):
         EXPERIMENTAL: This method interface might change in the future.
 
         Example:
-          >>> from library.library_service_api import LibraryServiceApi
+          >>> from google.cloud.gapic.example.library.v1.library_service_api import LibraryServiceApi
           >>> from google.example.library.v1 import library_pb2
           >>> api = LibraryServiceApi()
           >>> request = library_pb2.DiscussBookRequest()
@@ -1050,7 +1052,7 @@ class LibraryServiceApi(object):
         Adds a label to the entity.
 
         Example:
-          >>> from library.library_service_api import LibraryServiceApi
+          >>> from google.cloud.gapic.example.library.v1.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
           >>> resource = api.book_path('[SHELF]', '[BOOK]')
           >>> label = ''

--- a/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
@@ -1,4 +1,4 @@
-============== file: library/library_service_api.py ==============
+============== file: google/example/library/v1/library_service_api.py ==============
 # Copyright 2016 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -107,42 +107,6 @@ class LibraryServiceApi(object):
         'https://www.googleapis.com/auth/cloud-platform',
         'https://www.googleapis.com/auth/library',
     )
-
-    class Material(object):
-        """
-        Attributes:
-          PAPIER_MACHE (int)
-          WOOD (int)
-          PORCELAIN (int)
-          SEQUINS (int)
-          CARDBOARD (int)
-        """
-        PAPIER_MACHE = 0
-        WOOD = 1
-        PORCELAIN = 2
-        SEQUINS = 3
-        CARDBOARD = 4
-
-    class NullValue(object):
-        """
-        ``NullValue`` is a singleton enumeration to represent the null value for the
-        ``Value`` type union.
-
-         The JSON representation for ``NullValue`` is JSON ``null``.
-
-        Attributes:
-          NULL_VALUE (int): Null value.
-        """
-        NULL_VALUE = 0
-
-    class Rating(object):
-        """
-        Attributes:
-          GOOD (int): GOOD enum description
-          BAD (int)
-        """
-        GOOD = 0
-        BAD = 1
 
     _SHELF_PATH_TEMPLATE = path_template.PathTemplate(
         'shelves/{shelf}')
@@ -385,7 +349,7 @@ class LibraryServiceApi(object):
         Creates a shelf, and returns the new Shelf.
 
         Example:
-          >>> from library.library_service_api import LibraryServiceApi
+          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
           >>> from google.example.library.v1 import library_pb2
           >>> api = LibraryServiceApi()
           >>> shelf = library_pb2.Shelf()
@@ -418,7 +382,7 @@ class LibraryServiceApi(object):
         Gets a shelf.
 
         Example:
-          >>> from library.library_service_api import LibraryServiceApi
+          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
           >>> name = api.shelf_path('[SHELF]')
           >>> options_ = ''
@@ -457,7 +421,7 @@ class LibraryServiceApi(object):
         Lists shelves.
 
         Example:
-          >>> from library.library_service_api import LibraryServiceApi
+          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
           >>> from google.gax import CallOptions, INITIAL_PAGE
           >>> api = LibraryServiceApi()
           >>>
@@ -496,7 +460,7 @@ class LibraryServiceApi(object):
         Deletes a shelf.
 
         Example:
-          >>> from library.library_service_api import LibraryServiceApi
+          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
           >>> name = api.shelf_path('[SHELF]')
           >>> api.delete_shelf(name)
@@ -525,7 +489,7 @@ class LibraryServiceApi(object):
         ``other_shelf_name``. Returns the updated shelf.
 
         Example:
-          >>> from library.library_service_api import LibraryServiceApi
+          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
           >>> name = api.shelf_path('[SHELF]')
           >>> other_shelf_name = api.shelf_path('[SHELF]')
@@ -558,7 +522,7 @@ class LibraryServiceApi(object):
         Creates a book.
 
         Example:
-          >>> from library.library_service_api import LibraryServiceApi
+          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
           >>> from google.example.library.v1 import library_pb2
           >>> api = LibraryServiceApi()
           >>> name = api.shelf_path('[SHELF]')
@@ -593,7 +557,7 @@ class LibraryServiceApi(object):
         Creates a series of books.
 
         Example:
-          >>> from library.library_service_api import LibraryServiceApi
+          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
           >>> from google.example.library.v1 import library_pb2
           >>> api = LibraryServiceApi()
           >>> shelf = library_pb2.Shelf()
@@ -628,7 +592,7 @@ class LibraryServiceApi(object):
         Gets a book.
 
         Example:
-          >>> from library.library_service_api import LibraryServiceApi
+          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
           >>> name = api.book_path('[SHELF]', '[BOOK]')
           >>> response = api.get_book(name)
@@ -659,7 +623,7 @@ class LibraryServiceApi(object):
         Lists books in a shelf.
 
         Example:
-          >>> from library.library_service_api import LibraryServiceApi
+          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
           >>> from google.gax import CallOptions, INITIAL_PAGE
           >>> api = LibraryServiceApi()
           >>> name = api.shelf_path('[SHELF]')
@@ -710,7 +674,7 @@ class LibraryServiceApi(object):
         Deletes a book.
 
         Example:
-          >>> from library.library_service_api import LibraryServiceApi
+          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
           >>> name = api.book_path('[SHELF]', '[BOOK]')
           >>> api.delete_book(name)
@@ -739,7 +703,7 @@ class LibraryServiceApi(object):
         Updates a book.
 
         Example:
-          >>> from library.library_service_api import LibraryServiceApi
+          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
           >>> from google.example.library.v1 import library_pb2
           >>> api = LibraryServiceApi()
           >>> name = api.book_path('[SHELF]', '[BOOK]')
@@ -781,7 +745,7 @@ class LibraryServiceApi(object):
         Moves a book to another shelf, and returns the new book.
 
         Example:
-          >>> from library.library_service_api import LibraryServiceApi
+          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
           >>> name = api.book_path('[SHELF]', '[BOOK]')
           >>> other_shelf_name = api.shelf_path('[SHELF]')
@@ -814,7 +778,7 @@ class LibraryServiceApi(object):
         Lists a primitive resource. To test go page streaming.
 
         Example:
-          >>> from library.library_service_api import LibraryServiceApi
+          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
           >>> from google.gax import CallOptions, INITIAL_PAGE
           >>> api = LibraryServiceApi()
           >>>
@@ -863,7 +827,7 @@ class LibraryServiceApi(object):
         Adds comments to a book
 
         Example:
-          >>> from library.library_service_api import LibraryServiceApi
+          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
           >>> from google.example.library.v1 import library_pb2
           >>> api = LibraryServiceApi()
           >>> name = api.book_path('[SHELF]', '[BOOK]')
@@ -896,7 +860,7 @@ class LibraryServiceApi(object):
         Gets a book from an archive.
 
         Example:
-          >>> from library.library_service_api import LibraryServiceApi
+          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
           >>> name = api.archived_book_path('[ARCHIVE_PATH]', '[BOOK]')
           >>> response = api.get_book_from_archive(name)
@@ -927,7 +891,7 @@ class LibraryServiceApi(object):
         Updates the index of a book.
 
         Example:
-          >>> from library.library_service_api import LibraryServiceApi
+          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
           >>> name = api.book_path('[SHELF]', '[BOOK]')
           >>> index_name = ''
@@ -1054,7 +1018,7 @@ class LibraryServiceApi(object):
         Adds a tag to the book. This RPC is a mixin.
 
         Example:
-          >>> from library.library_service_api import LibraryServiceApi
+          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
           >>> resource = api.book_path('[SHELF]', '[BOOK]')
           >>> tag = ''

--- a/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
@@ -1,4 +1,4 @@
-============== file: google/example/library/v1/library_service_api.py ==============
+============== file: google/cloud/gapic/example/library/v1/library_service_api.py ==============
 # Copyright 2016 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -349,7 +349,7 @@ class LibraryServiceApi(object):
         Creates a shelf, and returns the new Shelf.
 
         Example:
-          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
+          >>> from google.cloud.gapic.example.library.v1.library_service_api import LibraryServiceApi
           >>> from google.example.library.v1 import library_pb2
           >>> api = LibraryServiceApi()
           >>> shelf = library_pb2.Shelf()
@@ -382,7 +382,7 @@ class LibraryServiceApi(object):
         Gets a shelf.
 
         Example:
-          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
+          >>> from google.cloud.gapic.example.library.v1.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
           >>> name = api.shelf_path('[SHELF]')
           >>> options_ = ''
@@ -421,7 +421,7 @@ class LibraryServiceApi(object):
         Lists shelves.
 
         Example:
-          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
+          >>> from google.cloud.gapic.example.library.v1.library_service_api import LibraryServiceApi
           >>> from google.gax import CallOptions, INITIAL_PAGE
           >>> api = LibraryServiceApi()
           >>>
@@ -460,7 +460,7 @@ class LibraryServiceApi(object):
         Deletes a shelf.
 
         Example:
-          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
+          >>> from google.cloud.gapic.example.library.v1.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
           >>> name = api.shelf_path('[SHELF]')
           >>> api.delete_shelf(name)
@@ -489,7 +489,7 @@ class LibraryServiceApi(object):
         ``other_shelf_name``. Returns the updated shelf.
 
         Example:
-          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
+          >>> from google.cloud.gapic.example.library.v1.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
           >>> name = api.shelf_path('[SHELF]')
           >>> other_shelf_name = api.shelf_path('[SHELF]')
@@ -522,7 +522,7 @@ class LibraryServiceApi(object):
         Creates a book.
 
         Example:
-          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
+          >>> from google.cloud.gapic.example.library.v1.library_service_api import LibraryServiceApi
           >>> from google.example.library.v1 import library_pb2
           >>> api = LibraryServiceApi()
           >>> name = api.shelf_path('[SHELF]')
@@ -557,7 +557,7 @@ class LibraryServiceApi(object):
         Creates a series of books.
 
         Example:
-          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
+          >>> from google.cloud.gapic.example.library.v1.library_service_api import LibraryServiceApi
           >>> from google.example.library.v1 import library_pb2
           >>> api = LibraryServiceApi()
           >>> shelf = library_pb2.Shelf()
@@ -592,7 +592,7 @@ class LibraryServiceApi(object):
         Gets a book.
 
         Example:
-          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
+          >>> from google.cloud.gapic.example.library.v1.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
           >>> name = api.book_path('[SHELF]', '[BOOK]')
           >>> response = api.get_book(name)
@@ -623,7 +623,7 @@ class LibraryServiceApi(object):
         Lists books in a shelf.
 
         Example:
-          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
+          >>> from google.cloud.gapic.example.library.v1.library_service_api import LibraryServiceApi
           >>> from google.gax import CallOptions, INITIAL_PAGE
           >>> api = LibraryServiceApi()
           >>> name = api.shelf_path('[SHELF]')
@@ -674,7 +674,7 @@ class LibraryServiceApi(object):
         Deletes a book.
 
         Example:
-          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
+          >>> from google.cloud.gapic.example.library.v1.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
           >>> name = api.book_path('[SHELF]', '[BOOK]')
           >>> api.delete_book(name)
@@ -703,7 +703,7 @@ class LibraryServiceApi(object):
         Updates a book.
 
         Example:
-          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
+          >>> from google.cloud.gapic.example.library.v1.library_service_api import LibraryServiceApi
           >>> from google.example.library.v1 import library_pb2
           >>> api = LibraryServiceApi()
           >>> name = api.book_path('[SHELF]', '[BOOK]')
@@ -745,7 +745,7 @@ class LibraryServiceApi(object):
         Moves a book to another shelf, and returns the new book.
 
         Example:
-          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
+          >>> from google.cloud.gapic.example.library.v1.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
           >>> name = api.book_path('[SHELF]', '[BOOK]')
           >>> other_shelf_name = api.shelf_path('[SHELF]')
@@ -778,7 +778,7 @@ class LibraryServiceApi(object):
         Lists a primitive resource. To test go page streaming.
 
         Example:
-          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
+          >>> from google.cloud.gapic.example.library.v1.library_service_api import LibraryServiceApi
           >>> from google.gax import CallOptions, INITIAL_PAGE
           >>> api = LibraryServiceApi()
           >>>
@@ -827,7 +827,7 @@ class LibraryServiceApi(object):
         Adds comments to a book
 
         Example:
-          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
+          >>> from google.cloud.gapic.example.library.v1.library_service_api import LibraryServiceApi
           >>> from google.example.library.v1 import library_pb2
           >>> api = LibraryServiceApi()
           >>> name = api.book_path('[SHELF]', '[BOOK]')
@@ -860,7 +860,7 @@ class LibraryServiceApi(object):
         Gets a book from an archive.
 
         Example:
-          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
+          >>> from google.cloud.gapic.example.library.v1.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
           >>> name = api.archived_book_path('[ARCHIVE_PATH]', '[BOOK]')
           >>> response = api.get_book_from_archive(name)
@@ -891,7 +891,7 @@ class LibraryServiceApi(object):
         Updates the index of a book.
 
         Example:
-          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
+          >>> from google.cloud.gapic.example.library.v1.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
           >>> name = api.book_path('[SHELF]', '[BOOK]')
           >>> index_name = ''
@@ -1018,7 +1018,7 @@ class LibraryServiceApi(object):
         Adds a tag to the book. This RPC is a mixin.
 
         Example:
-          >>> from google.example.library.v1.library_service_api import LibraryServiceApi
+          >>> from google.cloud.gapic.example.library.v1.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
           >>> resource = api.book_path('[SHELF]', '[BOOK]')
           >>> tag = ''

--- a/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
@@ -108,6 +108,42 @@ class LibraryServiceApi(object):
         'https://www.googleapis.com/auth/library',
     )
 
+    class Material(object):
+        """
+        Attributes:
+          PAPIER_MACHE (int)
+          WOOD (int)
+          PORCELAIN (int)
+          SEQUINS (int)
+          CARDBOARD (int)
+        """
+        PAPIER_MACHE = 0
+        WOOD = 1
+        PORCELAIN = 2
+        SEQUINS = 3
+        CARDBOARD = 4
+
+    class NullValue(object):
+        """
+        ``NullValue`` is a singleton enumeration to represent the null value for the
+        ``Value`` type union.
+
+         The JSON representation for ``NullValue`` is JSON ``null``.
+
+        Attributes:
+          NULL_VALUE (int): Null value.
+        """
+        NULL_VALUE = 0
+
+    class Rating(object):
+        """
+        Attributes:
+          GOOD (int): GOOD enum description
+          BAD (int)
+        """
+        GOOD = 0
+        BAD = 1
+
     _SHELF_PATH_TEMPLATE = path_template.PathTemplate(
         'shelves/{shelf}')
     _BOOK_PATH_TEMPLATE = path_template.PathTemplate(


### PR DESCRIPTION
This change creates convenient aliases for protocol buffer enums to allow us to document enums succinctly and correctly.

Note that generation is done into a single file per model (not service) to avoid duplication.

Fixes #275 