### PR TITLE
Always set "gax/{gax_version}" in x-goog-api-client

### DIFF
--- a/src/main/resources/com/google/api/codegen/nodejs/main.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/main.snip
@@ -200,11 +200,12 @@
       var clientConfig = opts.clientConfig || {};
       var timeout = opts.timeout || DEFAULT_TIMEOUT;
       var appName = opts.appName || 'gax';
-      var appVersion = opts.appVersion || gax.Version;
+      var appVersion = opts.appVersion || gax.version;
 
       var googleApiClient = [
         appName + '/' + appVersion,
         CODE_GEN_NAME_VERSION,
+        'gax/' + gax.version,
         'nodejs/' + process.version].join(' ');
 
       @if context.messages.filterBundlingMethods(ifaceConfig, context.getNonStreamingMethods(service))

--- a/src/main/resources/com/google/api/codegen/ruby/main.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/main.snip
@@ -216,7 +216,8 @@
       require "{@context.getGrpcFilename(service)}"
 
       google_api_client = "#{app_name}/#{app_version} " @\
-        "#{CODE_GEN_NAME_VERSION} ruby/#{RUBY_VERSION}".freeze
+        "#{CODE_GEN_NAME_VERSION} gax/#{Google::Gax::Version} " @\
+        "ruby/#{RUBY_VERSION}".freeze
       headers = { :"x-goog-api-client" => google_api_client }
       {@constructDefaults(service)}
       @@stub = Google::Gax::Grpc.create_stub(

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_doc_main_library.baseline
@@ -99,11 +99,12 @@ function LibraryServiceApi(gaxGrpc, grpcClient, opts) {
   var clientConfig = opts.clientConfig || {};
   var timeout = opts.timeout || DEFAULT_TIMEOUT;
   var appName = opts.appName || 'gax';
-  var appVersion = opts.appVersion || gax.Version;
+  var appVersion = opts.appVersion || gax.version;
 
   var googleApiClient = [
     appName + '/' + appVersion,
     CODE_GEN_NAME_VERSION,
+    'gax/' + gax.version,
     'nodejs/' + process.version].join(' ');
 
 

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_main_library.baseline
@@ -99,11 +99,12 @@ function LibraryServiceApi(gaxGrpc, grpcClient, opts) {
   var clientConfig = opts.clientConfig || {};
   var timeout = opts.timeout || DEFAULT_TIMEOUT;
   var appName = opts.appName || 'gax';
-  var appVersion = opts.appVersion || gax.Version;
+  var appVersion = opts.appVersion || gax.version;
 
   var googleApiClient = [
     appName + '/' + appVersion,
     CODE_GEN_NAME_VERSION,
+    'gax/' + gax.version,
     'nodejs/' + process.version].join(' ');
 
 

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_main_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_main_no_path_templates.baseline
@@ -69,11 +69,12 @@ function NoTemplatesServiceApi(gaxGrpc, grpcClient, opts) {
   var clientConfig = opts.clientConfig || {};
   var timeout = opts.timeout || DEFAULT_TIMEOUT;
   var appName = opts.appName || 'gax';
-  var appVersion = opts.appVersion || gax.Version;
+  var appVersion = opts.appVersion || gax.version;
 
   var googleApiClient = [
     appName + '/' + appVersion,
     CODE_GEN_NAME_VERSION,
+    'gax/' + gax.version,
     'nodejs/' + process.version].join(' ');
 
   var defaults = gaxGrpc.constructSettings(

--- a/src/test/java/com/google/api/codegen/testdata/ruby_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_doc_main_library.baseline
@@ -214,7 +214,8 @@ module Library
         require "library_services_pb"
 
         google_api_client = "#{app_name}/#{app_version} " \
-          "#{CODE_GEN_NAME_VERSION} ruby/#{RUBY_VERSION}".freeze
+          "#{CODE_GEN_NAME_VERSION} gax/#{Google::Gax::Version} " \
+          "ruby/#{RUBY_VERSION}".freeze
         headers = { :"x-goog-api-client" => google_api_client }
         client_config_file = Pathname.new(__dir__).join(
           "library_service_client_config.json"

--- a/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
@@ -214,7 +214,8 @@ module Library
         require "library_services_pb"
 
         google_api_client = "#{app_name}/#{app_version} " \
-          "#{CODE_GEN_NAME_VERSION} ruby/#{RUBY_VERSION}".freeze
+          "#{CODE_GEN_NAME_VERSION} gax/#{Google::Gax::Version} " \
+          "ruby/#{RUBY_VERSION}".freeze
         headers = { :"x-goog-api-client" => google_api_client }
         client_config_file = Pathname.new(__dir__).join(
           "library_service_client_config.json"


### PR DESCRIPTION
Fixes #467