### PR TITLE
Rename getCredential stub in C# discovery gen

### DIFF
--- a/src/main/resources/com/google/api/codegen/csharp/discovery_fragment.snip
+++ b/src/main/resources/com/google/api/codegen/csharp/discovery_fragment.snip
@@ -52,7 +52,7 @@
                 }
                 @if context.getApiaryConfig.getAuthType.toString != "APPLICATION_DEFAULT_CREDENTIALS"
 
-                    public static UserCredential getCredential() {
+                    public static UserCredential GetCredential() {
                         // TODO: Implement this function to get authentication credentials.
                         @let authInstructionsUrl = context.getApiaryConfig.getAuthInstructionsUrl
                             @if authInstructionsUrl

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_adexchangebuyer.v1.4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_adexchangebuyer.v1.4.json.baseline
@@ -41,7 +41,7 @@ namespace AdExchangeBuyerSample
             // Data.Account response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -87,7 +87,7 @@ namespace AdExchangeBuyerSample
             // Data.AccountsList response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -141,7 +141,7 @@ namespace AdExchangeBuyerSample
             // Data.Account response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -195,7 +195,7 @@ namespace AdExchangeBuyerSample
             // Data.Account response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -246,7 +246,7 @@ namespace AdExchangeBuyerSample
             // Data.BillingInfo response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -292,7 +292,7 @@ namespace AdExchangeBuyerSample
             // Data.BillingInfoList response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -346,7 +346,7 @@ namespace AdExchangeBuyerSample
             // Data.Budget response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -403,7 +403,7 @@ namespace AdExchangeBuyerSample
             // Data.Budget response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -460,7 +460,7 @@ namespace AdExchangeBuyerSample
             // Data.Budget response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -515,7 +515,7 @@ namespace AdExchangeBuyerSample
             // await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -569,7 +569,7 @@ namespace AdExchangeBuyerSample
             // Data.Creative response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -618,7 +618,7 @@ namespace AdExchangeBuyerSample
             // Data.Creative response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -677,7 +677,7 @@ namespace AdExchangeBuyerSample
             // Data.CreativesList response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -732,7 +732,7 @@ namespace AdExchangeBuyerSample
             // await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -786,7 +786,7 @@ namespace AdExchangeBuyerSample
             // Data.DeleteOrderDealsResponse response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -840,7 +840,7 @@ namespace AdExchangeBuyerSample
             // Data.AddOrderDealsResponse response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -892,7 +892,7 @@ namespace AdExchangeBuyerSample
             // Data.GetOrderDealsResponse response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -946,7 +946,7 @@ namespace AdExchangeBuyerSample
             // Data.EditAllOrderDealsResponse response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -1000,7 +1000,7 @@ namespace AdExchangeBuyerSample
             // Data.AddOrderNotesResponse response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -1051,7 +1051,7 @@ namespace AdExchangeBuyerSample
             // Data.GetOrderNotesResponse response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -1105,7 +1105,7 @@ namespace AdExchangeBuyerSample
             // await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -1162,7 +1162,7 @@ namespace AdExchangeBuyerSample
             // Data.PerformanceReportList response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -1214,7 +1214,7 @@ namespace AdExchangeBuyerSample
             // await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -1268,7 +1268,7 @@ namespace AdExchangeBuyerSample
             // Data.PretargetingConfig response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -1322,7 +1322,7 @@ namespace AdExchangeBuyerSample
             // Data.PretargetingConfig response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -1373,7 +1373,7 @@ namespace AdExchangeBuyerSample
             // Data.PretargetingConfigList response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -1430,7 +1430,7 @@ namespace AdExchangeBuyerSample
             // Data.PretargetingConfig response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -1487,7 +1487,7 @@ namespace AdExchangeBuyerSample
             // Data.PretargetingConfig response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -1538,7 +1538,7 @@ namespace AdExchangeBuyerSample
             // Data.Product response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -1584,7 +1584,7 @@ namespace AdExchangeBuyerSample
             // Data.GetOffersResponse response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -1635,7 +1635,7 @@ namespace AdExchangeBuyerSample
             // Data.Proposal response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -1684,7 +1684,7 @@ namespace AdExchangeBuyerSample
             // Data.CreateOrdersResponse response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -1746,7 +1746,7 @@ namespace AdExchangeBuyerSample
             // Data.Proposal response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -1792,7 +1792,7 @@ namespace AdExchangeBuyerSample
             // Data.GetOrdersResponse response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -1841,7 +1841,7 @@ namespace AdExchangeBuyerSample
             // await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -1903,7 +1903,7 @@ namespace AdExchangeBuyerSample
             // Data.Proposal response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -1954,7 +1954,7 @@ namespace AdExchangeBuyerSample
             // Data.GetPublisherProfilesByAccountIdResponse response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_autoscaler.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_autoscaler.v1beta2.json.baseline
@@ -47,7 +47,7 @@ namespace AutoscalerSample
             // Data.Operation response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -104,7 +104,7 @@ namespace AutoscalerSample
             // Data.Autoscaler response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -162,7 +162,7 @@ namespace AutoscalerSample
             // Data.Operation response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -229,7 +229,7 @@ namespace AutoscalerSample
             // Data.AutoscalerListResponse response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -290,7 +290,7 @@ namespace AutoscalerSample
             // Data.Operation response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -350,7 +350,7 @@ namespace AutoscalerSample
             // Data.Operation response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -402,7 +402,7 @@ namespace AutoscalerSample
             // await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -456,7 +456,7 @@ namespace AutoscalerSample
             // Data.Operation response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -522,7 +522,7 @@ namespace AutoscalerSample
             // Data.OperationList response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -586,7 +586,7 @@ namespace AutoscalerSample
             // Data.ZoneList response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_prediction.v1.6.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_prediction.v1.6.json.baseline
@@ -47,7 +47,7 @@ namespace PredictionSample
             // Data.Output response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -101,7 +101,7 @@ namespace PredictionSample
             // Data.Analyze response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -153,7 +153,7 @@ namespace PredictionSample
             // await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -207,7 +207,7 @@ namespace PredictionSample
             // Data.Insert2 response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -261,7 +261,7 @@ namespace PredictionSample
             // Data.Insert2 response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -328,7 +328,7 @@ namespace PredictionSample
             // Data.List response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -385,7 +385,7 @@ namespace PredictionSample
             // Data.Output response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -442,7 +442,7 @@ namespace PredictionSample
             // Data.Insert2 response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_taskqueue.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_taskqueue.v1beta2.json.baseline
@@ -44,7 +44,7 @@ namespace TaskqueueSample
             // Data.TaskQueue response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -100,7 +100,7 @@ namespace TaskqueueSample
             // await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -158,7 +158,7 @@ namespace TaskqueueSample
             // Data.Task response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -216,7 +216,7 @@ namespace TaskqueueSample
             // Data.Task response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -277,7 +277,7 @@ namespace TaskqueueSample
             // Data.Tasks response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -332,7 +332,7 @@ namespace TaskqueueSample
             // Data.Tasks2 response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -394,7 +394,7 @@ namespace TaskqueueSample
             // Data.Task response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:
@@ -456,7 +456,7 @@ namespace TaskqueueSample
             // Data.Task response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             // Authorize using one of the following scopes in order to use this method:

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_translate.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_translate.v2.json.baseline
@@ -41,7 +41,7 @@ namespace TranslateSample
             // Data.DetectionsListResponse response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             return null;
@@ -84,7 +84,7 @@ namespace TranslateSample
             // Data.LanguagesListResponse response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             return null;
@@ -136,7 +136,7 @@ namespace TranslateSample
             // Data.TranslationsListResponse response = await request.ExecuteAsync();
         }
 
-        public static UserCredential getCredential() {
+        public static UserCredential GetCredential() {
             // TODO: Implement this function to get authentication credentials.
             // See https://foo.com/bar
             return null;


### PR DESCRIPTION
In discovery snippetgen for C#, the body for non-ADC snippets contains a
call to GetClient, but the stub is named getClient. This change renames
the stub to GetClient to fix compilecheck errors.