### PR TITLE
Fix Ruby package file path name

### DIFF
--- a/src/main/java/com/google/api/codegen/util/ruby/RubyNameFormatter.java
+++ b/src/main/java/com/google/api/codegen/util/ruby/RubyNameFormatter.java
@@ -65,7 +65,7 @@ public class RubyNameFormatter implements NameFormatter {
 
   @Override
   public String packageFilePathPiece(Name name) {
-    return name.toLowerUnderscore();
+    return name.toOriginal().toLowerCase();
   }
 
   @Override


### PR DESCRIPTION
Ruby package file path name should be lowercase original instead of lower underscore.

For example, 

package_name: Google::Cloud::ErrorReporting::V1beta1

should map to

google/cloud/errorreporting/v1beta1

instead of

google/cloud/error_reporting/v1beta1
