### PR TITLE
Google::Gax::VERSION was being called incorrectly in Ruby.

### DIFF
--- a/src/main/resources/com/google/api/codegen/ruby/main.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/main.snip
@@ -231,7 +231,7 @@
       @end
 
       google_api_client = "#{app_name}/#{app_version} " @\
-        "#{CODE_GEN_NAME_VERSION} gax/#{Google::Gax::Version} " @\
+        "#{CODE_GEN_NAME_VERSION} gax/#{Google::Gax::VERSION} " @\
         "ruby/#{RUBY_VERSION}".freeze
       headers = { :"x-goog-api-client" => google_api_client }
       {@constructDefaults(service)}

--- a/src/test/java/com/google/api/codegen/testdata/ruby_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_doc_main_library.baseline
@@ -217,7 +217,7 @@ module Library
         require "tagger_services_pb"
 
         google_api_client = "#{app_name}/#{app_version} " \
-          "#{CODE_GEN_NAME_VERSION} gax/#{Google::Gax::Version} " \
+          "#{CODE_GEN_NAME_VERSION} gax/#{Google::Gax::VERSION} " \
           "ruby/#{RUBY_VERSION}".freeze
         headers = { :"x-goog-api-client" => google_api_client }
         client_config_file = Pathname.new(__dir__).join(

--- a/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
@@ -217,7 +217,7 @@ module Library
         require "tagger_services_pb"
 
         google_api_client = "#{app_name}/#{app_version} " \
-          "#{CODE_GEN_NAME_VERSION} gax/#{Google::Gax::Version} " \
+          "#{CODE_GEN_NAME_VERSION} gax/#{Google::Gax::VERSION} " \
           "ruby/#{RUBY_VERSION}".freeze
         headers = { :"x-goog-api-client" => google_api_client }
         client_config_file = Pathname.new(__dir__).join(


### PR DESCRIPTION
[VERSION](https://github.com/googleapis/gax-ruby/blob/master/lib/google/gax/version.rb#L32) is all capitals in gax-ruby.