### PR TITLE
Remove gRPC beta types from Python GAPIC

### DIFF
--- a/src/main/resources/com/google/api/codegen/py/main.snip
+++ b/src/main/resources/com/google/api/codegen/py/main.snip
@@ -205,10 +205,11 @@
             Args:
               service_path (string): The domain name of the API remote host.
               port (int): The port on which to connect to the remote host.
-              channel (:class:`grpc.beta.implementations.Channel`): A ``Channel``
-                object through which to make calls.
-              ssl_creds (:class:`grpc.beta.implementations.ClientCredentials`):
-                A `ClientCredentials` for use with an SSL-enabled channel.
+              channel (:class:`grpc.Channel`): A ``Channel`` instance through
+                which to make calls.
+              ssl_creds (:class:`grpc.ChannelCredentials`): A
+                ``ChannelCredentials`` instance for use with an SSL-enabled
+                channel.
               client_config (dict):
                 A dictionary for call options for each method. See
                 :func:`google.gax.construct_settings` for the structure of
@@ -236,7 +237,7 @@
             metadata = [('x-goog-api-client', goog_api_client)]
             {@constructDefaults(service)}
             self.stub = config.create_stub(
-                {@stubModule}.beta_create_{@stubService}_stub,
+                {@stubModule}.{@stubService}Stub,
                 service_path,
                 port,
                 ssl_creds=ssl_creds,

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
@@ -219,10 +219,11 @@ class LibraryServiceApi(object):
         Args:
           service_path (string): The domain name of the API remote host.
           port (int): The port on which to connect to the remote host.
-          channel (:class:`grpc.beta.implementations.Channel`): A ``Channel``
-            object through which to make calls.
-          ssl_creds (:class:`grpc.beta.implementations.ClientCredentials`):
-            A `ClientCredentials` for use with an SSL-enabled channel.
+          channel (:class:`grpc.Channel`): A ``Channel`` instance through
+            which to make calls.
+          ssl_creds (:class:`grpc.ChannelCredentials`): A
+            ``ChannelCredentials`` instance for use with an SSL-enabled
+            channel.
           client_config (dict):
             A dictionary for call options for each method. See
             :func:`google.gax.construct_settings` for the structure of
@@ -259,7 +260,7 @@ class LibraryServiceApi(object):
             bundle_descriptors=self._BUNDLE_DESCRIPTORS,
             page_descriptors=self._PAGE_DESCRIPTORS)
         self.stub = config.create_stub(
-            library_pb2.beta_create_LibraryService_stub,
+            library_pb2.LibraryServiceStub,
             service_path,
             port,
             ssl_creds=ssl_creds,

--- a/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
@@ -219,10 +219,11 @@ class LibraryServiceApi(object):
         Args:
           service_path (string): The domain name of the API remote host.
           port (int): The port on which to connect to the remote host.
-          channel (:class:`grpc.beta.implementations.Channel`): A ``Channel``
-            object through which to make calls.
-          ssl_creds (:class:`grpc.beta.implementations.ClientCredentials`):
-            A `ClientCredentials` for use with an SSL-enabled channel.
+          channel (:class:`grpc.Channel`): A ``Channel`` instance through
+            which to make calls.
+          ssl_creds (:class:`grpc.ChannelCredentials`): A
+            ``ChannelCredentials`` instance for use with an SSL-enabled
+            channel.
           client_config (dict):
             A dictionary for call options for each method. See
             :func:`google.gax.construct_settings` for the structure of
@@ -259,7 +260,7 @@ class LibraryServiceApi(object):
             bundle_descriptors=self._BUNDLE_DESCRIPTORS,
             page_descriptors=self._PAGE_DESCRIPTORS)
         self.stub = config.create_stub(
-            library_pb2.beta_create_LibraryService_stub,
+            library_pb2.LibraryServiceStub,
             service_path,
             port,
             ssl_creds=ssl_creds,

--- a/src/test/java/com/google/api/codegen/testdata/python_main_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_main_no_path_templates.baseline
@@ -69,10 +69,11 @@ class NoTemplatesServiceApi(object):
         Args:
           service_path (string): The domain name of the API remote host.
           port (int): The port on which to connect to the remote host.
-          channel (:class:`grpc.beta.implementations.Channel`): A ``Channel``
-            object through which to make calls.
-          ssl_creds (:class:`grpc.beta.implementations.ClientCredentials`):
-            A `ClientCredentials` for use with an SSL-enabled channel.
+          channel (:class:`grpc.Channel`): A ``Channel`` instance through
+            which to make calls.
+          ssl_creds (:class:`grpc.ChannelCredentials`): A
+            ``ChannelCredentials`` instance for use with an SSL-enabled
+            channel.
           client_config (dict):
             A dictionary for call options for each method. See
             :func:`google.gax.construct_settings` for the structure of
@@ -107,7 +108,7 @@ class NoTemplatesServiceApi(object):
             config.STATUS_CODE_NAMES,
             kwargs={'metadata': metadata})
         self.stub = config.create_stub(
-            no_path_templates_pb2.beta_create_NoTemplatesService_stub,
+            no_path_templates_pb2.NoTemplatesServiceStub,
             service_path,
             port,
             ssl_creds=ssl_creds,


### PR DESCRIPTION
This will allow the codegen artifacts to interact with google-gax
0.13.0, which also drops gRPC beta.