### PR TITLE
Fix NodeJS style violations

### DIFF
--- a/src/main/resources/com/google/api/codegen/nodejs/main.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/main.snip
@@ -91,7 +91,7 @@
         return new {@apiName}(gaxGrpc, grpcClient, opts);
       };
       extend(this.{@context.upperCamelToLowerCamel(apiName)}, {@apiName});
-    };
+    }
     module.exports = {@apiName}Builder;
     module.exports.SERVICE_ADDRESS = SERVICE_ADDRESS;
     module.exports.ALL_SCOPES = ALL_SCOPES;
@@ -115,7 +115,7 @@
                requestToken = pageStreaming.getRequestTokenField().getSimpleName(), \
                responseToken = pageStreaming.getResponseTokenField().getSimpleName(), \
                resources = pageStreaming.getResourcesField().getSimpleName()
-              '{@methodName(method)}': new gax.PageDescriptor(
+              {@methodName(method)}: new gax.PageDescriptor(
                   '{@requestToken}',
                   '{@responseToken}',
                   '{@resources}')
@@ -212,7 +212,7 @@
         var bundleDescriptors = {
           @join method : context.messages.filterBundlingMethods(ifaceConfig, context.getNonStreamingMethods(service)) on {@", "}.add(BREAK)
             @let bundling = ifaceConfig.getMethodConfig(method).getBundling()
-              '{@methodName(method)}': new gax.BundleDescriptor(
+              {@methodName(method)}: new gax.BundleDescriptor(
                   '{@bundling.getBundledField().getSimpleName()}',
                   [
                     @join fieldSelector : bundling.getDiscriminatorFields() on {@", "}.add(BREAK)
@@ -322,7 +322,7 @@
 
 @private createRenderDictionary(collectionConfig)
   @join param: collectionConfig.getNameTemplate.vars() on {@","}.add(BREAK)
-    '{@param}': {@param}
+    {@param}: {@param}
   @end
 @end
 

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_doc_main_library.baseline
@@ -42,15 +42,15 @@ var CODE_GEN_NAME_VERSION = 'gapic/0.1.0';
 var DEFAULT_TIMEOUT = 30;
 
 var PAGE_DESCRIPTORS = {
-  'listShelves': new gax.PageDescriptor(
+  listShelves: new gax.PageDescriptor(
       'page_token',
       'next_page_token',
       'shelves'),
-  'listBooks': new gax.PageDescriptor(
+  listBooks: new gax.PageDescriptor(
       'page_token',
       'next_page_token',
       'books'),
-  'listStrings': new gax.PageDescriptor(
+  listStrings: new gax.PageDescriptor(
       'page_token',
       'next_page_token',
       'strings')
@@ -108,7 +108,7 @@ function LibraryServiceApi(gaxGrpc, grpcClient, opts) {
 
 
   var bundleDescriptors = {
-    'publishSeries': new gax.BundleDescriptor(
+    publishSeries: new gax.BundleDescriptor(
         'books',
         [
           'edition',
@@ -175,7 +175,7 @@ var ARCHIVED_BOOK_PATH_TEMPLATE = new gax.PathTemplate(
  */
 LibraryServiceApi.prototype.shelfPath = function shelfPath(shelf) {
   return SHELF_PATH_TEMPLATE.render({
-    'shelf': shelf
+    shelf: shelf
   });
 };
 
@@ -198,8 +198,8 @@ LibraryServiceApi.prototype.matchShelfFromShelfName =
  */
 LibraryServiceApi.prototype.bookPath = function bookPath(shelf, book) {
   return BOOK_PATH_TEMPLATE.render({
-    'shelf': shelf,
-    'book': book
+    shelf: shelf,
+    book: book
   });
 };
 
@@ -233,8 +233,8 @@ LibraryServiceApi.prototype.matchBookFromBookName =
  */
 LibraryServiceApi.prototype.archivedBookPath = function archivedBookPath(archive_path, book) {
   return ARCHIVED_BOOK_PATH_TEMPLATE.render({
-    'archive_path': archive_path,
-    'book': book
+    archive_path: archive_path,
+    book: book
   });
 };
 
@@ -1060,7 +1060,7 @@ function LibraryServiceApiBuilder(gaxGrpc) {
     return new LibraryServiceApi(gaxGrpc, grpcClient, opts);
   };
   extend(this.libraryServiceApi, LibraryServiceApi);
-};
+}
 module.exports = LibraryServiceApiBuilder;
 module.exports.SERVICE_ADDRESS = SERVICE_ADDRESS;
 module.exports.ALL_SCOPES = ALL_SCOPES;

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_main_library.baseline
@@ -42,15 +42,15 @@ var CODE_GEN_NAME_VERSION = 'gapic/0.1.0';
 var DEFAULT_TIMEOUT = 30;
 
 var PAGE_DESCRIPTORS = {
-  'listShelves': new gax.PageDescriptor(
+  listShelves: new gax.PageDescriptor(
       'page_token',
       'next_page_token',
       'shelves'),
-  'listBooks': new gax.PageDescriptor(
+  listBooks: new gax.PageDescriptor(
       'page_token',
       'next_page_token',
       'books'),
-  'listStrings': new gax.PageDescriptor(
+  listStrings: new gax.PageDescriptor(
       'page_token',
       'next_page_token',
       'strings')
@@ -108,7 +108,7 @@ function LibraryServiceApi(gaxGrpc, grpcClient, opts) {
 
 
   var bundleDescriptors = {
-    'publishSeries': new gax.BundleDescriptor(
+    publishSeries: new gax.BundleDescriptor(
         'books',
         [
           'edition',
@@ -175,7 +175,7 @@ var ARCHIVED_BOOK_PATH_TEMPLATE = new gax.PathTemplate(
  */
 LibraryServiceApi.prototype.shelfPath = function shelfPath(shelf) {
   return SHELF_PATH_TEMPLATE.render({
-    'shelf': shelf
+    shelf: shelf
   });
 };
 
@@ -198,8 +198,8 @@ LibraryServiceApi.prototype.matchShelfFromShelfName =
  */
 LibraryServiceApi.prototype.bookPath = function bookPath(shelf, book) {
   return BOOK_PATH_TEMPLATE.render({
-    'shelf': shelf,
-    'book': book
+    shelf: shelf,
+    book: book
   });
 };
 
@@ -233,8 +233,8 @@ LibraryServiceApi.prototype.matchBookFromBookName =
  */
 LibraryServiceApi.prototype.archivedBookPath = function archivedBookPath(archive_path, book) {
   return ARCHIVED_BOOK_PATH_TEMPLATE.render({
-    'archive_path': archive_path,
-    'book': book
+    archive_path: archive_path,
+    book: book
   });
 };
 
@@ -1060,7 +1060,7 @@ function LibraryServiceApiBuilder(gaxGrpc) {
     return new LibraryServiceApi(gaxGrpc, grpcClient, opts);
   };
   extend(this.libraryServiceApi, LibraryServiceApi);
-};
+}
 module.exports = LibraryServiceApiBuilder;
 module.exports.SERVICE_ADDRESS = SERVICE_ADDRESS;
 module.exports.ALL_SCOPES = ALL_SCOPES;

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_main_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_main_no_path_templates.baseline
@@ -170,7 +170,7 @@ function NoTemplatesServiceApiBuilder(gaxGrpc) {
     return new NoTemplatesServiceApi(gaxGrpc, grpcClient, opts);
   };
   extend(this.noTemplatesServiceApi, NoTemplatesServiceApi);
-};
+}
 module.exports = NoTemplatesServiceApiBuilder;
 module.exports.SERVICE_ADDRESS = SERVICE_ADDRESS;
 module.exports.ALL_SCOPES = ALL_SCOPES;


### PR DESCRIPTION
- unnecessary semicolon at the end of module initializer function
- keys of dictionaries are usually not quoted (i.e.
  not `{'foo': foo}` but `{foo: foo}`)

See https://github.com/GoogleCloudPlatform/google-cloud-node/pull/1548