### PR TITLE
Delay loading grpc Ruby.

### DIFF
--- a/src/main/resources/com/google/api/codegen/ruby/main.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/main.snip
@@ -45,7 +45,6 @@
   require "pathname"
 
   require "google/gax"
-  require "{@context.getGrpcFilename(service)}"
 @end
 
 @private serviceClass(service)
@@ -210,6 +209,12 @@
         timeout: DEFAULT_TIMEOUT,
         app_name: "gax",
         app_version: Google::Gax::VERSION
+      @# These require statements are intentionally placed here to initialize
+      @# the gRPC module only when it's required.
+      @# See https://github.com/googleapis/toolkit/issues/446
+      require "google/gax/grpc"
+      require "{@context.getGrpcFilename(service)}"
+
       google_api_client = "#{app_name}/#{app_version} " @\
         "#{CODE_GEN_NAME_VERSION} ruby/#{RUBY_VERSION}".freeze
       headers = { :"x-goog-api-client" => google_api_client }

--- a/src/test/java/com/google/api/codegen/testdata/ruby_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_doc_main_library.baseline
@@ -27,7 +27,6 @@ require "json"
 require "pathname"
 
 require "google/gax"
-require "library_services_pb"
 
 module Library
   module V1
@@ -208,6 +207,12 @@ module Library
           timeout: DEFAULT_TIMEOUT,
           app_name: "gax",
           app_version: Google::Gax::VERSION
+        # These require statements are intentionally placed here to initialize
+        # the gRPC module only when it's required.
+        # See https://github.com/googleapis/toolkit/issues/446
+        require "google/gax/grpc"
+        require "library_services_pb"
+
         google_api_client = "#{app_name}/#{app_version} " \
           "#{CODE_GEN_NAME_VERSION} ruby/#{RUBY_VERSION}".freeze
         headers = { :"x-goog-api-client" => google_api_client }

--- a/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
@@ -27,7 +27,6 @@ require "json"
 require "pathname"
 
 require "google/gax"
-require "library_services_pb"
 
 module Library
   module V1
@@ -208,6 +207,12 @@ module Library
           timeout: DEFAULT_TIMEOUT,
           app_name: "gax",
           app_version: Google::Gax::VERSION
+        # These require statements are intentionally placed here to initialize
+        # the gRPC module only when it's required.
+        # See https://github.com/googleapis/toolkit/issues/446
+        require "google/gax/grpc"
+        require "library_services_pb"
+
         google_api_client = "#{app_name}/#{app_version} " \
           "#{CODE_GEN_NAME_VERSION} ruby/#{RUBY_VERSION}".freeze
         headers = { :"x-goog-api-client" => google_api_client }


### PR DESCRIPTION
Fixes #446 with https://github.com/googleapis/gax-ruby/pull/41.