### PR TITLE
Remove the generate_samples flag altogether.

### DIFF
--- a/src/main/java/com/google/api/codegen/ApiConfig.java
+++ b/src/main/java/com/google/api/codegen/ApiConfig.java
@@ -40,11 +40,6 @@ public abstract class ApiConfig {
   public abstract String getPackageName();
 
   /**
-   * Whether or not we should generate code samples.
-   */
-  public abstract boolean generateSamples();
-
-  /**
    * Creates an instance of ApiConfig based on ConfigProto, linking up API interface configurations
    * with specified interfaces in interfaceConfigMap. On errors, null will be returned, and
    * diagnostics are reported to the model.
@@ -56,8 +51,7 @@ public abstract class ApiConfig {
     if (interfaceConfigMap == null) {
       return null;
     } else {
-      return new AutoValue_ApiConfig(
-          interfaceConfigMap, getPackageName(configProto), configProto.getGenerateSamples());
+      return new AutoValue_ApiConfig(interfaceConfigMap, getPackageName(configProto));
     }
   }
 
@@ -65,18 +59,13 @@ public abstract class ApiConfig {
    * Creates an ApiConfig with no content. Exposed for testing.
    */
   static ApiConfig createDummyApiConfig() {
-    return new AutoValue_ApiConfig(
-        ImmutableMap.<String, InterfaceConfig>builder().build(), null, false);
+    return new AutoValue_ApiConfig(ImmutableMap.<String, InterfaceConfig>builder().build(), null);
   }
 
-  /**
-   * Creates an ApiConfig with fixed content. Exposed for testing.
-   */
+  /** Creates an ApiConfig with fixed content. Exposed for testing. */
   static ApiConfig createDummyApiConfig(
-      ImmutableMap<String, InterfaceConfig> interfaceConfigMap,
-      String packageName,
-      boolean generateSamples) {
-    return new AutoValue_ApiConfig(interfaceConfigMap, packageName, generateSamples);
+      ImmutableMap<String, InterfaceConfig> interfaceConfigMap, String packageName) {
+    return new AutoValue_ApiConfig(interfaceConfigMap, packageName);
   }
 
   private static String getPackageName(ConfigProto configProto) {

--- a/src/main/java/com/google/api/codegen/config/ConfigGeneratorApi.java
+++ b/src/main/java/com/google/api/codegen/config/ConfigGeneratorApi.java
@@ -14,14 +14,10 @@
  */
 package com.google.api.codegen.config;
 
-import com.google.api.client.util.Lists;
 import com.google.api.codegen.ConfigProto;
-import com.google.api.tools.framework.aspects.http.model.HttpAttribute;
 import com.google.api.tools.framework.model.Interface;
 import com.google.api.tools.framework.model.Method;
 import com.google.api.tools.framework.model.stages.Merged;
-import com.google.api.tools.framework.processors.merger.Merger;
-import com.google.api.tools.framework.processors.resolver.Resolver;
 import com.google.api.tools.framework.tools.ToolDriverBase;
 import com.google.api.tools.framework.tools.ToolOptions;
 import com.google.api.tools.framework.tools.ToolOptions.Option;
@@ -30,11 +26,13 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Files;
 import com.google.protobuf.Api;
 
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.Yaml;
+
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -42,9 +40,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
-
-import org.yaml.snakeyaml.DumperOptions;
-import org.yaml.snakeyaml.Yaml;
 
 /** Main class for the config generator. */
 public class ConfigGeneratorApi extends ToolDriverBase {
@@ -54,7 +49,6 @@ public class ConfigGeneratorApi extends ToolDriverBase {
           String.class, "output_file", "The path of the output file to put generated config.", "");
 
   private static final String CONFIG_KEY_TYPE = "type";
-  private static final String CONFIG_KEY_GENERATE_SAMPLES = "generate_samples";
   private static final String CONFIG_KEY_LANGUAGE_SETTINGS = "language_settings";
   private static final String CONFIG_KEY_INTERFACES = "interfaces";
 
@@ -82,7 +76,6 @@ public class ConfigGeneratorApi extends ToolDriverBase {
 
     Map<String, Object> output = new LinkedHashMap<String, Object>();
     output.put(CONFIG_KEY_TYPE, CONFIG_PROTO_TYPE);
-    output.put(CONFIG_KEY_GENERATE_SAMPLES, true);
     output.put(CONFIG_KEY_LANGUAGE_SETTINGS, generateLanguageSettings());
     output.put(CONFIG_KEY_INTERFACES, generateInterfacesConfig());
     dump(output);

--- a/src/main/proto/com/google/api/codegen/config.proto
+++ b/src/main/proto/com/google/api/codegen/config.proto
@@ -79,10 +79,6 @@ message ConfigProto {
 
   // A list of API interface configurations.
   repeated InterfaceConfigProto interfaces = 10;
-
-  // Whether or not we should generate code samples.
-  // This flag should go away as the feature matures.
-  bool generate_samples = 15;
 }
 
 message LanguageSettingsProto {

--- a/src/main/resources/com/google/api/codegen/py/main.snip
+++ b/src/main/resources/com/google/api/codegen/py/main.snip
@@ -352,18 +352,16 @@
     @join comment : descriptionComments
       {@comment}
     @end
-    @if context.getApiConfig.generateSamples
-      @if descriptionComments.isEmpty
-      @else
+    @if descriptionComments.isEmpty
+    @else
 
 
-      @end
-      {@methodSample(method)}
-      @if signatureComments.isEmpty
-      @else
+    @end
+    {@methodSample(method)}
+    @if signatureComments.isEmpty
+    @else
 
 
-      @end
     @end
     @join comment : signatureComments
       {@comment}

--- a/src/test/java/com/google/api/codegen/PhpGapicCodePathMapperTest.java
+++ b/src/test/java/com/google/api/codegen/PhpGapicCodePathMapperTest.java
@@ -41,24 +41,21 @@ public class PhpGapicCodePathMapperTest {
     ApiConfig configWithGoogleCloud =
         ApiConfig.createDummyApiConfig(
             ImmutableMap.<String, InterfaceConfig>builder().build(),
-            "Google\\Cloud\\Sample\\Package\\V1",
-            false);
+            "Google\\Cloud\\Sample\\Package\\V1");
     Truth.assertThat(pathMapper.getOutputPath(null, configWithGoogleCloud))
         .isEqualTo("prefix/Sample/Package/V1/suffix");
 
     ApiConfig configWithGoogleNonCloud =
         ApiConfig.createDummyApiConfig(
             ImmutableMap.<String, InterfaceConfig>builder().build(),
-            "Google\\NonCloud\\Sample\\Package\\V1",
-            false);
+            "Google\\NonCloud\\Sample\\Package\\V1");
     Truth.assertThat(pathMapper.getOutputPath(null, configWithGoogleNonCloud))
         .isEqualTo("prefix/NonCloud/Sample/Package/V1/suffix");
 
     ApiConfig configWithAlphabet =
         ApiConfig.createDummyApiConfig(
             ImmutableMap.<String, InterfaceConfig>builder().build(),
-            "Alphabet\\Google\\Cloud\\Sample\\Package\\V1",
-            false);
+            "Alphabet\\Google\\Cloud\\Sample\\Package\\V1");
     Truth.assertThat(pathMapper.getOutputPath(null, configWithAlphabet))
         .isEqualTo("prefix/Alphabet/Google/Cloud/Sample/Package/V1/suffix");
   }

--- a/src/test/java/com/google/api/codegen/testdata/library_config.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/library_config.baseline
@@ -1,5 +1,4 @@
 type: com.google.api.codegen.ConfigProto
-generate_samples: true
 language_settings:
   java:
     package_name: com.google.cloud.example.library.spi.v1

--- a/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
@@ -1,5 +1,4 @@
 type: com.google.api.codegen.ConfigProto
-generate_samples: true
 language_settings:
   java:
     package_name: com.google.gcloud.pubsub.spi

--- a/src/test/java/com/google/api/codegen/testdata/no_path_templates_config.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/no_path_templates_config.baseline
@@ -1,5 +1,4 @@
 type: com.google.api.codegen.ConfigProto
-generate_samples: true
 language_settings:
   java:
     package_name: com.google.cloud.cloud.example.spi.v1

--- a/src/test/java/com/google/api/codegen/testdata/no_path_templates_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testdata/no_path_templates_gapic.yaml
@@ -1,5 +1,4 @@
 type: com.google.api.codegen.ConfigProto
-generate_samples: true
 language_settings:
   java:
     package_name: com.google.gcloud.example


### PR DESCRIPTION
We have already removed them from the GAPIC config files, but
Python was still looking for it.