### PR TITLE
Removing unused reference (grpc container in mock service)

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
@@ -289,13 +289,10 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
     SurfaceNamer namer = context.getNamer();
     String outputPath = pathMapper.getOutputPath(service, context.getApiConfig());
     String name = namer.getMockServiceClassName(context.getInterface());
-    String grpcContainerName =
-        context.getTypeTable().getAndSaveNicknameFor(namer.getGrpcContainerTypeName(service));
     return MockServiceView.newBuilder()
         .name(name)
         .serviceImplClassName(namer.getMockGrpcServiceImplName(context.getInterface()))
         .packageName(context.getApiConfig().getPackageName())
-        .grpcContainerName(grpcContainerName)
         .outputPath(namer.getSourceFilePath(outputPath, name))
         .templateFileName(MOCK_SERVICE_FILE)
         // Imports must be done as the last step to catch all imports.

--- a/src/main/java/com/google/api/codegen/viewmodel/testing/MockServiceView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/testing/MockServiceView.java
@@ -29,8 +29,6 @@ public abstract class MockServiceView implements ViewModel {
 
   public abstract String serviceImplClassName();
 
-  public abstract String grpcContainerName();
-
   public abstract List<ImportTypeView> imports();
 
   @Override
@@ -55,8 +53,6 @@ public abstract class MockServiceView implements ViewModel {
     public abstract Builder name(String val);
 
     public abstract Builder serviceImplClassName(String val);
-
-    public abstract Builder grpcContainerName(String val);
 
     public abstract Builder imports(List<ImportTypeView> val);
 

--- a/src/test/java/com/google/api/codegen/testdata/java_mock_service_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_mock_service_library.baseline
@@ -17,7 +17,6 @@ package com.google.gcloud.pubsub.spi;
 
 import com.google.api.gax.testing.MockGrpcService;
 import com.google.protobuf.GeneratedMessageV3;
-import com.google.tagger.v1.LabelerGrpc;
 import io.grpc.ServerServiceDefinition;
 import java.util.List;
 
@@ -67,7 +66,6 @@ public class MockLabeler implements MockGrpcService  {
 package com.google.gcloud.pubsub.spi;
 
 import com.google.api.gax.testing.MockGrpcService;
-import com.google.example.library.v1.LibraryServiceGrpc;
 import com.google.protobuf.GeneratedMessageV3;
 import io.grpc.ServerServiceDefinition;
 import java.util.List;


### PR DESCRIPTION
This no longer necessary after https://github.com/googleapis/toolkit/commit/702e06aa02bb48cdb74a61eebf1bce41039bea7c (since you can call bindService() directly on a service impl)