### PR TITLE
Add getClient function stub in Go discovery gen

### DIFF
--- a/src/main/resources/com/google/api/codegen/go/discovery_fragment.snip
+++ b/src/main/resources/com/google/api/codegen/go/discovery_fragment.snip
@@ -31,8 +31,13 @@ package main
 @end
 
 import (
+  @if context.getApiaryConfig.getAuthType.toString != "APPLICATION_DEFAULT_CREDENTIALS"
+    "errors"
+    "net/http"
+
+  @end
   "golang.org/x/net/context"
-  @if context.getApiaryConfig.getAuthType == "APPLICATION_DEFAULT_CREDENTIALS"
+  @if context.getApiaryConfig.getAuthType.toString == "APPLICATION_DEFAULT_CREDENTIALS"
     "golang.org/x/oauth2/google"
   @end
 
@@ -41,25 +46,13 @@ import (
 
 func main() {
   ctx := context.Background()
-  @switch context.getApiaryConfig.getAuthType
+  @switch context.getApiaryConfig.getAuthType.toString
   @case "APPLICATION_DEFAULT_CREDENTIALS"
     hc, err := google.DefaultClient(ctx{@scopeArg(method)})
     if err != nil {
       // {@TODO()} Handle error.
     }
   @default
-    // {@TODO()} Implement this function to get authentication credentials.
-    @let authInstructionsUrl = context.getApiaryConfig.getAuthInstructionsUrl
-      @if authInstructionsUrl
-        // See {@authInstructionsUrl}
-      @end
-    @end
-    @if context.getApiaryConfig.hasAuthScopes(method.getName)
-      // Authorize using one of the following scopes in order to use this method:
-      @join scope : context.getApiaryConfig.getAuthScopes.get(method.getName)
-        //   {@scope}
-      @end
-    @end
     hc, err := getClient(ctx)
     if err != nil {
       // {@TODO()} Handle error.
@@ -78,6 +71,24 @@ func main() {
     {@compactCall(method)}
   @end
 }
+@if context.getApiaryConfig.getAuthType.toString != "APPLICATION_DEFAULT_CREDENTIALS"
+
+func getClient(ctx Context) (*http.Client, error) {
+  // {@TODO()} Implement this function to get authentication credentials.
+  @let authInstructionsUrl = context.getApiaryConfig.getAuthInstructionsUrl
+    @if authInstructionsUrl
+      // See {@authInstructionsUrl}
+    @end
+  @end
+  @if context.getApiaryConfig.hasAuthScopes(method.getName)
+    // Authorize using one of the following scopes in order to use this method:
+    @join scope : context.getApiaryConfig.getAuthScopes.get(method.getName)
+      //   {@scope}
+    @end
+  @end
+  return nil, errors.New("Not implemented")
+}
+@end
 @end
 
 @private scopeArg(method)

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_adexchangebuyer.v1.4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_adexchangebuyer.v1.4.json.baseline
@@ -10,6 +10,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/adexchangebuyer/v1.4"
@@ -17,10 +20,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/adexchange.buyer
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -41,6 +40,14 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/adexchange.buyer
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -52,6 +59,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/adexchangebuyer/v1.4"
@@ -59,10 +69,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/adexchange.buyer
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -81,6 +87,14 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/adexchange.buyer
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -92,6 +106,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/adexchangebuyer/v1.4"
@@ -99,10 +116,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/adexchange.buyer
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -125,6 +138,14 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/adexchange.buyer
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -136,6 +157,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/adexchangebuyer/v1.4"
@@ -143,10 +167,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/adexchange.buyer
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -169,6 +189,14 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/adexchange.buyer
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -180,6 +208,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/adexchangebuyer/v1.4"
@@ -187,10 +218,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/adexchange.buyer
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -211,6 +238,14 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/adexchange.buyer
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -222,6 +257,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/adexchangebuyer/v1.4"
@@ -229,10 +267,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/adexchange.buyer
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -251,6 +285,14 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/adexchange.buyer
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -262,6 +304,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/adexchangebuyer/v1.4"
@@ -269,10 +314,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/adexchange.buyer
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -297,6 +338,14 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/adexchange.buyer
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -308,6 +357,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/adexchangebuyer/v1.4"
@@ -315,10 +367,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/adexchange.buyer
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -345,6 +393,14 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/adexchange.buyer
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -356,6 +412,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/adexchangebuyer/v1.4"
@@ -363,10 +422,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/adexchange.buyer
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -393,6 +448,14 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/adexchange.buyer
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -404,6 +467,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/adexchangebuyer/v1.4"
@@ -411,10 +477,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/adexchange.buyer
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -440,6 +502,14 @@ func main() {
     // TODO: Handle error.
   }
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/adexchange.buyer
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -451,6 +521,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/adexchangebuyer/v1.4"
@@ -458,10 +531,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/adexchange.buyer
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -486,6 +555,14 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/adexchange.buyer
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -497,6 +574,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/adexchangebuyer/v1.4"
@@ -504,10 +584,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/adexchange.buyer
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -528,6 +604,14 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/adexchange.buyer
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -539,6 +623,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/adexchangebuyer/v1.4"
@@ -546,10 +633,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/adexchange.buyer
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -573,6 +656,14 @@ func main() {
     // TODO: Handle error.
   }
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/adexchange.buyer
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -584,6 +675,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/adexchangebuyer/v1.4"
@@ -591,10 +685,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/adexchange.buyer
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -620,6 +710,14 @@ func main() {
     // TODO: Handle error.
   }
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/adexchange.buyer
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -631,6 +729,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/adexchangebuyer/v1.4"
@@ -638,10 +739,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/adexchange.buyer
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -664,6 +761,14 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/adexchange.buyer
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -675,6 +780,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/adexchangebuyer/v1.4"
@@ -682,10 +790,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/adexchange.buyer
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -708,6 +812,14 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/adexchange.buyer
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -719,6 +831,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/adexchangebuyer/v1.4"
@@ -726,10 +841,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/adexchange.buyer
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -751,6 +862,14 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/adexchange.buyer
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -762,6 +881,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/adexchangebuyer/v1.4"
@@ -769,10 +891,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/adexchange.buyer
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -795,6 +913,14 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/adexchange.buyer
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -806,6 +932,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/adexchangebuyer/v1.4"
@@ -813,10 +942,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/adexchange.buyer
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -839,6 +964,14 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/adexchange.buyer
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -850,6 +983,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/adexchangebuyer/v1.4"
@@ -857,10 +993,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/adexchange.buyer
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -881,6 +1013,14 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/adexchange.buyer
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -892,6 +1032,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/adexchangebuyer/v1.4"
@@ -899,10 +1042,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/adexchange.buyer
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -923,6 +1062,14 @@ func main() {
     // TODO: Handle error.
   }
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/adexchange.buyer
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -934,6 +1081,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/adexchangebuyer/v1.4"
@@ -941,10 +1091,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/adexchange.buyer
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -973,6 +1119,14 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/adexchange.buyer
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -984,6 +1138,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/adexchangebuyer/v1.4"
@@ -991,10 +1148,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/adexchange.buyer
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -1016,6 +1169,14 @@ func main() {
     // TODO: Handle error.
   }
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/adexchange.buyer
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -1027,6 +1188,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/adexchangebuyer/v1.4"
@@ -1034,10 +1198,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/adexchange.buyer
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -1062,6 +1222,14 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/adexchange.buyer
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -1073,6 +1241,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/adexchangebuyer/v1.4"
@@ -1080,10 +1251,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/adexchange.buyer
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -1106,6 +1273,14 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/adexchange.buyer
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -1117,6 +1292,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/adexchangebuyer/v1.4"
@@ -1124,10 +1302,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/adexchange.buyer
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -1148,6 +1322,14 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/adexchange.buyer
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -1159,6 +1341,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/adexchangebuyer/v1.4"
@@ -1166,10 +1351,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/adexchange.buyer
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -1196,6 +1377,14 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/adexchange.buyer
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -1207,6 +1396,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/adexchangebuyer/v1.4"
@@ -1214,10 +1406,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/adexchange.buyer
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -1244,6 +1432,14 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/adexchange.buyer
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -1255,6 +1451,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/adexchangebuyer/v1.4"
@@ -1262,10 +1461,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/adexchange.buyer
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -1286,6 +1481,14 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/adexchange.buyer
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -1297,6 +1500,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/adexchangebuyer/v1.4"
@@ -1304,10 +1510,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/adexchange.buyer
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -1326,6 +1528,14 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/adexchange.buyer
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -1337,6 +1547,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/adexchangebuyer/v1.4"
@@ -1344,10 +1557,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/adexchange.buyer
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -1368,6 +1577,14 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/adexchange.buyer
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -1379,6 +1596,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/adexchangebuyer/v1.4"
@@ -1386,10 +1606,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/adexchange.buyer
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -1410,6 +1626,14 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/adexchange.buyer
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -1421,6 +1645,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/adexchangebuyer/v1.4"
@@ -1428,10 +1655,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/adexchange.buyer
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -1464,6 +1687,14 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/adexchange.buyer
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -1475,6 +1706,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/adexchangebuyer/v1.4"
@@ -1482,10 +1716,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/adexchange.buyer
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -1504,6 +1734,14 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/adexchange.buyer
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -1515,6 +1753,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/adexchangebuyer/v1.4"
@@ -1522,10 +1763,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/adexchange.buyer
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -1543,6 +1780,14 @@ func main() {
     // TODO: Handle error.
   }
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/adexchange.buyer
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -1554,6 +1799,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/adexchangebuyer/v1.4"
@@ -1561,10 +1809,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/adexchange.buyer
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -1597,6 +1841,14 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/adexchange.buyer
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -1608,6 +1860,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/adexchangebuyer/v1.4"
@@ -1615,10 +1870,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/adexchange.buyer
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -1638,4 +1889,12 @@ func main() {
   }
   // TODO: Use resp.
   _ = resp
+}
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/adexchange.buyer
+  return nil, errors.New("Not implemented")
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_autoscaler.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_autoscaler.v1beta2.json.baseline
@@ -10,6 +10,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/autoscaler/v1beta2"
@@ -17,10 +20,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/compute
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -49,6 +48,14 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/compute
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -60,6 +67,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/autoscaler/v1beta2"
@@ -67,11 +77,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/compute
-  //   https://www.googleapis.com/auth/compute.readonly
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -100,6 +105,15 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/compute
+  //   https://www.googleapis.com/auth/compute.readonly
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -111,6 +125,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/autoscaler/v1beta2"
@@ -118,10 +135,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/compute
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -148,6 +161,14 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/compute
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -159,6 +180,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/autoscaler/v1beta2"
@@ -166,11 +190,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/compute
-  //   https://www.googleapis.com/auth/compute.readonly
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -200,6 +219,15 @@ func main() {
     // TODO: Handle error.
   }
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/compute
+  //   https://www.googleapis.com/auth/compute.readonly
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -211,6 +239,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/autoscaler/v1beta2"
@@ -218,10 +249,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/compute
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -252,6 +279,14 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/compute
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -263,6 +298,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/autoscaler/v1beta2"
@@ -270,10 +308,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/compute
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -304,6 +338,14 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/compute
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -315,6 +357,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/autoscaler/v1beta2"
@@ -322,10 +367,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/compute
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -351,6 +392,14 @@ func main() {
     // TODO: Handle error.
   }
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/compute
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -362,6 +411,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/autoscaler/v1beta2"
@@ -369,11 +421,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/compute
-  //   https://www.googleapis.com/auth/compute.readonly
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -402,6 +449,15 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/compute
+  //   https://www.googleapis.com/auth/compute.readonly
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -413,6 +469,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/autoscaler/v1beta2"
@@ -420,11 +479,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/compute
-  //   https://www.googleapis.com/auth/compute.readonly
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -454,6 +508,15 @@ func main() {
     // TODO: Handle error.
   }
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/compute
+  //   https://www.googleapis.com/auth/compute.readonly
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -465,6 +528,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/autoscaler/v1beta2"
@@ -472,11 +538,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/compute
-  //   https://www.googleapis.com/auth/compute.readonly
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -501,4 +562,13 @@ func main() {
   }); err != nil {
     // TODO: Handle error.
   }
+}
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/compute
+  //   https://www.googleapis.com/auth/compute.readonly
+  return nil, errors.New("Not implemented")
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_prediction.v1.6.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_prediction.v1.6.json.baseline
@@ -10,6 +10,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/prediction/v1.6"
@@ -17,10 +20,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/prediction
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -47,6 +46,14 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/prediction
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -58,6 +65,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/prediction/v1.6"
@@ -65,10 +75,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/prediction
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -93,6 +99,14 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/prediction
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -104,6 +118,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/prediction/v1.6"
@@ -111,10 +128,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/prediction
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -136,6 +149,14 @@ func main() {
     // TODO: Handle error.
   }
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/prediction
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -147,6 +168,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/prediction/v1.6"
@@ -154,10 +178,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/prediction
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -182,6 +202,14 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/prediction
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -193,6 +221,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/prediction/v1.6"
@@ -200,13 +231,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/devstorage.full_control
-  //   https://www.googleapis.com/auth/devstorage.read_only
-  //   https://www.googleapis.com/auth/devstorage.read_write
-  //   https://www.googleapis.com/auth/prediction
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -229,6 +253,17 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/devstorage.full_control
+  //   https://www.googleapis.com/auth/devstorage.read_only
+  //   https://www.googleapis.com/auth/devstorage.read_write
+  //   https://www.googleapis.com/auth/prediction
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -240,6 +275,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/prediction/v1.6"
@@ -247,10 +285,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/prediction
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -276,6 +310,14 @@ func main() {
     // TODO: Handle error.
   }
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/prediction
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -287,6 +329,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/prediction/v1.6"
@@ -294,10 +339,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/prediction
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -324,6 +365,14 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/prediction
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -335,6 +384,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/prediction/v1.6"
@@ -342,10 +394,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/prediction
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -371,4 +419,12 @@ func main() {
   }
   // TODO: Use resp.
   _ = resp
+}
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/prediction
+  return nil, errors.New("Not implemented")
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_taskqueue.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_taskqueue.v1beta2.json.baseline
@@ -10,6 +10,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/taskqueue/v1beta2"
@@ -17,11 +20,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/taskqueue
-  //   https://www.googleapis.com/auth/taskqueue.consumer
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -46,6 +44,15 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/taskqueue
+  //   https://www.googleapis.com/auth/taskqueue.consumer
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -57,6 +64,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/taskqueue/v1beta2"
@@ -64,11 +74,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/taskqueue
-  //   https://www.googleapis.com/auth/taskqueue.consumer
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -94,6 +99,15 @@ func main() {
     // TODO: Handle error.
   }
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/taskqueue
+  //   https://www.googleapis.com/auth/taskqueue.consumer
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -105,6 +119,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/taskqueue/v1beta2"
@@ -112,11 +129,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/taskqueue
-  //   https://www.googleapis.com/auth/taskqueue.consumer
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -145,6 +157,15 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/taskqueue
+  //   https://www.googleapis.com/auth/taskqueue.consumer
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -156,6 +177,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/taskqueue/v1beta2"
@@ -163,11 +187,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/taskqueue
-  //   https://www.googleapis.com/auth/taskqueue.consumer
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -194,6 +213,15 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/taskqueue
+  //   https://www.googleapis.com/auth/taskqueue.consumer
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -205,6 +233,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/taskqueue/v1beta2"
@@ -212,11 +243,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/taskqueue
-  //   https://www.googleapis.com/auth/taskqueue.consumer
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -249,6 +275,15 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/taskqueue
+  //   https://www.googleapis.com/auth/taskqueue.consumer
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -260,6 +295,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/taskqueue/v1beta2"
@@ -267,11 +305,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/taskqueue
-  //   https://www.googleapis.com/auth/taskqueue.consumer
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -296,6 +329,15 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/taskqueue
+  //   https://www.googleapis.com/auth/taskqueue.consumer
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -307,6 +349,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/taskqueue/v1beta2"
@@ -314,11 +359,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/taskqueue
-  //   https://www.googleapis.com/auth/taskqueue.consumer
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -353,6 +393,15 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/taskqueue
+  //   https://www.googleapis.com/auth/taskqueue.consumer
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -364,6 +413,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/taskqueue/v1beta2"
@@ -371,11 +423,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
-  // Authorize using one of the following scopes in order to use this method:
-  //   https://www.googleapis.com/auth/taskqueue
-  //   https://www.googleapis.com/auth/taskqueue.consumer
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -409,4 +456,13 @@ func main() {
   }
   // TODO: Use resp.
   _ = resp
+}
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  // Authorize using one of the following scopes in order to use this method:
+  //   https://www.googleapis.com/auth/taskqueue
+  //   https://www.googleapis.com/auth/taskqueue.consumer
+  return nil, errors.New("Not implemented")
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_translate.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_translate.v2.json.baseline
@@ -10,6 +10,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/translate/v2"
@@ -17,8 +20,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -39,6 +40,12 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -50,6 +57,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/translate/v2"
@@ -57,8 +67,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -77,6 +85,12 @@ func main() {
   // TODO: Use resp.
   _ = resp
 }
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  return nil, errors.New("Not implemented")
+}
 package main
 
 // BEFORE RUNNING:
@@ -88,6 +102,9 @@ package main
 //    project directory.
 
 import (
+  "errors"
+  "net/http"
+
   "golang.org/x/net/context"
 
   "google.golang.org/api/translate/v2"
@@ -95,8 +112,6 @@ import (
 
 func main() {
   ctx := context.Background()
-  // TODO: Implement this function to get authentication credentials.
-  // See https://foo.com/bar
   hc, err := getClient(ctx)
   if err != nil {
     // TODO: Handle error.
@@ -120,4 +135,10 @@ func main() {
   }
   // TODO: Use resp.
   _ = resp
+}
+
+func getClient(ctx Context) (*http.Client, error) {
+  // TODO: Implement this function to get authentication credentials.
+  // See https://foo.com/bar
+  return nil, errors.New("Not implemented")
 }


### PR DESCRIPTION
Adds a getClient stub function for non-ADC APIs so compilecheck
succeeds.