### PR TITLE
Add API key and 3LO scaffold to discovery

### DIFF
--- a/src/main/java/com/google/api/codegen/ApiaryConfig.java
+++ b/src/main/java/com/google/api/codegen/ApiaryConfig.java
@@ -126,7 +126,7 @@ public class ApiaryConfig {
   public enum AuthType {
     APPLICATION_DEFAULT_CREDENTIALS,
     OAUTH_3L,
-    API_KEY
+    API_KEY,
   }
 
   /*
@@ -134,23 +134,17 @@ public class ApiaryConfig {
    */
   public AuthType getAuthType() {
     String key = getServiceCanonicalName();
-    if (authOverrides.containsKey(key)) {
+    if (!Strings.isNullOrEmpty(key) && authOverrides.containsKey(key)) {
       return authOverrides.get(key);
     }
-    // This statement is based on the assumption that every method in a service contains all the
-    // scopes necessary to determine the correct auth mechanism for the entire service.
-    // Therefore, we use the scopes of the first method in the auth scopes array.
-    key = getAuthScopes().keySet().iterator().next();
-    List<String> scopes = getAuthScopes().get(key);
-    if (scopes.isEmpty()) {
-      // If there are no scopes, it's api key based.
+    // If the API has no scopes, then we know it's API key-based.
+    if (getAuthScopes().isEmpty()) {
       return AuthType.API_KEY;
     } else {
-      // If there are scopes, but cloud platform is one of them, then we can use ADC.
-      if (scopes.contains(CLOUD_PLATFORM_SCOPE)) {
+      // If there are scopes and cloud platform is one of them, then we can use ADC.
+      if (getAuthScopes().containsValue(CLOUD_PLATFORM_SCOPE)) {
         return AuthType.APPLICATION_DEFAULT_CREDENTIALS;
       }
-      // Otherwise it's 3 legged OAuth.
       return AuthType.OAUTH_3L;
     }
   }

--- a/src/main/java/com/google/api/codegen/discovery/MainDiscoveryProviderFactory.java
+++ b/src/main/java/com/google/api/codegen/discovery/MainDiscoveryProviderFactory.java
@@ -49,16 +49,29 @@ public class MainDiscoveryProviderFactory implements DiscoveryProviderFactory {
   public static final String PYTHON = "python";
   public static final String RUBY = "ruby";
 
-  private static final String DEFAULT_SNIPPET_FILE = "discovery_fragment.snip";
+  private static final String ADC_SNIPPET_FILE = "discovery_fragment.snip";
+  private static final String OAUTH_3L_SNIPPET_FILE = "3lo_discovery_fragment.snip";
+  private static final String API_KEY_SNIPPET_FILE = "api_key_discovery_fragment.snip";
 
   public static DiscoveryProvider defaultCreate(
       Service service, ApiaryConfig apiaryConfig, String id) {
+    String snippetFile;
+    // TODO(saicheems): Update this as new auth types are supported.
+    switch (apiaryConfig.getAuthType()) {
+      case APPLICATION_DEFAULT_CREDENTIALS:
+      case OAUTH_3L:
+      case API_KEY:
+        snippetFile = ADC_SNIPPET_FILE;
+        break;
+      default:
+        throw new RuntimeException("unsupported auth type");
+    }
     if (id.equals(CSHARP)) {
       return CommonDiscoveryProvider.newBuilder()
           .setContext(new CSharpDiscoveryContext(service, apiaryConfig))
           .setSnippetSetRunner(
               new CSharpSnippetSetRunner<Method>(SnippetSetRunner.SNIPPET_RESOURCE_ROOT))
-          .setSnippetFileName(id + "/" + DEFAULT_SNIPPET_FILE)
+          .setSnippetFileName(id + "/" + snippetFile)
           .build();
 
     } else if (id.equals(GO)) {
@@ -66,7 +79,7 @@ public class MainDiscoveryProviderFactory implements DiscoveryProviderFactory {
           .setContext(new GoDiscoveryContext(service, apiaryConfig))
           .setSnippetSetRunner(
               new GoSnippetSetRunner<Method>(SnippetSetRunner.SNIPPET_RESOURCE_ROOT))
-          .setSnippetFileName(id + "/" + DEFAULT_SNIPPET_FILE)
+          .setSnippetFileName(id + "/" + snippetFile)
           .build();
 
     } else if (id.equals(JAVA)) {
@@ -74,7 +87,7 @@ public class MainDiscoveryProviderFactory implements DiscoveryProviderFactory {
           .setContext(new JavaDiscoveryContext(service, apiaryConfig))
           .setSnippetSetRunner(
               new JavaSnippetSetRunner<Method>(SnippetSetRunner.SNIPPET_RESOURCE_ROOT))
-          .setSnippetFileName(id + "/" + DEFAULT_SNIPPET_FILE)
+          .setSnippetFileName(id + "/" + snippetFile)
           .build();
 
     } else if (id.equals(NODEJS)) {
@@ -82,7 +95,7 @@ public class MainDiscoveryProviderFactory implements DiscoveryProviderFactory {
           .setContext(new NodeJSDiscoveryContext(service, apiaryConfig))
           .setSnippetSetRunner(
               new NodeJSSnippetSetRunner<Method>(SnippetSetRunner.SNIPPET_RESOURCE_ROOT))
-          .setSnippetFileName(id + "/" + DEFAULT_SNIPPET_FILE)
+          .setSnippetFileName(id + "/" + snippetFile)
           .build();
 
     } else if (id.equals(PHP)) {
@@ -90,7 +103,7 @@ public class MainDiscoveryProviderFactory implements DiscoveryProviderFactory {
           .setContext(new PhpDiscoveryContext(service, apiaryConfig))
           .setSnippetSetRunner(
               new PhpSnippetSetRunner<Method>(SnippetSetRunner.SNIPPET_RESOURCE_ROOT))
-          .setSnippetFileName(id + "/" + DEFAULT_SNIPPET_FILE)
+          .setSnippetFileName(id + "/" + snippetFile)
           .build();
 
     } else if (id.equals(PYTHON)) {
@@ -99,7 +112,7 @@ public class MainDiscoveryProviderFactory implements DiscoveryProviderFactory {
           .setSnippetSetRunner(
               new PythonSnippetSetRunner<Method>(
                   new PythonDiscoveryInitializer(), SnippetSetRunner.SNIPPET_RESOURCE_ROOT))
-          .setSnippetFileName("py/" + DEFAULT_SNIPPET_FILE)
+          .setSnippetFileName("py/" + snippetFile)
           .build();
 
     } else if (id.equals(RUBY)) {
@@ -107,7 +120,7 @@ public class MainDiscoveryProviderFactory implements DiscoveryProviderFactory {
           .setContext(new RubyDiscoveryContext(service, apiaryConfig))
           .setSnippetSetRunner(
               new RubySnippetSetRunner<Method>(SnippetSetRunner.SNIPPET_RESOURCE_ROOT))
-          .setSnippetFileName(id + "/" + DEFAULT_SNIPPET_FILE)
+          .setSnippetFileName(id + "/" + snippetFile)
           .build();
 
     } else {

--- a/src/main/java/com/google/api/codegen/discovery/MainDiscoveryProviderFactory.java
+++ b/src/main/java/com/google/api/codegen/discovery/MainDiscoveryProviderFactory.java
@@ -49,9 +49,9 @@ public class MainDiscoveryProviderFactory implements DiscoveryProviderFactory {
   public static final String PYTHON = "python";
   public static final String RUBY = "ruby";
 
-  private static final String ADC_SNIPPET_FILE = "discovery_fragment.snip";
-  private static final String OAUTH_3L_SNIPPET_FILE = "3lo_discovery_fragment.snip";
-  private static final String API_KEY_SNIPPET_FILE = "api_key_discovery_fragment.snip";
+  private static final String SNIPPET_FILE_ADC = "discovery_fragment.snip";
+  private static final String SNIPPET_FILE_3LO = "discovery_fragment_3lo.snip";
+  private static final String SNIPPET_FILE_API_KEY = "discovery_fragment_api_key.snip";
 
   public static DiscoveryProvider defaultCreate(
       Service service, ApiaryConfig apiaryConfig, String id) {
@@ -61,7 +61,7 @@ public class MainDiscoveryProviderFactory implements DiscoveryProviderFactory {
       case APPLICATION_DEFAULT_CREDENTIALS:
       case OAUTH_3L:
       case API_KEY:
-        snippetFile = ADC_SNIPPET_FILE;
+        snippetFile = SNIPPET_FILE_ADC;
         break;
       default:
         throw new RuntimeException("unsupported auth type");


### PR DESCRIPTION
Adds 3 methods to ApiaryConfig that allow language contexts to print the
correct auth boilerplate.