### PR TITLE
Implement path template field init rule.

### DIFF
--- a/src/main/java/com/google/api/codegen/DocConfig.java
+++ b/src/main/java/com/google/api/codegen/DocConfig.java
@@ -17,10 +17,10 @@ package com.google.api.codegen;
 import com.google.api.codegen.metacode.FieldSetting;
 import com.google.api.codegen.metacode.InitCode;
 import com.google.api.codegen.metacode.InitCodeLine;
-import com.google.api.codegen.metacode.InitValueConfig;
-import com.google.api.codegen.metacode.InputParameter;
 import com.google.api.codegen.metacode.InitCodeNode;
 import com.google.api.codegen.metacode.InitTreeParserContext;
+import com.google.api.codegen.metacode.InitValueConfig;
+import com.google.api.codegen.metacode.InputParameter;
 import com.google.api.codegen.metacode.StructureInitCodeLine;
 import com.google.api.codegen.util.Name;
 import com.google.api.codegen.util.SymbolTable;
@@ -111,7 +111,7 @@ public abstract class DocConfig {
                   .table(new SymbolTable())
                   .rootObjectType(method.getInputType())
                   .initValueConfigMap(initValueConfigMap.build())
-                  .dottedPathStrings(methodConfig.getSampleCodeInitFields())
+                  .initFieldConfigStrings(methodConfig.getSampleCodeInitFields())
                   .initFields(fields)
                   .suggestedName(Name.from("request"))
                   .build());

--- a/src/main/java/com/google/api/codegen/SmokeTestConfig.java
+++ b/src/main/java/com/google/api/codegen/SmokeTestConfig.java
@@ -19,15 +19,19 @@ import com.google.api.tools.framework.model.DiagCollector;
 import com.google.api.tools.framework.model.Interface;
 import com.google.api.tools.framework.model.Method;
 import com.google.api.tools.framework.model.SimpleLocation;
+
+import java.util.ArrayList;
 import java.util.List;
 
 /** SmokeTestConfig represents the smoke test configuration for a method. */
 public class SmokeTestConfig {
   private final Method method;
-  private final List<String> initFields;
+  private final List<String> initFieldNames;
+  private final List<String> initFieldSpecs;
 
-  private SmokeTestConfig(Method method, List<String> initFields) {
-    this.initFields = initFields;
+  private SmokeTestConfig(Method method, List<String> initFieldSpecs, List<String> initFieldNames) {
+    this.initFieldSpecs = initFieldSpecs;
+    this.initFieldNames = initFieldNames;
     this.method = method;
   }
 
@@ -42,7 +46,13 @@ public class SmokeTestConfig {
     }
 
     if (testedMethod != null) {
-      return new SmokeTestConfig(testedMethod, smokeTestConfigProto.getInitFieldsList());
+      List<String> initFieldSpecs = smokeTestConfigProto.getInitFieldsList();
+      ArrayList<String> initFieldNames = new ArrayList<>();
+      for (String fieldSpec : initFieldSpecs) {
+        String[] fieldSpecParts = fieldSpec.split("[<=>]");
+        initFieldNames.add(fieldSpecParts[0]);
+      }
+      return new SmokeTestConfig(testedMethod, initFieldSpecs, initFieldNames);
     } else {
       diagCollector.addDiag(
           Diag.error(SimpleLocation.TOPLEVEL, "The configured smoke test method does not exist."));
@@ -50,9 +60,14 @@ public class SmokeTestConfig {
     }
   }
 
+  /** Returns a list of initialized field names. */
+  public List<String> getInitFieldNames() {
+    return initFieldNames;
+  }
+
   /** Returns a list of initialized fields configuration. */
-  public List<String> getInitFields() {
-    return initFields;
+  public List<String> getInitFieldSpecs() {
+    return initFieldSpecs;
   }
 
   /** Returns the method that is used in the smoke test. */

--- a/src/main/java/com/google/api/codegen/SmokeTestConfig.java
+++ b/src/main/java/com/google/api/codegen/SmokeTestConfig.java
@@ -19,19 +19,15 @@ import com.google.api.tools.framework.model.DiagCollector;
 import com.google.api.tools.framework.model.Interface;
 import com.google.api.tools.framework.model.Method;
 import com.google.api.tools.framework.model.SimpleLocation;
-import java.util.ArrayList;
 import java.util.List;
 
 /** SmokeTestConfig represents the smoke test configuration for a method. */
 public class SmokeTestConfig {
   private final Method method;
-  private final List<String> initFieldNames;
   private final List<String> initFieldConfigStrings;
 
-  private SmokeTestConfig(
-      Method method, List<String> initFieldConfigStrings, List<String> initFieldNames) {
+  private SmokeTestConfig(Method method, List<String> initFieldConfigStrings) {
     this.method = method;
-    this.initFieldNames = initFieldNames;
     this.initFieldConfigStrings = initFieldConfigStrings;
   }
 
@@ -44,15 +40,8 @@ public class SmokeTestConfig {
         break;
       }
     }
-
     if (testedMethod != null) {
-      List<String> initFieldSpecs = smokeTestConfigProto.getInitFieldsList();
-      ArrayList<String> initFieldNames = new ArrayList<>();
-      for (String fieldSpec : initFieldSpecs) {
-        String[] fieldSpecParts = fieldSpec.split("[<=>]");
-        initFieldNames.add(fieldSpecParts[0]);
-      }
-      return new SmokeTestConfig(testedMethod, initFieldSpecs, initFieldNames);
+      return new SmokeTestConfig(testedMethod, smokeTestConfigProto.getInitFieldsList());
     } else {
       diagCollector.addDiag(
           Diag.error(SimpleLocation.TOPLEVEL, "The configured smoke test method does not exist."));

--- a/src/main/java/com/google/api/codegen/SmokeTestConfig.java
+++ b/src/main/java/com/google/api/codegen/SmokeTestConfig.java
@@ -19,7 +19,6 @@ import com.google.api.tools.framework.model.DiagCollector;
 import com.google.api.tools.framework.model.Interface;
 import com.google.api.tools.framework.model.Method;
 import com.google.api.tools.framework.model.SimpleLocation;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -27,12 +26,13 @@ import java.util.List;
 public class SmokeTestConfig {
   private final Method method;
   private final List<String> initFieldNames;
-  private final List<String> initFieldSpecs;
+  private final List<String> initFieldConfigStrings;
 
-  private SmokeTestConfig(Method method, List<String> initFieldSpecs, List<String> initFieldNames) {
-    this.initFieldSpecs = initFieldSpecs;
-    this.initFieldNames = initFieldNames;
+  private SmokeTestConfig(
+      Method method, List<String> initFieldConfigStrings, List<String> initFieldNames) {
     this.method = method;
+    this.initFieldNames = initFieldNames;
+    this.initFieldConfigStrings = initFieldConfigStrings;
   }
 
   public static SmokeTestConfig createSmokeTestConfig(
@@ -60,14 +60,9 @@ public class SmokeTestConfig {
     }
   }
 
-  /** Returns a list of initialized field names. */
-  public List<String> getInitFieldNames() {
-    return initFieldNames;
-  }
-
   /** Returns a list of initialized fields configuration. */
-  public List<String> getInitFieldSpecs() {
-    return initFieldSpecs;
+  public List<String> getInitFieldConfigStrings() {
+    return initFieldConfigStrings;
   }
 
   /** Returns the method that is used in the smoke test. */

--- a/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
+++ b/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
@@ -63,11 +63,14 @@ public class FieldStructureParser {
 
   private static InitValueConfig createInitValueConfig(
       InitFieldConfig fieldConfig, Map<String, InitValueConfig> initValueConfigMap) {
+    if (fieldConfig.isFormattedConfig()
+        && !initValueConfigMap.containsKey(fieldConfig.fieldPath())) {
+      // If the field is a formatted field, it must exist in the value config map.
+      throw new IllegalArgumentException("The field name is not found in the collection map.");
+    }
+
     InitValueConfig valueConfig = null;
     if (fieldConfig.hasFormattedInitValue()) {
-      if (!initValueConfigMap.containsKey(fieldConfig.fieldPath())) {
-        throw new IllegalArgumentException("The field name is not found in the collection map.");
-      }
       valueConfig =
           initValueConfigMap
               .get(fieldConfig.fieldPath())

--- a/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
+++ b/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
@@ -55,9 +55,8 @@ public class FieldStructureParser {
 
   public static InitCodeNode parse(
       String initFieldConfigString, Map<String, InitValueConfig> initValueConfigMap) {
-    InitFieldConfig fieldConfig = InitFieldConfig.of(initFieldConfigString);
-    InitValueConfig valueConfig =
-        createInitValueConfig(InitFieldConfig.of(initFieldConfigString), initValueConfigMap);
+    InitFieldConfig fieldConfig = InitFieldConfig.from(initFieldConfigString);
+    InitValueConfig valueConfig = createInitValueConfig(fieldConfig, initValueConfigMap);
     return parsePartialDottedPathToInitCodeNode(
         fieldConfig.fieldPath(), InitCodeLineType.Unknown, valueConfig, null);
   }
@@ -65,18 +64,16 @@ public class FieldStructureParser {
   private static InitValueConfig createInitValueConfig(
       InitFieldConfig fieldConfig, Map<String, InitValueConfig> initValueConfigMap) {
     InitValueConfig valueConfig = null;
-    if (fieldConfig.hasInitValue()) {
-      if (fieldConfig.isFormattedField()) {
-        if (!initValueConfigMap.containsKey(fieldConfig.fieldPath())) {
-          throw new IllegalArgumentException("The field name is not found in the collection map.");
-        }
-        valueConfig =
-            initValueConfigMap
-                .get(fieldConfig.fieldPath())
-                .withInitialCollectionValue(fieldConfig.entityName(), fieldConfig.value());
-      } else {
-        valueConfig = InitValueConfig.createWithValue(stripQuotes(fieldConfig.value()));
+    if (fieldConfig.hasFormattedInitValue()) {
+      if (!initValueConfigMap.containsKey(fieldConfig.fieldPath())) {
+        throw new IllegalArgumentException("The field name is not found in the collection map.");
       }
+      valueConfig =
+          initValueConfigMap
+              .get(fieldConfig.fieldPath())
+              .withInitialCollectionValue(fieldConfig.entityName(), fieldConfig.value());
+    } else if (fieldConfig.hasSimpleInitValue()) {
+      valueConfig = InitValueConfig.createWithValue(stripQuotes(fieldConfig.value()));
     } else if (initValueConfigMap.containsKey(fieldConfig.fieldPath())) {
       valueConfig = initValueConfigMap.get(fieldConfig.fieldPath());
     }

--- a/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
+++ b/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
@@ -17,11 +17,9 @@ package com.google.api.codegen.metacode;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
-
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import javax.annotation.Nullable;
 
 /*
@@ -80,20 +78,6 @@ public class FieldStructureParser {
 
   public static InitCodeNode parse(
       String initFieldConfigString, Map<String, InitValueConfig> initValueConfigMap) {
-    InitFieldConfig fieldConfig = parseInitFieldConfig(initFieldConfigString);
-    InitValueConfig valueConfig = null;
-
-    if (fieldConfig.hasInitValue()) {
-      valueConfig = createInitValueConfig(fieldConfig, initValueConfigMap);
-    } else if (initValueConfigMap.containsKey(fieldConfig.fieldPath())) {
-      valueConfig = initValueConfigMap.get(fieldConfig.fieldPath());
-    }
-
-    return parsePartialDottedPathToInitCodeNode(
-        fieldConfig.fieldPath(), InitCodeLineType.Unknown, valueConfig, null);
-  }
-
-  private static InitFieldConfig parseInitFieldConfig(String initFieldConfigString) {
     String fieldName = null;
     String entityName = null;
     String value = null;
@@ -112,8 +96,19 @@ public class FieldStructureParser {
     } else if (fieldSpecs.length > 2) {
       throw new IllegalArgumentException("Inconsistent: found multiple '%' characters");
     }
-    return new AutoValue_FieldStructureParser_InitFieldConfig(
-        initFieldConfigString, fieldName, entityName, value);
+    InitFieldConfig fieldConfig =
+        new AutoValue_FieldStructureParser_InitFieldConfig(
+            initFieldConfigString, fieldName, entityName, value);
+
+    InitValueConfig valueConfig = null;
+    if (fieldConfig.hasInitValue()) {
+      valueConfig = createInitValueConfig(fieldConfig, initValueConfigMap);
+    } else if (initValueConfigMap.containsKey(fieldConfig.fieldPath())) {
+      valueConfig = initValueConfigMap.get(fieldConfig.fieldPath());
+    }
+
+    return parsePartialDottedPathToInitCodeNode(
+        fieldConfig.fieldPath(), InitCodeLineType.Unknown, valueConfig, null);
   }
 
   private static InitValueConfig createInitValueConfig(

--- a/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
+++ b/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
@@ -80,7 +80,7 @@ public class FieldStructureParser {
 
   public static InitCodeNode parse(
       String initFieldConfigString, Map<String, InitValueConfig> initValueConfigMap) {
-    InitFieldConfig fieldConfig = createInitFieldConfig(initFieldConfigString);
+    InitFieldConfig fieldConfig = parseInitFieldConfig(initFieldConfigString);
     InitValueConfig valueConfig = null;
 
     if (fieldConfig.hasInitValue()) {
@@ -93,7 +93,7 @@ public class FieldStructureParser {
         fieldConfig.fieldPath(), InitCodeLineType.Unknown, valueConfig, null);
   }
 
-  private static InitFieldConfig createInitFieldConfig(String initFieldConfigString) {
+  private static InitFieldConfig parseInitFieldConfig(String initFieldConfigString) {
     String fieldName = null;
     String entityName = null;
     String value = null;

--- a/src/main/java/com/google/api/codegen/metacode/InitCodeNode.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitCodeNode.java
@@ -75,7 +75,7 @@ public class InitCodeNode {
   /*
    * Updates the InitValueConfig.
    */
-  public void updateInitValueConfig(InitValueConfig initValueConfig) {
+  private void updateInitValueConfig(InitValueConfig initValueConfig) {
     this.initValueConfig = initValueConfig;
   }
 
@@ -192,10 +192,10 @@ public class InitCodeNode {
         && oldConfig.getInitialValue().equals(newConfig.getInitialValue())) {
       throw new IllegalArgumentException("Inconsistent init values");
     }
-    if (oldConfig.hasFormattedInitialValue()) {
+    if (oldConfig.hasFormattingConfigInitialValues()) {
       collectionValues.putAll(oldConfig.getCollectionValues());
     }
-    if (newConfig.hasFormattedInitialValue()) {
+    if (newConfig.hasFormattingConfigInitialValues()) {
       collectionValues.putAll(newConfig.getCollectionValues());
     }
     return oldConfig.withInitialCollectionValues(collectionValues);

--- a/src/main/java/com/google/api/codegen/metacode/InitCodeNode.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitCodeNode.java
@@ -189,7 +189,7 @@ public class InitCodeNode {
     HashMap<String, String> collectionValues = new HashMap<>();
     if (oldConfig.hasSimpleInitialValue()
         && newConfig.hasSimpleInitialValue()
-        && oldConfig.getInitialValue().equals(newConfig.getInitialValue())) {
+        && !oldConfig.getInitialValue().equals(newConfig.getInitialValue())) {
       throw new IllegalArgumentException("Inconsistent init values");
     }
     if (oldConfig.hasFormattingConfigInitialValues()) {

--- a/src/main/java/com/google/api/codegen/metacode/InitFieldConfig.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitFieldConfig.java
@@ -60,6 +60,10 @@ public abstract class InitFieldConfig {
     return entityName() == null && value() != null;
   }
 
+  public boolean isFormattedConfig() {
+    return entityName() != null;
+  }
+
   public boolean hasFormattedInitValue() {
     return entityName() != null && value() != null;
   }

--- a/src/main/java/com/google/api/codegen/metacode/InitFieldConfig.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitFieldConfig.java
@@ -34,7 +34,7 @@ public abstract class InitFieldConfig {
   /*
    * Parses the given config string and returns the corresponding object.
    */
-  public static InitFieldConfig of(String initFieldConfigString) {
+  public static InitFieldConfig from(String initFieldConfigString) {
     String fieldName = null;
     String entityName = null;
     String value = null;
@@ -56,11 +56,11 @@ public abstract class InitFieldConfig {
     return new AutoValue_InitFieldConfig(fieldName, entityName, value);
   }
 
-  public boolean hasInitValue() {
-    return value() != null;
+  public boolean hasSimpleInitValue() {
+    return entityName() == null && value() != null;
   }
 
-  public boolean isFormattedField() {
-    return entityName() != null;
+  public boolean hasFormattedInitValue() {
+    return entityName() != null && value() != null;
   }
 }

--- a/src/main/java/com/google/api/codegen/metacode/InitFieldConfig.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitFieldConfig.java
@@ -1,0 +1,66 @@
+/* Copyright 2016 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.metacode;
+
+import com.google.auto.value.AutoValue;
+
+import javax.annotation.Nullable;
+
+/*
+ * A meta data class which stores the configuration data of a initialized field.
+ */
+@AutoValue
+public abstract class InitFieldConfig {
+  public abstract String fieldPath();
+
+  @Nullable
+  public abstract String entityName();
+
+  @Nullable
+  public abstract String value();
+
+  /*
+   * Parses the given config string and returns the corresponding object.
+   */
+  public static InitFieldConfig of(String initFieldConfigString) {
+    String fieldName = null;
+    String entityName = null;
+    String value = null;
+
+    String[] equalsParts = initFieldConfigString.split("[=]");
+    if (equalsParts.length > 2) {
+      throw new IllegalArgumentException("Inconsistent: found multiple '=' characters");
+    } else if (equalsParts.length == 2) {
+      value = equalsParts[1];
+    }
+
+    String[] fieldSpecs = equalsParts[0].split("[%]");
+    fieldName = fieldSpecs[0];
+    if (fieldSpecs.length == 2) {
+      entityName = fieldSpecs[1];
+    } else if (fieldSpecs.length > 2) {
+      throw new IllegalArgumentException("Inconsistent: found multiple '%' characters");
+    }
+    return new AutoValue_InitFieldConfig(fieldName, entityName, value);
+  }
+
+  public boolean hasInitValue() {
+    return value() != null;
+  }
+
+  public boolean isFormattedField() {
+    return entityName() != null;
+  }
+}

--- a/src/main/java/com/google/api/codegen/metacode/InitTreeParserContext.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitTreeParserContext.java
@@ -44,7 +44,7 @@ public abstract class InitTreeParserContext {
   public abstract Map<String, InitValueConfig> initValueConfigMap();
 
   @Nullable
-  public abstract List<String> dottedPathStrings();
+  public abstract List<String> initFieldConfigStrings();
 
   @Nullable
   public abstract List<InitCodeNode> additionalSubTrees();
@@ -67,7 +67,7 @@ public abstract class InitTreeParserContext {
 
     public abstract Builder initValueConfigMap(Map<String, InitValueConfig> val);
 
-    public abstract Builder dottedPathStrings(List<String> val);
+    public abstract Builder initFieldConfigStrings(List<String> val);
 
     public abstract Builder additionalSubTrees(List<InitCodeNode> val);
 

--- a/src/main/java/com/google/api/codegen/metacode/InitValueConfig.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitValueConfig.java
@@ -17,24 +17,32 @@ package com.google.api.codegen.metacode;
 import com.google.api.codegen.CollectionConfig;
 import com.google.auto.value.AutoValue;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import javax.annotation.Nullable;
 
-/**
- * InitValueConfig configures the initial value of an initialized variable.
- */
+/** InitValueConfig configures the initial value of an initialized variable. */
 @AutoValue
 public abstract class InitValueConfig {
 
   public static InitValueConfig create() {
-    return new AutoValue_InitValueConfig(null, null, null);
+    return new AutoValue_InitValueConfig(null, null, null, null);
   }
 
   public static InitValueConfig createWithValue(String value) {
-    return new AutoValue_InitValueConfig(null, null, value);
+    return new AutoValue_InitValueConfig(null, null, value, null);
   }
 
   public static InitValueConfig create(String apiWrapperName, CollectionConfig collectionConfig) {
-    return new AutoValue_InitValueConfig(apiWrapperName, collectionConfig, null);
+    return new AutoValue_InitValueConfig(apiWrapperName, collectionConfig, null, null);
+  }
+
+  public static InitValueConfig create(
+      String apiWrapperName,
+      CollectionConfig collectionConfig,
+      Map<String, String> collectionValues) {
+    return new AutoValue_InitValueConfig(apiWrapperName, collectionConfig, null, collectionValues);
   }
 
   @Nullable
@@ -46,11 +54,24 @@ public abstract class InitValueConfig {
   @Nullable
   public abstract String getInitialValue();
 
-  /**
-   * Creates an updated InitValueConfig with the provided value.
-   */
+  @Nullable
+  public abstract Map<String, String> getCollectionValues();
+
+  /** Creates an updated InitValueConfig with the provided value. */
   public InitValueConfig withInitialValue(String string) {
-    return new AutoValue_InitValueConfig(getApiWrapperName(), getCollectionConfig(), string);
+    return new AutoValue_InitValueConfig(getApiWrapperName(), getCollectionConfig(), string, null);
+  }
+
+  /** Creates an updated InitValueConfig with the provided value. */
+  public InitValueConfig withInitialCollectionValue(String entityName, String value) {
+    HashMap<String, String> collectionValues = new HashMap<>();
+    collectionValues.put(entityName, value);
+    return withInitialCollectionValues(collectionValues);
+  }
+
+  public InitValueConfig withInitialCollectionValues(Map<String, String> collectionValues) {
+    return new AutoValue_InitValueConfig(
+        getApiWrapperName(), getCollectionConfig(), null, collectionValues);
   }
 
   public boolean isEmpty() {
@@ -61,7 +82,11 @@ public abstract class InitValueConfig {
     return getCollectionConfig() != null;
   }
 
-  public boolean hasInitialValue() {
+  public boolean hasFormattedInitialValue() {
+    return getCollectionValues() != null && !getCollectionValues().isEmpty();
+  }
+
+  public boolean hasSimpleInitialValue() {
     return getInitialValue() != null;
   }
 }

--- a/src/main/java/com/google/api/codegen/metacode/InitValueConfig.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitValueConfig.java
@@ -58,11 +58,6 @@ public abstract class InitValueConfig {
   public abstract Map<String, String> getCollectionValues();
 
   /** Creates an updated InitValueConfig with the provided value. */
-  public InitValueConfig withInitialValue(String string) {
-    return new AutoValue_InitValueConfig(getApiWrapperName(), getCollectionConfig(), string, null);
-  }
-
-  /** Creates an updated InitValueConfig with the provided value. */
   public InitValueConfig withInitialCollectionValue(String entityName, String value) {
     HashMap<String, String> collectionValues = new HashMap<>();
     collectionValues.put(entityName, value);
@@ -82,7 +77,7 @@ public abstract class InitValueConfig {
     return getCollectionConfig() != null;
   }
 
-  public boolean hasFormattedInitialValue() {
+  public boolean hasFormattingConfigInitialValues() {
     return getCollectionValues() != null && !getCollectionValues().isEmpty();
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
@@ -42,6 +42,7 @@ import com.google.api.tools.framework.model.Field;
 import com.google.api.tools.framework.model.TypeRef;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -129,7 +130,7 @@ public class InitCodeTransformer {
                 .table(table)
                 .rootObjectType(testConfig.getMethod().getInputType())
                 .initValueConfigMap(createCollectionMap(context))
-                .initFieldConfigStrings(testConfig.getInitFieldSpecs())
+                .initFieldConfigStrings(testConfig.getInitFieldConfigStrings())
                 .suggestedName(Name.from("request"))
                 .build());
     return buildInitCodeViewFlattened(context, rootNode);
@@ -361,7 +362,7 @@ public class InitCodeTransformer {
       for (String entityName : initValueConfig.getCollectionConfig().getNameTemplate().vars()) {
         String entityValue =
             "\"[" + LanguageUtil.lowerUnderscoreToUpperUnderscore(entityName) + "]\"";
-        if (initValueConfig.hasFormattedInitialValue()
+        if (initValueConfig.hasFormattingConfigInitialValues()
             && initValueConfig.getCollectionValues().containsKey(entityName)) {
           entityValue = initValueConfig.getCollectionValues().get(entityName);
         }

--- a/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
@@ -42,7 +42,6 @@ import com.google.api.tools.framework.model.Field;
 import com.google.api.tools.framework.model.TypeRef;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -59,8 +58,8 @@ public class InitCodeTransformer {
             InitTreeParserContext.newBuilder()
                 .table(new SymbolTable())
                 .rootObjectType(context.getMethod().getInputType())
-                .initValueConfigMap(createInitValueMap(context))
-                .dottedPathStrings(context.getMethodConfig().getSampleCodeInitFields())
+                .initValueConfigMap(createCollectionMap(context))
+                .initFieldConfigStrings(context.getMethodConfig().getSampleCodeInitFields())
                 .initFields(fields)
                 .suggestedName(Name.from("request"))
                 .build());
@@ -73,8 +72,8 @@ public class InitCodeTransformer {
             InitTreeParserContext.newBuilder()
                 .table(new SymbolTable())
                 .rootObjectType(context.getMethod().getInputType())
-                .initValueConfigMap(createInitValueMap(context))
-                .dottedPathStrings(context.getMethodConfig().getSampleCodeInitFields())
+                .initValueConfigMap(createCollectionMap(context))
+                .initFieldConfigStrings(context.getMethodConfig().getSampleCodeInitFields())
                 .suggestedName(Name.from("request"))
                 .build());
     return buildInitCodeViewRequestObject(context, rootNode);
@@ -91,8 +90,8 @@ public class InitCodeTransformer {
                 .table(table)
                 .valueGenerator(valueGenerator)
                 .rootObjectType(context.getMethod().getInputType())
-                .initValueConfigMap(createInitValueMap(context))
-                .dottedPathStrings(context.getMethodConfig().getSampleCodeInitFields())
+                .initValueConfigMap(createCollectionMap(context))
+                .initFieldConfigStrings(context.getMethodConfig().getSampleCodeInitFields())
                 .initFields(fields)
                 .suggestedName(Name.from("request"))
                 .build());
@@ -113,7 +112,7 @@ public class InitCodeTransformer {
                 .table(table)
                 .valueGenerator(valueGenerator)
                 .rootObjectType(context.getMethod().getOutputType())
-                .initValueConfigMap(createInitValueMap(context))
+                .initValueConfigMap(createCollectionMap(context))
                 .additionalSubTrees(createMockResponseAdditionalSubTrees(context))
                 .initFields(primitiveFields)
                 .suggestedName(Name.from("expected_response"))
@@ -129,8 +128,8 @@ public class InitCodeTransformer {
             InitTreeParserContext.newBuilder()
                 .table(table)
                 .rootObjectType(testConfig.getMethod().getInputType())
-                .initValueConfigMap(createInitValueMap(context))
-                .dottedPathStrings(testConfig.getInitFields())
+                .initValueConfigMap(createCollectionMap(context))
+                .initFieldConfigStrings(testConfig.getInitFieldSpecs())
                 .suggestedName(Name.from("request"))
                 .build());
     return buildInitCodeViewFlattened(context, rootNode);
@@ -144,7 +143,7 @@ public class InitCodeTransformer {
             InitTreeParserContext.newBuilder()
                 .table(new SymbolTable())
                 .rootObjectType(context.getMethod().getInputType())
-                .initValueConfigMap(createInitValueMap(context))
+                .initValueConfigMap(createCollectionMap(context))
                 .initFields(fields)
                 .suggestedName(Name.from("request"))
                 .build());
@@ -233,7 +232,7 @@ public class InitCodeTransformer {
     return additionalSubTrees;
   }
 
-  private ImmutableMap<String, InitValueConfig> createInitValueMap(
+  private ImmutableMap<String, InitValueConfig> createCollectionMap(
       MethodTransformerContext context) {
     Map<String, String> fieldNamePatterns = context.getMethodConfig().getFieldNamePatterns();
     ImmutableMap.Builder<String, InitValueConfig> mapBuilder = ImmutableMap.builder();
@@ -359,8 +358,14 @@ public class InitCodeTransformer {
       initValue.formatFunctionName(
           context.getNamer().getFormatFunctionName(initValueConfig.getCollectionConfig()));
       List<String> formatFunctionArgs = new ArrayList<>();
-      for (String var : initValueConfig.getCollectionConfig().getNameTemplate().vars()) {
-        formatFunctionArgs.add("\"[" + LanguageUtil.lowerUnderscoreToUpperUnderscore(var) + "]\"");
+      for (String entityName : initValueConfig.getCollectionConfig().getNameTemplate().vars()) {
+        String entityValue =
+            "\"[" + LanguageUtil.lowerUnderscoreToUpperUnderscore(entityName) + "]\"";
+        if (initValueConfig.hasFormattedInitialValue()
+            && initValueConfig.getCollectionValues().containsKey(entityName)) {
+          entityValue = initValueConfig.getCollectionValues().get(entityName);
+        }
+        formatFunctionArgs.add(entityValue);
       }
       initValue.formatArgs(formatFunctionArgs);
 
@@ -368,7 +373,7 @@ public class InitCodeTransformer {
     } else {
       SimpleInitValueView.Builder initValue = SimpleInitValueView.newBuilder();
 
-      if (initValueConfig.hasInitialValue()) {
+      if (initValueConfig.hasSimpleInitialValue()) {
         initValue.initialValue(
             context.getTypeTable().renderPrimitiveValue(type, initValueConfig.getInitialValue()));
       } else {

--- a/src/test/java/com/google/api/codegen/metacode/SampleInitCodeTest.java
+++ b/src/test/java/com/google/api/codegen/metacode/SampleInitCodeTest.java
@@ -26,17 +26,16 @@ import com.google.api.tools.framework.setup.StandardSetup;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.truth.Truth;
-
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class SampleInitCodeTest {
 
@@ -161,6 +160,21 @@ public class SampleInitCodeTest {
   }
 
   @Test
+  public void testFormattedField() throws Exception {
+    String fieldSpec = "name%entity";
+
+    InitCodeNode expectedStructure =
+        InitCodeNode.createWithChildren("name", InitCodeLineType.SimpleInitLine);
+
+    HashMap<String, InitValueConfig> initValueMap = new HashMap<>();
+    InitValueConfig initValueConfig = InitValueConfig.create("test-api", null);
+    initValueMap.put("name", initValueConfig);
+
+    InitCodeNode actualStructure = FieldStructureParser.parse(fieldSpec, initValueMap);
+    Truth.assertThat(checkEquals(actualStructure, expectedStructure));
+  }
+
+  @Test
   public void testNestedMixedField() throws Exception {
     String fieldSpec = "mylist[0]{key}";
 
@@ -215,57 +229,63 @@ public class SampleInitCodeTest {
   }
 
   @Test(expected = IllegalArgumentException.class)
+  public void testFormattedFieldBadField() throws Exception {
+    String fieldSpec = "name%entity=test";
+    FieldStructureParser.parse(fieldSpec);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
   public void testListFieldBadIndex() throws Exception {
     List<String> fieldSpecs = Arrays.asList("mylist[1]");
-    InitCodeNode.createTree(getContextBuilder().dottedPathStrings(fieldSpecs).build());
+    InitCodeNode.createTree(getContextBuilder().initFieldConfigStrings(fieldSpecs).build());
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testListFieldIndexGap() throws Exception {
     List<String> fieldSpecs = Arrays.asList("mylist[0]", "mylist[2]");
-    InitCodeNode.createTree(getContextBuilder().dottedPathStrings(fieldSpecs).build());
+    InitCodeNode.createTree(getContextBuilder().initFieldConfigStrings(fieldSpecs).build());
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testListFieldMismatchedListThenField() throws Exception {
     List<String> fieldSpecs = Arrays.asList("myfield[0]", "myfield.subfield");
-    InitCodeNode.createTree(getContextBuilder().dottedPathStrings(fieldSpecs).build());
+    InitCodeNode.createTree(getContextBuilder().initFieldConfigStrings(fieldSpecs).build());
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testListFieldMismatchedFieldThenList() throws Exception {
     List<String> fieldSpecs = Arrays.asList("myfield.subfield", "myfield[0]");
-    InitCodeNode.createTree(getContextBuilder().dottedPathStrings(fieldSpecs).build());
+    InitCodeNode.createTree(getContextBuilder().initFieldConfigStrings(fieldSpecs).build());
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testBadField() throws Exception {
     List<String> fieldSpecs = Arrays.asList("notafield");
-    InitCodeNode.createTree(getContextBuilder().dottedPathStrings(fieldSpecs).build());
+    InitCodeNode.createTree(getContextBuilder().initFieldConfigStrings(fieldSpecs).build());
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testBadSubField() throws Exception {
     List<String> fieldSpecs = Arrays.asList("myfield.notafield");
-    InitCodeNode.createTree(getContextBuilder().dottedPathStrings(fieldSpecs).build());
+    InitCodeNode.createTree(getContextBuilder().initFieldConfigStrings(fieldSpecs).build());
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testMapFieldBadStringIndexUnclosedDoubleQuotes() throws Exception {
     List<String> fieldSpecs = Arrays.asList("stringmap{\"key}");
-    InitCodeNode.createTree(getContextBuilder().dottedPathStrings(fieldSpecs).build());
+    InitCodeNode.createTree(getContextBuilder().initFieldConfigStrings(fieldSpecs).build());
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testMapFieldBadStringIndexUnclosedSingleQuotes() throws Exception {
     List<String> fieldSpecs = Arrays.asList("stringmap{'key}");
-    InitCodeNode.createTree(getContextBuilder().dottedPathStrings(fieldSpecs).build());
+    InitCodeNode.createTree(getContextBuilder().initFieldConfigStrings(fieldSpecs).build());
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testMapFieldBadIntIndex() throws Exception {
     List<String> fieldSpecs = Arrays.asList("intmap{\"key\"}");
-    InitCodeNode.createTree(getContextBuilder().dottedPathStrings(fieldSpecs).build());
+    InitCodeNode.createTree(getContextBuilder().initFieldConfigStrings(fieldSpecs).build());
   }
 
   @Test
@@ -277,7 +297,7 @@ public class SampleInitCodeTest {
         Lists.newArrayList("mylist", "myfield", "secondfield", "stringmap", "intmap", "root");
 
     InitCodeNode rootNode =
-        InitCodeNode.createTree(getContextBuilder().dottedPathStrings(fieldSpecs).build());
+        InitCodeNode.createTree(getContextBuilder().initFieldConfigStrings(fieldSpecs).build());
     List<String> actualKeyList = new ArrayList<>();
     for (InitCodeNode node : rootNode.listInInitializationOrder()) {
       actualKeyList.add(node.getKey());
@@ -292,7 +312,7 @@ public class SampleInitCodeTest {
     List<String> expectedKeyList = Arrays.asList("0", "1", "mylist", "root");
 
     InitCodeNode rootNode =
-        InitCodeNode.createTree(getContextBuilder().dottedPathStrings(fieldSpecs).build());
+        InitCodeNode.createTree(getContextBuilder().initFieldConfigStrings(fieldSpecs).build());
     List<String> actualKeyList = new ArrayList<>();
     for (InitCodeNode node : rootNode.listInInitializationOrder()) {
       actualKeyList.add(node.getKey());
@@ -309,7 +329,24 @@ public class SampleInitCodeTest {
         Arrays.asList("key1", "key2", "stringmap", "123", "456", "intmap", "root");
 
     InitCodeNode rootNode =
-        InitCodeNode.createTree(getContextBuilder().dottedPathStrings(fieldSpecs).build());
+        InitCodeNode.createTree(getContextBuilder().initFieldConfigStrings(fieldSpecs).build());
+    List<String> actualKeyList = new ArrayList<>();
+    for (InitCodeNode node : rootNode.listInInitializationOrder()) {
+      actualKeyList.add(node.getKey());
+    }
+    Truth.assertThat(actualKeyList.equals(expectedKeyList));
+  }
+
+  @Test
+  public void testMultipleFormattedEntries() throws Exception {
+    List<String> fieldSpecs =
+        Arrays.asList(
+            "formatted_field%entity1", "formatted_field%entity2", "formatted_field%entity3");
+
+    List<String> expectedKeyList = Arrays.asList("formattedField");
+
+    InitCodeNode rootNode =
+        InitCodeNode.createTree(getContextBuilder().initFieldConfigStrings(fieldSpecs).build());
     List<String> actualKeyList = new ArrayList<>();
     for (InitCodeNode node : rootNode.listInInitializationOrder()) {
       actualKeyList.add(node.getKey());
@@ -325,7 +362,7 @@ public class SampleInitCodeTest {
         Arrays.asList("subfield", "subsecondfield", "0", "mylist", "root");
 
     InitCodeNode rootNode =
-        InitCodeNode.createTree(getContextBuilder().dottedPathStrings(fieldSpecs).build());
+        InitCodeNode.createTree(getContextBuilder().initFieldConfigStrings(fieldSpecs).build());
     List<String> actualKeyList = new ArrayList<>();
     for (InitCodeNode node : rootNode.listInInitializationOrder()) {
       actualKeyList.add(node.getKey());
@@ -340,7 +377,7 @@ public class SampleInitCodeTest {
     List<String> expectedKeyList = Arrays.asList("subfield", "myfield", "root");
 
     InitCodeNode rootNode =
-        InitCodeNode.createTree(getContextBuilder().dottedPathStrings(fieldSpecs).build());
+        InitCodeNode.createTree(getContextBuilder().initFieldConfigStrings(fieldSpecs).build());
     List<String> actualKeyList = new ArrayList<>();
     for (InitCodeNode node : rootNode.listInInitializationOrder()) {
       actualKeyList.add(node.getKey());
@@ -355,7 +392,7 @@ public class SampleInitCodeTest {
     List<String> expectedKeyList = Arrays.asList("subfield", "0", "mylist", "root");
 
     InitCodeNode rootNode =
-        InitCodeNode.createTree(getContextBuilder().dottedPathStrings(fieldSpecs).build());
+        InitCodeNode.createTree(getContextBuilder().initFieldConfigStrings(fieldSpecs).build());
     List<String> actualKeyList = new ArrayList<>();
     for (InitCodeNode node : rootNode.listInInitializationOrder()) {
       actualKeyList.add(node.getKey());

--- a/src/test/java/com/google/api/codegen/metacode/SampleInitCodeTest.java
+++ b/src/test/java/com/google/api/codegen/metacode/SampleInitCodeTest.java
@@ -163,15 +163,14 @@ public class SampleInitCodeTest {
   public void testFormattedField() throws Exception {
     String fieldSpec = "name%entity";
 
-    InitCodeNode expectedStructure =
-        InitCodeNode.createWithChildren("name", InitCodeLineType.SimpleInitLine);
-
     HashMap<String, InitValueConfig> initValueMap = new HashMap<>();
     InitValueConfig initValueConfig = InitValueConfig.create("test-api", null);
     initValueMap.put("name", initValueConfig);
 
+    InitCodeNode expectedStructure = InitCodeNode.createWithValue("name", initValueConfig);
+
     InitCodeNode actualStructure = FieldStructureParser.parse(fieldSpec, initValueMap);
-    Truth.assertThat(checkEquals(actualStructure, expectedStructure));
+    Truth.assertThat(checkEquals(actualStructure, expectedStructure)).isTrue();
   }
 
   @Test
@@ -343,7 +342,7 @@ public class SampleInitCodeTest {
         Arrays.asList(
             "formatted_field%entity1", "formatted_field%entity2", "formatted_field%entity3");
 
-    List<String> expectedKeyList = Arrays.asList("formattedField");
+    List<String> expectedKeyList = Arrays.asList("formatted_field", "root");
 
     InitCodeNode rootNode =
         InitCodeNode.createTree(getContextBuilder().initFieldConfigStrings(fieldSpecs).build());

--- a/src/test/java/com/google/api/codegen/metacode/SampleInitCodeTest.java
+++ b/src/test/java/com/google/api/codegen/metacode/SampleInitCodeTest.java
@@ -26,18 +26,16 @@ import com.google.api.tools.framework.setup.StandardSetup;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.truth.Truth;
-
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 public class SampleInitCodeTest {
 
@@ -264,6 +262,12 @@ public class SampleInitCodeTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void testFormattedFieldBadField() throws Exception {
+    String fieldSpec = "name%entity";
+    FieldStructureParser.parse(fieldSpec);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testFormattedFieldBadFieldWithValue() throws Exception {
     String fieldSpec = "name%entity=test";
     FieldStructureParser.parse(fieldSpec);
   }
@@ -379,8 +383,16 @@ public class SampleInitCodeTest {
 
     List<String> expectedKeyList = Arrays.asList("formatted_field", "root");
 
+    HashMap<String, InitValueConfig> initValueMap = new HashMap<>();
+    InitValueConfig initValueConfig = InitValueConfig.create("test-api", null);
+    initValueMap.put("formatted_field", initValueConfig);
+
     InitCodeNode rootNode =
-        InitCodeNode.createTree(getContextBuilder().initFieldConfigStrings(fieldSpecs).build());
+        InitCodeNode.createTree(
+            getContextBuilder()
+                .initFieldConfigStrings(fieldSpecs)
+                .initValueConfigMap(initValueMap)
+                .build());
     List<String> actualKeyList = new ArrayList<>();
     for (InitCodeNode node : rootNode.listInInitializationOrder()) {
       actualKeyList.add(node.getKey());

--- a/src/test/java/com/google/api/codegen/metacode/testdata/myproto.proto
+++ b/src/test/java/com/google/api/codegen/metacode/testdata/myproto.proto
@@ -15,6 +15,8 @@ message MethodRequest {
 
   map<string, string> stringmap = 4;
   map<int32, string> intmap = 5;
+
+  string formatted_field = 6;
 }
 
 message SubMessage {

--- a/src/test/java/com/google/api/codegen/testdata/java_smoke_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_smoke_test_library.baseline
@@ -17,7 +17,7 @@ package com.google.gcloud.pubsub.spi;
 
 import com.google.api.gax.core.PagedListResponse;
 import com.google.common.collect.Lists;
-import com.google.example.library.v1.Shelf;
+import com.google.example.library.v1.Book;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -40,9 +40,9 @@ public class LibraryServiceSmokeTest {
 
   public static void executeNoCatch(String args[]) throws Exception {
     try (LibraryServiceApi api = LibraryServiceApi.create()) {
-      Shelf shelf = Shelf.newBuilder().build();
+      String formattedName = LibraryServiceApi.formatBookName("testShelf", "testBook");
 
-      Shelf response = api.createShelf(shelf);
+      Book response = api.getBook(formattedName);
       System.out.println(ReflectionToStringBuilder.toString(response, ToStringStyle.MULTI_LINE_STYLE));
     }
   }

--- a/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
@@ -43,9 +43,10 @@ interfaces:
   - name_pattern: archives/{archive_path=**}/books/{book}
     entity_name: archived_book
   smoke_test:
-    method: CreateShelf
+    method: GetBook
     init_fields:
-      - shelf
+      - name%shelf="testShelf"
+      - name%book="testBook"
   methods:
   - name: CreateShelf
     flattening:


### PR DESCRIPTION
- Implemented a new field spec rule in GAPIC yaml: `field_name%entity_name=value` which allows value assignments of path template variables.
- Refactor FieldStructureParser by creating a new class which stores config data
- Handles the case that the init values may have conflicts.
- A few renames
  - dottedPathStrings -> initFieldConfigStrings
  - hasInitialValue -> hasSimpleInitialValue

Tests:
 - Unit tests
 - Baseline tests