### PR TITLE
Add basic 3LO and API key auth support in discovery

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,6 +110,9 @@ task discoJar(type: com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar) 
   }
   from sourceSets.main.output
   configurations = [ project.configurations.runtime ]
+  exclude "META-INF/*.SF"
+  exclude "META-INF/*.DSA"
+  exclude "META-INF/*.RSA"
 }
 
 jacocoTestReport {

--- a/src/main/java/com/google/api/codegen/ApiaryConfig.java
+++ b/src/main/java/com/google/api/codegen/ApiaryConfig.java
@@ -102,14 +102,63 @@ public class ApiaryConfig {
   private final Table<Type, String, Field> fields = HashBasedTable.<Type, String, Field>create();
 
   /*
-   * The service canonical name, or name if no canonical name
+   * The service canonical name, or name if no canonical name.
    */
   private String serviceCanonicalName;
 
   /*
-   * The service version string
+   * The service version string.
    */
   private String serviceVersion;
+
+  /*
+   * The auth instructions URL.
+   */
+  private String authInstructionsUrl;
+
+  /*
+   * Maps API names to an AuthType override.
+   */
+  private Map<String, AuthType> authOverrides = new HashMap<>();
+
+  /*
+   * If present in the scope list, indicates that the API supports application default credentials
+   * based auth.
+   */
+  private static final String CLOUD_PLATFORM_SCOPE =
+      "https://www.googleapis.com/auth/cloud-platform";
+
+  /*
+   * Possible auth types supported by discovery.
+   */
+  public enum AuthType {
+    APPLICATION_DEFAULT_CREDENTIALS,
+    OAUTH_3L,
+    API_KEY,
+  }
+
+  /*
+   * Returns the auth type supported by the service.
+   */
+  public AuthType getAuthType() {
+    String key = getServiceCanonicalName();
+    if (!Strings.isNullOrEmpty(key) && authOverrides.containsKey(key)) {
+      return authOverrides.get(key);
+    }
+    // If the API has no scopes, then we know it's API key-based.
+    if (getAuthScopes().isEmpty()) {
+      return AuthType.API_KEY;
+    }
+    // If there are scopes and cloud platform is one of them, then we can use ADC.
+    if (getAuthScopes().containsValue(CLOUD_PLATFORM_SCOPE)) {
+      return AuthType.APPLICATION_DEFAULT_CREDENTIALS;
+    }
+    return AuthType.OAUTH_3L;
+  }
+
+  public String getAuthInstructionsUrl() {
+    return Strings.nullToEmpty(authInstructionsUrl);
+  }
 
   public ListMultimap<String, String> getMethodParams() {
     return methodParams;
@@ -165,6 +214,10 @@ public class ApiaryConfig {
 
   public void setServiceVersion(String serviceVersion) {
     this.serviceVersion = serviceVersion;
+  }
+
+  public void setAuthInstructionsUrl(String authInstructionsUrl) {
+    this.authInstructionsUrl = authInstructionsUrl;
   }
 
   /**
@@ -229,5 +282,12 @@ public class ApiaryConfig {
    */
   public ListMultimap<String, String> getAuthScopes() {
     return authScopes;
+  }
+
+  /*
+   * @return true if method has any auth scopes.
+   */
+  public boolean hasAuthScopes(String methodName) {
+    return authScopes.containsKey(methodName);
   }
 }

--- a/src/main/java/com/google/api/codegen/DiscoveryFragmentGeneratorApi.java
+++ b/src/main/java/com/google/api/codegen/DiscoveryFragmentGeneratorApi.java
@@ -74,7 +74,7 @@ public class DiscoveryFragmentGeneratorApi {
       ToolOptions.createOption(
           String.class,
           "auth_instructions",
-          "A comma-delimited map of language to auth instructions URL: lang:URL,lang:URL",
+          "A comma-delimited map of language to auth instructions URL: lang:URL,lang:URL,...",
           "");
 
   private final ToolOptions options;
@@ -129,7 +129,7 @@ public class DiscoveryFragmentGeneratorApi {
   /*
    * Parses strings of the format
    * "go:https://www.hello.com,java:https://www.world.com" and returns the value
-   * of the key corresponding to id.
+   * of the key corresponding to the key id.
    */
   private String parseAuthInstructionsUrl(String authInstructionsUrl, String id) {
     if (Strings.isNullOrEmpty(authInstructionsUrl)) {

--- a/src/main/java/com/google/api/codegen/DiscoveryFragmentGeneratorApi.java
+++ b/src/main/java/com/google/api/codegen/DiscoveryFragmentGeneratorApi.java
@@ -73,8 +73,8 @@ public class DiscoveryFragmentGeneratorApi {
   public static final Option<String> AUTH_INSTRUCTIONS_URL =
       ToolOptions.createOption(
           String.class,
-          "auth_url",
-          "A comma delimited map of language to auth instructions URL.",
+          "auth_instructions",
+          "A comma-delimited map of language to auth instructions URL: lang:URL,lang:URL",
           "");
 
   private final ToolOptions options;
@@ -111,9 +111,9 @@ public class DiscoveryFragmentGeneratorApi {
     String factory = generator.getFactory();
     String id = generator.getId();
 
-    String authUrl = options.get(AUTH_INSTRUCTIONS_URL);
+    String authInstructions = options.get(AUTH_INSTRUCTIONS_URL);
     ApiaryConfig apiaryConfig = discovery.getConfig();
-    apiaryConfig.setAuthInstructionsUrl(parseAuthUrl(authUrl, id));
+    apiaryConfig.setAuthInstructionsUrl(parseAuthInstructionsUrl(authInstructions, id));
 
     DiscoveryProviderFactory providerFactory = createProviderFactory(factory);
     DiscoveryProvider provider = providerFactory.create(discovery.getService(), apiaryConfig, id);
@@ -131,12 +131,12 @@ public class DiscoveryFragmentGeneratorApi {
    * "go:https://www.hello.com,java:https://www.world.com" and returns the value
    * of the key corresponding to id.
    */
-  private String parseAuthUrl(String authUrl, String id) {
-    if (Strings.isNullOrEmpty(authUrl)) {
+  private String parseAuthInstructionsUrl(String authInstructionsUrl, String id) {
+    if (Strings.isNullOrEmpty(authInstructionsUrl)) {
       return "";
     }
     // Split on ','
-    Iterable<String> it = Splitter.on(',').split(authUrl);
+    Iterable<String> it = Splitter.on(',').split(authInstructionsUrl);
     for (String item : it) {
       // Split on only the first ':' and return if there are two values and the
       // language matches.

--- a/src/main/java/com/google/api/codegen/DiscoveryFragmentGeneratorApi.java
+++ b/src/main/java/com/google/api/codegen/DiscoveryFragmentGeneratorApi.java
@@ -14,6 +14,18 @@
  */
 package com.google.api.codegen;
 
+import java.io.File;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+
 import com.google.api.codegen.discovery.DiscoveryProvider;
 import com.google.api.codegen.discovery.DiscoveryProviderFactory;
 import com.google.api.codegen.util.ClassInstantiator;
@@ -32,17 +44,6 @@ import com.google.inject.TypeLiteral;
 import com.google.protobuf.Api;
 import com.google.protobuf.Message;
 import com.google.protobuf.Method;
-
-import java.io.File;
-import java.nio.charset.Charset;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
-import javax.annotation.Nullable;
 
 /**
  * Main class for the discovery doc fragment generator.
@@ -68,6 +69,13 @@ public class DiscoveryFragmentGeneratorApi {
           "config_files",
           "The list of YAML configuration files for the fragment generator.",
           ImmutableList.<String>of());
+
+  public static final Option<String> AUTH_INSTRUCTIONS_URL =
+      ToolOptions.createOption(
+          String.class,
+          "auth_url",
+          "A comma delimited map of language to auth instructions URL.",
+          "");
 
   private final ToolOptions options;
   private final String dataPath;
@@ -103,9 +111,12 @@ public class DiscoveryFragmentGeneratorApi {
     String factory = generator.getFactory();
     String id = generator.getId();
 
+    String authUrl = options.get(AUTH_INSTRUCTIONS_URL);
+    ApiaryConfig apiaryConfig = discovery.getConfig();
+    apiaryConfig.setAuthInstructionsUrl(parseAuthUrl(authUrl, id));
+
     DiscoveryProviderFactory providerFactory = createProviderFactory(factory);
-    DiscoveryProvider provider =
-        providerFactory.create(discovery.getService(), discovery.getConfig(), id);
+    DiscoveryProvider provider = providerFactory.create(discovery.getService(), apiaryConfig, id);
 
     for (Api api : discovery.getService().getApisList()) {
       for (Method method : api.getMethodsList()) {
@@ -113,6 +124,28 @@ public class DiscoveryFragmentGeneratorApi {
         ToolUtil.writeFiles(files, options.get(OUTPUT_FILE));
       }
     }
+  }
+
+  /*
+   * Parses strings of the format
+   * "go:https://www.hello.com,java:https://www.world.com" and returns the value
+   * of the key corresponding to id.
+   */
+  private String parseAuthUrl(String authUrl, String id) {
+    if (Strings.isNullOrEmpty(authUrl)) {
+      return "";
+    }
+    // Split on ','
+    Iterable<String> it = Splitter.on(',').split(authUrl);
+    for (String item : it) {
+      // Split on only the first ':' and return if there are two values and the
+      // language matches.
+      String[] pair = item.split(":", 2);
+      if (pair[0].equals(id) && pair.length == 2) {
+        return pair[1];
+      }
+    }
+    return "";
   }
 
   private static DiscoveryProviderFactory createProviderFactory(String factory) {

--- a/src/main/java/com/google/api/codegen/DiscoveryFragmentGeneratorApi.java
+++ b/src/main/java/com/google/api/codegen/DiscoveryFragmentGeneratorApi.java
@@ -74,7 +74,7 @@ public class DiscoveryFragmentGeneratorApi {
       ToolOptions.createOption(
           String.class,
           "auth_instructions",
-          "A comma-delimited map of language to auth instructions URL: lang:URL,lang:URL,...",
+          "An @-delimited map of language to auth instructions URL: lang:URL@lang:URL@...",
           "");
 
   private final ToolOptions options;
@@ -128,15 +128,15 @@ public class DiscoveryFragmentGeneratorApi {
 
   /*
    * Parses strings of the format
-   * "go:https://www.hello.com,java:https://www.world.com" and returns the value
+   * "go:https://www.hello.com@java:https://www.world.com" and returns the value
    * of the key corresponding to the key id.
    */
   private String parseAuthInstructionsUrl(String authInstructionsUrl, String id) {
     if (Strings.isNullOrEmpty(authInstructionsUrl)) {
       return "";
     }
-    // Split on ','
-    Iterable<String> it = Splitter.on(',').split(authInstructionsUrl);
+    // Split on '@'
+    Iterable<String> it = Splitter.on('@').split(authInstructionsUrl);
     for (String item : it) {
       // Split on only the first ':' and return if there are two values and the
       // language matches.

--- a/src/main/java/com/google/api/codegen/DiscoveryFragmentGeneratorTool.java
+++ b/src/main/java/com/google/api/codegen/DiscoveryFragmentGeneratorTool.java
@@ -57,6 +57,13 @@ public class DiscoveryFragmentGeneratorTool {
             .hasArg()
             .argName("OUTPUT-DIRECTORY")
             .build());
+    options.addOption(
+        Option.builder()
+            .longOpt("auth_url")
+            .desc("A comma delimited map of language to auth instructions URL.")
+            .hasArg()
+            .argName("AUTH-URL")
+            .build());
 
     CommandLine cl = (new DefaultParser()).parse(options, args);
     if (cl.hasOption("help")) {
@@ -67,18 +74,21 @@ public class DiscoveryFragmentGeneratorTool {
     generate(
         cl.getOptionValue("discovery_doc"),
         cl.getOptionValues("gapic_yaml"),
-        cl.getOptionValue("output", ""));
+        cl.getOptionValue("output", ""),
+        cl.getOptionValue("auth_url", ""));
   }
 
   @SuppressWarnings("unchecked")
   private static void generate(
-      String discoveryDoc, String[] generatorConfigs, String outputDirectory) throws Exception {
+      String discoveryDoc, String[] generatorConfigs, String outputDirectory, String authUrl)
+      throws Exception {
 
     ToolOptions options = ToolOptions.create();
     options.set(DiscoveryFragmentGeneratorApi.DISCOVERY_DOC, discoveryDoc);
     options.set(DiscoveryFragmentGeneratorApi.OUTPUT_FILE, outputDirectory);
     options.set(
         DiscoveryFragmentGeneratorApi.GENERATOR_CONFIG_FILES, Arrays.asList(generatorConfigs));
+    options.set(DiscoveryFragmentGeneratorApi.AUTH_INSTRUCTIONS_URL, authUrl);
     DiscoveryFragmentGeneratorApi generator = new DiscoveryFragmentGeneratorApi(options);
     generator.run();
   }

--- a/src/main/java/com/google/api/codegen/DiscoveryFragmentGeneratorTool.java
+++ b/src/main/java/com/google/api/codegen/DiscoveryFragmentGeneratorTool.java
@@ -60,8 +60,7 @@ public class DiscoveryFragmentGeneratorTool {
     options.addOption(
         Option.builder()
             .longOpt("auth_instructions")
-            .desc(
-                "A comma-delimited map of language to auth instructions URL: lang:URL,lang:URL,...")
+            .desc("An @-delimited map of language to auth instructions URL: lang:URL@lang:URL@...")
             .hasArg()
             .argName("AUTH-INSTRUCTIONS")
             .build());

--- a/src/main/java/com/google/api/codegen/DiscoveryFragmentGeneratorTool.java
+++ b/src/main/java/com/google/api/codegen/DiscoveryFragmentGeneratorTool.java
@@ -59,10 +59,10 @@ public class DiscoveryFragmentGeneratorTool {
             .build());
     options.addOption(
         Option.builder()
-            .longOpt("auth_url")
-            .desc("A comma delimited map of language to auth instructions URL.")
+            .longOpt("auth_instructions")
+            .desc("A comma-delimited map of language to auth instructions URL: lang:URL,lang:URL")
             .hasArg()
-            .argName("AUTH-URL")
+            .argName("AUTH-INSTRUCTIONS")
             .build());
 
     CommandLine cl = (new DefaultParser()).parse(options, args);
@@ -75,12 +75,15 @@ public class DiscoveryFragmentGeneratorTool {
         cl.getOptionValue("discovery_doc"),
         cl.getOptionValues("gapic_yaml"),
         cl.getOptionValue("output", ""),
-        cl.getOptionValue("auth_url", ""));
+        cl.getOptionValue("auth_instructions", ""));
   }
 
   @SuppressWarnings("unchecked")
   private static void generate(
-      String discoveryDoc, String[] generatorConfigs, String outputDirectory, String authUrl)
+      String discoveryDoc,
+      String[] generatorConfigs,
+      String outputDirectory,
+      String authInstructions)
       throws Exception {
 
     ToolOptions options = ToolOptions.create();
@@ -88,7 +91,7 @@ public class DiscoveryFragmentGeneratorTool {
     options.set(DiscoveryFragmentGeneratorApi.OUTPUT_FILE, outputDirectory);
     options.set(
         DiscoveryFragmentGeneratorApi.GENERATOR_CONFIG_FILES, Arrays.asList(generatorConfigs));
-    options.set(DiscoveryFragmentGeneratorApi.AUTH_INSTRUCTIONS_URL, authUrl);
+    options.set(DiscoveryFragmentGeneratorApi.AUTH_INSTRUCTIONS_URL, authInstructions);
     DiscoveryFragmentGeneratorApi generator = new DiscoveryFragmentGeneratorApi(options);
     generator.run();
   }

--- a/src/main/java/com/google/api/codegen/DiscoveryFragmentGeneratorTool.java
+++ b/src/main/java/com/google/api/codegen/DiscoveryFragmentGeneratorTool.java
@@ -60,7 +60,8 @@ public class DiscoveryFragmentGeneratorTool {
     options.addOption(
         Option.builder()
             .longOpt("auth_instructions")
-            .desc("A comma-delimited map of language to auth instructions URL: lang:URL,lang:URL")
+            .desc(
+                "A comma-delimited map of language to auth instructions URL: lang:URL,lang:URL,...")
             .hasArg()
             .argName("AUTH-INSTRUCTIONS")
             .build());

--- a/src/main/resources/com/google/api/codegen/java/discovery_fragment.snip
+++ b/src/main/resources/com/google/api/codegen/java/discovery_fragment.snip
@@ -41,18 +41,26 @@
        params = apiaryConfig.getMethodParams(method.getName)
     public class {@ApiName}Example {
       public static void main(String[] args) throws IOException, GeneralSecurityException {
-        // Authentication is provided by the 'gcloud' tool when running locally
-        // and by built-in service accounts when running on GAE, GCE, or GKE.
-        GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-        // The createScopedRequired method returns true when running on GAE or a local developer
-        // machine. In that case, the desired scopes must be passed in manually. When the code is
-        // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-        // For more information, see
-        // https://developers.google.com/identity/protocols/application-default-credentials
-        if (credential.createScopedRequired()) {
-          credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-        }
+        @let authType = apiaryConfig.getAuthType.toString
+          @switch authType
+          @case "APPLICATION_DEFAULT_CREDENTIALS"
+            {@importGoogleCredential()}{@adcBoilerplate()}
+          @default
+            // {@TODO()} Implement this function to get authentication credentials.
+            @let authInstructionsUrl = apiaryConfig.getAuthInstructionsUrl
+              @if authInstructionsUrl
+                // See {@authInstructionsUrl}
+              @end
+            @end
+            @if apiaryConfig.hasAuthScopes(method.getName)
+              // Authorize using the following scopes in order to use this method:
+              @join scope : apiaryConfig.getAuthScopes.get(method.getName)
+                //   {@scope}
+              @end
+            @end
+            {@importCredential()}Credential credential = getAuth();
+          @end
+        @end
 
         HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
         JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -70,6 +78,21 @@
       }
     }
   @end
+@end
+
+@private adcBoilerplate()
+  // Authentication is provided by the 'gcloud' tool when running locally
+  // and by built-in service accounts when running on GAE, GCE, or GKE.
+  GoogleCredential credential = GoogleCredential.getApplicationDefault();
+
+  // The createScopedRequired method returns true when running on GAE or a local developer
+  // machine. In that case, the desired scopes must be passed in manually. When the code is
+  // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
+  // For more information, see
+  // https://developers.google.com/identity/protocols/application-default-credentials
+  if (credential.createScopedRequired()) {
+    credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
+  }
 @end
 
 # TODO(tcoffee): check if resource field is always first repeated field of response type
@@ -226,11 +249,18 @@
   @end
 @end
 
+@private importCredential()
+  {@context.addImport("com.google.api.client.auth.oauth2.Credential")}
+@end
+
+@private importGoogleCredential()
+  {@context.addImport("com.google.api.client.googleapis.auth.oauth2.GoogleCredential")}
+@end
+
 @private alwaysImport() fill
   {@context.addImport("java.io.IOException")}
   {@context.addImport("java.security.GeneralSecurityException")}
   {@context.addImport("java.util.Collections")}
-  {@context.addImport("com.google.api.client.googleapis.auth.oauth2.GoogleCredential")}
   {@context.addImport("com.google.api.client.googleapis.javanet.GoogleNetHttpTransport")}
   {@context.addImport("com.google.api.client.http.HttpTransport")}
   {@context.addImport("com.google.api.client.json.JsonFactory")}

--- a/src/main/resources/com/google/api/codegen/java/discovery_fragment.snip
+++ b/src/main/resources/com/google/api/codegen/java/discovery_fragment.snip
@@ -8,13 +8,15 @@
   @let api = context.getApi, \
        apiName = api.getName, \
        apiVersion = api.getVersion, \
-       serviceTitle = context.getService.getTitle
+       serviceTitle = context.getService.getTitle, \
+       authType = context.getApiaryConfig.getAuthType.toString
     /*
      * BEFORE RUNNING:
      * ---------------
      * 1. If not already done, enable the {@serviceTitle}
      *    and check the quota for your project at
      *    https://console.developers.google.com/apis/api/{@apiName}
+     @if authType == "APPLICATION_DEFAULT_CREDENTIALS"
      * 2. This sample uses Application Default Credentials for authentication.
      *    If not already done, install the gcloud CLI from
      *    https://cloud.google.com/sdk/ and run
@@ -23,6 +25,12 @@
      *    instructions at https://github.com/google/google-api-java-client.
      *    On other build systems, you can add the jar files to your project from
      *    https://developers.google.com/resources/api-libraries/download/{@apiName}/{@apiVersion}/java
+     @else
+     * 2. Install the Java client library on maven or gradle. Check installation
+     *    instructions at https://github.com/google/google-api-java-client.
+     *    On other build systems, you can add the jar files to your project from
+     *    https://developers.google.com/resources/api-libraries/download/{@apiName}/{@apiVersion}/java
+     @end
      */
 
     @join import : imports

--- a/src/main/resources/com/google/api/codegen/java/discovery_fragment.snip
+++ b/src/main/resources/com/google/api/codegen/java/discovery_fragment.snip
@@ -41,6 +41,7 @@
        params = apiaryConfig.getMethodParams(method.getName)
     public class {@ApiName}Example {
       public static void main(String[] args) throws IOException, GeneralSecurityException {
+
         @let authType = apiaryConfig.getAuthType.toString
           @switch authType
           @case "APPLICATION_DEFAULT_CREDENTIALS"
@@ -53,7 +54,7 @@
               @end
             @end
             @if apiaryConfig.hasAuthScopes(method.getName)
-              // Authorize using the following scopes in order to use this method:
+              // Authorize using one of the following scopes in order to use this method:
               @join scope : apiaryConfig.getAuthScopes.get(method.getName)
                 //   {@scope}
               @end

--- a/src/test/java/com/google/api/codegen/DiscoveryGeneratorTestBase.java
+++ b/src/test/java/com/google/api/codegen/DiscoveryGeneratorTestBase.java
@@ -84,7 +84,6 @@ public abstract class DiscoveryGeneratorTestBase extends ConfigBaselineTestCase 
     // This field is manually populated to test the end-to-end behavior of the
     // "auth_instructions" flag.
     discoveryImporter.getConfig().setAuthInstructionsUrl("https://foo.com/bar");
-
     DiscoveryProvider provider =
         MainDiscoveryProviderFactory.defaultCreate(
             discoveryImporter.getService(), discoveryImporter.getConfig(), id);

--- a/src/test/java/com/google/api/codegen/DiscoveryGeneratorTestBase.java
+++ b/src/test/java/com/google/api/codegen/DiscoveryGeneratorTestBase.java
@@ -81,6 +81,10 @@ public abstract class DiscoveryGeneratorTestBase extends ConfigBaselineTestCase 
     String factory = generator.getFactory();
     String id = generator.getId();
 
+    // This field is manually populated to test the end-to-end behavior of the
+    // "auth_instructions" flag.
+    discoveryImporter.getConfig().setAuthInstructionsUrl("https://foo.com/bar");
+
     DiscoveryProvider provider =
         MainDiscoveryProviderFactory.defaultCreate(
             discoveryImporter.getService(), discoveryImporter.getConfig(), id);

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_adexchangebuyer.v1.4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_adexchangebuyer.v1.4.json.baseline
@@ -32,6 +32,7 @@ public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
@@ -86,6 +87,7 @@ public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
@@ -136,6 +138,7 @@ public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
@@ -193,6 +196,7 @@ public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
@@ -250,6 +254,7 @@ public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
@@ -304,6 +309,7 @@ public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
@@ -354,6 +360,7 @@ public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
@@ -411,6 +418,7 @@ public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
@@ -471,6 +479,7 @@ public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
@@ -530,6 +539,7 @@ public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
@@ -588,6 +598,7 @@ public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
@@ -645,6 +656,7 @@ public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
@@ -699,6 +711,7 @@ public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
@@ -757,6 +770,7 @@ public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
@@ -816,6 +830,7 @@ public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
@@ -874,6 +889,7 @@ public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
@@ -931,6 +947,7 @@ public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
@@ -987,6 +1004,7 @@ public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
@@ -1045,6 +1063,7 @@ public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
@@ -1102,6 +1121,7 @@ public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
@@ -1156,6 +1176,7 @@ public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
@@ -1211,6 +1232,7 @@ public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
@@ -1270,6 +1292,7 @@ public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
@@ -1325,6 +1348,7 @@ public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
@@ -1382,6 +1406,7 @@ public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
@@ -1439,6 +1464,7 @@ public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
@@ -1493,6 +1519,7 @@ public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
@@ -1553,6 +1580,7 @@ public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
@@ -1613,6 +1641,7 @@ public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
@@ -1667,6 +1696,7 @@ public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
@@ -1717,6 +1747,7 @@ public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
@@ -1772,6 +1803,7 @@ public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
@@ -1825,6 +1857,7 @@ public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
@@ -1890,6 +1923,7 @@ public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
@@ -1939,6 +1973,7 @@ public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
@@ -1991,6 +2026,7 @@ public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
@@ -2056,6 +2092,7 @@ public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_adexchangebuyer.v1.4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_adexchangebuyer.v1.4.json.baseline
@@ -15,7 +15,7 @@
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -30,18 +30,10 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/adexchange.buyer
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -76,7 +68,7 @@ public class AdexchangebuyerExample {
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -91,18 +83,10 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/adexchange.buyer
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -133,7 +117,7 @@ public class AdexchangebuyerExample {
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -148,18 +132,10 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/adexchange.buyer
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -197,7 +173,7 @@ public class AdexchangebuyerExample {
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -212,18 +188,10 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/adexchange.buyer
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -261,7 +229,7 @@ public class AdexchangebuyerExample {
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -276,18 +244,10 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/adexchange.buyer
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -322,7 +282,7 @@ public class AdexchangebuyerExample {
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -337,18 +297,10 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/adexchange.buyer
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -379,7 +331,7 @@ public class AdexchangebuyerExample {
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -394,18 +346,10 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/adexchange.buyer
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -443,7 +387,7 @@ public class AdexchangebuyerExample {
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -458,18 +402,10 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/adexchange.buyer
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -510,7 +446,7 @@ public class AdexchangebuyerExample {
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -525,18 +461,10 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/adexchange.buyer
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -577,7 +505,7 @@ public class AdexchangebuyerExample {
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -591,18 +519,10 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/adexchange.buyer
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -641,7 +561,7 @@ public class AdexchangebuyerExample {
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -656,18 +576,10 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/adexchange.buyer
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -705,7 +617,7 @@ public class AdexchangebuyerExample {
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -720,18 +632,10 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/adexchange.buyer
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -765,7 +669,7 @@ public class AdexchangebuyerExample {
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -781,18 +685,10 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/adexchange.buyer
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -832,7 +728,7 @@ public class AdexchangebuyerExample {
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -846,18 +742,10 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/adexchange.buyer
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -896,7 +784,7 @@ public class AdexchangebuyerExample {
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -912,18 +800,10 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/adexchange.buyer
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -961,7 +841,7 @@ public class AdexchangebuyerExample {
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -977,18 +857,10 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/adexchange.buyer
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -1026,7 +898,7 @@ public class AdexchangebuyerExample {
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -1041,18 +913,10 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/adexchange.buyer
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -1088,7 +952,7 @@ public class AdexchangebuyerExample {
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -1104,18 +968,10 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/adexchange.buyer
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -1153,7 +1009,7 @@ public class AdexchangebuyerExample {
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -1169,18 +1025,10 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/adexchange.buyer
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -1218,7 +1066,7 @@ public class AdexchangebuyerExample {
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -1233,18 +1081,10 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/adexchange.buyer
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -1279,7 +1119,7 @@ public class AdexchangebuyerExample {
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -1294,18 +1134,10 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/adexchange.buyer
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -1341,7 +1173,7 @@ public class AdexchangebuyerExample {
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -1356,18 +1188,10 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/adexchange.buyer
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -1408,7 +1232,7 @@ public class AdexchangebuyerExample {
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -1422,18 +1246,10 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/adexchange.buyer
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -1469,7 +1285,7 @@ public class AdexchangebuyerExample {
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -1484,18 +1300,10 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/adexchange.buyer
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -1533,7 +1341,7 @@ public class AdexchangebuyerExample {
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -1548,18 +1356,10 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/adexchange.buyer
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -1597,7 +1397,7 @@ public class AdexchangebuyerExample {
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -1612,18 +1412,10 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/adexchange.buyer
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -1658,7 +1450,7 @@ public class AdexchangebuyerExample {
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -1673,18 +1465,10 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/adexchange.buyer
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -1725,7 +1509,7 @@ public class AdexchangebuyerExample {
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -1740,18 +1524,10 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/adexchange.buyer
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -1792,7 +1568,7 @@ public class AdexchangebuyerExample {
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -1807,18 +1583,10 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/adexchange.buyer
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -1853,7 +1621,7 @@ public class AdexchangebuyerExample {
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -1868,18 +1636,10 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/adexchange.buyer
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -1910,7 +1670,7 @@ public class AdexchangebuyerExample {
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -1925,18 +1685,10 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/adexchange.buyer
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -1971,7 +1723,7 @@ public class AdexchangebuyerExample {
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -1987,18 +1739,10 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/adexchange.buyer
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -2032,7 +1776,7 @@ public class AdexchangebuyerExample {
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -2047,18 +1791,10 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/adexchange.buyer
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -2104,7 +1840,7 @@ public class AdexchangebuyerExample {
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -2119,18 +1855,10 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/adexchange.buyer
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -2161,7 +1889,7 @@ public class AdexchangebuyerExample {
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -2175,18 +1903,10 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/adexchange.buyer
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -2219,7 +1939,7 @@ public class AdexchangebuyerExample {
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -2234,18 +1954,10 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/adexchange.buyer
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -2291,7 +2003,7 @@ public class AdexchangebuyerExample {
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -2306,18 +2018,10 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/adexchange.buyer
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_adexchangebuyer.v1.4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_adexchangebuyer.v1.4.json.baseline
@@ -30,8 +30,9 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
 
@@ -83,8 +84,9 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
 
@@ -132,8 +134,9 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
 
@@ -188,8 +191,9 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
 
@@ -244,8 +248,9 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
 
@@ -297,8 +302,9 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
 
@@ -346,8 +352,9 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
 
@@ -402,8 +409,9 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
 
@@ -461,8 +469,9 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
 
@@ -519,8 +528,9 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
 
@@ -576,8 +586,9 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
 
@@ -632,8 +643,9 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
 
@@ -685,8 +697,9 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
 
@@ -742,8 +755,9 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
 
@@ -800,8 +814,9 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
 
@@ -857,8 +872,9 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
 
@@ -913,8 +929,9 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
 
@@ -968,8 +985,9 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
 
@@ -1025,8 +1043,9 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
 
@@ -1081,8 +1100,9 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
 
@@ -1134,8 +1154,9 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
 
@@ -1188,8 +1209,9 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
 
@@ -1246,8 +1268,9 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
 
@@ -1300,8 +1323,9 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
 
@@ -1356,8 +1380,9 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
 
@@ -1412,8 +1437,9 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
 
@@ -1465,8 +1491,9 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
 
@@ -1524,8 +1551,9 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
 
@@ -1583,8 +1611,9 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
 
@@ -1636,8 +1665,9 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
 
@@ -1685,8 +1715,9 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
 
@@ -1739,8 +1770,9 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
 
@@ -1791,8 +1823,9 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
 
@@ -1855,8 +1888,9 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
 
@@ -1903,8 +1937,9 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
 
@@ -1954,8 +1989,9 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
 
@@ -2018,8 +2054,9 @@ import java.util.Collections;
 
 public class AdexchangebuyerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/adexchange.buyer
     Credential credential = getAuth();
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_adexchangebuyer.v1.4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_adexchangebuyer.v1.4.json.baseline
@@ -5,11 +5,7 @@
  * 1. If not already done, enable the Ad Exchange Buyer API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/adexchangebuyer
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
@@ -60,11 +56,7 @@ public class AdexchangebuyerExample {
  * 1. If not already done, enable the Ad Exchange Buyer API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/adexchangebuyer
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
@@ -111,11 +103,7 @@ public class AdexchangebuyerExample {
  * 1. If not already done, enable the Ad Exchange Buyer API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/adexchangebuyer
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
@@ -169,11 +157,7 @@ public class AdexchangebuyerExample {
  * 1. If not already done, enable the Ad Exchange Buyer API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/adexchangebuyer
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
@@ -227,11 +211,7 @@ public class AdexchangebuyerExample {
  * 1. If not already done, enable the Ad Exchange Buyer API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/adexchangebuyer
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
@@ -282,11 +262,7 @@ public class AdexchangebuyerExample {
  * 1. If not already done, enable the Ad Exchange Buyer API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/adexchangebuyer
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
@@ -333,11 +309,7 @@ public class AdexchangebuyerExample {
  * 1. If not already done, enable the Ad Exchange Buyer API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/adexchangebuyer
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
@@ -391,11 +363,7 @@ public class AdexchangebuyerExample {
  * 1. If not already done, enable the Ad Exchange Buyer API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/adexchangebuyer
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
@@ -452,11 +420,7 @@ public class AdexchangebuyerExample {
  * 1. If not already done, enable the Ad Exchange Buyer API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/adexchangebuyer
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
@@ -513,11 +477,7 @@ public class AdexchangebuyerExample {
  * 1. If not already done, enable the Ad Exchange Buyer API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/adexchangebuyer
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
@@ -571,11 +531,7 @@ public class AdexchangebuyerExample {
  * 1. If not already done, enable the Ad Exchange Buyer API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/adexchangebuyer
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
@@ -629,11 +585,7 @@ public class AdexchangebuyerExample {
  * 1. If not already done, enable the Ad Exchange Buyer API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/adexchangebuyer
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
@@ -683,11 +635,7 @@ public class AdexchangebuyerExample {
  * 1. If not already done, enable the Ad Exchange Buyer API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/adexchangebuyer
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
@@ -744,11 +692,7 @@ public class AdexchangebuyerExample {
  * 1. If not already done, enable the Ad Exchange Buyer API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/adexchangebuyer
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
@@ -802,11 +746,7 @@ public class AdexchangebuyerExample {
  * 1. If not already done, enable the Ad Exchange Buyer API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/adexchangebuyer
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
@@ -861,11 +801,7 @@ public class AdexchangebuyerExample {
  * 1. If not already done, enable the Ad Exchange Buyer API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/adexchangebuyer
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
@@ -920,11 +856,7 @@ public class AdexchangebuyerExample {
  * 1. If not already done, enable the Ad Exchange Buyer API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/adexchangebuyer
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
@@ -976,11 +908,7 @@ public class AdexchangebuyerExample {
  * 1. If not already done, enable the Ad Exchange Buyer API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/adexchangebuyer
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
@@ -1035,11 +963,7 @@ public class AdexchangebuyerExample {
  * 1. If not already done, enable the Ad Exchange Buyer API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/adexchangebuyer
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
@@ -1094,11 +1018,7 @@ public class AdexchangebuyerExample {
  * 1. If not already done, enable the Ad Exchange Buyer API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/adexchangebuyer
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
@@ -1149,11 +1069,7 @@ public class AdexchangebuyerExample {
  * 1. If not already done, enable the Ad Exchange Buyer API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/adexchangebuyer
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
@@ -1205,11 +1121,7 @@ public class AdexchangebuyerExample {
  * 1. If not already done, enable the Ad Exchange Buyer API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/adexchangebuyer
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
@@ -1266,11 +1178,7 @@ public class AdexchangebuyerExample {
  * 1. If not already done, enable the Ad Exchange Buyer API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/adexchangebuyer
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
@@ -1321,11 +1229,7 @@ public class AdexchangebuyerExample {
  * 1. If not already done, enable the Ad Exchange Buyer API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/adexchangebuyer
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
@@ -1379,11 +1283,7 @@ public class AdexchangebuyerExample {
  * 1. If not already done, enable the Ad Exchange Buyer API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/adexchangebuyer
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
@@ -1437,11 +1337,7 @@ public class AdexchangebuyerExample {
  * 1. If not already done, enable the Ad Exchange Buyer API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/adexchangebuyer
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
@@ -1492,11 +1388,7 @@ public class AdexchangebuyerExample {
  * 1. If not already done, enable the Ad Exchange Buyer API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/adexchangebuyer
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
@@ -1553,11 +1445,7 @@ public class AdexchangebuyerExample {
  * 1. If not already done, enable the Ad Exchange Buyer API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/adexchangebuyer
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
@@ -1614,11 +1502,7 @@ public class AdexchangebuyerExample {
  * 1. If not already done, enable the Ad Exchange Buyer API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/adexchangebuyer
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
@@ -1669,11 +1553,7 @@ public class AdexchangebuyerExample {
  * 1. If not already done, enable the Ad Exchange Buyer API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/adexchangebuyer
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
@@ -1720,11 +1600,7 @@ public class AdexchangebuyerExample {
  * 1. If not already done, enable the Ad Exchange Buyer API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/adexchangebuyer
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
@@ -1775,11 +1651,7 @@ public class AdexchangebuyerExample {
  * 1. If not already done, enable the Ad Exchange Buyer API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/adexchangebuyer
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
@@ -1830,11 +1702,7 @@ public class AdexchangebuyerExample {
  * 1. If not already done, enable the Ad Exchange Buyer API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/adexchangebuyer
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
@@ -1896,11 +1764,7 @@ public class AdexchangebuyerExample {
  * 1. If not already done, enable the Ad Exchange Buyer API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/adexchangebuyer
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
@@ -1947,11 +1811,7 @@ public class AdexchangebuyerExample {
  * 1. If not already done, enable the Ad Exchange Buyer API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/adexchangebuyer
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
@@ -1999,11 +1859,7 @@ public class AdexchangebuyerExample {
  * 1. If not already done, enable the Ad Exchange Buyer API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/adexchangebuyer
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java
@@ -2065,11 +1921,7 @@ public class AdexchangebuyerExample {
  * 1. If not already done, enable the Ad Exchange Buyer API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/adexchangebuyer
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/adexchangebuyer/v1.4/java

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_appengine.v1beta5.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_appengine.v1beta5.json.baseline
@@ -30,6 +30,7 @@ import java.util.Collections;
 
 public class AppengineExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -91,6 +92,7 @@ import java.util.Collections;
 
 public class AppengineExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -156,6 +158,7 @@ import java.util.Collections;
 
 public class AppengineExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -226,6 +229,7 @@ import java.util.Collections;
 
 public class AppengineExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -290,6 +294,7 @@ import java.util.Collections;
 
 public class AppengineExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -355,6 +360,7 @@ import java.util.Collections;
 
 public class AppengineExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -426,6 +432,7 @@ import java.util.Collections;
 
 public class AppengineExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -494,6 +501,7 @@ import java.util.Collections;
 
 public class AppengineExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -561,6 +569,7 @@ import java.util.Collections;
 
 public class AppengineExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -629,6 +638,7 @@ import java.util.Collections;
 
 public class AppengineExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -698,6 +708,7 @@ import java.util.Collections;
 
 public class AppengineExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -776,6 +787,7 @@ import java.util.Collections;
 
 public class AppengineExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -850,6 +862,7 @@ import java.util.Collections;
 
 public class AppengineExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_autoscaler.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_autoscaler.v1beta2.json.baseline
@@ -5,11 +5,7 @@
  * 1. If not already done, enable the Google Compute Engine Autoscaler API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/autoscaler
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/autoscaler/v1beta2/java
@@ -66,11 +62,7 @@ public class AutoscalerExample {
  * 1. If not already done, enable the Google Compute Engine Autoscaler API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/autoscaler
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/autoscaler/v1beta2/java
@@ -127,11 +119,7 @@ public class AutoscalerExample {
  * 1. If not already done, enable the Google Compute Engine Autoscaler API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/autoscaler
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/autoscaler/v1beta2/java
@@ -188,11 +176,7 @@ public class AutoscalerExample {
  * 1. If not already done, enable the Google Compute Engine Autoscaler API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/autoscaler
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/autoscaler/v1beta2/java
@@ -256,11 +240,7 @@ public class AutoscalerExample {
  * 1. If not already done, enable the Google Compute Engine Autoscaler API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/autoscaler
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/autoscaler/v1beta2/java
@@ -320,11 +300,7 @@ public class AutoscalerExample {
  * 1. If not already done, enable the Google Compute Engine Autoscaler API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/autoscaler
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/autoscaler/v1beta2/java
@@ -384,11 +360,7 @@ public class AutoscalerExample {
  * 1. If not already done, enable the Google Compute Engine Autoscaler API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/autoscaler
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/autoscaler/v1beta2/java
@@ -442,11 +414,7 @@ public class AutoscalerExample {
  * 1. If not already done, enable the Google Compute Engine Autoscaler API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/autoscaler
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/autoscaler/v1beta2/java
@@ -504,11 +472,7 @@ public class AutoscalerExample {
  * 1. If not already done, enable the Google Compute Engine Autoscaler API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/autoscaler
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/autoscaler/v1beta2/java
@@ -573,11 +537,7 @@ public class AutoscalerExample {
  * 1. If not already done, enable the Google Compute Engine Autoscaler API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/autoscaler
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/autoscaler/v1beta2/java

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_autoscaler.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_autoscaler.v1beta2.json.baseline
@@ -30,8 +30,9 @@ import java.util.Collections;
 
 public class AutoscalerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/compute
     Credential credential = getAuth();
 
@@ -88,8 +89,9 @@ import java.util.Collections;
 
 public class AutoscalerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/compute
     //   https://www.googleapis.com/auth/compute.readonly
     Credential credential = getAuth();
@@ -148,8 +150,9 @@ import java.util.Collections;
 
 public class AutoscalerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/compute
     Credential credential = getAuth();
 
@@ -207,8 +210,9 @@ import java.util.Collections;
 
 public class AutoscalerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/compute
     //   https://www.googleapis.com/auth/compute.readonly
     Credential credential = getAuth();
@@ -273,8 +277,9 @@ import java.util.Collections;
 
 public class AutoscalerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/compute
     Credential credential = getAuth();
 
@@ -335,8 +340,9 @@ import java.util.Collections;
 
 public class AutoscalerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/compute
     Credential credential = getAuth();
 
@@ -396,8 +402,9 @@ import java.util.Collections;
 
 public class AutoscalerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/compute
     Credential credential = getAuth();
 
@@ -453,8 +460,9 @@ import java.util.Collections;
 
 public class AutoscalerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/compute
     //   https://www.googleapis.com/auth/compute.readonly
     Credential credential = getAuth();
@@ -514,8 +522,9 @@ import java.util.Collections;
 
 public class AutoscalerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/compute
     //   https://www.googleapis.com/auth/compute.readonly
     Credential credential = getAuth();
@@ -581,8 +590,9 @@ import java.util.Collections;
 
 public class AutoscalerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/compute
     //   https://www.googleapis.com/auth/compute.readonly
     Credential credential = getAuth();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_autoscaler.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_autoscaler.v1beta2.json.baseline
@@ -15,7 +15,7 @@
  *    https://developers.google.com/resources/api-libraries/download/autoscaler/v1beta2/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -30,18 +30,10 @@ import java.util.Collections;
 
 public class AutoscalerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/compute
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -82,7 +74,7 @@ public class AutoscalerExample {
  *    https://developers.google.com/resources/api-libraries/download/autoscaler/v1beta2/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -96,18 +88,11 @@ import java.util.Collections;
 
 public class AutoscalerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/compute
+    //   https://www.googleapis.com/auth/compute.readonly
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -148,7 +133,7 @@ public class AutoscalerExample {
  *    https://developers.google.com/resources/api-libraries/download/autoscaler/v1beta2/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -163,18 +148,10 @@ import java.util.Collections;
 
 public class AutoscalerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/compute
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -215,7 +192,7 @@ public class AutoscalerExample {
  *    https://developers.google.com/resources/api-libraries/download/autoscaler/v1beta2/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -230,18 +207,11 @@ import java.util.Collections;
 
 public class AutoscalerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/compute
+    //   https://www.googleapis.com/auth/compute.readonly
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -288,7 +258,7 @@ public class AutoscalerExample {
  *    https://developers.google.com/resources/api-libraries/download/autoscaler/v1beta2/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -303,18 +273,10 @@ import java.util.Collections;
 
 public class AutoscalerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/compute
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -358,7 +320,7 @@ public class AutoscalerExample {
  *    https://developers.google.com/resources/api-libraries/download/autoscaler/v1beta2/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -373,18 +335,10 @@ import java.util.Collections;
 
 public class AutoscalerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/compute
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -428,7 +382,7 @@ public class AutoscalerExample {
  *    https://developers.google.com/resources/api-libraries/download/autoscaler/v1beta2/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -442,18 +396,10 @@ import java.util.Collections;
 
 public class AutoscalerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/compute
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -492,7 +438,7 @@ public class AutoscalerExample {
  *    https://developers.google.com/resources/api-libraries/download/autoscaler/v1beta2/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -507,18 +453,11 @@ import java.util.Collections;
 
 public class AutoscalerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/compute
+    //   https://www.googleapis.com/auth/compute.readonly
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -559,7 +498,7 @@ public class AutoscalerExample {
  *    https://developers.google.com/resources/api-libraries/download/autoscaler/v1beta2/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -575,18 +514,11 @@ import java.util.Collections;
 
 public class AutoscalerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/compute
+    //   https://www.googleapis.com/auth/compute.readonly
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -633,7 +565,7 @@ public class AutoscalerExample {
  *    https://developers.google.com/resources/api-libraries/download/autoscaler/v1beta2/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -649,18 +581,11 @@ import java.util.Collections;
 
 public class AutoscalerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/compute
+    //   https://www.googleapis.com/auth/compute.readonly
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_autoscaler.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_autoscaler.v1beta2.json.baseline
@@ -32,6 +32,7 @@ public class AutoscalerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/compute
     Credential credential = getAuth();
@@ -91,6 +92,7 @@ public class AutoscalerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/compute
     //   https://www.googleapis.com/auth/compute.readonly
@@ -152,6 +154,7 @@ public class AutoscalerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/compute
     Credential credential = getAuth();
@@ -212,6 +215,7 @@ public class AutoscalerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/compute
     //   https://www.googleapis.com/auth/compute.readonly
@@ -279,6 +283,7 @@ public class AutoscalerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/compute
     Credential credential = getAuth();
@@ -342,6 +347,7 @@ public class AutoscalerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/compute
     Credential credential = getAuth();
@@ -404,6 +410,7 @@ public class AutoscalerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/compute
     Credential credential = getAuth();
@@ -462,6 +469,7 @@ public class AutoscalerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/compute
     //   https://www.googleapis.com/auth/compute.readonly
@@ -524,6 +532,7 @@ public class AutoscalerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/compute
     //   https://www.googleapis.com/auth/compute.readonly
@@ -592,6 +601,7 @@ public class AutoscalerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/compute
     //   https://www.googleapis.com/auth/compute.readonly

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_bigquery.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_bigquery.v2.json.baseline
@@ -29,6 +29,7 @@ import java.util.Collections;
 
 public class BigqueryExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -91,6 +92,7 @@ import java.util.Collections;
 
 public class BigqueryExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -155,6 +157,7 @@ import java.util.Collections;
 
 public class BigqueryExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -220,6 +223,7 @@ import java.util.Collections;
 
 public class BigqueryExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -290,6 +294,7 @@ import java.util.Collections;
 
 public class BigqueryExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -357,6 +362,7 @@ import java.util.Collections;
 
 public class BigqueryExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -424,6 +430,7 @@ import java.util.Collections;
 
 public class BigqueryExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -488,6 +495,7 @@ import java.util.Collections;
 
 public class BigqueryExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -552,6 +560,7 @@ import java.util.Collections;
 
 public class BigqueryExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -616,6 +625,7 @@ import java.util.Collections;
 
 public class BigqueryExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -681,6 +691,7 @@ import java.util.Collections;
 
 public class BigqueryExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -752,6 +763,7 @@ import java.util.Collections;
 
 public class BigqueryExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -817,6 +829,7 @@ import java.util.Collections;
 
 public class BigqueryExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -884,6 +897,7 @@ import java.util.Collections;
 
 public class BigqueryExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -954,6 +968,7 @@ import java.util.Collections;
 
 public class BigqueryExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1020,6 +1035,7 @@ import java.util.Collections;
 
 public class BigqueryExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1085,6 +1101,7 @@ import java.util.Collections;
 
 public class BigqueryExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1152,6 +1169,7 @@ import java.util.Collections;
 
 public class BigqueryExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1220,6 +1238,7 @@ import java.util.Collections;
 
 public class BigqueryExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1293,6 +1312,7 @@ import java.util.Collections;
 
 public class BigqueryExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1363,6 +1383,7 @@ import java.util.Collections;
 
 public class BigqueryExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_cloudbilling.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_cloudbilling.v1.json.baseline
@@ -30,6 +30,7 @@ import java.util.Collections;
 
 public class CloudbillingExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -93,6 +94,7 @@ import java.util.Collections;
 
 public class CloudbillingExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -160,6 +162,7 @@ import java.util.Collections;
 
 public class CloudbillingExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -231,6 +234,7 @@ import java.util.Collections;
 
 public class CloudbillingExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -293,6 +297,7 @@ import java.util.Collections;
 
 public class CloudbillingExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_clouddebugger.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_clouddebugger.v2.json.baseline
@@ -30,6 +30,7 @@ import java.util.Collections;
 
 public class CloudDebuggerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -92,6 +93,7 @@ import java.util.Collections;
 
 public class CloudDebuggerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -160,6 +162,7 @@ import java.util.Collections;
 
 public class CloudDebuggerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -219,6 +222,7 @@ import java.util.Collections;
 
 public class CloudDebuggerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -281,6 +285,7 @@ import java.util.Collections;
 
 public class CloudDebuggerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -345,6 +350,7 @@ import java.util.Collections;
 
 public class CloudDebuggerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -407,6 +413,7 @@ import java.util.Collections;
 
 public class CloudDebuggerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -471,6 +478,7 @@ import java.util.Collections;
 
 public class CloudDebuggerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_cloudmonitoring.v2beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_cloudmonitoring.v2beta2.json.baseline
@@ -30,6 +30,7 @@ import java.util.Collections;
 
 public class CloudMonitoringExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -94,6 +95,7 @@ import java.util.Collections;
 
 public class CloudMonitoringExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -159,6 +161,7 @@ import java.util.Collections;
 
 public class CloudMonitoringExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -230,6 +233,7 @@ import java.util.Collections;
 
 public class CloudMonitoringExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -309,6 +313,7 @@ import java.util.Collections;
 
 public class CloudMonitoringExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -374,6 +379,7 @@ import java.util.Collections;
 
 public class CloudMonitoringExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_cloudresourcemanager.v1beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_cloudresourcemanager.v1beta1.json.baseline
@@ -30,6 +30,7 @@ import java.util.Collections;
 
 public class CloudResourceManagerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -92,6 +93,7 @@ import java.util.Collections;
 
 public class CloudResourceManagerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -159,6 +161,7 @@ import java.util.Collections;
 
 public class CloudResourceManagerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -226,6 +229,7 @@ import java.util.Collections;
 
 public class CloudResourceManagerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -293,6 +297,7 @@ import java.util.Collections;
 
 public class CloudResourceManagerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -360,6 +365,7 @@ import java.util.Collections;
 
 public class CloudResourceManagerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -425,6 +431,7 @@ import java.util.Collections;
 
 public class CloudResourceManagerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -484,6 +491,7 @@ import java.util.Collections;
 
 public class CloudResourceManagerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -543,6 +551,7 @@ import java.util.Collections;
 
 public class CloudResourceManagerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -605,6 +614,7 @@ import java.util.Collections;
 
 public class CloudResourceManagerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -672,6 +682,7 @@ import java.util.Collections;
 
 public class CloudResourceManagerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -739,6 +750,7 @@ import java.util.Collections;
 
 public class CloudResourceManagerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -806,6 +818,7 @@ import java.util.Collections;
 
 public class CloudResourceManagerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -873,6 +886,7 @@ import java.util.Collections;
 
 public class CloudResourceManagerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -935,6 +949,7 @@ import java.util.Collections;
 
 public class CloudResourceManagerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_cloudtrace.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_cloudtrace.v1.json.baseline
@@ -30,6 +30,7 @@ import java.util.Collections;
 
 public class CloudTraceExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -92,6 +93,7 @@ import java.util.Collections;
 
 public class CloudTraceExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -157,6 +159,7 @@ import java.util.Collections;
 
 public class CloudTraceExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_clouduseraccounts.beta.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_clouduseraccounts.beta.json.baseline
@@ -29,6 +29,7 @@ import java.util.Collections;
 
 public class CloudUserAccountsExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -91,6 +92,7 @@ import java.util.Collections;
 
 public class CloudUserAccountsExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -156,6 +158,7 @@ import java.util.Collections;
 
 public class CloudUserAccountsExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -227,6 +230,7 @@ import java.util.Collections;
 
 public class CloudUserAccountsExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -294,6 +298,7 @@ import java.util.Collections;
 
 public class CloudUserAccountsExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -358,6 +363,7 @@ import java.util.Collections;
 
 public class CloudUserAccountsExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -423,6 +429,7 @@ import java.util.Collections;
 
 public class CloudUserAccountsExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -488,6 +495,7 @@ import java.util.Collections;
 
 public class CloudUserAccountsExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -559,6 +567,7 @@ import java.util.Collections;
 
 public class CloudUserAccountsExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -626,6 +635,7 @@ import java.util.Collections;
 
 public class CloudUserAccountsExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -696,6 +706,7 @@ import java.util.Collections;
 
 public class CloudUserAccountsExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -764,6 +775,7 @@ import java.util.Collections;
 
 public class CloudUserAccountsExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -831,6 +843,7 @@ import java.util.Collections;
 
 public class CloudUserAccountsExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -895,6 +908,7 @@ import java.util.Collections;
 
 public class CloudUserAccountsExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -960,6 +974,7 @@ import java.util.Collections;
 
 public class CloudUserAccountsExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1025,6 +1040,7 @@ import java.util.Collections;
 
 public class CloudUserAccountsExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1095,6 +1111,7 @@ import java.util.Collections;
 
 public class CloudUserAccountsExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_compute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_compute.v1.json.baseline
@@ -32,6 +32,7 @@ import java.util.Map;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -102,6 +103,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -169,6 +171,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -237,6 +240,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -305,6 +309,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -380,6 +385,7 @@ import java.util.Map;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -450,6 +456,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -517,6 +524,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -585,6 +593,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -653,6 +662,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -727,6 +737,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -798,6 +809,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -865,6 +877,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -929,6 +942,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -994,6 +1008,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1062,6 +1077,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1127,6 +1143,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1198,6 +1215,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1266,6 +1284,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1335,6 +1354,7 @@ import java.util.Map;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1405,6 +1425,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1473,6 +1494,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1548,6 +1570,7 @@ import java.util.Map;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1619,6 +1642,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1689,6 +1713,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1756,6 +1781,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1824,6 +1850,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1892,6 +1919,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1965,6 +1993,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -2029,6 +2058,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -2094,6 +2124,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -2159,6 +2190,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -2230,6 +2262,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -2298,6 +2331,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -2367,6 +2401,7 @@ import java.util.Map;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -2437,6 +2472,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -2504,6 +2540,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -2572,6 +2609,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -2640,6 +2678,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -2714,6 +2753,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -2784,6 +2824,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -2848,6 +2889,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -2913,6 +2955,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -2978,6 +3021,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -3048,6 +3092,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -3112,6 +3157,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -3177,6 +3223,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -3242,6 +3289,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -3313,6 +3361,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -3382,6 +3431,7 @@ import java.util.Map;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -3451,6 +3501,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -3513,6 +3564,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -3578,6 +3630,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -3648,6 +3701,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -3712,6 +3766,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -3777,6 +3832,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -3842,6 +3898,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -3913,6 +3970,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -3981,6 +4039,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -4048,6 +4107,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -4112,6 +4172,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -4177,6 +4238,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -4242,6 +4304,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -4313,6 +4376,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -4381,6 +4445,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -4448,6 +4513,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -4513,6 +4579,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -4580,6 +4647,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -4645,6 +4713,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -4710,6 +4779,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -4781,6 +4851,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -4853,6 +4924,7 @@ import java.util.Map;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -4923,6 +4995,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -4991,6 +5064,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -5061,6 +5135,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -5129,6 +5204,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -5197,6 +5273,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -5270,6 +5347,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -5338,6 +5416,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -5408,6 +5487,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -5481,6 +5561,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -5552,6 +5633,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -5623,6 +5705,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -5695,6 +5778,7 @@ import java.util.Map;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -5765,6 +5849,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -5832,6 +5917,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -5900,6 +5986,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -5968,6 +6055,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -6043,6 +6131,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -6123,6 +6212,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -6194,6 +6284,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -6264,6 +6355,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -6328,6 +6420,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -6393,6 +6486,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -6458,6 +6552,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -6529,6 +6624,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -6604,6 +6700,7 @@ import java.util.Map;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -6675,6 +6772,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -6745,6 +6843,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -6812,6 +6911,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -6885,6 +6985,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -6955,6 +7056,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -7022,6 +7124,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -7090,6 +7193,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -7158,6 +7262,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -7231,6 +7336,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -7298,6 +7404,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -7372,6 +7479,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -7443,6 +7551,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -7514,6 +7623,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -7585,6 +7695,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -7655,6 +7766,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -7722,6 +7834,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -7789,6 +7902,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -7855,6 +7969,7 @@ import java.util.Map;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -7925,6 +8040,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -7993,6 +8109,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -8066,6 +8183,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -8130,6 +8248,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -8195,6 +8314,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -8260,6 +8380,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -8330,6 +8451,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -8392,6 +8514,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -8457,6 +8580,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -8522,6 +8646,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -8587,6 +8712,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -8650,6 +8776,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -8715,6 +8842,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -8783,6 +8911,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -8856,6 +8985,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -8921,6 +9051,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -8991,6 +9122,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -9055,6 +9187,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -9120,6 +9253,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -9185,6 +9319,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -9255,6 +9390,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -9319,6 +9455,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -9384,6 +9521,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -9454,6 +9592,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -9518,6 +9657,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -9583,6 +9723,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -9648,6 +9789,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -9720,6 +9862,7 @@ import java.util.Map;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -9790,6 +9933,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -9857,6 +10001,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -9925,6 +10070,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -9993,6 +10139,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -10066,6 +10213,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -10130,6 +10278,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -10195,6 +10344,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -10260,6 +10410,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -10331,6 +10482,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -10398,6 +10550,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -10462,6 +10615,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -10527,6 +10681,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -10592,6 +10747,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -10663,6 +10819,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -10731,6 +10888,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -10800,6 +10958,7 @@ import java.util.Map;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -10870,6 +11029,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -10937,6 +11097,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -11005,6 +11166,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -11073,6 +11235,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -11147,6 +11310,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -11218,6 +11382,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -11290,6 +11455,7 @@ import java.util.Map;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -11360,6 +11526,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -11427,6 +11594,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -11495,6 +11663,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -11566,6 +11735,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -11634,6 +11804,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -11708,6 +11879,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -11779,6 +11951,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -11850,6 +12023,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -11922,6 +12096,7 @@ import java.util.Map;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -11992,6 +12167,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -12059,6 +12235,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -12127,6 +12304,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -12195,6 +12373,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -12268,6 +12447,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -12332,6 +12512,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -12397,6 +12578,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -12462,6 +12644,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -12533,6 +12716,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -12601,6 +12785,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -12669,6 +12854,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -12738,6 +12924,7 @@ import java.util.Map;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -12808,6 +12995,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -12875,6 +13063,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -12943,6 +13132,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -13011,6 +13201,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -13083,6 +13274,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -13148,6 +13340,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -13216,6 +13409,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -13289,6 +13483,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -13354,6 +13549,7 @@ import java.util.Collections;
 
 public class ComputeExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_container.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_container.v1.json.baseline
@@ -31,6 +31,7 @@ import java.util.Collections;
 
 public class ContainerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -100,6 +101,7 @@ import java.util.Collections;
 
 public class ContainerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -169,6 +171,7 @@ import java.util.Collections;
 
 public class ContainerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -238,6 +241,7 @@ import java.util.Collections;
 
 public class ContainerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -305,6 +309,7 @@ import java.util.Collections;
 
 public class ContainerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -377,6 +382,7 @@ import java.util.Collections;
 
 public class ContainerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -443,6 +449,7 @@ import java.util.Collections;
 
 public class ContainerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -512,6 +519,7 @@ import java.util.Collections;
 
 public class ContainerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_dataflow.v1b3.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_dataflow.v1b3.json.baseline
@@ -30,6 +30,7 @@ import java.util.Collections;
 
 public class DataflowExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -94,6 +95,7 @@ import java.util.Collections;
 
 public class DataflowExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -158,6 +160,7 @@ import java.util.Collections;
 
 public class DataflowExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -223,6 +226,7 @@ import java.util.Collections;
 
 public class DataflowExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -294,6 +298,7 @@ import java.util.Collections;
 
 public class DataflowExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -367,6 +372,7 @@ import java.util.Collections;
 
 public class DataflowExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -435,6 +441,7 @@ import java.util.Collections;
 
 public class DataflowExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -503,6 +510,7 @@ import java.util.Collections;
 
 public class DataflowExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -571,6 +579,7 @@ import java.util.Collections;
 
 public class DataflowExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_dataproc.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_dataproc.v1.json.baseline
@@ -31,6 +31,7 @@ import java.util.Collections;
 
 public class DataprocExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -98,6 +99,7 @@ import java.util.Collections;
 
 public class DataprocExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -166,6 +168,7 @@ import java.util.Collections;
 
 public class DataprocExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -236,6 +239,7 @@ import java.util.Collections;
 
 public class DataprocExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -304,6 +308,7 @@ import java.util.Collections;
 
 public class DataprocExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -378,6 +383,7 @@ import java.util.Collections;
 
 public class DataprocExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -449,6 +455,7 @@ import java.util.Collections;
 
 public class DataprocExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -518,6 +525,7 @@ import java.util.Collections;
 
 public class DataprocExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -583,6 +591,7 @@ import java.util.Collections;
 
 public class DataprocExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -651,6 +660,7 @@ import java.util.Collections;
 
 public class DataprocExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -725,6 +735,7 @@ import java.util.Collections;
 
 public class DataprocExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -791,6 +802,7 @@ import java.util.Collections;
 
 public class DataprocExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -849,6 +861,7 @@ import java.util.Collections;
 
 public class DataprocExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -908,6 +921,7 @@ import java.util.Collections;
 
 public class DataprocExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -970,6 +984,7 @@ import java.util.Collections;
 
 public class DataprocExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_datastore.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_datastore.v1beta2.json.baseline
@@ -31,6 +31,7 @@ import java.util.Collections;
 
 public class DatastoreExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -96,6 +97,7 @@ import java.util.Collections;
 
 public class DatastoreExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -161,6 +163,7 @@ import java.util.Collections;
 
 public class DatastoreExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -226,6 +229,7 @@ import java.util.Collections;
 
 public class DatastoreExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -291,6 +295,7 @@ import java.util.Collections;
 
 public class DatastoreExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -356,6 +361,7 @@ import java.util.Collections;
 
 public class DatastoreExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_deploymentmanager.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_deploymentmanager.v2.json.baseline
@@ -31,6 +31,7 @@ import java.util.Collections;
 
 public class DeploymentManagerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -98,6 +99,7 @@ import java.util.Collections;
 
 public class DeploymentManagerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -162,6 +164,7 @@ import java.util.Collections;
 
 public class DeploymentManagerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -227,6 +230,7 @@ import java.util.Collections;
 
 public class DeploymentManagerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -292,6 +296,7 @@ import java.util.Collections;
 
 public class DeploymentManagerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -363,6 +368,7 @@ import java.util.Collections;
 
 public class DeploymentManagerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -431,6 +437,7 @@ import java.util.Collections;
 
 public class DeploymentManagerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -499,6 +506,7 @@ import java.util.Collections;
 
 public class DeploymentManagerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -566,6 +574,7 @@ import java.util.Collections;
 
 public class DeploymentManagerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -634,6 +643,7 @@ import java.util.Collections;
 
 public class DeploymentManagerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -707,6 +717,7 @@ import java.util.Collections;
 
 public class DeploymentManagerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -772,6 +783,7 @@ import java.util.Collections;
 
 public class DeploymentManagerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -842,6 +854,7 @@ import java.util.Collections;
 
 public class DeploymentManagerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -910,6 +923,7 @@ import java.util.Collections;
 
 public class DeploymentManagerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -984,6 +998,7 @@ import java.util.Collections;
 
 public class DeploymentManagerExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_dns.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_dns.v1.json.baseline
@@ -30,6 +30,7 @@ import java.util.Collections;
 
 public class DnsExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -97,6 +98,7 @@ import java.util.Collections;
 
 public class DnsExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -165,6 +167,7 @@ import java.util.Collections;
 
 public class DnsExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -238,6 +241,7 @@ import java.util.Collections;
 
 public class DnsExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -301,6 +305,7 @@ import java.util.Collections;
 
 public class DnsExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -363,6 +368,7 @@ import java.util.Collections;
 
 public class DnsExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -428,6 +434,7 @@ import java.util.Collections;
 
 public class DnsExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -498,6 +505,7 @@ import java.util.Collections;
 
 public class DnsExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -560,6 +568,7 @@ import java.util.Collections;
 
 public class DnsExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_logging.v2beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_logging.v2beta1.json.baseline
@@ -32,6 +32,7 @@ import java.util.Collections;
 
 public class LoggingExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -102,6 +103,7 @@ import java.util.Collections;
 
 public class LoggingExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -163,6 +165,7 @@ import java.util.Collections;
 
 public class LoggingExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -228,6 +231,7 @@ import java.util.Collections;
 
 public class LoggingExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -287,6 +291,7 @@ import java.util.Collections;
 
 public class LoggingExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -351,6 +356,7 @@ import java.util.Collections;
 
 public class LoggingExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -411,6 +417,7 @@ import java.util.Collections;
 
 public class LoggingExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -473,6 +480,7 @@ import java.util.Collections;
 
 public class LoggingExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -544,6 +552,7 @@ import java.util.Collections;
 
 public class LoggingExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -611,6 +620,7 @@ import java.util.Collections;
 
 public class LoggingExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -675,6 +685,7 @@ import java.util.Collections;
 
 public class LoggingExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -734,6 +745,7 @@ import java.util.Collections;
 
 public class LoggingExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -796,6 +808,7 @@ import java.util.Collections;
 
 public class LoggingExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -867,6 +880,7 @@ import java.util.Collections;
 
 public class LoggingExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_prediction.v1.6.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_prediction.v1.6.json.baseline
@@ -31,8 +31,9 @@ import java.util.Collections;
 
 public class PredictionExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/prediction
     Credential credential = getAuth();
 
@@ -90,8 +91,9 @@ import java.util.Collections;
 
 public class PredictionExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/prediction
     Credential credential = getAuth();
 
@@ -145,8 +147,9 @@ import java.util.Collections;
 
 public class PredictionExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/prediction
     Credential credential = getAuth();
 
@@ -199,8 +202,9 @@ import java.util.Collections;
 
 public class PredictionExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/prediction
     Credential credential = getAuth();
 
@@ -256,8 +260,9 @@ import java.util.Collections;
 
 public class PredictionExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/devstorage.full_control
     //   https://www.googleapis.com/auth/devstorage.read_only
     //   https://www.googleapis.com/auth/devstorage.read_write
@@ -316,8 +321,9 @@ import java.util.Collections;
 
 public class PredictionExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/prediction
     Credential credential = getAuth();
 
@@ -379,8 +385,9 @@ import java.util.Collections;
 
 public class PredictionExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/prediction
     Credential credential = getAuth();
 
@@ -439,8 +446,9 @@ import java.util.Collections;
 
 public class PredictionExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/prediction
     Credential credential = getAuth();
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_prediction.v1.6.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_prediction.v1.6.json.baseline
@@ -15,7 +15,7 @@
  *    https://developers.google.com/resources/api-libraries/download/prediction/v1.6/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -31,18 +31,10 @@ import java.util.Collections;
 
 public class PredictionExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/prediction
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -83,7 +75,7 @@ public class PredictionExample {
  *    https://developers.google.com/resources/api-libraries/download/prediction/v1.6/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -98,18 +90,10 @@ import java.util.Collections;
 
 public class PredictionExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/prediction
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -147,7 +131,7 @@ public class PredictionExample {
  *    https://developers.google.com/resources/api-libraries/download/prediction/v1.6/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -161,18 +145,10 @@ import java.util.Collections;
 
 public class PredictionExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/prediction
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -208,7 +184,7 @@ public class PredictionExample {
  *    https://developers.google.com/resources/api-libraries/download/prediction/v1.6/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -223,18 +199,10 @@ import java.util.Collections;
 
 public class PredictionExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/prediction
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -272,7 +240,7 @@ public class PredictionExample {
  *    https://developers.google.com/resources/api-libraries/download/prediction/v1.6/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -288,18 +256,13 @@ import java.util.Collections;
 
 public class PredictionExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/devstorage.full_control
+    //   https://www.googleapis.com/auth/devstorage.read_only
+    //   https://www.googleapis.com/auth/devstorage.read_write
+    //   https://www.googleapis.com/auth/prediction
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -337,7 +300,7 @@ public class PredictionExample {
  *    https://developers.google.com/resources/api-libraries/download/prediction/v1.6/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -353,18 +316,10 @@ import java.util.Collections;
 
 public class PredictionExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/prediction
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -408,7 +363,7 @@ public class PredictionExample {
  *    https://developers.google.com/resources/api-libraries/download/prediction/v1.6/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -424,18 +379,10 @@ import java.util.Collections;
 
 public class PredictionExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/prediction
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -476,7 +423,7 @@ public class PredictionExample {
  *    https://developers.google.com/resources/api-libraries/download/prediction/v1.6/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -492,18 +439,10 @@ import java.util.Collections;
 
 public class PredictionExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/prediction
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_prediction.v1.6.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_prediction.v1.6.json.baseline
@@ -5,11 +5,7 @@
  * 1. If not already done, enable the Prediction API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/prediction
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/prediction/v1.6/java
@@ -67,11 +63,7 @@ public class PredictionExample {
  * 1. If not already done, enable the Prediction API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/prediction
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/prediction/v1.6/java
@@ -125,11 +117,7 @@ public class PredictionExample {
  * 1. If not already done, enable the Prediction API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/prediction
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/prediction/v1.6/java
@@ -180,11 +168,7 @@ public class PredictionExample {
  * 1. If not already done, enable the Prediction API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/prediction
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/prediction/v1.6/java
@@ -238,11 +222,7 @@ public class PredictionExample {
  * 1. If not already done, enable the Prediction API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/prediction
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/prediction/v1.6/java
@@ -300,11 +280,7 @@ public class PredictionExample {
  * 1. If not already done, enable the Prediction API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/prediction
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/prediction/v1.6/java
@@ -365,11 +341,7 @@ public class PredictionExample {
  * 1. If not already done, enable the Prediction API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/prediction
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/prediction/v1.6/java
@@ -427,11 +399,7 @@ public class PredictionExample {
  * 1. If not already done, enable the Prediction API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/prediction
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/prediction/v1.6/java

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_prediction.v1.6.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_prediction.v1.6.json.baseline
@@ -33,6 +33,7 @@ public class PredictionExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/prediction
     Credential credential = getAuth();
@@ -93,6 +94,7 @@ public class PredictionExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/prediction
     Credential credential = getAuth();
@@ -149,6 +151,7 @@ public class PredictionExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/prediction
     Credential credential = getAuth();
@@ -204,6 +207,7 @@ public class PredictionExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/prediction
     Credential credential = getAuth();
@@ -262,6 +266,7 @@ public class PredictionExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/devstorage.full_control
     //   https://www.googleapis.com/auth/devstorage.read_only
@@ -323,6 +328,7 @@ public class PredictionExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/prediction
     Credential credential = getAuth();
@@ -387,6 +393,7 @@ public class PredictionExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/prediction
     Credential credential = getAuth();
@@ -448,6 +455,7 @@ public class PredictionExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/prediction
     Credential credential = getAuth();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_pubsub.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_pubsub.v1.json.baseline
@@ -30,6 +30,7 @@ import java.util.Collections;
 
 public class PubsubExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -92,6 +93,7 @@ import java.util.Collections;
 
 public class PubsubExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -159,6 +161,7 @@ import java.util.Collections;
 
 public class PubsubExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -218,6 +221,7 @@ import java.util.Collections;
 
 public class PubsubExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -279,6 +283,7 @@ import java.util.Collections;
 
 public class PubsubExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -344,6 +349,7 @@ import java.util.Collections;
 
 public class PubsubExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -414,6 +420,7 @@ import java.util.Collections;
 
 public class PubsubExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -476,6 +483,7 @@ import java.util.Collections;
 
 public class PubsubExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -539,6 +547,7 @@ import java.util.Collections;
 
 public class PubsubExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -604,6 +613,7 @@ import java.util.Collections;
 
 public class PubsubExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -672,6 +682,7 @@ import java.util.Collections;
 
 public class PubsubExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -739,6 +750,7 @@ import java.util.Collections;
 
 public class PubsubExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -805,6 +817,7 @@ import java.util.Collections;
 
 public class PubsubExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -864,6 +877,7 @@ import java.util.Collections;
 
 public class PubsubExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -925,6 +939,7 @@ import java.util.Collections;
 
 public class PubsubExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -990,6 +1005,7 @@ import java.util.Collections;
 
 public class PubsubExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1061,6 +1077,7 @@ import java.util.Collections;
 
 public class PubsubExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1126,6 +1143,7 @@ import java.util.Collections;
 
 public class PubsubExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1193,6 +1211,7 @@ import java.util.Collections;
 
 public class PubsubExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1264,6 +1283,7 @@ import java.util.Collections;
 
 public class PubsubExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_replicapoolupdater.v1beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_replicapoolupdater.v1beta1.json.baseline
@@ -30,6 +30,7 @@ import java.util.Collections;
 
 public class ReplicapoolupdaterExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -97,6 +98,7 @@ import java.util.Collections;
 
 public class ReplicapoolupdaterExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -165,6 +167,7 @@ import java.util.Collections;
 
 public class ReplicapoolupdaterExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -233,6 +236,7 @@ import java.util.Collections;
 
 public class ReplicapoolupdaterExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -307,6 +311,7 @@ import java.util.Collections;
 
 public class ReplicapoolupdaterExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -383,6 +388,7 @@ import java.util.Collections;
 
 public class ReplicapoolupdaterExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -450,6 +456,7 @@ import java.util.Collections;
 
 public class ReplicapoolupdaterExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -517,6 +524,7 @@ import java.util.Collections;
 
 public class ReplicapoolupdaterExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -584,6 +592,7 @@ import java.util.Collections;
 
 public class ReplicapoolupdaterExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -652,6 +661,7 @@ import java.util.Collections;
 
 public class ReplicapoolupdaterExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_sqladmin.v1beta4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_sqladmin.v1beta4.json.baseline
@@ -30,6 +30,7 @@ import java.util.Collections;
 
 public class SQLAdminExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -97,6 +98,7 @@ import java.util.Collections;
 
 public class SQLAdminExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -165,6 +167,7 @@ import java.util.Collections;
 
 public class SQLAdminExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -238,6 +241,7 @@ import java.util.Collections;
 
 public class SQLAdminExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -305,6 +309,7 @@ import java.util.Collections;
 
 public class SQLAdminExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -373,6 +378,7 @@ import java.util.Collections;
 
 public class SQLAdminExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -440,6 +446,7 @@ import java.util.Collections;
 
 public class SQLAdminExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -505,6 +512,7 @@ import java.util.Collections;
 
 public class SQLAdminExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -576,6 +584,7 @@ import java.util.Collections;
 
 public class SQLAdminExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -646,6 +655,7 @@ import java.util.Collections;
 
 public class SQLAdminExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -704,6 +714,7 @@ import java.util.Collections;
 
 public class SQLAdminExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -771,6 +782,7 @@ import java.util.Collections;
 
 public class SQLAdminExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -836,6 +848,7 @@ import java.util.Collections;
 
 public class SQLAdminExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -904,6 +917,7 @@ import java.util.Collections;
 
 public class SQLAdminExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -971,6 +985,7 @@ import java.util.Collections;
 
 public class SQLAdminExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1036,6 +1051,7 @@ import java.util.Collections;
 
 public class SQLAdminExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1104,6 +1120,7 @@ import java.util.Collections;
 
 public class SQLAdminExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1169,6 +1186,7 @@ import java.util.Collections;
 
 public class SQLAdminExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1240,6 +1258,7 @@ import java.util.Collections;
 
 public class SQLAdminExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1307,6 +1326,7 @@ import java.util.Collections;
 
 public class SQLAdminExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1371,6 +1391,7 @@ import java.util.Collections;
 
 public class SQLAdminExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1435,6 +1456,7 @@ import java.util.Collections;
 
 public class SQLAdminExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1500,6 +1522,7 @@ import java.util.Collections;
 
 public class SQLAdminExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1567,6 +1590,7 @@ import java.util.Collections;
 
 public class SQLAdminExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1631,6 +1655,7 @@ import java.util.Collections;
 
 public class SQLAdminExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1696,6 +1721,7 @@ import java.util.Collections;
 
 public class SQLAdminExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1763,6 +1789,7 @@ import java.util.Collections;
 
 public class SQLAdminExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1828,6 +1855,7 @@ import java.util.Collections;
 
 public class SQLAdminExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1902,6 +1930,7 @@ import java.util.Collections;
 
 public class SQLAdminExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1969,6 +1998,7 @@ import java.util.Collections;
 
 public class SQLAdminExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -2036,6 +2066,7 @@ import java.util.Collections;
 
 public class SQLAdminExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -2104,6 +2135,7 @@ import java.util.Collections;
 
 public class SQLAdminExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -2171,6 +2203,7 @@ import java.util.Collections;
 
 public class SQLAdminExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -2235,6 +2268,7 @@ import java.util.Collections;
 
 public class SQLAdminExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -2296,6 +2330,7 @@ import java.util.Collections;
 
 public class SQLAdminExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -2367,6 +2402,7 @@ import java.util.Collections;
 
 public class SQLAdminExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -2434,6 +2470,7 @@ import java.util.Collections;
 
 public class SQLAdminExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -2499,6 +2536,7 @@ import java.util.Collections;
 
 public class SQLAdminExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_storage.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_storage.v1.json.baseline
@@ -29,6 +29,7 @@ import java.util.Collections;
 
 public class StorageExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -92,6 +93,7 @@ import java.util.Collections;
 
 public class StorageExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -157,6 +159,7 @@ import java.util.Collections;
 
 public class StorageExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -221,6 +224,7 @@ import java.util.Collections;
 
 public class StorageExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -282,6 +286,7 @@ import java.util.Collections;
 
 public class StorageExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -350,6 +355,7 @@ import java.util.Collections;
 
 public class StorageExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -417,6 +423,7 @@ import java.util.Collections;
 
 public class StorageExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -476,6 +483,7 @@ import java.util.Collections;
 
 public class StorageExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -537,6 +545,7 @@ import java.util.Collections;
 
 public class StorageExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -602,6 +611,7 @@ import java.util.Collections;
 
 public class StorageExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -672,6 +682,7 @@ import java.util.Collections;
 
 public class StorageExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -736,6 +747,7 @@ import java.util.Collections;
 
 public class StorageExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -800,6 +812,7 @@ import java.util.Collections;
 
 public class StorageExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -857,6 +870,7 @@ import java.util.Collections;
 
 public class StorageExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -920,6 +934,7 @@ import java.util.Collections;
 
 public class StorageExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -985,6 +1000,7 @@ import java.util.Collections;
 
 public class StorageExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1049,6 +1065,7 @@ import java.util.Collections;
 
 public class StorageExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1110,6 +1127,7 @@ import java.util.Collections;
 
 public class StorageExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1178,6 +1196,7 @@ import java.util.Collections;
 
 public class StorageExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1245,6 +1264,7 @@ import java.util.Collections;
 
 public class StorageExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1312,6 +1332,7 @@ import java.util.Collections;
 
 public class StorageExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1381,6 +1402,7 @@ import java.util.Collections;
 
 public class StorageExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1449,6 +1471,7 @@ import java.util.Collections;
 
 public class StorageExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1514,6 +1537,7 @@ import java.util.Collections;
 
 public class StorageExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1586,6 +1610,7 @@ import java.util.Collections;
 
 public class StorageExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1659,6 +1684,7 @@ import java.util.Collections;
 
 public class StorageExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1727,6 +1753,7 @@ import java.util.Collections;
 
 public class StorageExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1803,6 +1830,7 @@ import java.util.Collections;
 
 public class StorageExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1866,6 +1894,7 @@ import java.util.Collections;
 
 public class StorageExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1931,6 +1960,7 @@ import java.util.Collections;
 
 public class StorageExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -1997,6 +2027,7 @@ import java.util.Collections;
 
 public class StorageExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -2067,6 +2098,7 @@ import java.util.Collections;
 
 public class StorageExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -2136,6 +2168,7 @@ import java.util.Collections;
 
 public class StorageExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -2213,6 +2246,7 @@ import java.util.Collections;
 
 public class StorageExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -2281,6 +2315,7 @@ import java.util.Collections;
 
 public class StorageExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_storagetransfer.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_storagetransfer.v1.json.baseline
@@ -30,6 +30,7 @@ import java.util.Collections;
 
 public class StoragetransferExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -87,6 +88,7 @@ import java.util.Collections;
 
 public class StoragetransferExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -149,6 +151,7 @@ import java.util.Collections;
 
 public class StoragetransferExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -209,6 +212,7 @@ import java.util.Collections;
 
 public class StoragetransferExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -271,6 +275,7 @@ import java.util.Collections;
 
 public class StoragetransferExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -338,6 +343,7 @@ import java.util.Collections;
 
 public class StoragetransferExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -401,6 +407,7 @@ import java.util.Collections;
 
 public class StoragetransferExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -459,6 +466,7 @@ import java.util.Collections;
 
 public class StoragetransferExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -518,6 +526,7 @@ import java.util.Collections;
 
 public class StoragetransferExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -580,6 +589,7 @@ import java.util.Collections;
 
 public class StoragetransferExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -650,6 +660,7 @@ import java.util.Collections;
 
 public class StoragetransferExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
@@ -712,6 +723,7 @@ import java.util.Collections;
 
 public class StoragetransferExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_taskqueue.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_taskqueue.v1beta2.json.baseline
@@ -30,8 +30,9 @@ import java.util.Collections;
 
 public class TaskqueueExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/taskqueue
     //   https://www.googleapis.com/auth/taskqueue.consumer
     Credential credential = getAuth();
@@ -86,8 +87,9 @@ import java.util.Collections;
 
 public class TaskqueueExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/taskqueue
     //   https://www.googleapis.com/auth/taskqueue.consumer
     Credential credential = getAuth();
@@ -144,8 +146,9 @@ import java.util.Collections;
 
 public class TaskqueueExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/taskqueue
     //   https://www.googleapis.com/auth/taskqueue.consumer
     Credential credential = getAuth();
@@ -204,8 +207,9 @@ import java.util.Collections;
 
 public class TaskqueueExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/taskqueue
     //   https://www.googleapis.com/auth/taskqueue.consumer
     Credential credential = getAuth();
@@ -264,8 +268,9 @@ import java.util.Collections;
 
 public class TaskqueueExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/taskqueue
     //   https://www.googleapis.com/auth/taskqueue.consumer
     Credential credential = getAuth();
@@ -327,8 +332,9 @@ import java.util.Collections;
 
 public class TaskqueueExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/taskqueue
     //   https://www.googleapis.com/auth/taskqueue.consumer
     Credential credential = getAuth();
@@ -384,8 +390,9 @@ import java.util.Collections;
 
 public class TaskqueueExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/taskqueue
     //   https://www.googleapis.com/auth/taskqueue.consumer
     Credential credential = getAuth();
@@ -450,8 +457,9 @@ import java.util.Collections;
 
 public class TaskqueueExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
-    // Authorize using the following scopes in order to use this method:
+    // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/taskqueue
     //   https://www.googleapis.com/auth/taskqueue.consumer
     Credential credential = getAuth();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_taskqueue.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_taskqueue.v1beta2.json.baseline
@@ -5,11 +5,7 @@
  * 1. If not already done, enable the TaskQueue API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/taskqueue
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/taskqueue/v1beta2/java
@@ -64,11 +60,7 @@ public class TaskqueueExample {
  * 1. If not already done, enable the TaskQueue API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/taskqueue
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/taskqueue/v1beta2/java
@@ -123,11 +115,7 @@ public class TaskqueueExample {
  * 1. If not already done, enable the TaskQueue API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/taskqueue
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/taskqueue/v1beta2/java
@@ -185,11 +173,7 @@ public class TaskqueueExample {
  * 1. If not already done, enable the TaskQueue API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/taskqueue
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/taskqueue/v1beta2/java
@@ -247,11 +231,7 @@ public class TaskqueueExample {
  * 1. If not already done, enable the TaskQueue API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/taskqueue
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/taskqueue/v1beta2/java
@@ -312,11 +292,7 @@ public class TaskqueueExample {
  * 1. If not already done, enable the TaskQueue API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/taskqueue
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/taskqueue/v1beta2/java
@@ -371,11 +347,7 @@ public class TaskqueueExample {
  * 1. If not already done, enable the TaskQueue API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/taskqueue
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/taskqueue/v1beta2/java
@@ -439,11 +411,7 @@ public class TaskqueueExample {
  * 1. If not already done, enable the TaskQueue API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/taskqueue
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/taskqueue/v1beta2/java

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_taskqueue.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_taskqueue.v1beta2.json.baseline
@@ -32,6 +32,7 @@ public class TaskqueueExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/taskqueue
     //   https://www.googleapis.com/auth/taskqueue.consumer
@@ -89,6 +90,7 @@ public class TaskqueueExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/taskqueue
     //   https://www.googleapis.com/auth/taskqueue.consumer
@@ -148,6 +150,7 @@ public class TaskqueueExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/taskqueue
     //   https://www.googleapis.com/auth/taskqueue.consumer
@@ -209,6 +212,7 @@ public class TaskqueueExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/taskqueue
     //   https://www.googleapis.com/auth/taskqueue.consumer
@@ -270,6 +274,7 @@ public class TaskqueueExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/taskqueue
     //   https://www.googleapis.com/auth/taskqueue.consumer
@@ -334,6 +339,7 @@ public class TaskqueueExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/taskqueue
     //   https://www.googleapis.com/auth/taskqueue.consumer
@@ -392,6 +398,7 @@ public class TaskqueueExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/taskqueue
     //   https://www.googleapis.com/auth/taskqueue.consumer
@@ -459,6 +466,7 @@ public class TaskqueueExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     // Authorize using one of the following scopes in order to use this method:
     //   https://www.googleapis.com/auth/taskqueue
     //   https://www.googleapis.com/auth/taskqueue.consumer

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_taskqueue.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_taskqueue.v1beta2.json.baseline
@@ -15,7 +15,7 @@
  *    https://developers.google.com/resources/api-libraries/download/taskqueue/v1beta2/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -30,18 +30,11 @@ import java.util.Collections;
 
 public class TaskqueueExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/taskqueue
+    //   https://www.googleapis.com/auth/taskqueue.consumer
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -79,7 +72,7 @@ public class TaskqueueExample {
  *    https://developers.google.com/resources/api-libraries/download/taskqueue/v1beta2/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -93,18 +86,11 @@ import java.util.Collections;
 
 public class TaskqueueExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/taskqueue
+    //   https://www.googleapis.com/auth/taskqueue.consumer
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -143,7 +129,7 @@ public class TaskqueueExample {
  *    https://developers.google.com/resources/api-libraries/download/taskqueue/v1beta2/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -158,18 +144,11 @@ import java.util.Collections;
 
 public class TaskqueueExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/taskqueue
+    //   https://www.googleapis.com/auth/taskqueue.consumer
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -210,7 +189,7 @@ public class TaskqueueExample {
  *    https://developers.google.com/resources/api-libraries/download/taskqueue/v1beta2/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -225,18 +204,11 @@ import java.util.Collections;
 
 public class TaskqueueExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/taskqueue
+    //   https://www.googleapis.com/auth/taskqueue.consumer
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -277,7 +249,7 @@ public class TaskqueueExample {
  *    https://developers.google.com/resources/api-libraries/download/taskqueue/v1beta2/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -292,18 +264,11 @@ import java.util.Collections;
 
 public class TaskqueueExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/taskqueue
+    //   https://www.googleapis.com/auth/taskqueue.consumer
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -347,7 +312,7 @@ public class TaskqueueExample {
  *    https://developers.google.com/resources/api-libraries/download/taskqueue/v1beta2/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -362,18 +327,11 @@ import java.util.Collections;
 
 public class TaskqueueExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/taskqueue
+    //   https://www.googleapis.com/auth/taskqueue.consumer
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -411,7 +369,7 @@ public class TaskqueueExample {
  *    https://developers.google.com/resources/api-libraries/download/taskqueue/v1beta2/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -426,18 +384,11 @@ import java.util.Collections;
 
 public class TaskqueueExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/taskqueue
+    //   https://www.googleapis.com/auth/taskqueue.consumer
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -484,7 +435,7 @@ public class TaskqueueExample {
  *    https://developers.google.com/resources/api-libraries/download/taskqueue/v1beta2/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -499,18 +450,11 @@ import java.util.Collections;
 
 public class TaskqueueExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    // Authorize using the following scopes in order to use this method:
+    //   https://www.googleapis.com/auth/taskqueue
+    //   https://www.googleapis.com/auth/taskqueue.consumer
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_translate.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_translate.v2.json.baseline
@@ -15,7 +15,7 @@
  *    https://developers.google.com/resources/api-libraries/download/translate/v2/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -32,18 +32,8 @@ import java.util.List;
 
 public class TranslateExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -78,7 +68,7 @@ public class TranslateExample {
  *    https://developers.google.com/resources/api-libraries/download/translate/v2/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -93,18 +83,8 @@ import java.util.Collections;
 
 public class TranslateExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
@@ -135,7 +115,7 @@ public class TranslateExample {
  *    https://developers.google.com/resources/api-libraries/download/translate/v2/java
  */
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.auth.oauth2.Credential;
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
@@ -152,18 +132,8 @@ import java.util.List;
 
 public class TranslateExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
-    // Authentication is provided by the 'gcloud' tool when running locally
-    // and by built-in service accounts when running on GAE, GCE, or GKE.
-    GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
-    // The createScopedRequired method returns true when running on GAE or a local developer
-    // machine. In that case, the desired scopes must be passed in manually. When the code is
-    // running in GCE, GKE or a Managed VM, the scopes are pulled from the GCE metadata server.
-    // For more information, see
-    // https://developers.google.com/identity/protocols/application-default-credentials
-    if (credential.createScopedRequired()) {
-      credential = credential.createScoped(Collections.singletonList("https://www.googleapis.com/auth/cloud-platform"));
-    }
+    // TODO: Implement this function to get authentication credentials.
+    Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_translate.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_translate.v2.json.baseline
@@ -34,6 +34,7 @@ public class TranslateExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
@@ -86,6 +87,7 @@ public class TranslateExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
@@ -136,6 +138,7 @@ public class TranslateExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
 
     // TODO: Implement this function to get authentication credentials.
+    // See https://foo.com/bar
     Credential credential = getAuth();
 
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_translate.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_translate.v2.json.baseline
@@ -32,6 +32,7 @@ import java.util.List;
 
 public class TranslateExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
     Credential credential = getAuth();
 
@@ -83,6 +84,7 @@ import java.util.Collections;
 
 public class TranslateExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
     Credential credential = getAuth();
 
@@ -132,6 +134,7 @@ import java.util.List;
 
 public class TranslateExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // TODO: Implement this function to get authentication credentials.
     Credential credential = getAuth();
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_translate.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_translate.v2.json.baseline
@@ -5,11 +5,7 @@
  * 1. If not already done, enable the Translate API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/translate
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/translate/v2/java
@@ -60,11 +56,7 @@ public class TranslateExample {
  * 1. If not already done, enable the Translate API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/translate
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/translate/v2/java
@@ -109,11 +101,7 @@ public class TranslateExample {
  * 1. If not already done, enable the Translate API
  *    and check the quota for your project at
  *    https://console.developers.google.com/apis/api/translate
- * 2. This sample uses Application Default Credentials for authentication.
- *    If not already done, install the gcloud CLI from
- *    https://cloud.google.com/sdk/ and run
- *    'gcloud beta auth application-default login'
- * 3. Install the Java client library on maven or gradle. Check installation
+ * 2. Install the Java client library on maven or gradle. Check installation
  *    instructions at https://github.com/google/google-api-java-client.
  *    On other build systems, you can add the jar files to your project from
  *    https://developers.google.com/resources/api-libraries/download/translate/v2/java

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_vision.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_vision.v1.json.baseline
@@ -31,6 +31,7 @@ import java.util.Collections;
 
 public class VisionExample {
   public static void main(String[] args) throws IOException, GeneralSecurityException {
+
     // Authentication is provided by the 'gcloud' tool when running locally
     // and by built-in service accounts when running on GAE, GCE, or GKE.
     GoogleCredential credential = GoogleCredential.getApplicationDefault();


### PR DESCRIPTION
Adds an auth placeholder in the Java sample depending on the API's auth
type.

Adds `auth_url` option to `DiscoveryFragmentGeneratorTool.java` to pass
custom auth instructions URLs to the fragments.

Adds `AuthType` enum and logic to `ApiaryConfig.java`
- Selects API key if there are no scopes
- Selects ADC if there are scopes and cloud is one of them
- Selects 3LO otherwise