### PR TITLE
Go: Use new retry mechanism

### DIFF
--- a/src/main/resources/com/google/api/codegen/go/main.snip
+++ b/src/main/resources/com/google/api/codegen/go/main.snip
@@ -83,22 +83,24 @@
 
     func default{@context.getClientPrefix(service)}CallOptions() *{@context.getClientPrefix(service)}CallOptions {
         retry := map[[2]string][]gax.CallOption{
-            @join retryName : context.getRetryConfigNames(service) if context.getApiConfig.getInterfaceConfig(service).getRetryCodesDefinition.get(retryName.getCodesName)
-                @let retryCodes = context.getApiConfig.getInterfaceConfig(service).getRetryCodesDefinition.get(retryName.getCodesName), \
-                        retrySettings = context.getApiConfig.getInterfaceConfig(service).getRetrySettingsDefinition.get(retryName.getSettingsName)
-                    {"{@retryName.getSettingsName}", "{@retryName.getCodesName}"}: {
-                        gax.WithRetry(func() gax.Retryer {
-                            return gax.OnCodes([]codes.Code{
-                                @join code : retryCodes
-                                    codes.{@context.upperUnderscoreToUpperCamel(code.toString())},
-                                @end
-                            }, gax.Backoff{
-                                Initial: {@retrySettings.getInitialRetryDelay.getMillis}*time.Millisecond,
-                                Max: {@retrySettings.getMaxRetryDelay.getMillis}*time.Millisecond,
-                                Multiplier: {@retrySettings.getRetryDelayMultiplier},
-                            })
-                        }),
-                    },
+            @let interfaceConf = context.getApiConfig.getInterfaceConfig(service)
+                @join retryName : context.getRetryConfigNames(service) if interfaceConf.getRetryCodesDefinition.get(retryName.getCodesName)
+                    @let retryCodes = interfaceConf.getRetryCodesDefinition.get(retryName.getCodesName), \
+                         retrySettings = interfaceConf.getRetrySettingsDefinition.get(retryName.getSettingsName)
+                        {"{@retryName.getSettingsName}", "{@retryName.getCodesName}"}: {
+                            gax.WithRetry(func() gax.Retryer {
+                                return gax.OnCodes([]codes.Code{
+                                    @join code : retryCodes
+                                        codes.{@context.upperUnderscoreToUpperCamel(code.toString())},
+                                    @end
+                                }, gax.Backoff{
+                                    Initial: {@retrySettings.getInitialRetryDelay.getMillis}*time.Millisecond,
+                                    Max: {@retrySettings.getMaxRetryDelay.getMillis}*time.Millisecond,
+                                    Multiplier: {@retrySettings.getRetryDelayMultiplier},
+                                })
+                            }),
+                        },
+                    @end
                 @end
             @end
         }
@@ -109,7 +111,7 @@
                      methodConfig = context.getApiConfig.getInterfaceConfig(service).getMethodConfig(method), \
                      retryParamsName = methodConfig.getRetrySettingsConfigName, \
                      retryCodesName = methodConfig.getRetryCodesConfigName
-                        {@methodName}: retry[[2]string{"{@retryParamsName}", "{@retryCodesName}"}],
+                    {@methodName}: retry[[2]string{"{@retryParamsName}", "{@retryCodesName}"}],
                 @end
             @end
         }

--- a/src/main/resources/com/google/api/codegen/go/main.snip
+++ b/src/main/resources/com/google/api/codegen/go/main.snip
@@ -81,35 +81,35 @@
         }
     }
 
-    @join retryDef : context.entrySet(context.getApiConfig.getInterfaceConfig(service).getRetrySettingsDefinition)
-        func {@context.lowerUnderscoreToLowerCamel(retryDef.getKey)}{@context.getClientPrefix(service)}RetryOptions() []gax.CallOption {
-            return []gax.CallOption{
-                gax.WithTimeout({@retryDef.getValue.getTotalTimeout.getMillis()}*time.Millisecond),
-                gax.WithDelayTimeoutSettings({@retryDef.getValue.getInitialRetryDelay.getMillis}*time.Millisecond, {@retryDef.getValue.getMaxRetryDelay.getMillis}*time.Millisecond, {@retryDef.getValue.getRetryDelayMultiplier}),
-                gax.WithRPCTimeoutSettings({@retryDef.getValue.getInitialRpcTimeout.getMillis}*time.Millisecond, {@retryDef.getValue.getMaxRpcTimeout.getMillis}*time.Millisecond, {@retryDef.getValue.getRpcTimeoutMultiplier}),
-            }
-        }
-    @end
-
     func default{@context.getClientPrefix(service)}CallOptions() *{@context.getClientPrefix(service)}CallOptions {
-        @join retryCodesDef : context.entrySet(context.getApiConfig.getInterfaceConfig(service).getRetryCodesDefinition) if retryCodesDef.getValue
-            with{@context.lowerUnderscoreToUpperCamel(retryCodesDef.getKey)}RetryCodes := gax.WithRetryCodes([]codes.Code{
-                @join code : retryCodesDef.getValue
-                    codes.{@context.upperUnderscoreToUpperCamel(code.toString())},
+        retry := map[[2]string][]gax.CallOption{
+            @join retryName : context.getRetryConfigNames(service) if context.getApiConfig.getInterfaceConfig(service).getRetryCodesDefinition.get(retryName.getCodesName)
+                @let retryCodes = context.getApiConfig.getInterfaceConfig(service).getRetryCodesDefinition.get(retryName.getCodesName), \
+                        retrySettings = context.getApiConfig.getInterfaceConfig(service).getRetrySettingsDefinition.get(retryName.getSettingsName)
+                    {"{@retryName.getSettingsName}", "{@retryName.getCodesName}"}: {
+                        gax.WithRetry(func() gax.Retryer {
+                            return gax.OnCodes([]codes.Code{
+                                @join code : retryCodes
+                                    codes.{@context.upperUnderscoreToUpperCamel(code.toString())},
+                                @end
+                            }, gax.Backoff{
+                                Initial: {@retrySettings.getInitialRetryDelay.getMillis}*time.Millisecond,
+                                Max: {@retrySettings.getMaxRetryDelay.getMillis}*time.Millisecond,
+                                Multiplier: {@retrySettings.getRetryDelayMultiplier},
+                            })
+                        }),
+                    },
                 @end
-            })
-        @end
+            @end
+        }
+
         return &{@context.getClientPrefix(service)}CallOptions{
             @join method : context.getNonStreamingMethods(service)
                 @let methodName = method.getSimpleName, \
                      methodConfig = context.getApiConfig.getInterfaceConfig(service).getMethodConfig(method), \
-                     retryParamsName = context.lowerUnderscoreToLowerCamel(methodConfig.getRetrySettingsConfigName), \
-                     retryCodesName = context.lowerUnderscoreToUpperCamel(methodConfig.getRetryCodesConfigName)
-                    @if {@context.hasEmptyRetryCodes(service, methodConfig)}
-                        {@methodName}: {@retryParamsName}{@context.getClientPrefix(service)}RetryOptions(),
-                    @else
-                        {@methodName}: append({@retryParamsName}{@context.getClientPrefix(service)}RetryOptions(), with{@retryCodesName}RetryCodes),
-                    @end
+                     retryParamsName = methodConfig.getRetrySettingsConfigName, \
+                     retryCodesName = methodConfig.getRetryCodesConfigName
+                        {@methodName}: retry[[2]string{"{@retryParamsName}", "{@retryCodesName}"}],
                 @end
             @end
         }

--- a/src/test/java/com/google/api/codegen/testdata/go_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_main_library.baseline
@@ -71,37 +71,40 @@ func defaultClientOptions() []option.ClientOption {
     }
 }
 
-func defaultRetryOptions() []gax.CallOption {
-    return []gax.CallOption{
-        gax.WithTimeout(30000*time.Millisecond),
-        gax.WithDelayTimeoutSettings(100*time.Millisecond, 1000*time.Millisecond, 1.2),
-        gax.WithRPCTimeoutSettings(300*time.Millisecond, 3000*time.Millisecond, 1.3),
-    }
-}
-
 func defaultCallOptions() *CallOptions {
-    withIdempotentRetryCodes := gax.WithRetryCodes([]codes.Code{
-        codes.DeadlineExceeded,
-        codes.Unavailable,
-    })
+    retry := map[[2]string][]gax.CallOption{
+        {"default", "idempotent"}: {
+            gax.WithRetry(func() gax.Retryer {
+                return gax.OnCodes([]codes.Code{
+                    codes.DeadlineExceeded,
+                    codes.Unavailable,
+                }, gax.Backoff{
+                    Initial: 100*time.Millisecond,
+                    Max: 1000*time.Millisecond,
+                    Multiplier: 1.2,
+                })
+            }),
+        },
+    }
+
     return &CallOptions{
-        CreateShelf: defaultRetryOptions(),
-        GetShelf: append(defaultRetryOptions(), withIdempotentRetryCodes),
-        ListShelves: append(defaultRetryOptions(), withIdempotentRetryCodes),
-        DeleteShelf: append(defaultRetryOptions(), withIdempotentRetryCodes),
-        MergeShelves: defaultRetryOptions(),
-        CreateBook: defaultRetryOptions(),
-        PublishSeries: defaultRetryOptions(),
-        GetBook: append(defaultRetryOptions(), withIdempotentRetryCodes),
-        ListBooks: append(defaultRetryOptions(), withIdempotentRetryCodes),
-        DeleteBook: append(defaultRetryOptions(), withIdempotentRetryCodes),
-        UpdateBook: append(defaultRetryOptions(), withIdempotentRetryCodes),
-        MoveBook: defaultRetryOptions(),
-        ListStrings: append(defaultRetryOptions(), withIdempotentRetryCodes),
-        AddComments: defaultRetryOptions(),
-        GetBookFromArchive: append(defaultRetryOptions(), withIdempotentRetryCodes),
-        UpdateBookIndex: append(defaultRetryOptions(), withIdempotentRetryCodes),
-        AddTag: defaultRetryOptions(),
+        CreateShelf: retry[[2]string{"default", "non_idempotent"}],
+        GetShelf: retry[[2]string{"default", "idempotent"}],
+        ListShelves: retry[[2]string{"default", "idempotent"}],
+        DeleteShelf: retry[[2]string{"default", "idempotent"}],
+        MergeShelves: retry[[2]string{"default", "non_idempotent"}],
+        CreateBook: retry[[2]string{"default", "non_idempotent"}],
+        PublishSeries: retry[[2]string{"default", "non_idempotent"}],
+        GetBook: retry[[2]string{"default", "idempotent"}],
+        ListBooks: retry[[2]string{"default", "idempotent"}],
+        DeleteBook: retry[[2]string{"default", "idempotent"}],
+        UpdateBook: retry[[2]string{"default", "idempotent"}],
+        MoveBook: retry[[2]string{"default", "non_idempotent"}],
+        ListStrings: retry[[2]string{"default", "idempotent"}],
+        AddComments: retry[[2]string{"default", "non_idempotent"}],
+        GetBookFromArchive: retry[[2]string{"default", "idempotent"}],
+        UpdateBookIndex: retry[[2]string{"default", "idempotent"}],
+        AddTag: retry[[2]string{"default", "non_idempotent"}],
     }
 }
 


### PR DESCRIPTION
This commit accompanies https://github.com/googleapis/gax-go/pull/36 .
It updates the client library generation to use the new retry mechanism.

A notable change:
defaultCallOptions and its friends now lookup the appropriate CallOption
in a map. This has two advantages:
- We should now initialize fewer anonymous functions.
  This is nice but does not greatly matter.
- In the YAML config, the names are normally in snake case.
  The previous implementation converts it into camel.
  We can get rid of this dance completely by just making the names
  opague strings.