### PR TITLE
Update configgen package name for Ruby/NodeJS

### DIFF
--- a/src/main/java/com/google/api/codegen/config/LanguageGenerator.java
+++ b/src/main/java/com/google/api/codegen/config/LanguageGenerator.java
@@ -40,20 +40,16 @@ public class LanguageGenerator {
         Arrays.asList(
             new RewriteRule("^google", "com.google.cloud"),
             new RewriteRule("(.v[^.]+)$", ".spi$1"));
-    List<RewriteRule> phpRewriteRules =
-        Arrays.asList(new RewriteRule("^google(?!\\.cloud)", "google.cloud"));
-    List<RewriteRule> pythonRewriteRules =
-        Arrays.asList(new RewriteRule("^google(?!\\.cloud)", "google.cloud"));
-    List<RewriteRule> rubyRewriteRules =
+    List<RewriteRule> commonRewriteRules =
         Arrays.asList(new RewriteRule("^google(?!\\.cloud)", "google.cloud"));
     LANGUAGE_FORMATTERS =
         ImmutableMap.<String, LanguageFormatter>builder()
             .put("java", new SimpleLanguageFormatter(".", javaRewriteRules, false))
-            .put("python", new SimpleLanguageFormatter(".", pythonRewriteRules, false))
+            .put("python", new SimpleLanguageFormatter(".", commonRewriteRules, false))
             .put("go", new GoLanguageFormatter())
             .put("csharp", new SimpleLanguageFormatter(".", null, true))
-            .put("ruby", new SimpleLanguageFormatter("::", rubyRewriteRules, true))
-            .put("php", new SimpleLanguageFormatter("\\", phpRewriteRules, true))
+            .put("ruby", new SimpleLanguageFormatter("::", commonRewriteRules, true))
+            .put("php", new SimpleLanguageFormatter("\\", commonRewriteRules, true))
             .put("nodejs", new NodeJSLanguageFormatter())
             .build();
   }

--- a/src/main/java/com/google/api/codegen/config/LanguageGenerator.java
+++ b/src/main/java/com/google/api/codegen/config/LanguageGenerator.java
@@ -75,7 +75,7 @@ public class LanguageGenerator {
   /**
    * Returns true if it is a Google Cloud API.
    */
-  private static boolean IsApiGoogleCloud(List<String> nameComponents) {
+  private static boolean isApiGoogleCloud(List<String> nameComponents) {
     int size = nameComponents.size();
     return size >= 3
         && nameComponents.get(0).equals("google")
@@ -127,7 +127,7 @@ public class LanguageGenerator {
       // we reformat it into cloud.google.com.
       // google.logging.v2 => cloud.google.com/go/logging/apiv2
       // Otherwise, fall back to backup
-      if (!IsApiGoogleCloud(nameComponents)) {
+      if (!isApiGoogleCloud(nameComponents)) {
         nameComponents.add(0, "google.golang.org");
         return Joiner.on("/").join(nameComponents);
       }
@@ -144,7 +144,7 @@ public class LanguageGenerator {
       List<String> nameComponents = Splitter.on(DEFAULT_PACKAGE_SEPARATOR).splitToList(packageName);
       // NodeJS uses "@google-cloud/<APINAME>" for the package name of a Google Cloud API.
       // Otherwise falls back to a pattern of "foo-bar" style with "gax-" prefix.
-      if (!IsApiGoogleCloud(nameComponents)) {
+      if (!isApiGoogleCloud(nameComponents)) {
         return "gax-" + Joiner.on("-").join(nameComponents);
       }
       return "@google-cloud/" + nameComponents.get(nameComponents.size() - 2);

--- a/src/test/java/com/google/api/codegen/testdata/library_config.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/library_config.baseline
@@ -9,9 +9,11 @@ language_settings:
   csharp:
     package_name: Google.Example.Library.V1
   ruby:
-    package_name: Google::Example::Library::V1
+    package_name: Google::Cloud::Example::Library::V1
   php:
     package_name: Google\Cloud\Example\Library\V1
+  nodejs:
+    package_name: '@google-cloud/library'
 interfaces:
 - name: google.example.library.v1.LibraryService
   collections:

--- a/src/test/java/com/google/api/codegen/testdata/no_path_templates_config.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/no_path_templates_config.baseline
@@ -12,6 +12,8 @@ language_settings:
     package_name: Google::Cloud::Example::V1
   php:
     package_name: Google\Cloud\Example\V1
+  nodejs:
+    package_name: '@google-cloud/example'
 interfaces:
 - name: google.cloud.example.v1.NoTemplatesService
   collections: []


### PR DESCRIPTION
- Ruby has the same naming policy of Google::Cloud as other
  languages have.
- NodeJS -- uses @google-cloud/... for cloud APIs.