### PR TITLE
Draft the smoke test generator with MVVM.

### DIFF
--- a/src/main/java/com/google/api/codegen/InterfaceConfig.java
+++ b/src/main/java/com/google/api/codegen/InterfaceConfig.java
@@ -77,7 +77,8 @@ public class InterfaceConfig {
       methodConfigs = createMethodConfigs(methodConfigMap, interfaceConfigProto);
     }
 
-    SmokeTestConfig smokeTestConfig = createSmokeTestConfig(iface, interfaceConfigProto);
+    SmokeTestConfig smokeTestConfig =
+        createSmokeTestConfig(diagCollector, iface, interfaceConfigProto);
 
     if (collectionConfigs == null || methodConfigMap == null) {
       return null;
@@ -93,9 +94,10 @@ public class InterfaceConfig {
   }
 
   private static SmokeTestConfig createSmokeTestConfig(
-      Interface iface, InterfaceConfigProto proto) {
-    if (proto.hasSmokeTest()) {
-      return SmokeTestConfig.createSmokeTestConfig(iface, proto.getSmokeTest());
+      DiagCollector diagCollector, Interface iface, InterfaceConfigProto interfaceConfigProto) {
+    if (interfaceConfigProto.hasSmokeTest()) {
+      return SmokeTestConfig.createSmokeTestConfig(
+          iface, interfaceConfigProto.getSmokeTest(), diagCollector);
     } else {
       return null;
     }

--- a/src/main/java/com/google/api/codegen/InterfaceConfig.java
+++ b/src/main/java/com/google/api/codegen/InterfaceConfig.java
@@ -25,6 +25,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 
+import org.joda.time.Duration;
+
 import io.grpc.Status;
 
 import java.util.ArrayList;
@@ -34,14 +36,13 @@ import java.util.List;
 
 import javax.annotation.Nullable;
 
-import org.joda.time.Duration;
-
 /**
  * InterfaceConfig represents the code-gen config for an API interface, and includes the
  * configuration for methods and resource names.
  */
 public class InterfaceConfig {
   private final List<MethodConfig> methodConfigs;
+  private final SmokeTestConfig smokeTestConfig;
   private final ImmutableMap<String, CollectionConfig> collectionConfigs;
   private final ImmutableMap<String, MethodConfig> methodConfigMap;
   private final ImmutableMap<String, ImmutableSet<Status.Code>> retryCodesDefinition;
@@ -76,15 +77,27 @@ public class InterfaceConfig {
       methodConfigs = createMethodConfigs(methodConfigMap, interfaceConfigProto);
     }
 
+    SmokeTestConfig smokeTestConfig = createSmokeTestConfig(iface, interfaceConfigProto);
+
     if (collectionConfigs == null || methodConfigMap == null) {
       return null;
     } else {
       return new InterfaceConfig(
           methodConfigs,
+          smokeTestConfig,
           collectionConfigs,
           methodConfigMap,
           retryCodesDefinition,
           retrySettingsDefinition);
+    }
+  }
+
+  private static SmokeTestConfig createSmokeTestConfig(
+      Interface iface, InterfaceConfigProto proto) {
+    if (proto.hasSmokeTest()) {
+      return SmokeTestConfig.createSmokeTestConfig(iface, proto.getSmokeTest());
+    } else {
+      return null;
     }
   }
 
@@ -217,11 +230,13 @@ public class InterfaceConfig {
 
   private InterfaceConfig(
       List<MethodConfig> methodConfigs,
+      SmokeTestConfig smokeTestConfig,
       ImmutableMap<String, CollectionConfig> collectionConfigs,
       ImmutableMap<String, MethodConfig> methodConfigMap,
       ImmutableMap<String, ImmutableSet<Status.Code>> retryCodesDefinition,
       ImmutableMap<String, RetrySettings> retryParamsDefinition) {
     this.methodConfigs = methodConfigs;
+    this.smokeTestConfig = smokeTestConfig;
     this.collectionConfigs = collectionConfigs;
     this.methodConfigMap = methodConfigMap;
     this.retryCodesDefinition = retryCodesDefinition;
@@ -233,6 +248,13 @@ public class InterfaceConfig {
    */
   public List<MethodConfig> getMethodConfigs() {
     return methodConfigs;
+  }
+
+  /**
+   * Returns the SmokeTestConfig.
+   */
+  public SmokeTestConfig getSmokeTestConfig() {
+    return smokeTestConfig;
   }
 
   public CollectionConfig getCollectionConfig(String entityName) {

--- a/src/main/java/com/google/api/codegen/InterfaceConfig.java
+++ b/src/main/java/com/google/api/codegen/InterfaceConfig.java
@@ -80,7 +80,7 @@ public class InterfaceConfig {
     SmokeTestConfig smokeTestConfig =
         createSmokeTestConfig(diagCollector, iface, interfaceConfigProto);
 
-    if (collectionConfigs == null || methodConfigMap == null || diagCollector.hasErrors()) {
+    if (diagCollector.hasErrors()) {
       return null;
     } else {
       return new InterfaceConfig(

--- a/src/main/java/com/google/api/codegen/InterfaceConfig.java
+++ b/src/main/java/com/google/api/codegen/InterfaceConfig.java
@@ -80,7 +80,7 @@ public class InterfaceConfig {
     SmokeTestConfig smokeTestConfig =
         createSmokeTestConfig(diagCollector, iface, interfaceConfigProto);
 
-    if (collectionConfigs == null || methodConfigMap == null) {
+    if (collectionConfigs == null || methodConfigMap == null || diagCollector.hasErrors()) {
       return null;
     } else {
       return new InterfaceConfig(

--- a/src/main/java/com/google/api/codegen/SmokeTestConfig.java
+++ b/src/main/java/com/google/api/codegen/SmokeTestConfig.java
@@ -1,0 +1,64 @@
+/* Copyright 2016 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen;
+
+import com.google.api.tools.framework.model.Interface;
+import com.google.api.tools.framework.model.Method;
+
+import java.util.List;
+
+/**
+ * SmokeTestConfig represents the smoke test configuration for a method.
+ */
+public class SmokeTestConfig {
+  private final Method method;
+  private final List<String> initFields;
+
+  private SmokeTestConfig(Method method, List<String> initFields) {
+    this.initFields = initFields;
+    this.method = method;
+  }
+
+  public static SmokeTestConfig createSmokeTestConfig(
+      Interface service, SmokeTestConfigProto proto) {
+    Method testedMethod = null;
+    for (Method method : service.getMethods()) {
+      if (method.getSimpleName().equals(proto.getMethod())) {
+        testedMethod = method;
+        break;
+      }
+    }
+
+    if (testedMethod != null) {
+      return new SmokeTestConfig(testedMethod, proto.getInitFieldsList());
+    } else {
+      throw new RuntimeException("The configured smoke test method does not exist.");
+    }
+  }
+
+  /**
+   * Returns a list of initialized fields configuration.
+   */
+  public List<String> getInitFields() {
+    return initFields;
+  }
+
+  /**
+   * Returns the method that is used in the smoke test.
+   */
+  public Method getMethod() {
+    return method;
+  }
+}

--- a/src/main/java/com/google/api/codegen/SmokeTestConfig.java
+++ b/src/main/java/com/google/api/codegen/SmokeTestConfig.java
@@ -14,14 +14,14 @@
  */
 package com.google.api.codegen;
 
+import com.google.api.tools.framework.model.Diag;
+import com.google.api.tools.framework.model.DiagCollector;
 import com.google.api.tools.framework.model.Interface;
 import com.google.api.tools.framework.model.Method;
-
+import com.google.api.tools.framework.model.SimpleLocation;
 import java.util.List;
 
-/**
- * SmokeTestConfig represents the smoke test configuration for a method.
- */
+/** SmokeTestConfig represents the smoke test configuration for a method. */
 public class SmokeTestConfig {
   private final Method method;
   private final List<String> initFields;
@@ -32,32 +32,30 @@ public class SmokeTestConfig {
   }
 
   public static SmokeTestConfig createSmokeTestConfig(
-      Interface service, SmokeTestConfigProto proto) {
+      Interface service, SmokeTestConfigProto smokeTestConfigProto, DiagCollector diagCollector) {
     Method testedMethod = null;
     for (Method method : service.getMethods()) {
-      if (method.getSimpleName().equals(proto.getMethod())) {
+      if (method.getSimpleName().equals(smokeTestConfigProto.getMethod())) {
         testedMethod = method;
         break;
       }
     }
 
     if (testedMethod != null) {
-      return new SmokeTestConfig(testedMethod, proto.getInitFieldsList());
+      return new SmokeTestConfig(testedMethod, smokeTestConfigProto.getInitFieldsList());
     } else {
-      throw new RuntimeException("The configured smoke test method does not exist.");
+      diagCollector.addDiag(
+          Diag.error(SimpleLocation.TOPLEVEL, "The configured smoke test method does not exist."));
+      return null;
     }
   }
 
-  /**
-   * Returns a list of initialized fields configuration.
-   */
+  /** Returns a list of initialized fields configuration. */
   public List<String> getInitFields() {
     return initFields;
   }
 
-  /**
-   * Returns the method that is used in the smoke test.
-   */
+  /** Returns the method that is used in the smoke test. */
   public Method getMethod() {
     return method;
   }

--- a/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
@@ -116,17 +116,14 @@ public class InitCodeTransformer {
   }
 
   public InitCodeView generateSmokeTestInitCode(
-      SurfaceTransformerContext context, SymbolTable table) {
-    SmokeTestConfig testConfig = context.getInterfaceConfig().getSmokeTestConfig();
+      MethodTransformerContext methodContext, SymbolTable table) {
+    SmokeTestConfig testConfig = methodContext.getInterfaceConfig().getSmokeTestConfig();
     Method method = testConfig.getMethod();
-    MethodTransformerContext methodContext =
-        context.asMethodContext(context.getInterfaceConfig().getSmokeTestConfig().getMethod());
     Map<String, Object> initFieldStructure =
         createSmokeTestInitMap(testConfig.getInitFields(), methodContext);
 
     ArrayList<Field> fields = new ArrayList<>();
     for (Field field : method.getInputMessage().getFields()) {
-      System.out.println(field.getSimpleName());
       if (testConfig.getInitFields().contains(field.getSimpleName())) {
         fields.add(field);
       }

--- a/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
@@ -463,9 +463,14 @@ public class SurfaceNamer extends NameFormatterDelegator {
     return methodName(Name.upperCamel(method.getSimpleName(), "Test"));
   }
 
-  /** The test class name for the given API service. */
-  public String getTestClassName(Interface service) {
+  /** The unit test class name for the given API service. */
+  public String getUnitTestClassName(Interface service) {
     return className(Name.upperCamel(service.getSimpleName(), "Test"));
+  }
+
+  /** The smoke test class name for the given API service. */
+  public String getSmokeTestClassName(Interface service) {
+    return className(Name.upperCamel(service.getSimpleName(), "Smoke", "Test"));
   }
 
   /** The class name of the mock gRPC service for the given API service. */

--- a/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
@@ -22,6 +22,7 @@ import com.google.api.codegen.util.Name;
 import com.google.api.codegen.util.NameFormatter;
 import com.google.api.codegen.util.NameFormatterDelegator;
 import com.google.api.codegen.util.NamePath;
+import com.google.api.codegen.util.SymbolTable;
 import com.google.api.codegen.util.TypeNameConverter;
 import com.google.api.tools.framework.aspects.documentation.model.DocumentationUtil;
 import com.google.api.tools.framework.model.Field;
@@ -459,8 +460,9 @@ public class SurfaceNamer extends NameFormatterDelegator {
   /**
    * The test case name for the given method.
    */
-  public String getTestCaseName(Method method) {
-    return methodName(Name.upperCamel(method.getSimpleName(), "Test"));
+  public String getTestCaseName(SymbolTable symbolTable, Method method) {
+    Name testCaseName = symbolTable.getNewSymbol(Name.upperCamel(method.getSimpleName(), "Test"));
+    return methodName(testCaseName);
   }
 
   /** The unit test class name for the given API service. */

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
@@ -407,8 +407,8 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
     typeTable.saveNicknameFor("java.util.List");
     typeTable.saveNicknameFor("com.google.common.collect.Lists");
     typeTable.saveNicknameFor("com.google.api.gax.core.PageAccessor");
-    typeTable.saveNicknameFor(
-        "autovalue.shaded.org.apache.commons.lang.builder.ReflectionToStringBuilder");
+    typeTable.saveNicknameFor("org.apache.commons.lang.builder.ReflectionToStringBuilder");
+    typeTable.saveNicknameFor("org.apache.commons.lang.builder.ToStringStyle");
   }
 
   private void addMockServiceImplImports(SurfaceTransformerContext context) {

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
@@ -43,6 +43,8 @@ import com.google.api.codegen.viewmodel.testing.MockGrpcResponseView;
 import com.google.api.codegen.viewmodel.testing.MockServiceImplView;
 import com.google.api.codegen.viewmodel.testing.MockServiceUsageView;
 import com.google.api.codegen.viewmodel.testing.MockServiceView;
+import com.google.api.codegen.viewmodel.testing.SmokeTestClassView;
+import com.google.api.codegen.viewmodel.testing.TestMethodView;
 import com.google.api.tools.framework.model.Field;
 import com.google.api.tools.framework.model.Interface;
 import com.google.api.tools.framework.model.Method;
@@ -56,18 +58,28 @@ import java.util.Map;
 
 /** A subclass of ModelToViewTransformer which translates model into API tests in Java. */
 public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
-  private ImportTypeTransformer importTypeTransformer;
-
-  private static String TEST_TEMPLATE_FILE = "java/test.snip";
+  // Template files
+  private static String UNIT_TEST_TEMPLATE_FILE = "java/test.snip";
+  private static String SMOKE_TEST_TEMPLATE_FILE = "java/smoke_test.snip";
   private static String MOCK_SERVICE_FILE = "java/mock_service.snip";
   private static String MOCK_SERVICE_IMPL_FILE = "java/mock_service_impl.snip";
 
   private final GapicCodePathMapper pathMapper;
+  private ImportTypeTransformer importTypeTransformer = new ImportTypeTransformer();
   private final TestValueGenerator valueGenerator = new TestValueGenerator(new JavaValueProducer());
 
   public JavaGapicSurfaceTestTransformer(GapicCodePathMapper javaPathMapper) {
     this.pathMapper = javaPathMapper;
-    this.importTypeTransformer = new ImportTypeTransformer();
+  }
+
+  @Override
+  public List<String> getTemplateFileNames() {
+    List<String> fileNames = new ArrayList<>();
+    fileNames.add(UNIT_TEST_TEMPLATE_FILE);
+    fileNames.add(SMOKE_TEST_TEMPLATE_FILE);
+    fileNames.add(MOCK_SERVICE_IMPL_FILE);
+    fileNames.add(MOCK_SERVICE_FILE);
+    return fileNames;
   }
 
   @Override
@@ -75,7 +87,10 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
     List<ViewModel> views = new ArrayList<>();
     for (Interface service : new InterfaceView().getElementIterable(model)) {
       SurfaceTransformerContext context = createContext(service, apiConfig);
-      views.add(createTestClassView(context));
+      views.add(createUnitTestClassView(context));
+      if (context.getInterfaceConfig().getSmokeTestConfig() != null) {
+        views.add(createSmokeTestClassView(context));
+      }
     }
     for (Interface service : getGrpcInterfacesToMock(model, apiConfig)) {
       SurfaceTransformerContext context = createContext(service, apiConfig);
@@ -87,90 +102,64 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
     return views;
   }
 
-  private Iterable<Interface> getGrpcInterfacesToMock(Model model, ApiConfig apiConfig) {
-    Map<String, Interface> interfaces = new LinkedHashMap<>();
+  ///////////////////////////////////// Smoke Test ///////////////////////////////////////
 
-    for (Interface service : new InterfaceView().getElementIterable(model)) {
-      if (!service.isReachable()) {
-        continue;
-      }
-      interfaces.put(service.getFullName(), service);
-      InterfaceConfig interfaceConfig = apiConfig.getInterfaceConfig(service);
-      for (MethodConfig methodConfig : interfaceConfig.getMethodConfigs()) {
-        String reroute = methodConfig.getRerouteToGrpcInterface();
-        if (!Strings.isNullOrEmpty(reroute)) {
-          Interface targetInterface = model.getSymbolTable().lookupInterface(reroute);
-          interfaces.put(reroute, targetInterface);
-        }
-      }
-    }
-
-    return interfaces.values();
-  }
-
-  private SurfaceTransformerContext createContext(Interface service, ApiConfig apiConfig) {
-    ModelTypeTable typeTable =
-        new ModelTypeTable(
-            new JavaTypeTable(apiConfig.getPackageName()),
-            new JavaModelTypeNameConverter(apiConfig.getPackageName()));
-    return SurfaceTransformerContext.create(
-        service, apiConfig, typeTable, new JavaSurfaceNamer(apiConfig.getPackageName()));
-  }
-
-  @Override
-  public List<String> getTemplateFileNames() {
-    List<String> fileNames = new ArrayList<>();
-    fileNames.add(TEST_TEMPLATE_FILE);
-    fileNames.add(MOCK_SERVICE_IMPL_FILE);
-    fileNames.add(MOCK_SERVICE_FILE);
-    return fileNames;
-  }
-
-  private void addTestImports(SurfaceTransformerContext context) {
-    ModelTypeTable typeTable = context.getTypeTable();
-    typeTable.saveNicknameFor("org.junit.After");
-    typeTable.saveNicknameFor("org.junit.AfterClass");
-    typeTable.saveNicknameFor("org.junit.Assert");
-    typeTable.saveNicknameFor("org.junit.Before");
-    typeTable.saveNicknameFor("org.junit.BeforeClass");
-    typeTable.saveNicknameFor("org.junit.Test");
-    typeTable.saveNicknameFor("java.io.IOException");
-    typeTable.saveNicknameFor("java.util.ArrayList");
-    typeTable.saveNicknameFor("java.util.Arrays");
-    typeTable.saveNicknameFor("java.util.List");
-    typeTable.saveNicknameFor("com.google.api.gax.testing.MockServiceHelper");
-    typeTable.saveNicknameFor("com.google.api.gax.testing.MockGrpcService");
-    typeTable.saveNicknameFor("com.google.api.gax.core.PageAccessor");
-    typeTable.saveNicknameFor("com.google.common.collect.Lists");
-    typeTable.saveNicknameFor("com.google.protobuf.GeneratedMessage");
-  }
-
-  private void addMockServiceImplImports(SurfaceTransformerContext context) {
-    ModelTypeTable typeTable = context.getTypeTable();
-    typeTable.saveNicknameFor("java.util.ArrayList");
-    typeTable.saveNicknameFor("java.util.List");
-    typeTable.saveNicknameFor("java.util.LinkedList");
-    typeTable.saveNicknameFor("java.util.Queue");
-    typeTable.saveNicknameFor("com.google.common.collect.Lists");
-    typeTable.saveNicknameFor("com.google.protobuf.GeneratedMessage");
-    typeTable.saveNicknameFor("io.grpc.stub.StreamObserver");
-  }
-
-  private void addMockServiceImports(SurfaceTransformerContext context) {
-    ModelTypeTable typeTable = context.getTypeTable();
-    typeTable.saveNicknameFor("java.util.List");
-    typeTable.saveNicknameFor("com.google.api.gax.testing.MockGrpcService");
-    typeTable.saveNicknameFor("com.google.protobuf.GeneratedMessage");
-    typeTable.saveNicknameFor("io.grpc.ServerServiceDefinition");
-  }
-
-  private GapicSurfaceTestClassView createTestClassView(SurfaceTransformerContext context) {
-    addTestImports(context);
+  private SmokeTestClassView createSmokeTestClassView(SurfaceTransformerContext context) {
+    context = context.withNewTypeTable();
+    addSmokeTestImports(context);
 
     Interface service = context.getInterface();
     String outputPath = pathMapper.getOutputPath(service, context.getApiConfig());
     SurfaceNamer namer = context.getNamer();
-    String name = namer.getTestClassName(service);
+    String name = namer.getSmokeTestClassName(service);
+
+    SmokeTestClassView testClass =
+        SmokeTestClassView.newBuilder()
+            .packageName(context.getApiConfig().getPackageName())
+            .apiSettingsClassName(namer.getApiSettingsClassName(service))
+            .apiClassName(namer.getApiWrapperClassName(service))
+            .name(name)
+            .outputPath(namer.getSourceFilePath(outputPath, name))
+            .templateFileName(SMOKE_TEST_TEMPLATE_FILE)
+            .method(createSmokeTestMethodView(context))
+            // Imports must be done as the last step to catch all imports.
+            .imports(importTypeTransformer.generateImports(context.getTypeTable().getImports()))
+            .build();
+    return testClass;
+  }
+
+  private TestMethodView createSmokeTestMethodView(SurfaceTransformerContext context) {
+    Method method = context.getInterfaceConfig().getSmokeTestConfig().getMethod();
+    SurfaceNamer namer = context.getNamer();
+
+    ApiMethodType methodType = ApiMethodType.FlattenedMethod;
+    if (context.asMethodContext(method).getMethodConfig().isPageStreaming()) {
+      methodType = ApiMethodType.PagedFlattenedMethod;
+    }
+
+    InitCodeTransformer initCodeTransformer = new InitCodeTransformer();
+    SymbolTable initSymbolTable = new SymbolTable();
+    InitCodeView initCodeView =
+        initCodeTransformer.generateSmokeTestInitCode(context, initSymbolTable);
+
+    return TestMethodView.newBuilder()
+        .name(namer.getApiMethodName(method))
+        .responseTypeName(context.getTypeTable().getAndSaveNicknameFor(method.getOutputType()))
+        .type(methodType)
+        .initCode(initCodeView)
+        .hasReturnValue(!ServiceMessages.s_isEmptyType(method.getOutputType()))
+        .build();
+  }
+
+  ///////////////////////////////////// Unit Test /////////////////////////////////////////
+
+  private GapicSurfaceTestClassView createUnitTestClassView(SurfaceTransformerContext context) {
+    addUnitTestImports(context);
+
+    Interface service = context.getInterface();
+    String outputPath = pathMapper.getOutputPath(service, context.getApiConfig());
+    SurfaceNamer namer = context.getNamer();
+    String name = namer.getUnitTestClassName(service);
 
     GapicSurfaceTestClassView testClass =
         GapicSurfaceTestClassView.newBuilder()
@@ -181,7 +170,7 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
             .testCases(createTestCaseViews(context))
             .mockServices(createMockServices(context))
             .outputPath(namer.getSourceFilePath(outputPath, name))
-            .templateFileName(TEST_TEMPLATE_FILE)
+            .templateFileName(UNIT_TEST_TEMPLATE_FILE)
             // Imports must be done as the last step to catch all imports.
             .imports(importTypeTransformer.generateImports(context.getTypeTable().getImports()))
             .build();
@@ -208,22 +197,7 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
     return testCaseViews;
   }
 
-  private List<MockServiceUsageView> createMockServices(SurfaceTransformerContext context) {
-    List<MockServiceUsageView> mockServices = new ArrayList<>();
-
-    SurfaceNamer namer = context.getNamer();
-    for (Interface service : getGrpcInterfacesToMock(context.getModel(), context.getApiConfig())) {
-      MockServiceUsageView mockService =
-          MockServiceUsageView.newBuilder()
-              .className(namer.getMockServiceClassName(service))
-              .varName(namer.getMockServiceVarName(service))
-              .build();
-      mockServices.add(mockService);
-    }
-
-    return mockServices;
-  }
-
+  // TODO: Convert to use TestMethodView.
   private GapicSurfaceTestCaseView createTestCaseView(
       MethodTransformerContext methodContext, List<Field> paramFields, SymbolTable testNameTable) {
     MethodConfig methodConfig = methodContext.getMethodConfig();
@@ -287,6 +261,29 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
             .getTypeTable()
             .getAndSaveNicknameFor(methodContext.getMethod().getOutputType());
     return MockGrpcResponseView.newBuilder().typeName(typeName).initCode(initCodeView).build();
+  }
+
+  private String getTestName(SymbolTable symbolTable, SurfaceNamer namer, Method method) {
+    Name name = symbolTable.getNewSymbol(Name.lowerCamel(namer.getTestCaseName(method)));
+    return namer.methodName(name);
+  }
+
+  ///////////////////////////////////// Mock Service /////////////////////////////////////////
+
+  private List<MockServiceUsageView> createMockServices(SurfaceTransformerContext context) {
+    List<MockServiceUsageView> mockServices = new ArrayList<>();
+
+    SurfaceNamer namer = context.getNamer();
+    for (Interface service : getGrpcInterfacesToMock(context.getModel(), context.getApiConfig())) {
+      MockServiceUsageView mockService =
+          MockServiceUsageView.newBuilder()
+              .className(namer.getMockServiceClassName(service))
+              .varName(namer.getMockServiceVarName(service))
+              .build();
+      mockServices.add(mockService);
+    }
+
+    return mockServices;
   }
 
   private MockServiceView createMockServiceView(SurfaceTransformerContext context) {
@@ -354,8 +351,86 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
         .build();
   }
 
-  private String getTestName(SymbolTable symbolTable, SurfaceNamer namer, Method method) {
-    Name name = symbolTable.getNewSymbol(Name.lowerCamel(namer.getTestCaseName(method)));
-    return namer.methodName(name);
+  /////////////////////////////////// General Helpers //////////////////////////////////////
+
+  private Iterable<Interface> getGrpcInterfacesToMock(Model model, ApiConfig apiConfig) {
+    Map<String, Interface> interfaces = new LinkedHashMap<>();
+
+    for (Interface service : new InterfaceView().getElementIterable(model)) {
+      if (!service.isReachable()) {
+        continue;
+      }
+      interfaces.put(service.getFullName(), service);
+      InterfaceConfig interfaceConfig = apiConfig.getInterfaceConfig(service);
+      for (MethodConfig methodConfig : interfaceConfig.getMethodConfigs()) {
+        String reroute = methodConfig.getRerouteToGrpcInterface();
+        if (!Strings.isNullOrEmpty(reroute)) {
+          Interface targetInterface = model.getSymbolTable().lookupInterface(reroute);
+          interfaces.put(reroute, targetInterface);
+        }
+      }
+    }
+
+    return interfaces.values();
+  }
+
+  private SurfaceTransformerContext createContext(Interface service, ApiConfig apiConfig) {
+    ModelTypeTable typeTable =
+        new ModelTypeTable(
+            new JavaTypeTable(apiConfig.getPackageName()),
+            new JavaModelTypeNameConverter(apiConfig.getPackageName()));
+    return SurfaceTransformerContext.create(
+        service, apiConfig, typeTable, new JavaSurfaceNamer(apiConfig.getPackageName()));
+  }
+
+  /////////////////////////////////// Imports //////////////////////////////////////
+
+  private void addUnitTestImports(SurfaceTransformerContext context) {
+    ModelTypeTable typeTable = context.getTypeTable();
+    typeTable.saveNicknameFor("org.junit.After");
+    typeTable.saveNicknameFor("org.junit.AfterClass");
+    typeTable.saveNicknameFor("org.junit.Assert");
+    typeTable.saveNicknameFor("org.junit.Before");
+    typeTable.saveNicknameFor("org.junit.BeforeClass");
+    typeTable.saveNicknameFor("org.junit.Test");
+    typeTable.saveNicknameFor("java.io.IOException");
+    typeTable.saveNicknameFor("java.util.ArrayList");
+    typeTable.saveNicknameFor("java.util.Arrays");
+    typeTable.saveNicknameFor("java.util.List");
+    typeTable.saveNicknameFor("com.google.api.gax.testing.MockServiceHelper");
+    typeTable.saveNicknameFor("com.google.api.gax.testing.MockGrpcService");
+    typeTable.saveNicknameFor("com.google.api.gax.core.PageAccessor");
+    typeTable.saveNicknameFor("com.google.common.collect.Lists");
+    typeTable.saveNicknameFor("com.google.protobuf.GeneratedMessage");
+  }
+
+  private void addSmokeTestImports(SurfaceTransformerContext context) {
+    ModelTypeTable typeTable = context.getTypeTable();
+    typeTable.saveNicknameFor("java.util.logging.Level");
+    typeTable.saveNicknameFor("java.util.logging.Logger");
+    typeTable.saveNicknameFor("java.util.List");
+    typeTable.saveNicknameFor("com.google.common.collect.Lists");
+    typeTable.saveNicknameFor("com.google.api.gax.core.PageAccessor");
+    typeTable.saveNicknameFor(
+        "autovalue.shaded.org.apache.commons.lang.builder.ReflectionToStringBuilder");
+  }
+
+  private void addMockServiceImplImports(SurfaceTransformerContext context) {
+    ModelTypeTable typeTable = context.getTypeTable();
+    typeTable.saveNicknameFor("java.util.ArrayList");
+    typeTable.saveNicknameFor("java.util.List");
+    typeTable.saveNicknameFor("java.util.LinkedList");
+    typeTable.saveNicknameFor("java.util.Queue");
+    typeTable.saveNicknameFor("com.google.common.collect.Lists");
+    typeTable.saveNicknameFor("com.google.protobuf.GeneratedMessage");
+    typeTable.saveNicknameFor("io.grpc.stub.StreamObserver");
+  }
+
+  private void addMockServiceImports(SurfaceTransformerContext context) {
+    ModelTypeTable typeTable = context.getTypeTable();
+    typeTable.saveNicknameFor("java.util.List");
+    typeTable.saveNicknameFor("com.google.api.gax.testing.MockGrpcService");
+    typeTable.saveNicknameFor("com.google.protobuf.GeneratedMessage");
+    typeTable.saveNicknameFor("io.grpc.ServerServiceDefinition");
   }
 }

--- a/src/main/java/com/google/api/codegen/viewmodel/testing/SmokeTestClassView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/testing/SmokeTestClassView.java
@@ -1,0 +1,73 @@
+/* Copyright 2016 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.viewmodel.testing;
+
+import com.google.api.codegen.SnippetSetRunner;
+import com.google.api.codegen.viewmodel.ImportTypeView;
+import com.google.api.codegen.viewmodel.ViewModel;
+import com.google.auto.value.AutoValue;
+
+import java.util.List;
+
+@AutoValue
+public abstract class SmokeTestClassView implements ViewModel {
+  public abstract String packageName();
+
+  public abstract String name();
+
+  public abstract String apiClassName();
+
+  public abstract String apiSettingsClassName();
+
+  public abstract List<ImportTypeView> imports();
+
+  public abstract TestMethodView method();
+
+  @Override
+  public String resourceRoot() {
+    return SnippetSetRunner.SNIPPET_RESOURCE_ROOT;
+  }
+
+  @Override
+  public abstract String templateFileName();
+
+  @Override
+  public abstract String outputPath();
+
+  public static Builder newBuilder() {
+    return new AutoValue_SmokeTestClassView.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder packageName(String val);
+
+    public abstract Builder name(String val);
+
+    public abstract Builder imports(List<ImportTypeView> val);
+
+    public abstract Builder apiClassName(String val);
+
+    public abstract Builder apiSettingsClassName(String val);
+
+    public abstract Builder outputPath(String val);
+
+    public abstract Builder templateFileName(String val);
+
+    public abstract Builder method(TestMethodView val);
+
+    public abstract SmokeTestClassView build();
+  }
+}

--- a/src/main/java/com/google/api/codegen/viewmodel/testing/TestMethodView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/testing/TestMethodView.java
@@ -1,0 +1,53 @@
+/* Copyright 2016 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.viewmodel.testing;
+
+import com.google.api.codegen.viewmodel.ApiMethodType;
+import com.google.api.codegen.viewmodel.InitCodeView;
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class TestMethodView {
+
+  public abstract InitCodeView initCode();
+
+  public abstract ApiMethodType type();
+
+  public abstract String responseTypeName();
+
+  public abstract String name();
+
+  public abstract boolean hasReturnValue();
+
+  public static Builder newBuilder() {
+    return new AutoValue_TestMethodView.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    public abstract Builder name(String val);
+
+    public abstract Builder initCode(InitCodeView val);
+
+    public abstract Builder type(ApiMethodType val);
+
+    public abstract Builder responseTypeName(String val);
+
+    public abstract Builder hasReturnValue(boolean val);
+
+    public abstract TestMethodView build();
+  }
+}

--- a/src/main/proto/com/google/api/codegen/config.proto
+++ b/src/main/proto/com/google/api/codegen/config.proto
@@ -104,6 +104,9 @@ message InterfaceConfigProto {
   // The fully qualified name of the API interface.
   string name = 1;
 
+  // Configuration of smoke test.
+  SmokeTestConfigProto smoke_test = 2;
+
   // A list of resource collection configurations.
   repeated CollectionConfigProto collections = 10;
 
@@ -115,6 +118,14 @@ message InterfaceConfigProto {
 
   // Definition for retry/backoff parameters
   repeated RetryParamsDefinitionProto retry_params_def = 31;
+}
+
+message SmokeTestConfigProto {
+  // The name of the method used in the smoke test.
+  string method = 1;
+
+  // A list describing the name and the value of the init fields.
+  repeated string init_fields = 2;
 }
 
 message CollectionConfigProto {

--- a/src/main/resources/com/google/api/codegen/java/smoke_test.snip
+++ b/src/main/resources/com/google/api/codegen/java/smoke_test.snip
@@ -1,0 +1,59 @@
+@extends "java/common.snip"
+@extends "java/initcode.snip"
+
+
+@snippet generate(smokeTest)
+  {@license()}
+
+  package {@smokeTest.packageName};
+
+  @join import : smokeTest.imports
+    import {@import.fullName};
+  @end
+
+  @@javax.annotation.Generated("by GAPIC")
+  public class {@smokeTest.name} {
+    public static void main(String args[]) {
+      Logger.getLogger("").setLevel(Level.WARNING);
+      try {
+        executeNoCatch(args);
+        System.out.println("ok");
+      } catch (Exception e) {
+        System.err.println("Failed with exception:");
+        e.printStackTrace(System.err);
+        System.exit(1);
+      }
+    }
+
+    public static void executeNoCatch(String args[]) throws Exception {
+      @let method = smokeTest.method
+        try ({@smokeTest.apiClassName} api = {@smokeTest.apiClassName}.create()) {
+          {@initCode(method.initCode)}
+
+          @switch method.type
+          @case "PagedFlattenedMethod"
+            PageAccessor<{@method.responseTypeName}> pageAccessor =
+                api.{@method.name}(\
+                  {@sampleMethodCallArgList(method.initCode.fieldSettings)});
+            System.out.println(ReflectionToStringBuilder.toString(pageAccessor));
+          @case "FlattenedMethod"
+            @if method.hasReturnValue
+              {@method.responseTypeName} response = \
+                api.{@method.name}({@args(method.initCode.fieldSettings)});
+              System.out.println(ReflectionToStringBuilder.toString(response));
+            @else
+              api.{@method.name}(\
+                {@sampleMethodCallArgList(method.initCode.fieldSettings)});
+            @end
+          @end
+        }
+      @end
+    }
+  }
+@end
+
+@private args(fieldSettings)
+  @join fieldSetting : fieldSettings on ", "
+    {@fieldSetting.identifier}
+  @end
+@end

--- a/src/main/resources/com/google/api/codegen/java/smoke_test.snip
+++ b/src/main/resources/com/google/api/codegen/java/smoke_test.snip
@@ -25,31 +25,37 @@
       }
     }
 
-    public static void executeNoCatch(String args[]) throws Exception {
-      @let method = smokeTest.method
-        try ({@smokeTest.apiClassName} api = {@smokeTest.apiClassName}.create()) {
-          {@initCode(method.initCode)}
+    {@executeNoCatch(smokeTest)}
+  }
+@end
 
-          @switch method.type
-          @case "PagedFlattenedMethod"
-            PageAccessor<{@method.responseTypeName}> pageAccessor =
-                api.{@method.name}(\
-                  {@sampleMethodCallArgList(method.initCode.fieldSettings)});
-            System.out.println(ReflectionToStringBuilder.toString(pageAccessor));
-          @case "FlattenedMethod"
-            @if method.hasReturnValue
-              {@method.responseTypeName} response = \
-                api.{@method.name}({@args(method.initCode.fieldSettings)});
-              System.out.println(ReflectionToStringBuilder.toString(response));
-            @else
-              api.{@method.name}(\
-                {@sampleMethodCallArgList(method.initCode.fieldSettings)});
-            @end
-          @end
-        }
-      @end
+@private executeNoCatch(smokeTest)
+  public static void executeNoCatch(String args[]) throws Exception {
+    try ({@smokeTest.apiClassName} api = {@smokeTest.apiClassName}.create()) {
+      {@methodCall(smokeTest.method)}
     }
   }
+@end
+
+@private methodCall(method)
+  {@initCode(method.initCode)}
+
+  @switch method.type
+  @case "PagedFlattenedMethod"
+    PageAccessor<{@method.responseTypeName}> pageAccessor =
+        api.{@method.name}(\
+          {@sampleMethodCallArgList(method.initCode.fieldSettings)});
+    System.out.println(ReflectionToStringBuilder.toString(pageAccessor));
+  @case "FlattenedMethod"
+    @if method.hasReturnValue
+      {@method.responseTypeName} response = \
+        api.{@method.name}({@args(method.initCode.fieldSettings)});
+      System.out.println(ReflectionToStringBuilder.toString(response, ToStringStyle.MULTI_LINE_STYLE));
+    @else
+      api.{@method.name}(\
+        {@sampleMethodCallArgList(method.initCode.fieldSettings)});
+    @end
+  @end
 @end
 
 @private args(fieldSettings)

--- a/src/test/java/com/google/api/codegen/testdata/java_smoke_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_smoke_test_library.baseline
@@ -1,0 +1,48 @@
+============== file: src/test/java/com/google/gcloud/pubsub/spi/LibraryServiceSmokeTest.java ==============
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.gcloud.pubsub.spi;
+
+import autovalue.shaded.org.apache.commons.lang.builder.ReflectionToStringBuilder;
+import com.google.api.gax.core.PageAccessor;
+import com.google.common.collect.Lists;
+import com.google.example.library.v1.Shelf;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@javax.annotation.Generated("by GAPIC")
+public class LibraryServiceSmokeTest {
+  public static void main(String args[]) {
+    Logger.getLogger("").setLevel(Level.WARNING);
+    try {
+      executeNoCatch(args);
+      System.out.println("ok");
+    } catch (Exception e) {
+      System.err.println("Failed with exception:");
+      e.printStackTrace(System.err);
+      System.exit(1);
+    }
+  }
+
+  public static void executeNoCatch(String args[]) throws Exception {
+    try (LibraryServiceApi api = LibraryServiceApi.create()) {
+      Shelf shelf = Shelf.newBuilder().build();
+
+      Shelf response = api.createShelf(shelf);
+      System.out.println(ReflectionToStringBuilder.toString(response));
+    }
+  }
+}

--- a/src/test/java/com/google/api/codegen/testdata/java_smoke_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_smoke_test_library.baseline
@@ -15,13 +15,14 @@
 
 package com.google.gcloud.pubsub.spi;
 
-import autovalue.shaded.org.apache.commons.lang.builder.ReflectionToStringBuilder;
 import com.google.api.gax.core.PageAccessor;
 import com.google.common.collect.Lists;
 import com.google.example.library.v1.Shelf;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.apache.commons.lang.builder.ReflectionToStringBuilder;
+import org.apache.commons.lang.builder.ToStringStyle;
 
 @javax.annotation.Generated("by GAPIC")
 public class LibraryServiceSmokeTest {

--- a/src/test/java/com/google/api/codegen/testdata/java_smoke_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_smoke_test_library.baseline
@@ -42,7 +42,7 @@ public class LibraryServiceSmokeTest {
       Shelf shelf = Shelf.newBuilder().build();
 
       Shelf response = api.createShelf(shelf);
-      System.out.println(ReflectionToStringBuilder.toString(response));
+      System.out.println(ReflectionToStringBuilder.toString(response, ToStringStyle.MULTI_LINE_STYLE));
     }
   }
 }

--- a/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
@@ -43,6 +43,10 @@ interfaces:
     entity_name: book
   - name_pattern: archives/{archive_path=**}/books/{book}
     entity_name: archived_book
+  smoke_test:
+    method: CreateShelf
+    init_fields:
+      - shelf
   methods:
   - name: CreateShelf
     flattening:


### PR DESCRIPTION
This is the initial implementation of the automate smoke generator. The basic structure is implemented but some functionalities are missing

**MVVM changes:**
- Config Model
  - Add smoke test into config proto
  - Add SmokeTestConfig class which contains the config data
- Transformer
  - Reorganize JavaGapicSurfaceTestTransformer to improve readability.
  - Implement transformer for smoke test.
  - Implement init code transformer for smoke test.
- View Model
  - SmokeTestClassView
  - TestMethodClassView (This view can be shared by unit test as well, I will make the change in a following PR).
- View
  - smoke_test.snip

**TODOs:**
- Add new config rules so users could assign init values to the fields such as:
   - Support collection pattern
   - Support random value
- Make unit test transformer reuse TestMethodClassView.
