### PR TITLE
gRPC streaming support in Python.

### DIFF
--- a/src/main/java/com/google/api/codegen/GapicContext.java
+++ b/src/main/java/com/google/api/codegen/GapicContext.java
@@ -112,21 +112,21 @@ public class GapicContext extends CodegenContext {
   }
 
   /**
-   * Returns true when the method should appear in the result of codegen. Currently only non
-   * stremaing methods are allowed by defualt, because majority of language clients do not support
-   * streaming APIs. Subclass may override this method to allow them.
+   * Returns true when the method is supported by the current codegen context. By default, only non
+   * stremaing methods are supported unless subclass explicitly allows.
+   * TODO: remove this method when all languages support gRPC streaming.
    */
-  protected boolean shouldMethodAppear(Method method) {
+  protected boolean isSupported(Method method) {
     return !method.getRequestStreaming() && !method.getResponseStreaming();
   }
 
   /**
    * Returns a list of RPC methods supported by the context.
    */
-  public List<Method> getMethods(Interface service) {
+  public List<Method> getSupportedMethods(Interface service) {
     List<Method> simples = new ArrayList<>(service.getMethods().size());
     for (Method method : service.getMethods()) {
-      if (shouldMethodAppear(method)) {
+      if (isSupported(method)) {
         simples.add(method);
       }
     }
@@ -136,9 +136,9 @@ public class GapicContext extends CodegenContext {
   /**
    * Returns a list of RPC methods supported by the context, taking into account GRPC interface
    * rerouting.
-   * TODO replace getMethods with this when all languages are migrated.
+   * TODO replace getSupportedMethods with this when all languages are migrated.
    */
-  public List<Method> getMethodsV2(Interface service) {
+  public List<Method> getSupportedMethodsV2(Interface service) {
     InterfaceConfig interfaceConfig = getApiConfig().getInterfaceConfig(service);
     if (interfaceConfig == null) {
       throw new IllegalStateException(
@@ -147,7 +147,7 @@ public class GapicContext extends CodegenContext {
     List<Method> methods = new ArrayList<>(interfaceConfig.getMethodConfigs().size());
     for (MethodConfig methodConfig : interfaceConfig.getMethodConfigs()) {
       Method method = methodConfig.getMethod();
-      if (shouldMethodAppear(method)) {
+      if (isSupported(method)) {
         methods.add(method);
       }
     }

--- a/src/main/java/com/google/api/codegen/GapicContext.java
+++ b/src/main/java/com/google/api/codegen/GapicContext.java
@@ -112,12 +112,21 @@ public class GapicContext extends CodegenContext {
   }
 
   /**
-   * Returns a list of simple RPC methods.
+   * Returns true when the method should appear in the result of codegen. Currently only non
+   * stremaing methods are allowed by defualt, because majority of language clients do not support
+   * streaming APIs. Subclass may override this method to allow them.
    */
-  public List<Method> getNonStreamingMethods(Interface service) {
+  protected boolean shouldMethodAppear(Method method) {
+    return !method.getRequestStreaming() && !method.getResponseStreaming();
+  }
+
+  /**
+   * Returns a list of RPC methods supported by the context.
+   */
+  public List<Method> getMethods(Interface service) {
     List<Method> simples = new ArrayList<>(service.getMethods().size());
     for (Method method : service.getMethods()) {
-      if (!method.getRequestStreaming() && !method.getResponseStreaming()) {
+      if (shouldMethodAppear(method)) {
         simples.add(method);
       }
     }
@@ -125,10 +134,11 @@ public class GapicContext extends CodegenContext {
   }
 
   /**
-   * Returns a list of simple RPC methods, taking into account GRPC interface rerouting.
-   * TODO replace getNonStreamingMethods with this when all languages are migrated.
+   * Returns a list of RPC methods supported by the context, taking into account GRPC interface
+   * rerouting.
+   * TODO replace getMethods with this when all languages are migrated.
    */
-  public List<Method> getNonStreamingMethodsV2(Interface service) {
+  public List<Method> getMethodsV2(Interface service) {
     InterfaceConfig interfaceConfig = getApiConfig().getInterfaceConfig(service);
     if (interfaceConfig == null) {
       throw new IllegalStateException(
@@ -137,7 +147,7 @@ public class GapicContext extends CodegenContext {
     List<Method> methods = new ArrayList<>(interfaceConfig.getMethodConfigs().size());
     for (MethodConfig methodConfig : interfaceConfig.getMethodConfigs()) {
       Method method = methodConfig.getMethod();
-      if (!method.getRequestStreaming() && !method.getResponseStreaming()) {
+      if (shouldMethodAppear(method)) {
         methods.add(method);
       }
     }

--- a/src/main/java/com/google/api/codegen/MethodConfig.java
+++ b/src/main/java/com/google/api/codegen/MethodConfig.java
@@ -42,6 +42,7 @@ public class MethodConfig {
 
   private final Method method;
   private final PageStreamingConfig pageStreaming;
+  private final PageStreamingConfig grpcStreaming;
   private final FlatteningConfig flattening;
   private final String retryCodesConfigName;
   private final String retrySettingsConfigName;
@@ -77,6 +78,19 @@ public class MethodConfig {
           PageStreamingConfig.createPageStreaming(
               diagCollector, methodConfigProto.getPageStreaming(), method);
       if (pageStreaming == null) {
+        error = true;
+      }
+    }
+
+    PageStreamingConfig grpcStreaming;
+    if (PageStreamingConfigProto.getDefaultInstance()
+        .equals(methodConfigProto.getGrpcStreaming())) {
+      grpcStreaming = null;
+    } else {
+      grpcStreaming =
+          PageStreamingConfig.createGrpcStreaming(
+              diagCollector, methodConfigProto.getGrpcStreaming(), method);
+      if (grpcStreaming == null) {
         error = true;
       }
     }
@@ -183,6 +197,7 @@ public class MethodConfig {
       return new MethodConfig(
           method,
           pageStreaming,
+          grpcStreaming,
           flattening,
           retryCodesName,
           retryParamsName,
@@ -200,6 +215,7 @@ public class MethodConfig {
   private MethodConfig(
       Method method,
       PageStreamingConfig pageStreaming,
+      PageStreamingConfig grpcStreaming,
       FlatteningConfig flattening,
       String retryCodesConfigName,
       String retrySettingsConfigName,
@@ -213,6 +229,7 @@ public class MethodConfig {
       String rerouteToGrpcInterface) {
     this.method = method;
     this.pageStreaming = pageStreaming;
+    this.grpcStreaming = grpcStreaming;
     this.flattening = flattening;
     this.retryCodesConfigName = retryCodesConfigName;
     this.retrySettingsConfigName = retrySettingsConfigName;
@@ -239,6 +256,16 @@ public class MethodConfig {
   /** Returns the page streaming configuration of the method. */
   public PageStreamingConfig getPageStreaming() {
     return pageStreaming;
+  }
+
+  /** Returns true if this method has grpc response streaming configured. */
+  public boolean isGrpcStreaming() {
+    return grpcStreaming != null;
+  }
+
+  /** Returns the configuration for grpc response streaming. */
+  public PageStreamingConfig getGrpcStreaing() {
+    return grpcStreaming;
   }
 
   /** Returns true if this method has flattening configured. */

--- a/src/main/java/com/google/api/codegen/PageStreamingConfig.java
+++ b/src/main/java/com/google/api/codegen/PageStreamingConfig.java
@@ -94,7 +94,9 @@ public class PageStreamingConfig {
               resourcesFieldName));
     }
 
-    if (requestTokenField == null && responseTokenField == null && resourcesField == null) {
+    if ((!method.getResponseStreaming()
+            && (requestTokenField == null || responseTokenField == null))
+        || resourcesField == null) {
       return null;
     }
     return new PageStreamingConfig(

--- a/src/main/java/com/google/api/codegen/PageStreamingConfig.java
+++ b/src/main/java/com/google/api/codegen/PageStreamingConfig.java
@@ -44,7 +44,7 @@ public class PageStreamingConfig {
     String requestTokenFieldName = pageStreaming.getRequest().getTokenField();
     Field requestTokenField =
         method.getInputType().getMessageType().lookupField(requestTokenFieldName);
-    if (requestTokenField == null) {
+    if (requestTokenField == null && !method.getResponseStreaming()) {
       diagCollector.addDiag(
           Diag.error(
               SimpleLocation.TOPLEVEL,
@@ -72,7 +72,7 @@ public class PageStreamingConfig {
     String responseTokenFieldName = pageStreaming.getResponse().getTokenField();
     Field responseTokenField =
         method.getOutputType().getMessageType().lookupField(responseTokenFieldName);
-    if (responseTokenField == null) {
+    if (responseTokenField == null && !method.getResponseStreaming()) {
       diagCollector.addDiag(
           Diag.error(
               SimpleLocation.TOPLEVEL,
@@ -94,7 +94,7 @@ public class PageStreamingConfig {
               resourcesFieldName));
     }
 
-    if (requestTokenField == null || responseTokenField == null || resourcesField == null) {
+    if (requestTokenField == null && responseTokenField == null && resourcesField == null) {
       return null;
     }
     return new PageStreamingConfig(

--- a/src/main/java/com/google/api/codegen/PageStreamingConfig.java
+++ b/src/main/java/com/google/api/codegen/PageStreamingConfig.java
@@ -118,7 +118,7 @@ public class PageStreamingConfig {
         diagCollector.addDiag(
             Diag.error(
                 SimpleLocation.TOPLEVEL,
-                "Request field missing for page streaming: method = %s, message type = %s, field = %s",
+                "Request field missing for gRPC streaming: method = %s, message type = %s, field = %s",
                 method.getFullName(),
                 method.getInputType().getMessageType().getFullName(),
                 requestTokenFieldName));
@@ -134,7 +134,7 @@ public class PageStreamingConfig {
         diagCollector.addDiag(
             Diag.error(
                 SimpleLocation.TOPLEVEL,
-                "Response field missing for page streaming: method = %s, message type = %s, field = %s",
+                "Response field missing for gRPC streaming: method = %s, message type = %s, field = %s",
                 method.getFullName(),
                 method.getOutputType().getMessageType().getFullName(),
                 responseTokenFieldName));
@@ -147,7 +147,7 @@ public class PageStreamingConfig {
       diagCollector.addDiag(
           Diag.error(
               SimpleLocation.TOPLEVEL,
-              "Resources field missing for page streaming: method = %s, message type = %s, field = %s",
+              "Resources field missing for gRPC streaming: method = %s, message type = %s, field = %s",
               method.getFullName(),
               method.getOutputType().getMessageType().getFullName(),
               resourcesFieldName));

--- a/src/main/java/com/google/api/codegen/PageStreamingConfig.java
+++ b/src/main/java/com/google/api/codegen/PageStreamingConfig.java
@@ -125,21 +125,6 @@ public class PageStreamingConfig {
       }
     }
 
-    String pageSizeFieldName = pageStreaming.getRequest().getPageSizeField();
-    Field pageSizeField = null;
-    if (!Strings.isNullOrEmpty(pageSizeFieldName)) {
-      pageSizeField = method.getInputType().getMessageType().lookupField(pageSizeFieldName);
-      if (pageSizeField == null) {
-        diagCollector.addDiag(
-            Diag.error(
-                SimpleLocation.TOPLEVEL,
-                "Request field missing for page streaming: method = %s, message type = %s, field = %s",
-                method.getFullName(),
-                method.getInputType().getMessageType().getFullName(),
-                pageSizeFieldName));
-      }
-    }
-
     String responseTokenFieldName = pageStreaming.getResponse().getTokenField();
     Field responseTokenField = null;
     if (!Strings.isNullOrEmpty(responseTokenFieldName)) {
@@ -172,7 +157,10 @@ public class PageStreamingConfig {
       return null;
     }
     return new PageStreamingConfig(
-        requestTokenField, pageSizeField, responseTokenField, resourcesField);
+        requestTokenField,
+        null /* pageSize field is not used for gRPC streaming */,
+        responseTokenField,
+        resourcesField);
   }
 
   private PageStreamingConfig(

--- a/src/main/java/com/google/api/codegen/ServiceMessages.java
+++ b/src/main/java/com/google/api/codegen/ServiceMessages.java
@@ -48,7 +48,8 @@ public class ServiceMessages {
         new Predicate<Method>() {
           @Override
           public boolean apply(Method method) {
-            return config.getMethodConfig(method).isPageStreaming();
+            return !method.getResponseStreaming()
+                && config.getMethodConfig(method).isPageStreaming();
           }
         };
 

--- a/src/main/java/com/google/api/codegen/ServiceMessages.java
+++ b/src/main/java/com/google/api/codegen/ServiceMessages.java
@@ -48,8 +48,7 @@ public class ServiceMessages {
         new Predicate<Method>() {
           @Override
           public boolean apply(Method method) {
-            return !method.getResponseStreaming()
-                && config.getMethodConfig(method).isPageStreaming();
+            return config.getMethodConfig(method).isPageStreaming();
           }
         };
 

--- a/src/main/java/com/google/api/codegen/clientconfig/ClientConfigGapicContext.java
+++ b/src/main/java/com/google/api/codegen/clientconfig/ClientConfigGapicContext.java
@@ -55,7 +55,12 @@ public class ClientConfigGapicContext extends GapicContext {
   }
 
   @Override
-  public List<Method> getNonStreamingMethods(Interface service) {
-    return getNonStreamingMethodsV2(service);
+  protected boolean shouldMethodAppear(Method method) {
+    return true;
+  }
+
+  @Override
+  public List<Method> getMethods(Interface service) {
+    return getMethodsV2(service);
   }
 }

--- a/src/main/java/com/google/api/codegen/clientconfig/ClientConfigGapicContext.java
+++ b/src/main/java/com/google/api/codegen/clientconfig/ClientConfigGapicContext.java
@@ -55,12 +55,12 @@ public class ClientConfigGapicContext extends GapicContext {
   }
 
   @Override
-  protected boolean shouldMethodAppear(Method method) {
+  protected boolean isSupported(Method method) {
     return true;
   }
 
   @Override
-  public List<Method> getMethods(Interface service) {
-    return getMethodsV2(service);
+  public List<Method> getSupportedMethods(Interface service) {
+    return getSupportedMethodsV2(service);
   }
 }

--- a/src/main/java/com/google/api/codegen/csharp/CSharpGapicContext.java
+++ b/src/main/java/com/google/api/codegen/csharp/CSharpGapicContext.java
@@ -545,7 +545,7 @@ public class CSharpGapicContext extends GapicContext implements CSharpContext {
             });
     // TODO: Change back to .from(service.getMethods()) once streaming is implemented.
     //   We ignore streaming for now to not cause test failures.
-    return FluentIterable.from(getMethods(service))
+    return FluentIterable.from(getSupportedMethods(service))
         .transform(
             new Function<Method, MethodInfo>() {
               @Override
@@ -596,7 +596,7 @@ public class CSharpGapicContext extends GapicContext implements CSharpContext {
     final InterfaceConfig interfaceConfig = getApiConfig().getInterfaceConfig(service);
     // TODO: Change back to .from(service.getMethods()) once streaming is implemented.
     //   We ignore streaming for now to not cause test failures.
-    return FluentIterable.from(getMethods(service))
+    return FluentIterable.from(getSupportedMethods(service))
         .transform(
             new Function<Method, PageStreamerInfo>() {
               @Override

--- a/src/main/java/com/google/api/codegen/csharp/CSharpGapicContext.java
+++ b/src/main/java/com/google/api/codegen/csharp/CSharpGapicContext.java
@@ -545,7 +545,7 @@ public class CSharpGapicContext extends GapicContext implements CSharpContext {
             });
     // TODO: Change back to .from(service.getMethods()) once streaming is implemented.
     //   We ignore streaming for now to not cause test failures.
-    return FluentIterable.from(getNonStreamingMethods(service))
+    return FluentIterable.from(getMethods(service))
         .transform(
             new Function<Method, MethodInfo>() {
               @Override
@@ -596,7 +596,7 @@ public class CSharpGapicContext extends GapicContext implements CSharpContext {
     final InterfaceConfig interfaceConfig = getApiConfig().getInterfaceConfig(service);
     // TODO: Change back to .from(service.getMethods()) once streaming is implemented.
     //   We ignore streaming for now to not cause test failures.
-    return FluentIterable.from(getNonStreamingMethods(service))
+    return FluentIterable.from(getMethods(service))
         .transform(
             new Function<Method, PageStreamerInfo>() {
               @Override

--- a/src/main/java/com/google/api/codegen/go/GoGapicContext.java
+++ b/src/main/java/com/google/api/codegen/go/GoGapicContext.java
@@ -272,7 +272,7 @@ public class GoGapicContext extends GapicContext implements GoContext {
    */
   public Collection<PageStreamingConfig> getPageStreamingConfigs(Interface service) {
     Map<String, PageStreamingConfig> streamingConfigs = new LinkedHashMap<>();
-    for (Method method : getNonStreamingMethods(service)) {
+    for (Method method : getMethods(service)) {
       MethodConfig methodConfig =
           getApiConfig().getInterfaceConfig(service).getMethodConfig(method);
 
@@ -432,7 +432,7 @@ public class GoGapicContext extends GapicContext implements GoContext {
     // Add method request-type imports
     // TODO(pongad): Change this back to service.getMethods() once streaming is implemented.
     //   imports for streaming methods are removed for now to not mess with tests.
-    for (Method method : getNonStreamingMethods(service)) {
+    for (Method method : getMethods(service)) {
       MessageType inputMessage = method.getInputMessage();
       MessageType outputMessage = method.getOutputMessage();
       MethodConfig methodConfig =
@@ -536,7 +536,7 @@ public class GoGapicContext extends GapicContext implements GoContext {
    */
   public TreeSet<RetryConfigName> getRetryConfigNames(Interface service) {
     TreeSet<RetryConfigName> set = new TreeSet<>();
-    for (Method method : getNonStreamingMethods(service)) {
+    for (Method method : getSupportedMethods(service)) {
       MethodConfig conf = getApiConfig().getInterfaceConfig(service).getMethodConfig(method);
       set.add(
           RetryConfigName.create(

--- a/src/main/java/com/google/api/codegen/go/GoGapicContext.java
+++ b/src/main/java/com/google/api/codegen/go/GoGapicContext.java
@@ -272,7 +272,7 @@ public class GoGapicContext extends GapicContext implements GoContext {
    */
   public Collection<PageStreamingConfig> getPageStreamingConfigs(Interface service) {
     Map<String, PageStreamingConfig> streamingConfigs = new LinkedHashMap<>();
-    for (Method method : getMethods(service)) {
+    for (Method method : getSupportedMethods(service)) {
       MethodConfig methodConfig =
           getApiConfig().getInterfaceConfig(service).getMethodConfig(method);
 
@@ -432,7 +432,7 @@ public class GoGapicContext extends GapicContext implements GoContext {
     // Add method request-type imports
     // TODO(pongad): Change this back to service.getMethods() once streaming is implemented.
     //   imports for streaming methods are removed for now to not mess with tests.
-    for (Method method : getMethods(service)) {
+    for (Method method : getSupportedMethods(service)) {
       MessageType inputMessage = method.getInputMessage();
       MessageType outputMessage = method.getOutputMessage();
       MethodConfig methodConfig =

--- a/src/main/java/com/google/api/codegen/py/PythonDocConfig.java
+++ b/src/main/java/com/google/api/codegen/py/PythonDocConfig.java
@@ -58,11 +58,25 @@ abstract class PythonDocConfig extends DocConfig {
   /**
    * Does this method return an iterable response?
    */
-  public boolean isIterableResponse() {
+  public boolean isPageStreaming() {
     Method method = getMethod();
     MethodConfig methodConfig =
         getApiConfig().getInterfaceConfig(getInterface()).getMethodConfig(method);
     return methodConfig.isPageStreaming();
+  }
+
+  /**
+   * Does this method is a gRPC-response streaming?
+   */
+  public boolean isResponseGrpcStreaming() {
+    return getMethod().getResponseStreaming();
+  }
+
+  /**
+   * Does this method is a gRPC-request streaming?
+   */
+  public boolean isRequestGrpcStreaming() {
+    return getMethod().getRequestStreaming();
   }
 
   /**

--- a/src/main/java/com/google/api/codegen/py/PythonDocConfig.java
+++ b/src/main/java/com/google/api/codegen/py/PythonDocConfig.java
@@ -66,14 +66,14 @@ abstract class PythonDocConfig extends DocConfig {
   }
 
   /**
-   * Does this method is a gRPC-response streaming?
+   * Is this method gRPC-response streaming?
    */
   public boolean isResponseGrpcStreaming() {
     return getMethod().getResponseStreaming();
   }
 
   /**
-   * Does this method is a gRPC-request streaming?
+   * Is this method gRPC-request streaming?
    */
   public boolean isRequestGrpcStreaming() {
     return getMethod().getRequestStreaming();

--- a/src/main/java/com/google/api/codegen/py/PythonDocConfig.java
+++ b/src/main/java/com/google/api/codegen/py/PythonDocConfig.java
@@ -32,6 +32,8 @@ import com.google.common.collect.ImmutableList;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * Represents the Python documentation settings for an Api method.
@@ -48,7 +50,7 @@ abstract class PythonDocConfig extends DocConfig {
 
   public abstract Interface getInterface();
 
-  public abstract PythonImportHandler getImportHandler();
+  abstract PythonImportHandler getImportHandler();
 
   @Override
   public String getMethodName() {
@@ -95,7 +97,8 @@ abstract class PythonDocConfig extends DocConfig {
     return PythonImport.create(ImportType.APP, moduleName, apiName).importString();
   }
 
-  private List<String> addProtoImports(List<String> importStrings) {
+  private void addProtoImports(List<String> importStrings) {
+    Set<String> protoImports = new TreeSet<>();
     for (InitCodeLine line : getInitCode().getLines()) {
       TypeRef lineType = null;
       switch (line.getLineType()) {
@@ -110,38 +113,21 @@ abstract class PythonDocConfig extends DocConfig {
       }
 
       if (lineType != null && lineType.isMessage()) {
-        importStrings.addAll(getImportHandler().calculateImports());
-        break;
+        protoImports.add(getImportHandler().fileToImport(lineType.getMessageType().getFile()));
       }
     }
-    return importStrings;
+    importStrings.addAll(protoImports);
   }
 
   @AutoValue.Builder
   abstract static class Builder extends DocConfig.Builder<Builder> {
-    abstract PythonDocConfig autoBuild();
-
-    abstract Method getMethod();
-
-    abstract Builder setImportHandler(PythonImportHandler importHandler);
-
-    abstract Interface getInterface();
-
-    abstract ApiConfig getApiConfig();
-
-    public PythonDocConfig build() {
-      setImportHandler(
-          new PythonImportHandler(
-              getApiConfig()
-                  .getInterfaceConfig(getInterface())
-                  .getMethodConfig(getMethod())
-                  .getRequiredFields()));
-      return autoBuild();
-    }
+    abstract PythonDocConfig build();
 
     public abstract Builder setApiConfig(ApiConfig apiConfig);
 
     public abstract Builder setApiName(String serviceName);
+
+    public abstract Builder setImportHandler(PythonImportHandler importHandler);
 
     public abstract Builder setMethod(Method method);
 

--- a/src/main/java/com/google/api/codegen/py/PythonGapicContext.java
+++ b/src/main/java/com/google/api/codegen/py/PythonGapicContext.java
@@ -261,9 +261,9 @@ public class PythonGapicContext extends GapicContext {
     contentBuilder.append("Args:\n");
     if (method.getRequestStreaming()) {
       contentBuilder.append(
-          "  requests (iterator of "
+          "  requests (iterator["
               + typeComment(method.getInputType(), importHandler)
-              + "): The input objects.\n");
+              + "]): The input objects.\n");
     } else {
       for (Field field :
           removePageTokenFromFields(method.getInputType().getMessageType().getFields(), config)) {

--- a/src/main/java/com/google/api/codegen/py/PythonGapicContext.java
+++ b/src/main/java/com/google/api/codegen/py/PythonGapicContext.java
@@ -98,6 +98,11 @@ public class PythonGapicContext extends GapicContext {
     return pythonCommon;
   }
 
+  @Override
+  protected boolean shouldMethodAppear(Method method) {
+    return true;
+  }
+
   // Snippet Helpers
   // ===============
 
@@ -212,7 +217,9 @@ public class PythonGapicContext extends GapicContext {
     String path = importHandler.elementPath(returnMessageType, true);
     String classInfo = ":class:`" + path + "` instance";
 
-    if (config.isPageStreaming()) {
+    if (method.getResponseStreaming()) {
+      return "Returns:\n" + "  An iterator which yields " + classInfo + "s.";
+    } else if (config.isPageStreaming()) {
       return "Returns:"
           + "\n  A :class:`google.gax.PageIterator` instance. By default, this"
           + "\n  is an iterable of "
@@ -220,7 +227,6 @@ public class PythonGapicContext extends GapicContext {
           + " instances."
           + "\n  This object can also be configured to iterate over the pages"
           + "\n  of the response through the `CallOptions` parameter.";
-
     } else {
       return "Returns:\n  A " + classInfo + ".";
     }
@@ -253,23 +259,30 @@ public class PythonGapicContext extends GapicContext {
 
     // parameter types
     contentBuilder.append("Args:\n");
-    for (Field field :
-        removePageTokenFromFields(method.getInputType().getMessageType().getFields(), config)) {
-      String name = pythonCommon.wrapIfKeywordOrBuiltIn(field.getSimpleName());
-      if (config.isPageStreaming()
-          && field.equals((config.getPageStreaming().getPageSizeField()))) {
-        contentBuilder.append(
-            fieldComment(
-                name,
-                field,
-                importHandler,
-                "The maximum number of resources contained in the\n"
-                    + "underlying API response. If page streaming is performed per-\n"
-                    + "resource, this parameter does not affect the return value. If page\n"
-                    + "streaming is performed per-page, this determines the maximum number\n"
-                    + "of resources in a page."));
-      } else {
-        contentBuilder.append(fieldComment(name, field, importHandler, null));
+    if (method.getRequestStreaming()) {
+      contentBuilder.append(
+          "  requests (iterator of "
+              + typeComment(method.getInputType(), importHandler)
+              + "): The input objects.\n");
+    } else {
+      for (Field field :
+          removePageTokenFromFields(method.getInputType().getMessageType().getFields(), config)) {
+        String name = pythonCommon.wrapIfKeywordOrBuiltIn(field.getSimpleName());
+        if (config.isPageStreaming()
+            && field.equals((config.getPageStreaming().getPageSizeField()))) {
+          contentBuilder.append(
+              fieldComment(
+                  name,
+                  field,
+                  importHandler,
+                  "The maximum number of resources contained in the\n"
+                      + "underlying API response. If page streaming is performed per-\n"
+                      + "resource, this parameter does not affect the return value. If page\n"
+                      + "streaming is performed per-page, this determines the maximum number\n"
+                      + "of resources in a page."));
+        } else {
+          contentBuilder.append(fieldComment(name, field, importHandler, null));
+        }
       }
     }
     contentBuilder.append(

--- a/src/main/java/com/google/api/codegen/py/PythonGapicContext.java
+++ b/src/main/java/com/google/api/codegen/py/PythonGapicContext.java
@@ -215,10 +215,10 @@ public class PythonGapicContext extends GapicContext {
     }
 
     String path = importHandler.elementPath(returnMessageType, true);
-    String classInfo = ":class:`" + path + "` instance";
+    String classInfo = ":class:`" + path + "`";
 
     if (method.getResponseStreaming()) {
-      return "Returns:\n" + "  An iterator which yields " + classInfo + "s.";
+      return "Returns:\n" + "  iterator[" + classInfo + "].";
     } else if (config.isPageStreaming()) {
       return "Returns:"
           + "\n  A :class:`google.gax.PageIterator` instance. By default, this"
@@ -228,7 +228,7 @@ public class PythonGapicContext extends GapicContext {
           + "\n  This object can also be configured to iterate over the pages"
           + "\n  of the response through the `CallOptions` parameter.";
     } else {
-      return "Returns:\n  A " + classInfo + ".";
+      return "Returns:\n  A " + classInfo + " instance.";
     }
   }
 

--- a/src/main/java/com/google/api/codegen/py/PythonGapicContext.java
+++ b/src/main/java/com/google/api/codegen/py/PythonGapicContext.java
@@ -99,7 +99,7 @@ public class PythonGapicContext extends GapicContext {
   }
 
   @Override
-  protected boolean shouldMethodAppear(Method method) {
+  protected boolean isSupported(Method method) {
     return true;
   }
 

--- a/src/main/java/com/google/api/codegen/py/PythonImportHandler.java
+++ b/src/main/java/com/google/api/codegen/py/PythonImportHandler.java
@@ -159,6 +159,15 @@ public class PythonImportHandler {
   private PythonImport addImport(ProtoFile file, PythonImport imp) {
     // No conflict
     if (stringImports.get(imp.shortName()) == null) {
+      if (file != null && fileImports.containsKey(file)) {
+        throw new IllegalArgumentException(
+            "fileImports already has "
+                + file.getSimpleName()
+                + " for "
+                + fileImports.get(file)
+                + " but adding "
+                + imp.shortName());
+      }
       fileImports.put(file, imp.shortName());
       stringImports.put(imp.shortName(), imp);
       return imp;

--- a/src/main/java/com/google/api/codegen/py/PythonImportHandler.java
+++ b/src/main/java/com/google/api/codegen/py/PythonImportHandler.java
@@ -99,25 +99,6 @@ public class PythonImportHandler {
     }
   }
 
-  /**
-   * This constructor is used for sample-gen where only the required fields of a method are needed
-   * to be imported.
-   */
-  public PythonImportHandler(Iterable<Field> requiredFields) {
-    for (Field field : requiredFields) {
-      if (!field.getType().isMessage()) {
-        continue;
-      }
-      MessageType messageType = field.getType().getMessageType();
-      addImport(
-          messageType.getFile(),
-          PythonImport.create(
-              ImportType.APP,
-              messageType.getFile().getProto().getPackage(),
-              PythonProtoElements.getPbFileName(messageType)));
-    }
-  }
-
   // Independent import handler to support fragment generation from discovery sources
   public PythonImportHandler() {}
 
@@ -265,6 +246,14 @@ public class PythonImportHandler {
   public String fileToModule(ProtoFile file) {
     if (fileImports.containsKey(file)) {
       return fileImports.get(file);
+    } else {
+      return "";
+    }
+  }
+
+  public String fileToImport(ProtoFile file) {
+    if (fileImports.containsKey(file)) {
+      return stringImports.get(fileImports.get(file)).importString();
     } else {
       return "";
     }

--- a/src/main/java/com/google/api/codegen/ruby/RubyGapicContext.java
+++ b/src/main/java/com/google/api/codegen/ruby/RubyGapicContext.java
@@ -370,6 +370,7 @@ public class RubyGapicContext extends GapicContext implements RubyContext {
             new RubyTypeTable(getApiConfig().getPackageName()),
             new RubyModelTypeNameConverter(getApiConfig().getPackageName()));
     return SurfaceTransformerContext.create(
+        this,
         service,
         getApiConfig(),
         modelTypeTable,

--- a/src/main/java/com/google/api/codegen/ruby/RubyGapicContext.java
+++ b/src/main/java/com/google/api/codegen/ruby/RubyGapicContext.java
@@ -370,7 +370,6 @@ public class RubyGapicContext extends GapicContext implements RubyContext {
             new RubyTypeTable(getApiConfig().getPackageName()),
             new RubyModelTypeNameConverter(getApiConfig().getPackageName()));
     return SurfaceTransformerContext.create(
-        this,
         service,
         getApiConfig(),
         modelTypeTable,

--- a/src/main/java/com/google/api/codegen/transformer/ApiCallableTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ApiCallableTransformer.java
@@ -36,7 +36,7 @@ public class ApiCallableTransformer {
   public List<ApiCallableView> generateStaticLangApiCallables(SurfaceTransformerContext context) {
     List<ApiCallableView> callableMembers = new ArrayList<>();
 
-    for (Method method : context.getNonStreamingMethods()) {
+    for (Method method : context.getSupportedMethods()) {
       callableMembers.addAll(generateStaticLangApiCallables(context.asMethodContext(method)));
     }
 
@@ -46,7 +46,7 @@ public class ApiCallableTransformer {
   public List<ApiCallSettingsView> generateCallSettings(SurfaceTransformerContext context) {
     List<ApiCallSettingsView> settingsMembers = new ArrayList<>();
 
-    for (Method method : context.getNonStreamingMethods()) {
+    for (Method method : context.getSupportedMethods()) {
       settingsMembers.addAll(generateApiCallableSettings(context.asMethodContext(method)));
     }
 

--- a/src/main/java/com/google/api/codegen/transformer/GrpcStubTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/GrpcStubTransformer.java
@@ -31,7 +31,7 @@ public class GrpcStubTransformer {
 
     Map<String, Interface> interfaces = new TreeMap<>();
     Map<String, List<String>> methods = new TreeMap<>();
-    for (Method method : context.getNonStreamingMethods()) {
+    for (Method method : context.getSupportedMethods()) {
       Interface targetInterface = context.asMethodContext(method).getTargetInterface();
       interfaces.put(targetInterface.getFullName(), targetInterface);
       if (methods.containsKey(targetInterface.getFullName())) {

--- a/src/main/java/com/google/api/codegen/transformer/ImportTypeTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ImportTypeTransformer.java
@@ -40,7 +40,7 @@ public class ImportTypeTransformer {
 
     fullNames.add(namer.getProtoFileImportFromService(context.getInterface()));
 
-    for (Method method : context.getNonStreamingMethods()) {
+    for (Method method : context.getSupportedMethods()) {
       Interface targetInterface = context.asMethodContext(method).getTargetInterface();
       fullNames.add(namer.getProtoFileImportFromService(targetInterface));
     }

--- a/src/main/java/com/google/api/codegen/transformer/SurfaceTransformerContext.java
+++ b/src/main/java/com/google/api/codegen/transformer/SurfaceTransformerContext.java
@@ -16,7 +16,6 @@ package com.google.api.codegen.transformer;
 
 import com.google.api.codegen.ApiConfig;
 import com.google.api.codegen.CollectionConfig;
-import com.google.api.codegen.GapicContext;
 import com.google.api.codegen.InterfaceConfig;
 import com.google.api.codegen.MethodConfig;
 import com.google.api.tools.framework.model.Interface;
@@ -32,15 +31,13 @@ import java.util.List;
 @AutoValue
 public abstract class SurfaceTransformerContext {
   public static SurfaceTransformerContext create(
-      GapicContext gapicContext, Interface interfaze, ApiConfig apiConfig, ModelTypeTable typeTable, SurfaceNamer namer) {
-    return new AutoValue_SurfaceTransformerContext(gapicContext, interfaze, apiConfig, typeTable, namer);
+      Interface interfaze, ApiConfig apiConfig, ModelTypeTable typeTable, SurfaceNamer namer) {
+    return new AutoValue_SurfaceTransformerContext(interfaze, apiConfig, typeTable, namer);
   }
 
   public Model getModel() {
     return getInterface().getModel();
   }
-
-  public abstract GapicContext getGapicContext();
 
   public abstract Interface getInterface();
 
@@ -85,13 +82,22 @@ public abstract class SurfaceTransformerContext {
   }
 
   /**
+   * Returns true if the method is supported by the current context.
+   * Currently no streaming methods are supported.
+   * TODO: integrate with GapicContext for this method.
+   */
+  private boolean isSupported(Method method) {
+    return !method.getResponseStreaming() && !method.getRequestStreaming();
+  }
+
+  /**
    * Returns a list of simple RPC methods.
    */
   public List<Method> getSupportedMethods() {
     List<Method> methods = new ArrayList<>(getInterfaceConfig().getMethodConfigs().size());
     for (MethodConfig methodConfig : getInterfaceConfig().getMethodConfigs()) {
       Method method = methodConfig.getMethod();
-      if (!getGapicContext().isSupported(method)) {
+      if (isSupported(method)) {
         methods.add(method);
       }
     }

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
@@ -181,7 +181,7 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
   private List<GapicSurfaceTestCaseView> createTestCaseViews(SurfaceTransformerContext context) {
     ArrayList<GapicSurfaceTestCaseView> testCaseViews = new ArrayList<>();
     SymbolTable testNameTable = new SymbolTable();
-    for (Method method : context.getNonStreamingMethods()) {
+    for (Method method : context.getSupportedMethods()) {
       MethodTransformerContext methodContext = context.asMethodContext(method);
       MethodConfig methodConfig = methodContext.getMethodConfig();
       if (methodConfig.isFlattening()) {

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTransformer.java
@@ -280,7 +280,7 @@ public class JavaGapicSurfaceTransformer implements ModelToViewTransformer {
   private List<StaticLangApiMethodView> generateApiMethods(SurfaceTransformerContext context) {
     List<StaticLangApiMethodView> apiMethods = new ArrayList<>();
 
-    for (Method method : context.getNonStreamingMethods()) {
+    for (Method method : context.getSupportedMethods()) {
       MethodConfig methodConfig = context.getMethodConfig(method);
       MethodTransformerContext methodContext = context.asMethodContext(method);
 

--- a/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSurfaceTransformer.java
@@ -153,7 +153,7 @@ public class PhpGapicSurfaceTransformer implements ModelToViewTransformer {
   private List<String> generateMethodKeys(SurfaceTransformerContext context) {
     List<String> methodKeys = new ArrayList<>(context.getInterface().getMethods().size());
 
-    for (Method method : context.getNonStreamingMethods()) {
+    for (Method method : context.getSupportedMethods()) {
       methodKeys.add(context.getNamer().getMethodKey(method));
     }
 
@@ -163,7 +163,7 @@ public class PhpGapicSurfaceTransformer implements ModelToViewTransformer {
   private List<ApiMethodView> generateApiMethods(SurfaceTransformerContext context) {
     List<ApiMethodView> apiMethods = new ArrayList<>(context.getInterface().getMethods().size());
 
-    for (Method method : context.getNonStreamingMethods()) {
+    for (Method method : context.getSupportedMethods()) {
       apiMethods.add(
           apiMethodTransformer.generateDynamicLangApiMethod(context.asMethodContext(method)));
     }

--- a/src/main/proto/com/google/api/codegen/config.proto
+++ b/src/main/proto/com/google/api/codegen/config.proto
@@ -149,6 +149,11 @@ message MethodConfigProto {
   // Specifies the configuration for paging.
   PageStreamingConfigProto page_streaming = 3;
 
+  // Specifies the configuration for gRPC-streaming responses.
+  // Note that this is for configuring paged gRPC-streaming responses.
+  // Some method can be gRPC-streaming even if this field does not exist.
+  PageStreamingConfigProto grpc_streaming = 13;
+
   // Specifies the configuration for retryable codes.
   // The name must be defined in InterfaceConfigProto::retry_codes_def.
   string retry_codes_name = 4;

--- a/src/main/resources/com/google/api/codegen/clientconfig/json.snip
+++ b/src/main/resources/com/google/api/codegen/clientconfig/json.snip
@@ -82,7 +82,7 @@
 @end
 
 @private methodsSection(service)
-    @join method : context.getMethods(service) on ",".add(BREAK)
+    @join method : context.getSupportedMethods(service) on ",".add(BREAK)
         @let methodConfig = context.getApiConfig.getInterfaceConfig(service).getMethodConfig(method), \
                 methodName = context.upperCamelToLowerUnderscore(method.getSimpleName), \
                 isBundling = methodConfig.isBundling, \

--- a/src/main/resources/com/google/api/codegen/clientconfig/json.snip
+++ b/src/main/resources/com/google/api/codegen/clientconfig/json.snip
@@ -82,7 +82,7 @@
 @end
 
 @private methodsSection(service)
-    @join method : context.getNonStreamingMethods(service) on ",".add(BREAK)
+    @join method : context.getMethods(service) on ",".add(BREAK)
         @let methodConfig = context.getApiConfig.getInterfaceConfig(service).getMethodConfig(method), \
                 methodName = context.upperCamelToLowerUnderscore(method.getSimpleName), \
                 isBundling = methodConfig.isBundling, \

--- a/src/main/resources/com/google/api/codegen/go/example.snip
+++ b/src/main/resources/com/google/api/codegen/go/example.snip
@@ -34,7 +34,7 @@
         // TODO: Use client.
         _ = c
     }
-    @join method : context.getNonStreamingMethods(service)
+    @join method : context.getMethods(service)
         @let methodName = method.getSimpleName, \
              inTypeName = context.messageTypeName(method.getInputType), \
              outTypeName = context.typeName(method.getOutputType), \

--- a/src/main/resources/com/google/api/codegen/go/example.snip
+++ b/src/main/resources/com/google/api/codegen/go/example.snip
@@ -34,7 +34,7 @@
         // TODO: Use client.
         _ = c
     }
-    @join method : context.getMethods(service)
+    @join method : context.getSupportedMethods(service)
         @let methodName = method.getSimpleName, \
              inTypeName = context.messageTypeName(method.getInputType), \
              outTypeName = context.typeName(method.getOutputType), \

--- a/src/main/resources/com/google/api/codegen/go/main.snip
+++ b/src/main/resources/com/google/api/codegen/go/main.snip
@@ -63,7 +63,7 @@
 
     // {@context.getClientPrefix(service)}CallOptions contains the retry settings for each method of this client.
     type {@context.getClientPrefix(service)}CallOptions struct {
-        @join method : context.getMethods(service)
+        @join method : context.getSupportedMethods(service)
             @let methodName = method.getSimpleName
                 {@methodName} []gax.CallOption
             @end
@@ -106,7 +106,7 @@
         }
 
         return &{@context.getClientPrefix(service)}CallOptions{
-            @join method : context.getMethods(service)
+            @join method : context.getSupportedMethods(service)
                 @let methodName = method.getSimpleName, \
                      methodConfig = context.getApiConfig.getInterfaceConfig(service).getMethodConfig(method), \
                      retryParamsName = methodConfig.getRetrySettingsConfigName, \
@@ -208,7 +208,7 @@
 @end
 
 @private methods(service)
-    @join method : context.getMethods(service)
+    @join method : context.getSupportedMethods(service)
         @let methodName = method.getSimpleName, \
              inTypeName = context.typeName(method.getInputType), \
              outTypeName = context.typeName(method.getOutputType), \

--- a/src/main/resources/com/google/api/codegen/go/main.snip
+++ b/src/main/resources/com/google/api/codegen/go/main.snip
@@ -63,7 +63,7 @@
 
     // {@context.getClientPrefix(service)}CallOptions contains the retry settings for each method of this client.
     type {@context.getClientPrefix(service)}CallOptions struct {
-        @join method : context.getNonStreamingMethods(service)
+        @join method : context.getMethods(service)
             @let methodName = method.getSimpleName
                 {@methodName} []gax.CallOption
             @end
@@ -106,7 +106,7 @@
         }
 
         return &{@context.getClientPrefix(service)}CallOptions{
-            @join method : context.getNonStreamingMethods(service)
+            @join method : context.getMethods(service)
                 @let methodName = method.getSimpleName, \
                      methodConfig = context.getApiConfig.getInterfaceConfig(service).getMethodConfig(method), \
                      retryParamsName = methodConfig.getRetrySettingsConfigName, \
@@ -208,7 +208,7 @@
 @end
 
 @private methods(service)
-    @join method : context.getNonStreamingMethods(service)
+    @join method : context.getMethods(service)
         @let methodName = method.getSimpleName, \
              inTypeName = context.typeName(method.getInputType), \
              outTypeName = context.typeName(method.getOutputType), \

--- a/src/main/resources/com/google/api/codegen/nodejs/main.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/main.snip
@@ -119,10 +119,10 @@
     var CODE_GEN_NAME_VERSION = 'gapic/0.1.0';
 
     var DEFAULT_TIMEOUT = 30;
-    @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getMethods(service))
+    @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getSupportedMethods(service))
 
       var PAGE_DESCRIPTORS = {
-        @join method : context.messages.filterPageStreamingMethods(ifaceConfig, context.getMethods(service)) on {@", "}.add(BREAK)
+        @join method : context.messages.filterPageStreamingMethods(ifaceConfig, context.getSupportedMethods(service)) on {@", "}.add(BREAK)
           @let pageStreaming = ifaceConfig.getMethodConfig(method).getPageStreaming(), \
                requestToken = pageStreaming.getRequestTokenField().getSimpleName(), \
                responseToken = pageStreaming.getResponseTokenField().getSimpleName(), \
@@ -155,12 +155,12 @@
         configData,
         clientConfig,
         timeout,
-        @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getMethods(service))
+        @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getSupportedMethods(service))
           PAGE_DESCRIPTORS,
         @else
           null,
         @end
-        @if context.messages.filterBundlingMethods(ifaceConfig, context.getMethods(service))
+        @if context.messages.filterBundlingMethods(ifaceConfig, context.getSupportedMethods(service))
           bundleDescriptors,
         @else
           null,
@@ -220,10 +220,10 @@
         'gax/' + gax.version,
         'nodejs/' + process.version].join(' ');
 
-      @if context.messages.filterBundlingMethods(ifaceConfig, context.getMethods(service))
+      @if context.messages.filterBundlingMethods(ifaceConfig, context.getSupportedMethods(service))
 
         var bundleDescriptors = {
-          @join method : context.messages.filterBundlingMethods(ifaceConfig, context.getMethods(service)) on {@", "}.add(BREAK)
+          @join method : context.messages.filterBundlingMethods(ifaceConfig, context.getSupportedMethods(service)) on {@", "}.add(BREAK)
             @let bundling = ifaceConfig.getMethodConfig(method).getBundling()
               {@methodName(method)}: new gax.BundleDescriptor(
                   '{@bundling.getBundledField().getSimpleName()}',
@@ -347,7 +347,7 @@
 
 @private serviceMethodsSection(service)
   // Service calls
-  @join method : context.getMethods(service)
+  @join method : context.getSupportedMethodsV2(service)
 
     {@flattenedMethod(service, method)}
   @end

--- a/src/main/resources/com/google/api/codegen/nodejs/main.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/main.snip
@@ -119,10 +119,10 @@
     var CODE_GEN_NAME_VERSION = 'gapic/0.1.0';
 
     var DEFAULT_TIMEOUT = 30;
-    @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getNonStreamingMethods(service))
+    @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getMethods(service))
 
       var PAGE_DESCRIPTORS = {
-        @join method : context.messages.filterPageStreamingMethods(ifaceConfig, context.getNonStreamingMethods(service)) on {@", "}.add(BREAK)
+        @join method : context.messages.filterPageStreamingMethods(ifaceConfig, context.getMethods(service)) on {@", "}.add(BREAK)
           @let pageStreaming = ifaceConfig.getMethodConfig(method).getPageStreaming(), \
                requestToken = pageStreaming.getRequestTokenField().getSimpleName(), \
                responseToken = pageStreaming.getResponseTokenField().getSimpleName(), \
@@ -155,12 +155,12 @@
         configData,
         clientConfig,
         timeout,
-        @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getNonStreamingMethods(service))
+        @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getMethods(service))
           PAGE_DESCRIPTORS,
         @else
           null,
         @end
-        @if context.messages.filterBundlingMethods(ifaceConfig, context.getNonStreamingMethods(service))
+        @if context.messages.filterBundlingMethods(ifaceConfig, context.getMethods(service))
           bundleDescriptors,
         @else
           null,
@@ -220,10 +220,10 @@
         'gax/' + gax.version,
         'nodejs/' + process.version].join(' ');
 
-      @if context.messages.filterBundlingMethods(ifaceConfig, context.getNonStreamingMethods(service))
+      @if context.messages.filterBundlingMethods(ifaceConfig, context.getMethods(service))
 
         var bundleDescriptors = {
-          @join method : context.messages.filterBundlingMethods(ifaceConfig, context.getNonStreamingMethods(service)) on {@", "}.add(BREAK)
+          @join method : context.messages.filterBundlingMethods(ifaceConfig, context.getMethods(service)) on {@", "}.add(BREAK)
             @let bundling = ifaceConfig.getMethodConfig(method).getBundling()
               {@methodName(method)}: new gax.BundleDescriptor(
                   '{@bundling.getBundledField().getSimpleName()}',
@@ -347,7 +347,7 @@
 
 @private serviceMethodsSection(service)
   // Service calls
-  @join method : context.getNonStreamingMethodsV2(service)
+  @join method : context.getMethods(service)
 
     {@flattenedMethod(service, method)}
   @end

--- a/src/main/resources/com/google/api/codegen/py/main.snip
+++ b/src/main/resources/com/google/api/codegen/py/main.snip
@@ -61,8 +61,8 @@
 
 @private aliasSection(service)
     @let ifaceConfig = context.getApiConfig.getInterfaceConfig(service), \
-            bundling = context.messages.filterBundlingMethods(ifaceConfig, context.getNonStreamingMethodsV2(service)), \
-            pageStreaming = context.messages.filterPageStreamingMethods(ifaceConfig, context.getNonStreamingMethodsV2(service))
+            bundling = context.messages.filterBundlingMethods(ifaceConfig, context.getSupportedMethodsV2(service)), \
+            pageStreaming = context.messages.filterPageStreamingMethods(ifaceConfig, context.getSupportedMethodsV2(service))
         @if bundling
             _BundleDesc = google.gax.BundleDescriptor
         @end
@@ -109,14 +109,14 @@
         _CODE_GEN_NAME_VERSION = 'gapic/0.1.0'
 
         _GAX_VERSION = pkg_resources.get_distribution('google-gax').version
-        @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getNonStreamingMethodsV2(service))
+        @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getSupportedMethodsV2(service))
 
             _PAGE_DESCRIPTORS = {
-                @join method : context.messages.filterPageStreamingMethods(ifaceConfig, context.getNonStreamingMethodsV2(service)) on {@", "}.add(BREAK)
+                @join method : context.messages.filterPageStreamingMethods(ifaceConfig, context.getSupportedMethodsV2(service)) on {@", "}.add(BREAK)
                     @let pageStreaming = ifaceConfig.getMethodConfig(method).getPageStreaming(), \
-                            requestToken = pageStreaming.getRequestTokenField().getSimpleName(), \
-                            responseToken = pageStreaming.getResponseTokenField().getSimpleName(), \
-                            resources = pageStreaming.getResourcesField().getSimpleName()
+                         requestToken = pageStreaming.getRequestTokenField().getSimpleName(), \
+                         responseToken = pageStreaming.getResponseTokenField().getSimpleName(), \
+                         resources = pageStreaming.getResourcesField().getSimpleName()
                         '{@methodName(method)}': _PageDesc(
                             '{@requestToken}',
                             '{@responseToken}',
@@ -126,11 +126,11 @@
                 @end
             }
         @end
-        @if context.messages.filterBundlingMethods(ifaceConfig, context.getNonStreamingMethodsV2(service))
+        @if context.messages.filterBundlingMethods(ifaceConfig, context.getSupportedMethodsV2(service))
 
             _BUNDLE_DESCRIPTORS = {
                 @let ifaceConfig = context.getApiConfig.getInterfaceConfig(service)
-                    @join method : context.messages.filterBundlingMethods(ifaceConfig, context.getNonStreamingMethodsV2(service)) on {@", "}.add(BREAK)
+                    @join method : context.messages.filterBundlingMethods(ifaceConfig, context.getSupportedMethodsV2(service)) on {@", "}.add(BREAK)
                         @let bundling = ifaceConfig.getMethodConfig(method).getBundling()
                             '{@methodName(method)}': _BundleDesc(
                                 {@bundleDescriptorBody(bundling, method)}
@@ -156,22 +156,22 @@
          jsonBaseName = {@context.upperCamelToLowerUnderscore(service.getSimpleName)}
         default_client_config = json.loads(pkg_resources.resource_string(
             __name__, '{@jsonBaseName}_client_config.json').decode())
-        @if or(context.messages.filterPageStreamingMethods(ifaceConfig, context.getNonStreamingMethodsV2(service)), \
-               context.messages.filterBundlingMethods(ifaceConfig, context.getNonStreamingMethodsV2(service)))
+        @if or(context.messages.filterPageStreamingMethods(ifaceConfig, context.getSupportedMethodsV2(service)), \
+               context.messages.filterBundlingMethods(ifaceConfig, context.getSupportedMethodsV2(service)))
             defaults = api_callable.construct_settings(
                 '{@service.getFullName}',
                 default_client_config,
                 client_config,
                 config.STATUS_CODE_NAMES,
                 kwargs={'metadata': metadata},
-                @if context.messages.filterBundlingMethods(ifaceConfig, context.getNonStreamingMethodsV2(service))
-                    @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getNonStreamingMethodsV2(service))
+                @if context.messages.filterBundlingMethods(ifaceConfig, context.getSupportedMethodsV2(service))
+                    @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getSupportedMethodsV2(service))
                         bundle_descriptors=self._BUNDLE_DESCRIPTORS,
                     @else
                         bundle_descriptors=self._BUNDLE_DESCRIPTORS)
                     @end
                 @end
-                @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getNonStreamingMethodsV2(service))
+                @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getSupportedMethodsV2(service))
                     page_descriptors=self._PAGE_DESCRIPTORS)
                 @end
         @else
@@ -249,7 +249,7 @@
                 @end
             @end
 
-            @join method : context.getNonStreamingMethodsV2(service)
+            @join method : context.getSupportedMethodsV2(service)
                 self._{@methodName(method)} = api_callable.create_api_call(
                     self.{@context.stubNameForMethod(service, method)}.{@method.getSimpleName()},
                     settings=defaults['{@methodName(method)}'])
@@ -363,6 +363,10 @@
 
 
     @end
+    @if method.getRequestStreaming()
+      EXPERIMENTAL: This method interface might change in the future.
+
+    @end
     {@methodSample(service, method)}
     @if signatureComments.isEmpty
     @else
@@ -380,32 +384,39 @@
   @let apiConfig = context.getApiConfig, \
        apiName = context.getApiWrapperName(service), \
        returnType = context.returnTypeOrEmpty(method, importHandler), \
-       fields = context.getRequiredFields(service, method)
-    {@generateMethodSampleCode(context.newDocConfigBuilder \
-      .setInterface(service) \
-      .setApiConfig(apiConfig) \
-      .setApiName(apiName) \
-      .setMethod(method) \
-      .setInterface(service) \
-      .setReturnType(returnType) \
-      .setFieldInitCode(context, service, method, fields) \
-      .setFieldParams(context, fields) \
-      .build)}
+       fields = context.getRequiredFields(method), \
+       builder = context.newDocConfigBuilder \
+         .setInterface(service) \
+         .setApiConfig(apiConfig) \
+         .setApiName(apiName) \
+         .setMethod(method) \
+         .setReturnType(returnType)
+    @if method.getRequestStreaming()
+      {@generateMethodSampleCode(builder \
+        .setRequestObjectInitCode(context, service, method) \
+        .setEmptyParams() \
+        .build)}
+    @else
+      {@generateMethodSampleCode(builder \
+        .setFieldInitCode(context, service, method, fields) \
+        .setFieldParams(context, fields) \
+        .build)}
+    @end
   @end
 @end
 
 @private serviceMethodsSection(service)
     @# Service calls
-    @join method : context.getNonStreamingMethodsV2(service) on BREAK.add(BREAK)
+    @join method : context.getSupportedMethodsV2(service) on BREAK.add(BREAK)
         {@flattenedMethod(service, method)}
     @end
 @end
 
-@private callLine(method)
+@private callLine(method, request)
     @if pyproto.isEmptyMessage(method.getOutputMessage)
-        self._{@methodName(method)}(request, options)
+        self._{@methodName(method)}({@request}, options)
     @else
-        return self._{@methodName(method)}(request, options)
+        return self._{@methodName(method)}({@request}, options)
     @end
 @end
 
@@ -419,15 +430,44 @@
              methodConfig = context.getApiConfig.getInterfaceConfig(service).getMethodConfig(method), \
              requiredParams = methodConfig.getRequiredFields(), \
              optionalParams = context.removePageTokenFromFields(methodConfig.getOptionalFields(), methodConfig)
-        @if or(requiredParams, optionalParams)
+        @if method.getRequestStreaming
             def {@methodName(method)}(
                     self,
+                    requests,
+                    options=None):
+                @if documentation
+                    {@documentation}
+                @end
+                {@callLine(method, "requests")}
+        @else
+            @if or(requiredParams, optionalParams)
+                def {@methodName(method)}(
+                        self,
+                        @if requiredParams
+                            @if optionalParams
+                                {@requiredParameterNames(requiredParams)},
+                                {@optionalParameterValues(optionalParams)},
+                            @else
+                                {@requiredParameterNames(requiredParams)},
+                            @end
+                        @else
+                            {@optionalParameterValues(optionalParams)},
+                        @end
+                        options=None):
+                    @if documentation
+                        {@documentation}
+                    @end
+                    @if {@defaultMutableValues(optionalParams)}
+                        {@defaultMutableValues(optionalParams)}
+                    @end
                     @if requiredParams
                         @if optionalParams
-                            {@requiredParameterNames(requiredParams)},
-                            {@optionalParameterValues(optionalParams)},
+                            request = {@methodInputModule}.{@inputTypeName}(
+                                {@namedParameters(requiredParams)},
+                                {@namedParameters(optionalParams)})
                         @else
-                            {@requiredParameterNames(requiredParams)},
+                            request = {@methodInputModule}.{@inputTypeName}(
+                                {@namedParameters(requiredParams)})
                         @end
                     @else
                         {@optionalParameterValues(optionalParams)},
@@ -452,7 +492,7 @@
                     request = {@methodInputElementPath}(
                         {@namedParameters(optionalParams)})
                 @end
-                {@callLine(method)}
+                {@callLine(method, "request")}
         @else
             def {@methodName(method)}(
                     self,
@@ -461,7 +501,7 @@
                     {@documentation}
                 @end
                 request = {@methodInputElementPath}()
-                {@callLine(method)}
+                {@callLine(method, "request")}
         @end
     @end
 @end

--- a/src/main/resources/com/google/api/codegen/py/main.snip
+++ b/src/main/resources/com/google/api/codegen/py/main.snip
@@ -384,7 +384,7 @@
   @let apiConfig = context.getApiConfig, \
        apiName = context.getApiWrapperName(service), \
        returnType = context.returnTypeOrEmpty(method, importHandler), \
-       fields = context.getRequiredFields(method), \
+       fields = context.getRequiredFields(service, method), \
        builder = context.newDocConfigBuilder \
          .setInterface(service) \
          .setApiConfig(apiConfig) \
@@ -463,46 +463,28 @@
                     @end
                     @if requiredParams
                         @if optionalParams
-                            request = {@methodInputModule}.{@inputTypeName}(
+                            request = {@methodInputElementPath}(
                                 {@namedParameters(requiredParams)},
                                 {@namedParameters(optionalParams)})
                         @else
-                            request = {@methodInputModule}.{@inputTypeName}(
+                            request = {@methodInputElementPath}(
                                 {@namedParameters(requiredParams)})
                         @end
                     @else
-                        {@optionalParameterValues(optionalParams)},
-                    @end
-                    options=None):
-                @if documentation
-                    {@documentation}
-                @end
-                @if {@defaultMutableValues(optionalParams)}
-                    {@defaultMutableValues(optionalParams)}
-                @end
-                @if requiredParams
-                    @if optionalParams
                         request = {@methodInputElementPath}(
-                            {@namedParameters(requiredParams)},
                             {@namedParameters(optionalParams)})
-                    @else
-                        request = {@methodInputElementPath}(
-                            {@namedParameters(requiredParams)})
                     @end
-                @else
-                    request = {@methodInputElementPath}(
-                        {@namedParameters(optionalParams)})
-                @end
-                {@callLine(method, "request")}
-        @else
-            def {@methodName(method)}(
-                    self,
-                    options=None):
-                @if documentation
-                    {@documentation}
-                @end
-                request = {@methodInputElementPath}()
-                {@callLine(method, "request")}
+                    {@callLine(method, "request")}
+            @else
+                def {@methodName(method)}(
+                        self,
+                        options=None):
+                    @if documentation
+                        {@documentation}
+                    @end
+                    request = {@methodInputElementPath}()
+                    {@callLine(method, "request")}
+            @end
         @end
     @end
 @end

--- a/src/main/resources/com/google/api/codegen/py/main.snip
+++ b/src/main/resources/com/google/api/codegen/py/main.snip
@@ -389,6 +389,7 @@
          .setInterface(service) \
          .setApiConfig(apiConfig) \
          .setApiName(apiName) \
+         .setImportHandler(importHandler) \
          .setMethod(method) \
          .setReturnType(returnType)
     @if method.getRequestStreaming()

--- a/src/main/resources/com/google/api/codegen/py/method_sample.snip
+++ b/src/main/resources/com/google/api/codegen/py/method_sample.snip
@@ -18,6 +18,7 @@
         {@initCode}
       @end
       @if docConfig.isResponseGrpcStreaming
+        {@prompt} requests = [request]
         {@prompt} for element in {@methodCallSampleCode(docConfig, {@FALSE})}:
         {@prompt}   # process element
         {@prompt}   pass
@@ -146,7 +147,7 @@
 # Render the API method call itself
 @private methodCallSampleCode(docConfig, isPageStreaming)
   @if docConfig.isRequestGrpcStreaming()
-    api.{@methodCallName(docConfig)}([request])
+    api.{@methodCallName(docConfig)}(requests)
   @else
     @let argFields = {@docConfig.getInitCode.getArgFields}
       api.{@methodCallName(docConfig)}(\

--- a/src/main/resources/com/google/api/codegen/py/method_sample.snip
+++ b/src/main/resources/com/google/api/codegen/py/method_sample.snip
@@ -4,8 +4,7 @@
 @snippet generateMethodSampleCode(docConfig)
   @let prompt = ">>>", \
        ApiName = docConfig.getApiName, \
-       docImportHandler = docConfig.getImportHandler, \
-       initCode = {@initCode(prompt, docConfig.getInitCode, docImportHandler)}
+       initCode = {@initCode(prompt, docConfig.getInitCode)}
     Example:
       @join import : docConfig.getAppImports
         {@prompt} {@import}
@@ -46,15 +45,15 @@
 # Helper functions for generateMethodSampleCode()
 
 # Generate argument initialization code for API call
-@private initCode(prompt, initCodeSpec, docImportHandler)
+@private initCode(prompt, initCodeSpec)
   @join line : initCodeSpec.getLines()
     @switch line.getLineType.toString()
     @case "StructureInitLine"
-      {@prompt} {@initLineStructure(line, docImportHandler)}
+      {@prompt} {@initLineStructure(line)}
     @case "ListInitLine"
       {@prompt} {@initLineList(line)}
     @case "SimpleInitLine"
-      {@prompt} {@initLineSimple(line, docImportHandler)}
+      {@prompt} {@initLineSimple(line)}
     @case "MapInitLine"
       {@prompt} {@initLineMap(line)}
     @default
@@ -64,9 +63,9 @@
 @end
 
 # Generate a Protobuf message argument
-@private initLineStructure(line, docImportHandler)
+@private initLineStructure(line)
   @let messageType = line.getType.getMessageType, \
-       initLineStructureClass = docImportHandler.elementPath(messageType, {@FALSE})
+       initLineStructureClass = importHandler.elementPath(messageType, {@FALSE})
     {@formattedIdentifier(line)} = {@initLineStructureClass}(\
       {@initLineStructureArgs(line)}\
     )
@@ -107,8 +106,8 @@
 @end
 
 # Generate a simple argument
-@private initLineSimple(line, docImportHandler)
-  {@formattedIdentifier(line)} = {@initValue(line, docImportHandler)}
+@private initLineSimple(line)
+  {@formattedIdentifier(line)} = {@initValue(line)}
 @end
 
 # Properly format an identifier for this language
@@ -117,14 +116,14 @@
 @end
 
 # Value for simple argument
-@private initValue(line, docImportHandler)
+@private initValue(line)
   @let metadata = line.getInitValueConfig
     @if metadata.hasFormattingConfig()
       api.{@formatResourceFunctionName(metadata.getCollectionConfig)}(\
         {@formatResourceFunctionArgs(metadata.getCollectionConfig)}\
       )
     @else
-      {@context.defaultValue(line.getType, docImportHandler)}
+      {@context.defaultValue(line.getType, importHandler)}
     @end
   @end
 @end

--- a/src/main/resources/com/google/api/codegen/py/method_sample.snip
+++ b/src/main/resources/com/google/api/codegen/py/method_sample.snip
@@ -10,28 +10,34 @@
       @join import : docConfig.getAppImports
         {@prompt} {@import}
       @end
-      @if docConfig.isIterableResponse
+      @if docConfig.isPageStreaming
         {@prompt} from google.gax import CallOptions, INITIAL_PAGE
       @end
       {@prompt} api = {@ApiName}()
       @if initCode
         {@initCode}
       @end
-      @if docConfig.isIterableResponse
-        {@prompt}
-        {@prompt} # Iterate over all results
+      @if docConfig.isResponseGrpcStreaming
         {@prompt} for element in {@methodCallSampleCode(docConfig, {@FALSE})}:
         {@prompt}   # process element
         {@prompt}   pass
-        {@prompt}
-        {@prompt} # Or iterate over results one page at a time
-        {@prompt} for page in {@methodCallSampleCode(docConfig, {@TRUE})}:
-        {@prompt}   for element in page:
-        {@prompt}     # process element
-        {@prompt}     pass
       @else
-        {@prompt} {@callResultSampleCode(docConfig.getReturnType)}\
-        {@methodCallSampleCode(docConfig, {@FALSE})}
+        @if docConfig.isPageStreaming
+          {@prompt}
+          {@prompt} # Iterate over all results
+          {@prompt} for element in {@methodCallSampleCode(docConfig, {@FALSE})}:
+          {@prompt}   # process element
+          {@prompt}   pass
+          {@prompt}
+          {@prompt} # Or iterate over results one page at a time
+          {@prompt} for page in {@methodCallSampleCode(docConfig, {@TRUE})}:
+          {@prompt}   for element in page:
+          {@prompt}     # process element
+          {@prompt}     pass
+        @else
+          {@prompt} {@callResultSampleCode(docConfig.getReturnType)}\
+          {@methodCallSampleCode(docConfig, {@FALSE})}
+        @end
       @end
   @end
 @end
@@ -139,11 +145,15 @@
 
 # Render the API method call itself
 @private methodCallSampleCode(docConfig, isPageStreaming)
-  @let argFields = {@docConfig.getInitCode.getArgFields}
-    api.{@methodCallName(docConfig)}(\
-      {@argList(argFields)}\
-      {@pageStreamingArg(argFields, isPageStreaming)}\
-    )
+  @if docConfig.isRequestGrpcStreaming()
+    api.{@methodCallName(docConfig)}([request])
+  @else
+    @let argFields = {@docConfig.getInitCode.getArgFields}
+      api.{@methodCallName(docConfig)}(\
+        {@argList(argFields)}\
+        {@pageStreamingArg(argFields, isPageStreaming)}\
+      )
+    @end
   @end
 @end
 

--- a/src/main/resources/com/google/api/codegen/py/method_sample.snip
+++ b/src/main/resources/com/google/api/codegen/py/method_sample.snip
@@ -15,9 +15,11 @@
       {@prompt} api = {@ApiName}()
       @if initCode
         {@initCode}
+        @if docConfig.isRequestGrpcStreaming
+          {@prompt} requests = [request]
+        @end
       @end
       @if docConfig.isResponseGrpcStreaming
-        {@prompt} requests = [request]
         {@prompt} for element in {@methodCallSampleCode(docConfig, {@FALSE})}:
         {@prompt}   # process element
         {@prompt}   pass

--- a/src/main/resources/com/google/api/codegen/ruby/main.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/main.snip
@@ -102,10 +102,10 @@
     CODE_GEN_NAME_VERSION = "gapic/0.1.0".freeze
 
     DEFAULT_TIMEOUT = 30
-    @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getMethods(service))
+    @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getSupportedMethods(service))
 
       PAGE_DESCRIPTORS = {
-        @join method : context.messages.filterPageStreamingMethods(ifaceConfig, context.getMethods(service)) on {@", "}.add(BREAK)
+        @join method : context.messages.filterPageStreamingMethods(ifaceConfig, context.getSupportedMethods(service)) on {@", "}.add(BREAK)
           @let pageStreaming = ifaceConfig.getMethodConfig(method).getPageStreaming(), \
                requestToken = pageStreaming.getRequestTokenField().getSimpleName(), \
                responseToken = pageStreaming.getResponseTokenField().getSimpleName(), \
@@ -121,11 +121,11 @@
 
       private_constant :PAGE_DESCRIPTORS
     @end
-    @if context.messages.filterBundlingMethods(ifaceConfig, context.getMethods(service))
+    @if context.messages.filterBundlingMethods(ifaceConfig, context.getSupportedMethods(service))
 
       BUNDLE_DESCRIPTORS = {
         @let ifaceConfig = context.getApiConfig.getInterfaceConfig(service)
-          @join method : context.messages.filterBundlingMethods(ifaceConfig, context.getMethods(service)) on {@", "}.add(BREAK)
+          @join method : context.messages.filterBundlingMethods(ifaceConfig, context.getSupportedMethods(service)) on {@", "}.add(BREAK)
             @let bundling = ifaceConfig.getMethodConfig(method).getBundling(), \
                  methodName = context.upperCamelToLowerUnderscore(method.getSimpleName)
               "{@methodName}" => Google::Gax::BundleDescriptor.new(
@@ -155,22 +155,22 @@
       "{@jsonBaseName}_client_config.json"
     )
     defaults = client_config_file.open do |f|
-      @if or(context.messages.filterPageStreamingMethods(ifaceConfig, context.getMethods(service)), \
-             context.messages.filterBundlingMethods(ifaceConfig, context.getMethods(service)))
+      @if or(context.messages.filterPageStreamingMethods(ifaceConfig, context.getSupportedMethods(service)), \
+             context.messages.filterBundlingMethods(ifaceConfig, context.getSupportedMethods(service)))
         Google::Gax.construct_settings(
           "{@service.getFullName}",
           JSON.parse(f.read),
           client_config,
           Google::Gax::Grpc::STATUS_CODE_NAMES,
           timeout,
-          @if context.messages.filterBundlingMethods(ifaceConfig, context.getMethods(service))
-            @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getMethods(service))
+          @if context.messages.filterBundlingMethods(ifaceConfig, context.getSupportedMethods(service))
+            @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getSupportedMethods(service))
               bundle_descriptors: BUNDLE_DESCRIPTORS,
             @else
               bundle_descriptors: BUNDLE_DESCRIPTORS,
             @end
           @end
-          @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getMethods(service))
+          @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getSupportedMethods(service))
             page_descriptors: PAGE_DESCRIPTORS,
           @end
           errors: Google::Gax::Grpc::API_ERRORS,
@@ -358,7 +358,7 @@
 
 @private serviceMethodsSection(service)
   @# Service calls
-  @join method : context.getMethodsV2(service)
+  @join method : context.getSupportedMethodsV2(service)
 
     {@flattenedMethod(service, method)}
   @end

--- a/src/main/resources/com/google/api/codegen/ruby/main.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/main.snip
@@ -102,10 +102,10 @@
     CODE_GEN_NAME_VERSION = "gapic/0.1.0".freeze
 
     DEFAULT_TIMEOUT = 30
-    @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getNonStreamingMethods(service))
+    @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getMethods(service))
 
       PAGE_DESCRIPTORS = {
-        @join method : context.messages.filterPageStreamingMethods(ifaceConfig, context.getNonStreamingMethods(service)) on {@", "}.add(BREAK)
+        @join method : context.messages.filterPageStreamingMethods(ifaceConfig, context.getMethods(service)) on {@", "}.add(BREAK)
           @let pageStreaming = ifaceConfig.getMethodConfig(method).getPageStreaming(), \
                requestToken = pageStreaming.getRequestTokenField().getSimpleName(), \
                responseToken = pageStreaming.getResponseTokenField().getSimpleName(), \
@@ -121,11 +121,11 @@
 
       private_constant :PAGE_DESCRIPTORS
     @end
-    @if context.messages.filterBundlingMethods(ifaceConfig, context.getNonStreamingMethods(service))
+    @if context.messages.filterBundlingMethods(ifaceConfig, context.getMethods(service))
 
       BUNDLE_DESCRIPTORS = {
         @let ifaceConfig = context.getApiConfig.getInterfaceConfig(service)
-          @join method : context.messages.filterBundlingMethods(ifaceConfig, context.getNonStreamingMethods(service)) on {@", "}.add(BREAK)
+          @join method : context.messages.filterBundlingMethods(ifaceConfig, context.getMethods(service)) on {@", "}.add(BREAK)
             @let bundling = ifaceConfig.getMethodConfig(method).getBundling(), \
                  methodName = context.upperCamelToLowerUnderscore(method.getSimpleName)
               "{@methodName}" => Google::Gax::BundleDescriptor.new(
@@ -155,22 +155,22 @@
       "{@jsonBaseName}_client_config.json"
     )
     defaults = client_config_file.open do |f|
-      @if or(context.messages.filterPageStreamingMethods(ifaceConfig, context.getNonStreamingMethods(service)), \
-             context.messages.filterBundlingMethods(ifaceConfig, context.getNonStreamingMethods(service)))
+      @if or(context.messages.filterPageStreamingMethods(ifaceConfig, context.getMethods(service)), \
+             context.messages.filterBundlingMethods(ifaceConfig, context.getMethods(service)))
         Google::Gax.construct_settings(
           "{@service.getFullName}",
           JSON.parse(f.read),
           client_config,
           Google::Gax::Grpc::STATUS_CODE_NAMES,
           timeout,
-          @if context.messages.filterBundlingMethods(ifaceConfig, context.getNonStreamingMethods(service))
-            @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getNonStreamingMethods(service))
+          @if context.messages.filterBundlingMethods(ifaceConfig, context.getMethods(service))
+            @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getMethods(service))
               bundle_descriptors: BUNDLE_DESCRIPTORS,
             @else
               bundle_descriptors: BUNDLE_DESCRIPTORS,
             @end
           @end
-          @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getNonStreamingMethods(service))
+          @if context.messages.filterPageStreamingMethods(ifaceConfig, context.getMethods(service))
             page_descriptors: PAGE_DESCRIPTORS,
           @end
           errors: Google::Gax::Grpc::API_ERRORS,
@@ -358,7 +358,7 @@
 
 @private serviceMethodsSection(service)
   @# Service calls
-  @join method : context.getNonStreamingMethodsV2(service)
+  @join method : context.getMethodsV2(service)
 
     {@flattenedMethod(service, method)}
   @end

--- a/src/test/java/com/google/api/codegen/testdata/client_config_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/client_config_json_library.baseline
@@ -110,6 +110,21 @@
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
+        "StreamShelves": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "StreamBooks": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "DiscussBook": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
         "AddTag": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",

--- a/src/test/java/com/google/api/codegen/testdata/java_mock_service_impl_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_mock_service_impl_library.baseline
@@ -79,10 +79,12 @@ package com.google.gcloud.pubsub.spi;
 import com.google.common.collect.Lists;
 import com.google.example.library.v1.AddCommentsRequest;
 import com.google.example.library.v1.Book;
+import com.google.example.library.v1.Comment;
 import com.google.example.library.v1.CreateBookRequest;
 import com.google.example.library.v1.CreateShelfRequest;
 import com.google.example.library.v1.DeleteBookRequest;
 import com.google.example.library.v1.DeleteShelfRequest;
+import com.google.example.library.v1.DiscussBookRequest;
 import com.google.example.library.v1.GetBookFromArchiveRequest;
 import com.google.example.library.v1.GetBookRequest;
 import com.google.example.library.v1.GetShelfRequest;
@@ -98,6 +100,9 @@ import com.google.example.library.v1.MoveBookRequest;
 import com.google.example.library.v1.PublishSeriesRequest;
 import com.google.example.library.v1.PublishSeriesResponse;
 import com.google.example.library.v1.Shelf;
+import com.google.example.library.v1.StreamBooksRequest;
+import com.google.example.library.v1.StreamShelvesRequest;
+import com.google.example.library.v1.StreamShelvesResponse;
 import com.google.example.library.v1.UpdateBookIndexRequest;
 import com.google.example.library.v1.UpdateBookRequest;
 import com.google.protobuf.Empty;
@@ -278,8 +283,22 @@ public class MockLibraryServiceImpl extends LibraryServiceImplBase  {
   }
 
   @Override
-  public StreamObserver<ListShelvesRequest> streamShelves(
-      StreamObserver<ListShelvesResponse> responseObserver) {
+  public StreamObserver<StreamShelvesRequest> streamShelves(
+      StreamObserver<StreamShelvesResponse> responseObserver) {
+    System.err.println("Streaming method is not supported.");
+    return null;
+  }
+
+  @Override
+  public StreamObserver<StreamBooksRequest> streamBooks(
+      StreamObserver<Book> responseObserver) {
+    System.err.println("Streaming method is not supported.");
+    return null;
+  }
+
+  @Override
+  public StreamObserver<DiscussBookRequest> discussBook(
+      StreamObserver<Comment> responseObserver) {
     System.err.println("Streaming method is not supported.");
     return null;
   }

--- a/src/test/java/com/google/api/codegen/testdata/library.proto
+++ b/src/test/java/com/google/api/codegen/testdata/library.proto
@@ -118,10 +118,18 @@ service LibraryService {
   }
 
   // Test server streaming
-  rpc StreamShelves(ListShelvesRequest) returns (stream ListShelvesResponse) {
+  rpc StreamShelves(StreamShelvesRequest) returns (stream StreamShelvesResponse) {
     // gRPC streaming methods don't have HTTP equivalent and need not have google.api.http option.
-    // TODO(jmuk): Delete option once https://github.com/googleapis/toolkit/pull/325 lands.
-    option (google.api.http) = { get: "/v1/StreamShelves" };
+  }
+
+  // Test server streaming, non-paged responses.
+  rpc StreamBooks(StreamBooksRequest) returns (stream Book) {
+    // gRPC streaming methods don't have HTTP equivalent and need not have google.api.http option.
+  }
+
+  // Test bidi-streaming.
+  rpc DiscussBook(stream DiscussBookRequest) returns (stream Comment) {
+    // gRPC streaming methods don't have HTTP equivalent and need not have google.api.http option.
   }
   
   // Adds a tag to the book. This RPC is a mixin.
@@ -237,7 +245,7 @@ message ListShelvesRequest {
   string page_token = 2;
 }
 
-// Request message for LibraryService.ListShelves.
+// Response message for LibraryService.ListShelves.
 message ListShelvesResponse {
   // The list of shelves.
   repeated Shelf shelves = 1;
@@ -248,6 +256,16 @@ message ListShelvesResponse {
   // field in the subsequent call to `ListShelves` method to retrieve the next
   // page of results.
   string next_page_token = 2;
+}
+
+// Request message for LibraryService.StreamShelves.
+message StreamShelvesRequest {
+}
+
+// Response message for LibraryService.StreamShelves.
+message StreamShelvesResponse {
+  // The list of shelves.
+  repeated Shelf shelves = 1;
 }
 
 // Request message for LibraryService.DeleteShelf.
@@ -329,6 +347,12 @@ message ListBooksResponse {
   // field in the subsequent call to `ListBooks` method to retrieve the next
   // page of results.
   string next_page_token = 2;
+}
+
+// Request message for LibraryService.StreamBooks.
+message StreamBooksRequest {
+  // The name of the shelf whose books we'd like to list.
+  string name = 1;
 }
 
 // Request message for LibraryService.UpdateBook.
@@ -413,4 +437,14 @@ message UpdateBookIndexRequest {
 
   // The index to update the book with
   map<string, string> index_map = 3;
+}
+
+message DiscussBookRequest {
+  // The name of the book to be discussed. If this is in the middle
+  // of the stream and this is not specified, the name in the previous
+  // message will be reused.
+  string name = 1;
+
+  // The new comment.
+  Comment comment = 2;
 }

--- a/src/test/java/com/google/api/codegen/testdata/library_config.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/library_config.baseline
@@ -285,14 +285,32 @@ interfaces:
       name: book_2
     timeout_millis: 60000
   - name: StreamShelves
+    request_object_method: false
+    retry_codes_name: non_idempotent
+    retry_params_name: default
+    timeout_millis: 60000
+  - name: StreamBooks
+    flattening:
+      groups:
+      - parameters:
+        - name
+    required_fields:
+    - name
+    request_object_method: false
+    retry_codes_name: non_idempotent
+    retry_params_name: default
+    timeout_millis: 60000
+  - name: DiscussBook
+    flattening:
+      groups:
+      - parameters:
+        - name
+        - comment
+    required_fields:
+    - name
+    - comment
     request_object_method: true
-    page_streaming:
-      request:
-        token_field: page_token
-      response:
-        token_field: next_page_token
-        resources_field: shelves
-    retry_codes_name: idempotent
+    retry_codes_name: non_idempotent
     retry_params_name: default
     timeout_millis: 60000
   - name: AddTag

--- a/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
@@ -317,7 +317,7 @@ interfaces:
       - index_map{"default_key"}
   - name: StreamShelves
     request_object_method: false
-    page_streaming:
+    grpc_streaming:
       response:
         resources_field: shelves
     retry_codes_name: idempotent

--- a/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
@@ -318,12 +318,25 @@ interfaces:
   - name: StreamShelves
     request_object_method: false
     page_streaming:
-      request:
-        token_field: page_token
       response:
-        token_field: next_page_token
         resources_field: shelves
     retry_codes_name: idempotent
+    retry_params_name: default
+    timeout_millis: 30000
+  - name: StreamBooks
+    request_object_method: false
+    flattening:
+      groups:
+      - parameters:
+        - name
+    required_fields:
+    - name
+    retry_codes_name: idempotent
+    retry_params_name: default
+    timeout_millis: 30000
+  - name: DiscussBook
+    request_object_method: false
+    retry_codes_name: non_idempotent
     retry_params_name: default
     timeout_millis: 30000
   - name: AddTag

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_doc_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_doc_json_library.baseline
@@ -110,6 +110,21 @@
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
+        "StreamShelves": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "StreamBooks": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "DiscussBook": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
         "AddTag": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_doc_message_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_doc_message_library.baseline
@@ -861,7 +861,7 @@ var ListShelvesRequest = {
 };
 
 /**
- * Request message for LibraryService.ListShelves.
+ * Response message for LibraryService.ListShelves.
  *
  * @property {Object[]} shelves
  *   The list of shelves.
@@ -879,6 +879,32 @@ var ListShelvesRequest = {
  * @see [google.example.library.v1.ListShelvesResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var ListShelvesResponse = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Request message for LibraryService.StreamShelves.
+ *
+
+ * @class
+ * @see [google.example.library.v1.StreamShelvesRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
+ */
+var StreamShelvesRequest = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Response message for LibraryService.StreamShelves.
+ *
+ * @property {Object[]} shelves
+ *   The list of shelves.
+ *
+ *   This object should have the same structure as [Shelf]{@link Shelf}
+ *
+ * @class
+ * @see [google.example.library.v1.StreamShelvesResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
+ */
+var StreamShelvesResponse = {
   // This is for documentation. Actual contents will be loaded by gRPC.
 };
 
@@ -1024,6 +1050,19 @@ var ListBooksRequest = {
  * @see [google.example.library.v1.ListBooksResponse definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var ListBooksResponse = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * Request message for LibraryService.StreamBooks.
+ *
+ * @property {string} name
+ *   The name of the shelf whose books we'd like to list.
+ *
+ * @class
+ * @see [google.example.library.v1.StreamBooksRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
+ */
+var StreamBooksRequest = {
   // This is for documentation. Actual contents will be loaded by gRPC.
 };
 
@@ -1185,5 +1224,23 @@ var GetBookFromArchiveRequest = {
  * @see [google.example.library.v1.UpdateBookIndexRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var UpdateBookIndexRequest = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * @property {string} name
+ *   The name of the book to be discussed. If this is in the middle
+ *   of the stream and this is not specified, the name in the previous
+ *   message will be reused.
+ *
+ * @property {Object} comment
+ *   The new comment.
+ *
+ *   This object should have the same structure as [Comment]{@link Comment}
+ *
+ * @class
+ * @see [google.example.library.v1.DiscussBookRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
+ */
+var DiscussBookRequest = {
   // This is for documentation. Actual contents will be loaded by gRPC.
 }

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_json_library.baseline
@@ -110,6 +110,21 @@
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
+        "StreamShelves": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "StreamBooks": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "DiscussBook": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
         "AddTag": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",

--- a/src/test/java/com/google/api/codegen/testdata/php_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php_json_library.baseline
@@ -110,6 +110,21 @@
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
+        "StreamShelves": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "StreamBooks": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "DiscussBook": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
         "AddTag": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_json_library.baseline
@@ -110,6 +110,21 @@
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
+        "StreamShelves": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "StreamBooks": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "DiscussBook": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
         "AddTag": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
@@ -920,7 +920,7 @@ class LibraryServiceApi(object):
             settings for this call, e.g, timeout, retries etc.
 
         Returns:
-          An iterator which yields :class:`google.example.library.v1.library_pb2.StreamShelvesResponse` instances.
+          iterator[:class:`google.example.library.v1.library_pb2.StreamShelvesResponse`].
 
         Raises:
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
@@ -950,7 +950,7 @@ class LibraryServiceApi(object):
             settings for this call, e.g, timeout, retries etc.
 
         Returns:
-          An iterator which yields :class:`google.example.library.v1.library_pb2.Book` instances.
+          iterator[:class:`google.example.library.v1.library_pb2.Book`].
 
         Raises:
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
@@ -985,7 +985,7 @@ class LibraryServiceApi(object):
             settings for this call, e.g, timeout, retries etc.
 
         Returns:
-          An iterator which yields :class:`google.example.library.v1.library_pb2.Comment` instances.
+          iterator[:class:`google.example.library.v1.library_pb2.Comment`].
 
         Raises:
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
@@ -325,13 +325,13 @@ class LibraryServiceApi(object):
             self.library_service_stub.UpdateBookIndex,
             settings=defaults['update_book_index'])
         self._stream_shelves = api_callable.create_api_call(
-            self.stub.StreamShelves,
+            self.library_service_stub.StreamShelves,
             settings=defaults['stream_shelves'])
         self._stream_books = api_callable.create_api_call(
-            self.stub.StreamBooks,
+            self.library_service_stub.StreamBooks,
             settings=defaults['stream_books'])
         self._discuss_book = api_callable.create_api_call(
-            self.stub.DiscussBook,
+            self.library_service_stub.DiscussBook,
             settings=defaults['discuss_book'])
         self._add_tag = api_callable.create_api_call(
             self.library_service_stub.AddTag,

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
@@ -911,7 +911,6 @@ class LibraryServiceApi(object):
         Example:
           >>> from library.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
-          >>> requests = [request]
           >>> for element in api.stream_shelves():
           >>>   # process element
           >>>   pass
@@ -941,7 +940,6 @@ class LibraryServiceApi(object):
           >>> from library.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
           >>> name = ''
-          >>> requests = [request]
           >>> for element in api.stream_books(name):
           >>>   # process element
           >>>   pass

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
@@ -324,6 +324,15 @@ class LibraryServiceApi(object):
         self._update_book_index = api_callable.create_api_call(
             self.library_service_stub.UpdateBookIndex,
             settings=defaults['update_book_index'])
+        self._stream_shelves = api_callable.create_api_call(
+            self.stub.StreamShelves,
+            settings=defaults['stream_shelves'])
+        self._stream_books = api_callable.create_api_call(
+            self.stub.StreamBooks,
+            settings=defaults['stream_books'])
+        self._discuss_book = api_callable.create_api_call(
+            self.stub.DiscussBook,
+            settings=defaults['discuss_book'])
         self._add_tag = api_callable.create_api_call(
             self.library_service_stub.AddTag,
             settings=defaults['add_tag'])
@@ -891,6 +900,97 @@ class LibraryServiceApi(object):
             index_name=index_name,
             index_map=index_map)
         self._update_book_index(request, options)
+
+    def stream_shelves(
+            self,
+            options=None):
+        """
+        Test server streaming
+        gRPC streaming methods don't have HTTP equivalent and need not have google.api.http option.
+
+        Example:
+          >>> from library.library_service_api import LibraryServiceApi
+          >>> from google.gax import CallOptions, INITIAL_PAGE
+          >>> api = LibraryServiceApi()
+          >>> for element in api.stream_shelves():
+          >>>   # process element
+          >>>   pass
+
+        Args:
+          options (:class:`google.gax.CallOptions`): Overrides the default
+            settings for this call, e.g, timeout, retries etc.
+
+        Returns:
+          An iterator which yields :class:`google.example.library.v1.library_pb2.StreamShelvesResponse` instances.
+
+        Raises:
+          :exc:`google.gax.errors.GaxError` if the RPC is aborted.
+        """
+        request = library_pb2.StreamShelvesRequest()
+        return self._stream_shelves(request, options)
+
+    def stream_books(
+            self,
+            name,
+            options=None):
+        """
+        Test server streaming, non-paged responses.
+        gRPC streaming methods don't have HTTP equivalent and need not have google.api.http option.
+
+        Example:
+          >>> from library.library_service_api import LibraryServiceApi
+          >>> api = LibraryServiceApi()
+          >>> name = ''
+          >>> for element in api.stream_books(name):
+          >>>   # process element
+          >>>   pass
+
+        Args:
+          name (string): The name of the shelf whose books we'd like to list.
+          options (:class:`google.gax.CallOptions`): Overrides the default
+            settings for this call, e.g, timeout, retries etc.
+
+        Returns:
+          An iterator which yields :class:`google.example.library.v1.library_pb2.Book` instances.
+
+        Raises:
+          :exc:`google.gax.errors.GaxError` if the RPC is aborted.
+        """
+        request = library_pb2.StreamBooksRequest(
+            name=name)
+        return self._stream_books(request, options)
+
+    def discuss_book(
+            self,
+            requests,
+            options=None):
+        """
+        Test bidi-streaming.
+        gRPC streaming methods don't have HTTP equivalent and need not have google.api.http option.
+
+        EXPERIMENTAL: This method interface might change in the future.
+
+        Example:
+          >>> from library.library_service_api import LibraryServiceApi
+          >>> from google.example.library.v1 import library_pb2
+          >>> api = LibraryServiceApi()
+          >>> request = tagger_pb2.DiscussBookRequest()
+          >>> for element in api.discuss_book([request]):
+          >>>   # process element
+          >>>   pass
+
+        Args:
+          requests (iterator of :class:`google.example.library.v1.library_pb2.DiscussBookRequest`): The input objects.
+          options (:class:`google.gax.CallOptions`): Overrides the default
+            settings for this call, e.g, timeout, retries etc.
+
+        Returns:
+          An iterator which yields :class:`google.example.library.v1.library_pb2.Comment` instances.
+
+        Raises:
+          :exc:`google.gax.errors.GaxError` if the RPC is aborted.
+        """
+        return self._discuss_book(requests, options)
 
     def add_tag(
             self,

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
@@ -982,7 +982,7 @@ class LibraryServiceApi(object):
           >>>   pass
 
         Args:
-          requests (iterator of :class:`google.example.library.v1.library_pb2.DiscussBookRequest`): The input objects.
+          requests (iterator[:class:`google.example.library.v1.library_pb2.DiscussBookRequest`]): The input objects.
           options (:class:`google.gax.CallOptions`): Overrides the default
             settings for this call, e.g, timeout, retries etc.
 

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
@@ -910,8 +910,8 @@ class LibraryServiceApi(object):
 
         Example:
           >>> from library.library_service_api import LibraryServiceApi
-          >>> from google.gax import CallOptions, INITIAL_PAGE
           >>> api = LibraryServiceApi()
+          >>> requests = [request]
           >>> for element in api.stream_shelves():
           >>>   # process element
           >>>   pass
@@ -941,6 +941,7 @@ class LibraryServiceApi(object):
           >>> from library.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
           >>> name = ''
+          >>> requests = [request]
           >>> for element in api.stream_books(name):
           >>>   # process element
           >>>   pass
@@ -974,8 +975,9 @@ class LibraryServiceApi(object):
           >>> from library.library_service_api import LibraryServiceApi
           >>> from google.example.library.v1 import library_pb2
           >>> api = LibraryServiceApi()
-          >>> request = tagger_pb2.DiscussBookRequest()
-          >>> for element in api.discuss_book([request]):
+          >>> request = library_pb2.DiscussBookRequest()
+          >>> requests = [request]
+          >>> for element in api.discuss_book(requests):
           >>>   # process element
           >>>   pass
 

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_message_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_message_library.baseline
@@ -733,7 +733,7 @@ class ListShelvesRequest(object):
 
 class ListShelvesResponse(object):
     """
-    Request message for LibraryService.ListShelves.
+    Response message for LibraryService.ListShelves.
 
     Attributes:
       shelves (list[:class:`google.example.library.v1.library_pb2.Shelf`]): The list of shelves.
@@ -742,6 +742,27 @@ class ListShelvesResponse(object):
         ``ListShelvesRequest.page_token``
         field in the subsequent call to ``ListShelves`` method to retrieve the next
         page of results.
+
+    """
+    pass
+
+
+class StreamShelvesRequest(object):
+    """
+    Request message for LibraryService.StreamShelves.
+
+    Attributes:
+
+    """
+    pass
+
+
+class StreamShelvesResponse(object):
+    """
+    Response message for LibraryService.StreamShelves.
+
+    Attributes:
+      shelves (list[:class:`google.example.library.v1.library_pb2.Shelf`]): The list of shelves.
 
     """
     pass
@@ -852,6 +873,17 @@ class ListBooksResponse(object):
     pass
 
 
+class StreamBooksRequest(object):
+    """
+    Request message for LibraryService.StreamBooks.
+
+    Attributes:
+      name (string): The name of the shelf whose books we'd like to list.
+
+    """
+    pass
+
+
 class UpdateBookRequest(object):
     """
     Request message for LibraryService.UpdateBook.
@@ -951,6 +983,18 @@ class UpdateBookIndexRequest(object):
       name (string): The name of the book to update.
       index_name (string): The name of the index for the book
       index_map (dict[string -> :class:`google.example.library.v1.library_pb2.UpdateBookIndexRequest.IndexMapEntry`]): The index to update the book with
+
+    """
+    pass
+
+
+class DiscussBookRequest(object):
+    """
+    Attributes:
+      name (string): The name of the book to be discussed. If this is in the middle
+        of the stream and this is not specified, the name in the previous
+        message will be reused.
+      comment (:class:`google.example.library.v1.library_pb2.Comment`): The new comment.
 
     """
     pass

--- a/src/test/java/com/google/api/codegen/testdata/python_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_json_library.baseline
@@ -110,6 +110,21 @@
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
+        "StreamShelves": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "StreamBooks": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "DiscussBook": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
         "AddTag": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",

--- a/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
@@ -920,7 +920,7 @@ class LibraryServiceApi(object):
             settings for this call, e.g, timeout, retries etc.
 
         Returns:
-          An iterator which yields :class:`google.example.library.v1.library_pb2.StreamShelvesResponse` instances.
+          iterator[:class:`google.example.library.v1.library_pb2.StreamShelvesResponse`].
 
         Raises:
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
@@ -950,7 +950,7 @@ class LibraryServiceApi(object):
             settings for this call, e.g, timeout, retries etc.
 
         Returns:
-          An iterator which yields :class:`google.example.library.v1.library_pb2.Book` instances.
+          iterator[:class:`google.example.library.v1.library_pb2.Book`].
 
         Raises:
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
@@ -985,7 +985,7 @@ class LibraryServiceApi(object):
             settings for this call, e.g, timeout, retries etc.
 
         Returns:
-          An iterator which yields :class:`google.example.library.v1.library_pb2.Comment` instances.
+          iterator[:class:`google.example.library.v1.library_pb2.Comment`].
 
         Raises:
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.

--- a/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
@@ -325,13 +325,13 @@ class LibraryServiceApi(object):
             self.library_service_stub.UpdateBookIndex,
             settings=defaults['update_book_index'])
         self._stream_shelves = api_callable.create_api_call(
-            self.stub.StreamShelves,
+            self.library_service_stub.StreamShelves,
             settings=defaults['stream_shelves'])
         self._stream_books = api_callable.create_api_call(
-            self.stub.StreamBooks,
+            self.library_service_stub.StreamBooks,
             settings=defaults['stream_books'])
         self._discuss_book = api_callable.create_api_call(
-            self.stub.DiscussBook,
+            self.library_service_stub.DiscussBook,
             settings=defaults['discuss_book'])
         self._add_tag = api_callable.create_api_call(
             self.library_service_stub.AddTag,

--- a/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
@@ -911,7 +911,6 @@ class LibraryServiceApi(object):
         Example:
           >>> from library.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
-          >>> requests = [request]
           >>> for element in api.stream_shelves():
           >>>   # process element
           >>>   pass
@@ -941,7 +940,6 @@ class LibraryServiceApi(object):
           >>> from library.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
           >>> name = ''
-          >>> requests = [request]
           >>> for element in api.stream_books(name):
           >>>   # process element
           >>>   pass

--- a/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
@@ -324,6 +324,15 @@ class LibraryServiceApi(object):
         self._update_book_index = api_callable.create_api_call(
             self.library_service_stub.UpdateBookIndex,
             settings=defaults['update_book_index'])
+        self._stream_shelves = api_callable.create_api_call(
+            self.stub.StreamShelves,
+            settings=defaults['stream_shelves'])
+        self._stream_books = api_callable.create_api_call(
+            self.stub.StreamBooks,
+            settings=defaults['stream_books'])
+        self._discuss_book = api_callable.create_api_call(
+            self.stub.DiscussBook,
+            settings=defaults['discuss_book'])
         self._add_tag = api_callable.create_api_call(
             self.library_service_stub.AddTag,
             settings=defaults['add_tag'])
@@ -891,6 +900,97 @@ class LibraryServiceApi(object):
             index_name=index_name,
             index_map=index_map)
         self._update_book_index(request, options)
+
+    def stream_shelves(
+            self,
+            options=None):
+        """
+        Test server streaming
+        gRPC streaming methods don't have HTTP equivalent and need not have google.api.http option.
+
+        Example:
+          >>> from library.library_service_api import LibraryServiceApi
+          >>> from google.gax import CallOptions, INITIAL_PAGE
+          >>> api = LibraryServiceApi()
+          >>> for element in api.stream_shelves():
+          >>>   # process element
+          >>>   pass
+
+        Args:
+          options (:class:`google.gax.CallOptions`): Overrides the default
+            settings for this call, e.g, timeout, retries etc.
+
+        Returns:
+          An iterator which yields :class:`google.example.library.v1.library_pb2.StreamShelvesResponse` instances.
+
+        Raises:
+          :exc:`google.gax.errors.GaxError` if the RPC is aborted.
+        """
+        request = library_pb2.StreamShelvesRequest()
+        return self._stream_shelves(request, options)
+
+    def stream_books(
+            self,
+            name,
+            options=None):
+        """
+        Test server streaming, non-paged responses.
+        gRPC streaming methods don't have HTTP equivalent and need not have google.api.http option.
+
+        Example:
+          >>> from library.library_service_api import LibraryServiceApi
+          >>> api = LibraryServiceApi()
+          >>> name = ''
+          >>> for element in api.stream_books(name):
+          >>>   # process element
+          >>>   pass
+
+        Args:
+          name (string): The name of the shelf whose books we'd like to list.
+          options (:class:`google.gax.CallOptions`): Overrides the default
+            settings for this call, e.g, timeout, retries etc.
+
+        Returns:
+          An iterator which yields :class:`google.example.library.v1.library_pb2.Book` instances.
+
+        Raises:
+          :exc:`google.gax.errors.GaxError` if the RPC is aborted.
+        """
+        request = library_pb2.StreamBooksRequest(
+            name=name)
+        return self._stream_books(request, options)
+
+    def discuss_book(
+            self,
+            requests,
+            options=None):
+        """
+        Test bidi-streaming.
+        gRPC streaming methods don't have HTTP equivalent and need not have google.api.http option.
+
+        EXPERIMENTAL: This method interface might change in the future.
+
+        Example:
+          >>> from library.library_service_api import LibraryServiceApi
+          >>> from google.example.library.v1 import library_pb2
+          >>> api = LibraryServiceApi()
+          >>> request = tagger_pb2.DiscussBookRequest()
+          >>> for element in api.discuss_book([request]):
+          >>>   # process element
+          >>>   pass
+
+        Args:
+          requests (iterator of :class:`google.example.library.v1.library_pb2.DiscussBookRequest`): The input objects.
+          options (:class:`google.gax.CallOptions`): Overrides the default
+            settings for this call, e.g, timeout, retries etc.
+
+        Returns:
+          An iterator which yields :class:`google.example.library.v1.library_pb2.Comment` instances.
+
+        Raises:
+          :exc:`google.gax.errors.GaxError` if the RPC is aborted.
+        """
+        return self._discuss_book(requests, options)
 
     def add_tag(
             self,

--- a/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
@@ -982,7 +982,7 @@ class LibraryServiceApi(object):
           >>>   pass
 
         Args:
-          requests (iterator of :class:`google.example.library.v1.library_pb2.DiscussBookRequest`): The input objects.
+          requests (iterator[:class:`google.example.library.v1.library_pb2.DiscussBookRequest`]): The input objects.
           options (:class:`google.gax.CallOptions`): Overrides the default
             settings for this call, e.g, timeout, retries etc.
 

--- a/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
@@ -910,8 +910,8 @@ class LibraryServiceApi(object):
 
         Example:
           >>> from library.library_service_api import LibraryServiceApi
-          >>> from google.gax import CallOptions, INITIAL_PAGE
           >>> api = LibraryServiceApi()
+          >>> requests = [request]
           >>> for element in api.stream_shelves():
           >>>   # process element
           >>>   pass
@@ -941,6 +941,7 @@ class LibraryServiceApi(object):
           >>> from library.library_service_api import LibraryServiceApi
           >>> api = LibraryServiceApi()
           >>> name = ''
+          >>> requests = [request]
           >>> for element in api.stream_books(name):
           >>>   # process element
           >>>   pass
@@ -974,8 +975,9 @@ class LibraryServiceApi(object):
           >>> from library.library_service_api import LibraryServiceApi
           >>> from google.example.library.v1 import library_pb2
           >>> api = LibraryServiceApi()
-          >>> request = tagger_pb2.DiscussBookRequest()
-          >>> for element in api.discuss_book([request]):
+          >>> request = library_pb2.DiscussBookRequest()
+          >>> requests = [request]
+          >>> for element in api.discuss_book(requests):
           >>>   # process element
           >>>   pass
 

--- a/src/test/java/com/google/api/codegen/testdata/ruby_doc_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_doc_json_library.baseline
@@ -110,6 +110,21 @@
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
+        "StreamShelves": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "StreamBooks": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "DiscussBook": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
         "AddTag": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",

--- a/src/test/java/com/google/api/codegen/testdata/ruby_doc_message_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_doc_message_library.baseline
@@ -700,7 +700,7 @@ module Google
         #     returned from the previous call to +ListShelves+ method.
         class ListShelvesRequest; end
 
-        # Request message for LibraryService.ListShelves.
+        # Response message for LibraryService.ListShelves.
         # @!attribute [rw] shelves
         #   @return [Array<Google::Example::Library::V1::Shelf>]
         #     The list of shelves.
@@ -712,6 +712,15 @@ module Google
         #     field in the subsequent call to +ListShelves+ method to retrieve the next
         #     page of results.
         class ListShelvesResponse; end
+
+        # Request message for LibraryService.StreamShelves.
+        class StreamShelvesRequest; end
+
+        # Response message for LibraryService.StreamShelves.
+        # @!attribute [rw] shelves
+        #   @return [Array<Google::Example::Library::V1::Shelf>]
+        #     The list of shelves.
+        class StreamShelvesResponse; end
 
         # Request message for LibraryService.DeleteShelf.
         # @!attribute [rw] name
@@ -793,6 +802,12 @@ module Google
         #     field in the subsequent call to +ListBooks+ method to retrieve the next
         #     page of results.
         class ListBooksResponse; end
+
+        # Request message for LibraryService.StreamBooks.
+        # @!attribute [rw] name
+        #   @return [String]
+        #     The name of the shelf whose books we'd like to list.
+        class StreamBooksRequest; end
 
         # Request message for LibraryService.UpdateBook.
         # @!attribute [rw] name
@@ -883,6 +898,16 @@ module Google
         #   @return [Hash{String => String}]
         #     The index to update the book with
         class UpdateBookIndexRequest; end
+
+        # @!attribute [rw] name
+        #   @return [String]
+        #     The name of the book to be discussed. If this is in the middle
+        #     of the stream and this is not specified, the name in the previous
+        #     message will be reused.
+        # @!attribute [rw] comment
+        #   @return [Google::Example::Library::V1::Comment]
+        #     The new comment.
+        class DiscussBookRequest; end
       end
     end
   end

--- a/src/test/java/com/google/api/codegen/testdata/ruby_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_json_library.baseline
@@ -110,6 +110,21 @@
           "retry_codes_name": "idempotent",
           "retry_params_name": "default"
         },
+        "StreamShelves": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "StreamBooks": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "idempotent",
+          "retry_params_name": "default"
+        },
+        "DiscussBook": {
+          "timeout_millis": 30000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
+        },
         "AddTag": {
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",


### PR DESCRIPTION
This is an effort of #343, for Python:

- allow parameter flattening and retrying for server-side streaming
- the same interface as grpc-generated one for
  client-side streaming and bidi-streaming
- something like page-streaming might be helpful for some server-side
  streaming methods -- that's not yet implemented.