### PR TITLE
Clarify placeholder TODO for singleton parameters in discovery samples.

### DIFF
--- a/src/main/resources/com/google/api/codegen/csharp/discovery_fragment.snip
+++ b/src/main/resources/com/google/api/codegen/csharp/discovery_fragment.snip
@@ -117,7 +117,11 @@
     {@BREAK}
     @if sample.params
 
-        // {@TODO()} Change placeholders below to desired parameter values for the `{@sample.methodName}` method:
+        @if context.isSingleton(sample.params)
+            // {@TODO()} Change placeholder below to desired parameter value for the `{@sample.methodName}` method:
+        @else
+            // {@TODO()} Change placeholders below to desired parameter values for the `{@sample.methodName}` method:
+        @end
 
         @join param : sample.params
             {@description(param.description)}

--- a/src/main/resources/com/google/api/codegen/nodejs/discovery_fragment.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/discovery_fragment.snip
@@ -99,7 +99,11 @@
        params = context.getFlatMethodParams(method)
     @if params
 
-      // {@TODO()} Change placeholders below to desired parameter values for the `{@methodName}` method:
+      @if context.isSingleton(params)
+        // {@TODO()} Change placeholder below to desired parameter value for the `{@methodName}` method:
+      @else
+        // {@TODO()} Change placeholders below to desired parameter values for the `{@methodName}` method:
+      @end
 
       @join param : params
         @let paramField = context.getField(signatureType, param), \

--- a/src/main/resources/com/google/api/codegen/php/discovery_fragment.snip
+++ b/src/main/resources/com/google/api/codegen/php/discovery_fragment.snip
@@ -103,7 +103,11 @@
        params = context.getFlatMethodParams(method)
     @if params
 
-      // {@TODO()} Change placeholders below to desired parameter values for the `{@methodName}` method:
+      @if context.isSingleton(params)
+        // {@TODO()} Change placeholder below to desired parameter value for the `{@methodName}` method:
+      @else
+        // {@TODO()} Change placeholders below to desired parameter values for the `{@methodName}` method:
+      @end
 
       @join param : params
         @let paramField = context.getField(signatureType, param), \

--- a/src/main/resources/com/google/api/codegen/py/discovery_fragment.snip
+++ b/src/main/resources/com/google/api/codegen/py/discovery_fragment.snip
@@ -164,7 +164,11 @@
          params = context.getFlatMethodParams(method)
         @if params
 
-            @# {@TODO()} Change placeholders below to desired parameter values for the `{@methodName}` method:
+            @if context.isSingleton(params)
+                @# {@TODO()} Change placeholder below to desired parameter value for the `{@methodName}` method:
+            @else
+                @# {@TODO()} Change placeholders below to desired parameter values for the `{@methodName}` method:
+            @end
 
             @join param : params
                 @let paramField = context.getField(signatureType, param), \
@@ -173,9 +177,9 @@
                      paramDescription = context.getDescription(signatureType.getName, param)
                     {@description(paramDescription)}
                     @if paramSample
-                      {@param} = {@paramValue}  @# {@paramSample}
+                        {@param} = {@paramValue}  @# {@paramSample}
                     @else
-                      {@param} = {@paramValue}
+                        {@param} = {@paramValue}
                     @end
 
                 @end

--- a/src/main/resources/com/google/api/codegen/ruby/discovery_fragment.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/discovery_fragment.snip
@@ -82,7 +82,11 @@
        ApiVersion = context.lowerCamelToUpperCamel(apiVersion)
     @if params
 
-      @# {@TODO()} Change placeholders below to desired parameter values for the `{@methodName}` method:
+      @if context.isSingleton(params)
+        @# {@TODO()} Change placeholder below to desired parameter value for the `{@methodName}` method:
+      @else
+        @# {@TODO()} Change placeholders below to desired parameter values for the `{@methodName}` method:
+      @end
 
       @join param : params
         @let paramField = context.getField(signatureType, param), \

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_adexchangebuyer.v1.4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_adexchangebuyer.v1.4.json.baseline
@@ -32,7 +32,7 @@ namespace AdExchangeBuyerSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Get` method:
+            // TODO: Change placeholder below to desired parameter value for the `Get` method:
 
             // The account id
             int id = 0;
@@ -143,7 +143,7 @@ namespace AdExchangeBuyerSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Patch` method:
+            // TODO: Change placeholder below to desired parameter value for the `Patch` method:
 
             // The account id
             int id = 0;
@@ -206,7 +206,7 @@ namespace AdExchangeBuyerSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Update` method:
+            // TODO: Change placeholder below to desired parameter value for the `Update` method:
 
             // The account id
             int id = 0;
@@ -269,7 +269,7 @@ namespace AdExchangeBuyerSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Get` method:
+            // TODO: Change placeholder below to desired parameter value for the `Get` method:
 
             // The account id.
             int accountId = 0;
@@ -874,7 +874,7 @@ namespace AdExchangeBuyerSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Delete` method:
+            // TODO: Change placeholder below to desired parameter value for the `Delete` method:
 
             // The proposalId to delete deals from.
             string proposalId = "{MY-PROPOSAL-ID}";
@@ -937,7 +937,7 @@ namespace AdExchangeBuyerSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Insert` method:
+            // TODO: Change placeholder below to desired parameter value for the `Insert` method:
 
             // proposalId for which deals need to be added.
             string proposalId = "{MY-PROPOSAL-ID}";
@@ -1000,7 +1000,7 @@ namespace AdExchangeBuyerSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // The proposalId to get deals for. To search across all proposals specify order_id = '-' as part of
             // the URL.
@@ -1060,7 +1060,7 @@ namespace AdExchangeBuyerSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Update` method:
+            // TODO: Change placeholder below to desired parameter value for the `Update` method:
 
             // The proposalId to edit deals on.
             string proposalId = "{MY-PROPOSAL-ID}";
@@ -1123,7 +1123,7 @@ namespace AdExchangeBuyerSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Insert` method:
+            // TODO: Change placeholder below to desired parameter value for the `Insert` method:
 
             // The proposalId to add notes for.
             string proposalId = "{MY-PROPOSAL-ID}";
@@ -1186,7 +1186,7 @@ namespace AdExchangeBuyerSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // The proposalId to get notes for. To search across all proposals specify order_id = '-' as part of
             // the URL.
@@ -1245,7 +1245,7 @@ namespace AdExchangeBuyerSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Updateproposal` method:
+            // TODO: Change placeholder below to desired parameter value for the `Updateproposal` method:
 
             // The private auction id to be updated.
             string privateAuctionId = "{MY-PRIVATE-AUCTION-ID}";
@@ -1488,7 +1488,7 @@ namespace AdExchangeBuyerSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Insert` method:
+            // TODO: Change placeholder below to desired parameter value for the `Insert` method:
 
             // The account id to insert the pretargeting config for.
             long accountId = 0L;
@@ -1551,7 +1551,7 @@ namespace AdExchangeBuyerSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // The account id to get the pretargeting configs for.
             long accountId = 0L;
@@ -1742,7 +1742,7 @@ namespace AdExchangeBuyerSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Get` method:
+            // TODO: Change placeholder below to desired parameter value for the `Get` method:
 
             // The id for the product to get the head revision for.
             string productId = "{MY-PRODUCT-ID}";
@@ -1853,7 +1853,7 @@ namespace AdExchangeBuyerSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Get` method:
+            // TODO: Change placeholder below to desired parameter value for the `Get` method:
 
             // Id of the proposal to retrieve.
             string proposalId = "{MY-PROPOSAL-ID}";
@@ -2089,7 +2089,7 @@ namespace AdExchangeBuyerSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Setupcomplete` method:
+            // TODO: Change placeholder below to desired parameter value for the `Setupcomplete` method:
 
             // The proposal id for which the setup is complete
             string proposalId = "{MY-PROPOSAL-ID}";
@@ -2217,7 +2217,7 @@ namespace AdExchangeBuyerSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // The accountId of the publisher to get profiles for.
             int accountId = 0;

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_appengine.v1beta5.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_appengine.v1beta5.json.baseline
@@ -101,7 +101,7 @@ namespace AppengineSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Get` method:
+            // TODO: Change placeholder below to desired parameter value for the `Get` method:
 
             // Part of `name`. Name of the application to get. Example: `apps/myapp`.
             string appsId = "{MY-APPS-ID}";
@@ -226,7 +226,7 @@ namespace AppengineSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // Part of `name`. The resource that owns the locations collection, if applicable.
             string appsId = "{MY-APPS-ID}";
@@ -363,7 +363,7 @@ namespace AppengineSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // Part of `name`. The name of the operation collection.
             string appsId = "{MY-APPS-ID}";
@@ -564,7 +564,7 @@ namespace AppengineSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // Part of `name`. Name of the resource requested. Example: `apps/myapp`.
             string appsId = "{MY-APPS-ID}";

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_bigquery.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_bigquery.v2.json.baseline
@@ -165,7 +165,7 @@ namespace BigquerySample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Insert` method:
+            // TODO: Change placeholder below to desired parameter value for the `Insert` method:
 
             // Project ID of the new dataset
             string projectId = "{MY-PROJECT-ID}";
@@ -230,7 +230,7 @@ namespace BigquerySample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // Project ID of the datasets to be listed
             string projectId = "{MY-PROJECT-ID}";
@@ -631,7 +631,7 @@ namespace BigquerySample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Insert` method:
+            // TODO: Change placeholder below to desired parameter value for the `Insert` method:
 
             // Project ID of the project that will be billed for the job
             string projectId = "{MY-PROJECT-ID}";
@@ -696,7 +696,7 @@ namespace BigquerySample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // Project ID of the jobs to list
             string projectId = "{MY-PROJECT-ID}";
@@ -769,7 +769,7 @@ namespace BigquerySample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Query` method:
+            // TODO: Change placeholder below to desired parameter value for the `Query` method:
 
             // Project ID of the project billed for the query
             string projectId = "{MY-PROJECT-ID}";

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_cloudbilling.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_cloudbilling.v1.json.baseline
@@ -43,7 +43,7 @@ namespace CloudbillingSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Get` method:
+            // TODO: Change placeholder below to desired parameter value for the `Get` method:
 
             // The resource name of the billing account to retrieve. For example,
             // `billingAccounts/012345-567890-ABCDEF`.
@@ -171,7 +171,7 @@ namespace CloudbillingSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // The resource name of the billing account associated with the projects that you want to list. For
             // example, `billingAccounts/012345-567890-ABCDEF`.
@@ -245,7 +245,7 @@ namespace CloudbillingSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `GetBillingInfo` method:
+            // TODO: Change placeholder below to desired parameter value for the `GetBillingInfo` method:
 
             // The resource name of the project for which billing information is retrieved. For example,
             // `projects/tokyo-rain-123`.
@@ -307,7 +307,7 @@ namespace CloudbillingSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `UpdateBillingInfo` method:
+            // TODO: Change placeholder below to desired parameter value for the `UpdateBillingInfo` method:
 
             // The resource name of the project associated with the billing information that you want to update.
             // For example, `projects/tokyo-rain-123`.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_clouddebugger.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_clouddebugger.v2.json.baseline
@@ -43,7 +43,7 @@ namespace CloudDebuggerSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // Identifies the debuggee.
             string debuggeeId = "{MY-DEBUGGEE-ID}";
@@ -358,7 +358,7 @@ namespace CloudDebuggerSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // ID of the debuggee whose breakpoints to list.
             string debuggeeId = "{MY-DEBUGGEE-ID}";
@@ -419,7 +419,7 @@ namespace CloudDebuggerSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Set` method:
+            // TODO: Change placeholder below to desired parameter value for the `Set` method:
 
             // ID of the debuggee where the breakpoint is to be set.
             string debuggeeId = "{MY-DEBUGGEE-ID}";

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_cloudmonitoring.v2beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_cloudmonitoring.v2beta2.json.baseline
@@ -43,7 +43,7 @@ namespace CloudMonitoringSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Create` method:
+            // TODO: Change placeholder below to desired parameter value for the `Create` method:
 
             // The project id. The value can be the numeric project ID or string-based project name.
             string project = "{MY-PROJECT}";
@@ -172,7 +172,7 @@ namespace CloudMonitoringSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // The project id. The value can be the numeric project ID or string-based project name.
             string project = "{MY-PROJECT}";
@@ -334,7 +334,7 @@ namespace CloudMonitoringSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Write` method:
+            // TODO: Change placeholder below to desired parameter value for the `Write` method:
 
             // The project ID. The value can be the numeric project ID or string-based project name.
             string project = "{MY-PROJECT}";

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_cloudresourcemanager.v1beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_cloudresourcemanager.v1beta1.json.baseline
@@ -43,7 +43,7 @@ namespace CloudResourceManagerSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Get` method:
+            // TODO: Change placeholder below to desired parameter value for the `Get` method:
 
             // The resource name of the Organization to fetch. Its format is "organizations/[organization_id]". For
             // example, "organizations/1234".
@@ -105,7 +105,7 @@ namespace CloudResourceManagerSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `GetIamPolicy` method:
+            // TODO: Change placeholder below to desired parameter value for the `GetIamPolicy` method:
 
             // REQUIRED: The resource for which the policy is being requested. `resource` is usually specified as a
             // path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
@@ -238,7 +238,7 @@ namespace CloudResourceManagerSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `SetIamPolicy` method:
+            // TODO: Change placeholder below to desired parameter value for the `SetIamPolicy` method:
 
             // REQUIRED: The resource for which the policy is being specified. `resource` is usually specified as a
             // path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
@@ -305,7 +305,7 @@ namespace CloudResourceManagerSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `TestIamPermissions` method:
+            // TODO: Change placeholder below to desired parameter value for the `TestIamPermissions` method:
 
             // REQUIRED: The resource for which the policy detail is being requested. `resource` is usually
             // specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path
@@ -373,7 +373,7 @@ namespace CloudResourceManagerSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Update` method:
+            // TODO: Change placeholder below to desired parameter value for the `Update` method:
 
             // Output Only. The resource name of the organization. This is the organization's relative path in the
             // API. Its format is "organizations/[organization_id]". For example, "organizations/1234".
@@ -497,7 +497,7 @@ namespace CloudResourceManagerSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Delete` method:
+            // TODO: Change placeholder below to desired parameter value for the `Delete` method:
 
             // The Project ID (for example, `foo-bar-123`). Required.
             string projectId = "{MY-PROJECT-ID}";
@@ -558,7 +558,7 @@ namespace CloudResourceManagerSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Get` method:
+            // TODO: Change placeholder below to desired parameter value for the `Get` method:
 
             // The Project ID (for example, `my-project-123`). Required.
             string projectId = "{MY-PROJECT-ID}";
@@ -619,7 +619,7 @@ namespace CloudResourceManagerSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `GetAncestry` method:
+            // TODO: Change placeholder below to desired parameter value for the `GetAncestry` method:
 
             // The Project ID (for example, `my-project-123`). Required.
             string projectId = "{MY-PROJECT-ID}";
@@ -684,7 +684,7 @@ namespace CloudResourceManagerSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `GetIamPolicy` method:
+            // TODO: Change placeholder below to desired parameter value for the `GetIamPolicy` method:
 
             // REQUIRED: The resource for which the policy is being requested. `resource` is usually specified as a
             // path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
@@ -817,7 +817,7 @@ namespace CloudResourceManagerSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `SetIamPolicy` method:
+            // TODO: Change placeholder below to desired parameter value for the `SetIamPolicy` method:
 
             // REQUIRED: The resource for which the policy is being specified. `resource` is usually specified as a
             // path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
@@ -884,7 +884,7 @@ namespace CloudResourceManagerSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `TestIamPermissions` method:
+            // TODO: Change placeholder below to desired parameter value for the `TestIamPermissions` method:
 
             // REQUIRED: The resource for which the policy detail is being requested. `resource` is usually
             // specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path
@@ -952,7 +952,7 @@ namespace CloudResourceManagerSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Undelete` method:
+            // TODO: Change placeholder below to desired parameter value for the `Undelete` method:
 
             // The project ID (for example, `foo-bar-123`). Required.
             string projectId = "{MY-PROJECT-ID}";
@@ -1017,7 +1017,7 @@ namespace CloudResourceManagerSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Update` method:
+            // TODO: Change placeholder below to desired parameter value for the `Update` method:
 
             // The project ID (for example, `my-project-123`). Required.
             string projectId = "{MY-PROJECT-ID}";

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_cloudtrace.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_cloudtrace.v1.json.baseline
@@ -43,7 +43,7 @@ namespace CloudTraceSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `PatchTraces` method:
+            // TODO: Change placeholder below to desired parameter value for the `PatchTraces` method:
 
             // ID of the Cloud project where the trace data is stored.
             string projectId = "{MY-PROJECT-ID}";
@@ -172,7 +172,7 @@ namespace CloudTraceSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // ID of the Cloud project where the trace data is stored.
             string projectId = "{MY-PROJECT-ID}";

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_clouduseraccounts.beta.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_clouduseraccounts.beta.json.baseline
@@ -165,7 +165,7 @@ namespace CloudUserAccountsSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -434,7 +434,7 @@ namespace CloudUserAccountsSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Insert` method:
+            // TODO: Change placeholder below to desired parameter value for the `Insert` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -499,7 +499,7 @@ namespace CloudUserAccountsSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -973,7 +973,7 @@ namespace CloudUserAccountsSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Insert` method:
+            // TODO: Change placeholder below to desired parameter value for the `Insert` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -1038,7 +1038,7 @@ namespace CloudUserAccountsSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_compute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_compute.v1.json.baseline
@@ -44,7 +44,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `AggregatedList` method:
+            // TODO: Change placeholder below to desired parameter value for the `AggregatedList` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -396,7 +396,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `AggregatedList` method:
+            // TODO: Change placeholder below to desired parameter value for the `AggregatedList` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -1082,7 +1082,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Insert` method:
+            // TODO: Change placeholder below to desired parameter value for the `Insert` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -1147,7 +1147,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -1357,7 +1357,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `AggregatedList` method:
+            // TODO: Change placeholder below to desired parameter value for the `AggregatedList` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -1574,7 +1574,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `AggregatedList` method:
+            // TODO: Change placeholder below to desired parameter value for the `AggregatedList` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -2195,7 +2195,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Insert` method:
+            // TODO: Change placeholder below to desired parameter value for the `Insert` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -2260,7 +2260,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -2470,7 +2470,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `AggregatedList` method:
+            // TODO: Change placeholder below to desired parameter value for the `AggregatedList` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -3020,7 +3020,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Insert` method:
+            // TODO: Change placeholder below to desired parameter value for the `Insert` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -3085,7 +3085,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -3286,7 +3286,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Insert` method:
+            // TODO: Change placeholder below to desired parameter value for the `Insert` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -3351,7 +3351,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -3493,7 +3493,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `AggregatedList` method:
+            // TODO: Change placeholder below to desired parameter value for the `AggregatedList` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -3688,7 +3688,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -3889,7 +3889,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Insert` method:
+            // TODO: Change placeholder below to desired parameter value for the `Insert` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -3954,7 +3954,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -4291,7 +4291,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Insert` method:
+            // TODO: Change placeholder below to desired parameter value for the `Insert` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -4356,7 +4356,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -4693,7 +4693,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Insert` method:
+            // TODO: Change placeholder below to desired parameter value for the `Insert` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -4758,7 +4758,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -5227,7 +5227,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Insert` method:
+            // TODO: Change placeholder below to desired parameter value for the `Insert` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -5292,7 +5292,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -5437,7 +5437,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `AggregatedList` method:
+            // TODO: Change placeholder below to desired parameter value for the `AggregatedList` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -6283,7 +6283,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `AggregatedList` method:
+            // TODO: Change placeholder below to desired parameter value for the `AggregatedList` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -6987,7 +6987,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Insert` method:
+            // TODO: Change placeholder below to desired parameter value for the `Insert` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -7052,7 +7052,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -7200,7 +7200,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `AggregatedList` method:
+            // TODO: Change placeholder below to desired parameter value for the `AggregatedList` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -8526,7 +8526,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `AggregatedList` method:
+            // TODO: Change placeholder below to desired parameter value for the `AggregatedList` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -8870,7 +8870,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Insert` method:
+            // TODO: Change placeholder below to desired parameter value for the `Insert` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -8935,7 +8935,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -9008,7 +9008,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Get` method:
+            // TODO: Change placeholder below to desired parameter value for the `Get` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -9069,7 +9069,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `MoveDisk` method:
+            // TODO: Change placeholder below to desired parameter value for the `MoveDisk` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -9134,7 +9134,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `MoveInstance` method:
+            // TODO: Change placeholder below to desired parameter value for the `MoveInstance` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -9199,7 +9199,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `SetCommonInstanceMetadata` method:
+            // TODO: Change placeholder below to desired parameter value for the `SetCommonInstanceMetadata` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -9264,7 +9264,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `SetUsageExportBucket` method:
+            // TODO: Change placeholder below to desired parameter value for the `SetUsageExportBucket` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -9597,7 +9597,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -9671,7 +9671,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `AggregatedList` method:
+            // TODO: Change placeholder below to desired parameter value for the `AggregatedList` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -10430,7 +10430,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Insert` method:
+            // TODO: Change placeholder below to desired parameter value for the `Insert` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -10495,7 +10495,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -10696,7 +10696,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -10897,7 +10897,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Insert` method:
+            // TODO: Change placeholder below to desired parameter value for the `Insert` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -10962,7 +10962,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -11036,7 +11036,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `AggregatedList` method:
+            // TODO: Change placeholder below to desired parameter value for the `AggregatedList` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -11515,7 +11515,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Insert` method:
+            // TODO: Change placeholder below to desired parameter value for the `Insert` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -11580,7 +11580,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -11849,7 +11849,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Insert` method:
+            // TODO: Change placeholder below to desired parameter value for the `Insert` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -11914,7 +11914,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -12124,7 +12124,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `AggregatedList` method:
+            // TODO: Change placeholder below to desired parameter value for the `AggregatedList` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -12618,7 +12618,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `AggregatedList` method:
+            // TODO: Change placeholder below to desired parameter value for the `AggregatedList` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -13381,7 +13381,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Insert` method:
+            // TODO: Change placeholder below to desired parameter value for the `Insert` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -13446,7 +13446,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -13724,7 +13724,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `AggregatedList` method:
+            // TODO: Change placeholder below to desired parameter value for the `AggregatedList` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -14203,7 +14203,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Insert` method:
+            // TODO: Change placeholder below to desired parameter value for the `Insert` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -14336,7 +14336,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -14614,7 +14614,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `AggregatedList` method:
+            // TODO: Change placeholder below to desired parameter value for the `AggregatedList` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";
@@ -15233,7 +15233,7 @@ namespace ComputeSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // Project ID for this request.
             string project = "{MY-PROJECT}";

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_dataflow.v1b3.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_dataflow.v1b3.json.baseline
@@ -43,7 +43,7 @@ namespace DataflowSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Create` method:
+            // TODO: Change placeholder below to desired parameter value for the `Create` method:
 
             // The project which owns the job.
             string projectId = "{MY-PROJECT-ID}";
@@ -372,7 +372,7 @@ namespace DataflowSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // The project which owns the jobs.
             string projectId = "{MY-PROJECT-ID}";
@@ -725,7 +725,7 @@ namespace DataflowSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Create` method:
+            // TODO: Change placeholder below to desired parameter value for the `Create` method:
 
             // The project which owns the job.
             string projectId = "{MY-PROJECT-ID}";
@@ -790,7 +790,7 @@ namespace DataflowSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `WorkerMessages` method:
+            // TODO: Change placeholder below to desired parameter value for the `WorkerMessages` method:
 
             // The project to send the WorkerMessages to.
             string projectId = "{MY-PROJECT-ID}";

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_dataproc.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_dataproc.v1.json.baseline
@@ -812,7 +812,7 @@ namespace DataprocSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Cancel` method:
+            // TODO: Change placeholder below to desired parameter value for the `Cancel` method:
 
             // The name of the operation resource to be cancelled.
             string name = "projects/{MY-PROJECT}/regions/{MY-REGION}/operations/{MY-OPERATION}";
@@ -873,7 +873,7 @@ namespace DataprocSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Delete` method:
+            // TODO: Change placeholder below to desired parameter value for the `Delete` method:
 
             // The name of the operation resource to be deleted.
             string name = "projects/{MY-PROJECT}/regions/{MY-REGION}/operations/{MY-OPERATION}";
@@ -934,7 +934,7 @@ namespace DataprocSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Get` method:
+            // TODO: Change placeholder below to desired parameter value for the `Get` method:
 
             // The name of the operation resource.
             string name = "projects/{MY-PROJECT}/regions/{MY-REGION}/operations/{MY-OPERATION}";
@@ -995,7 +995,7 @@ namespace DataprocSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // The name of the operation collection.
             string name = "{MY-NAME}";

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_datastore.v1beta3.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_datastore.v1beta3.json.baseline
@@ -43,7 +43,7 @@ namespace DatastoreSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `AllocateIds` method:
+            // TODO: Change placeholder below to desired parameter value for the `AllocateIds` method:
 
             // The ID of the project against which to make the request.
             string projectId = "{MY-PROJECT-ID}";
@@ -108,7 +108,7 @@ namespace DatastoreSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `BeginTransaction` method:
+            // TODO: Change placeholder below to desired parameter value for the `BeginTransaction` method:
 
             // The ID of the project against which to make the request.
             string projectId = "{MY-PROJECT-ID}";
@@ -173,7 +173,7 @@ namespace DatastoreSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Commit` method:
+            // TODO: Change placeholder below to desired parameter value for the `Commit` method:
 
             // The ID of the project against which to make the request.
             string projectId = "{MY-PROJECT-ID}";
@@ -238,7 +238,7 @@ namespace DatastoreSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Lookup` method:
+            // TODO: Change placeholder below to desired parameter value for the `Lookup` method:
 
             // The ID of the project against which to make the request.
             string projectId = "{MY-PROJECT-ID}";
@@ -303,7 +303,7 @@ namespace DatastoreSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Rollback` method:
+            // TODO: Change placeholder below to desired parameter value for the `Rollback` method:
 
             // The ID of the project against which to make the request.
             string projectId = "{MY-PROJECT-ID}";
@@ -368,7 +368,7 @@ namespace DatastoreSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `RunQuery` method:
+            // TODO: Change placeholder below to desired parameter value for the `RunQuery` method:
 
             // The ID of the project against which to make the request.
             string projectId = "{MY-PROJECT-ID}";

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_deploymentmanager.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_deploymentmanager.v2.json.baseline
@@ -239,7 +239,7 @@ namespace DeploymentManagerSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Insert` method:
+            // TODO: Change placeholder below to desired parameter value for the `Insert` method:
 
             // The project ID for this request.
             string project = "{MY-PROJECT}";
@@ -304,7 +304,7 @@ namespace DeploymentManagerSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // The project ID for this request.
             string project = "{MY-PROJECT}";
@@ -788,7 +788,7 @@ namespace DeploymentManagerSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // The project ID for this request.
             string project = "{MY-PROJECT}";
@@ -1004,7 +1004,7 @@ namespace DeploymentManagerSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // The project ID for this request.
             string project = "{MY-PROJECT}";

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_dns.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_dns.v1.json.baseline
@@ -254,7 +254,7 @@ namespace DnsSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Create` method:
+            // TODO: Change placeholder below to desired parameter value for the `Create` method:
 
             // Identifies the project addressed by this request.
             string project = "{MY-PROJECT}";
@@ -441,7 +441,7 @@ namespace DnsSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // Identifies the project addressed by this request.
             string project = "{MY-PROJECT}";
@@ -514,7 +514,7 @@ namespace DnsSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Get` method:
+            // TODO: Change placeholder below to desired parameter value for the `Get` method:
 
             // Identifies the project addressed by this request.
             string project = "{MY-PROJECT}";

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_logging.v2beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_logging.v2beta1.json.baseline
@@ -237,7 +237,7 @@ namespace LoggingSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Delete` method:
+            // TODO: Change placeholder below to desired parameter value for the `Delete` method:
 
             // Required. The resource name of the log to delete. Example: `"projects/my-project/logs/syslog"`.
             string logName = "projects/{MY-PROJECT}/logs/{MY-LOG}";
@@ -298,7 +298,7 @@ namespace LoggingSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Create` method:
+            // TODO: Change placeholder below to desired parameter value for the `Create` method:
 
             // The resource name of the project in which to create the metric. Example: `"projects/my-project-id"`.
             // The new metric must be provided in the request.
@@ -364,7 +364,7 @@ namespace LoggingSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Delete` method:
+            // TODO: Change placeholder below to desired parameter value for the `Delete` method:
 
             // The resource name of the metric to delete. Example: `"projects/my-project-id/metrics/my-metric-id"`.
             string metricName = "projects/{MY-PROJECT}/metrics/{MY-METRIC}";
@@ -425,7 +425,7 @@ namespace LoggingSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Get` method:
+            // TODO: Change placeholder below to desired parameter value for the `Get` method:
 
             // The resource name of the desired metric. Example: `"projects/my-project-id/metrics/my-metric-id"`.
             string metricName = "projects/{MY-PROJECT}/metrics/{MY-METRIC}";
@@ -486,7 +486,7 @@ namespace LoggingSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // Required. The resource name of the project containing the metrics. Example:
             // `"projects/my-project-id"`.
@@ -560,7 +560,7 @@ namespace LoggingSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Update` method:
+            // TODO: Change placeholder below to desired parameter value for the `Update` method:
 
             // The resource name of the metric to update. Example: `"projects/my-project-id/metrics/my-metric-id"`.
             // The updated metric must be provided in the request and have the same identifier that is specified in
@@ -627,7 +627,7 @@ namespace LoggingSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Create` method:
+            // TODO: Change placeholder below to desired parameter value for the `Create` method:
 
             // The resource name of the project in which to create the sink. Example: `"projects/my-project-id"`.
             // The new sink must be provided in the request.
@@ -693,7 +693,7 @@ namespace LoggingSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Delete` method:
+            // TODO: Change placeholder below to desired parameter value for the `Delete` method:
 
             // The resource name of the sink to delete. Example: `"projects/my-project-id/sinks/my-sink-id"`.
             string sinkName = "projects/{MY-PROJECT}/sinks/{MY-SINK}";
@@ -754,7 +754,7 @@ namespace LoggingSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Get` method:
+            // TODO: Change placeholder below to desired parameter value for the `Get` method:
 
             // The resource name of the sink to return. Example: `"projects/my-project-id/sinks/my-sink-id"`.
             string sinkName = "projects/{MY-PROJECT}/sinks/{MY-SINK}";
@@ -815,7 +815,7 @@ namespace LoggingSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // Required. The resource name of the project containing the sinks. Example:
             // `"projects/my-logging-project"`.
@@ -889,7 +889,7 @@ namespace LoggingSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Update` method:
+            // TODO: Change placeholder below to desired parameter value for the `Update` method:
 
             // The resource name of the sink to update. Example: `"projects/my-project-id/sinks/my-sink-id"`. The
             // updated sink must be provided in the request and have the same name that is specified in `sinkName`.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_prediction.v1.6.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_prediction.v1.6.json.baseline
@@ -297,7 +297,7 @@ namespace PredictionSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Insert` method:
+            // TODO: Change placeholder below to desired parameter value for the `Insert` method:
 
             // The project associated with the model.
             string project = "{MY-PROJECT}";
@@ -362,7 +362,7 @@ namespace PredictionSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // The project associated with the model.
             string project = "{MY-PROJECT}";

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_pubsub.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_pubsub.v1.json.baseline
@@ -43,7 +43,7 @@ namespace PubsubSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Acknowledge` method:
+            // TODO: Change placeholder below to desired parameter value for the `Acknowledge` method:
 
             // The subscription whose message is being acknowledged.
             string subscription = "projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}";
@@ -108,7 +108,7 @@ namespace PubsubSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Create` method:
+            // TODO: Change placeholder below to desired parameter value for the `Create` method:
 
             // The name of the subscription. It must have the format
             // `"projects/{project}/subscriptions/{subscription}"`. `{subscription}` must start with a letter, and
@@ -177,7 +177,7 @@ namespace PubsubSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Delete` method:
+            // TODO: Change placeholder below to desired parameter value for the `Delete` method:
 
             // The subscription to delete.
             string subscription = "projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}";
@@ -238,7 +238,7 @@ namespace PubsubSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Get` method:
+            // TODO: Change placeholder below to desired parameter value for the `Get` method:
 
             // The name of the subscription to get.
             string subscription = "projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}";
@@ -299,7 +299,7 @@ namespace PubsubSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `GetIamPolicy` method:
+            // TODO: Change placeholder below to desired parameter value for the `GetIamPolicy` method:
 
             // REQUIRED: The resource for which the policy is being requested. `resource` is usually specified as a
             // path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
@@ -362,7 +362,7 @@ namespace PubsubSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // The name of the cloud project that subscriptions belong to.
             string project = "projects/{MY-PROJECT}";
@@ -435,7 +435,7 @@ namespace PubsubSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `ModifyAckDeadline` method:
+            // TODO: Change placeholder below to desired parameter value for the `ModifyAckDeadline` method:
 
             // The name of the subscription.
             string subscription = "projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}";
@@ -500,7 +500,7 @@ namespace PubsubSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `ModifyPushConfig` method:
+            // TODO: Change placeholder below to desired parameter value for the `ModifyPushConfig` method:
 
             // The name of the subscription.
             string subscription = "projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}";
@@ -565,7 +565,7 @@ namespace PubsubSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Pull` method:
+            // TODO: Change placeholder below to desired parameter value for the `Pull` method:
 
             // The subscription from which messages should be pulled.
             string subscription = "projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}";
@@ -630,7 +630,7 @@ namespace PubsubSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `SetIamPolicy` method:
+            // TODO: Change placeholder below to desired parameter value for the `SetIamPolicy` method:
 
             // REQUIRED: The resource for which the policy is being specified. `resource` is usually specified as a
             // path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
@@ -697,7 +697,7 @@ namespace PubsubSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `TestIamPermissions` method:
+            // TODO: Change placeholder below to desired parameter value for the `TestIamPermissions` method:
 
             // REQUIRED: The resource for which the policy detail is being requested. `resource` is usually
             // specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path
@@ -765,7 +765,7 @@ namespace PubsubSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Create` method:
+            // TODO: Change placeholder below to desired parameter value for the `Create` method:
 
             // The name of the topic. It must have the format `"projects/{project}/topics/{topic}"`. `{topic}` must
             // start with a letter, and contain only letters (`[A-Za-z]`), numbers (`[0-9]`), dashes (`-`),
@@ -833,7 +833,7 @@ namespace PubsubSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Delete` method:
+            // TODO: Change placeholder below to desired parameter value for the `Delete` method:
 
             // Name of the topic to delete.
             string topic = "projects/{MY-PROJECT}/topics/{MY-TOPIC}";
@@ -894,7 +894,7 @@ namespace PubsubSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Get` method:
+            // TODO: Change placeholder below to desired parameter value for the `Get` method:
 
             // The name of the topic to get.
             string topic = "projects/{MY-PROJECT}/topics/{MY-TOPIC}";
@@ -955,7 +955,7 @@ namespace PubsubSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `GetIamPolicy` method:
+            // TODO: Change placeholder below to desired parameter value for the `GetIamPolicy` method:
 
             // REQUIRED: The resource for which the policy is being requested. `resource` is usually specified as a
             // path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
@@ -1018,7 +1018,7 @@ namespace PubsubSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // The name of the cloud project that topics belong to.
             string project = "projects/{MY-PROJECT}";
@@ -1091,7 +1091,7 @@ namespace PubsubSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Publish` method:
+            // TODO: Change placeholder below to desired parameter value for the `Publish` method:
 
             // The messages in the request will be published on this topic.
             string topic = "projects/{MY-PROJECT}/topics/{MY-TOPIC}";
@@ -1156,7 +1156,7 @@ namespace PubsubSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `SetIamPolicy` method:
+            // TODO: Change placeholder below to desired parameter value for the `SetIamPolicy` method:
 
             // REQUIRED: The resource for which the policy is being specified. `resource` is usually specified as a
             // path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
@@ -1223,7 +1223,7 @@ namespace PubsubSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // The name of the topic that subscriptions are attached to.
             string topic = "projects/{MY-PROJECT}/topics/{MY-TOPIC}";
@@ -1296,7 +1296,7 @@ namespace PubsubSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `TestIamPermissions` method:
+            // TODO: Change placeholder below to desired parameter value for the `TestIamPermissions` method:
 
             // REQUIRED: The resource for which the policy detail is being requested. `resource` is usually
             // specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_sqladmin.v1beta4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_sqladmin.v1beta4.json.baseline
@@ -1183,7 +1183,7 @@ namespace SQLAdminSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Insert` method:
+            // TODO: Change placeholder below to desired parameter value for the `Insert` method:
 
             // Project ID of the project to which the newly created Cloud SQL instances should belong.
             string project = "{MY-PROJECT}";
@@ -1248,7 +1248,7 @@ namespace SQLAdminSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // Project ID of the project for which to list Cloud SQL instances.
             string project = "{MY-PROJECT}";
@@ -2319,7 +2319,7 @@ namespace SQLAdminSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // Project ID of the project for which to list tiers.
             string project = "{MY-PROJECT}";

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_storage.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_storage.v1.json.baseline
@@ -167,7 +167,7 @@ namespace StorageSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Insert` method:
+            // TODO: Change placeholder below to desired parameter value for the `Insert` method:
 
             // Name of a bucket.
             string bucket = "{MY-BUCKET}";
@@ -232,7 +232,7 @@ namespace StorageSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // Name of a bucket.
             string bucket = "{MY-BUCKET}";
@@ -428,7 +428,7 @@ namespace StorageSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Delete` method:
+            // TODO: Change placeholder below to desired parameter value for the `Delete` method:
 
             // Name of a bucket.
             string bucket = "{MY-BUCKET}";
@@ -486,7 +486,7 @@ namespace StorageSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Get` method:
+            // TODO: Change placeholder below to desired parameter value for the `Get` method:
 
             // Name of a bucket.
             string bucket = "{MY-BUCKET}";
@@ -547,7 +547,7 @@ namespace StorageSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Insert` method:
+            // TODO: Change placeholder below to desired parameter value for the `Insert` method:
 
             // A valid API project identifier.
             string project = "{MY-PROJECT}";
@@ -612,7 +612,7 @@ namespace StorageSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // A valid API project identifier.
             string project = "{MY-PROJECT}";
@@ -685,7 +685,7 @@ namespace StorageSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Patch` method:
+            // TODO: Change placeholder below to desired parameter value for the `Patch` method:
 
             // Name of a bucket.
             string bucket = "{MY-BUCKET}";
@@ -750,7 +750,7 @@ namespace StorageSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Update` method:
+            // TODO: Change placeholder below to desired parameter value for the `Update` method:
 
             // Name of a bucket.
             string bucket = "{MY-BUCKET}";
@@ -993,7 +993,7 @@ namespace StorageSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Insert` method:
+            // TODO: Change placeholder below to desired parameter value for the `Insert` method:
 
             // Name of a bucket.
             string bucket = "{MY-BUCKET}";
@@ -1058,7 +1058,7 @@ namespace StorageSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // Name of a bucket.
             string bucket = "{MY-BUCKET}";
@@ -1940,7 +1940,7 @@ namespace StorageSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Insert` method:
+            // TODO: Change placeholder below to desired parameter value for the `Insert` method:
 
             // Name of the bucket in which to store the new object. Overrides the provided object metadata's bucket
             // value, if any.
@@ -2006,7 +2006,7 @@ namespace StorageSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // Name of the bucket in which to look for objects.
             string bucket = "{MY-BUCKET}";
@@ -2295,7 +2295,7 @@ namespace StorageSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `WatchAll` method:
+            // TODO: Change placeholder below to desired parameter value for the `WatchAll` method:
 
             // Name of the bucket in which to look for objects.
             string bucket = "{MY-BUCKET}";

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_storagetransfer.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_storagetransfer.v1.json.baseline
@@ -97,7 +97,7 @@ namespace StoragetransferSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Get` method:
+            // TODO: Change placeholder below to desired parameter value for the `Get` method:
 
             // The ID of the Google Developers Console project that the Google service account is associated with.
             // Required.
@@ -217,7 +217,7 @@ namespace StoragetransferSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Get` method:
+            // TODO: Change placeholder below to desired parameter value for the `Get` method:
 
             // The job to get. Required.
             string jobName = "{MY-JOB-NAME}";
@@ -344,7 +344,7 @@ namespace StoragetransferSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Patch` method:
+            // TODO: Change placeholder below to desired parameter value for the `Patch` method:
 
             // The name of job to update. Required.
             string jobName = "{MY-JOB-NAME}";
@@ -409,7 +409,7 @@ namespace StoragetransferSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Cancel` method:
+            // TODO: Change placeholder below to desired parameter value for the `Cancel` method:
 
             // The name of the operation resource to be cancelled.
             string name = "{MY-NAME}";
@@ -470,7 +470,7 @@ namespace StoragetransferSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Delete` method:
+            // TODO: Change placeholder below to desired parameter value for the `Delete` method:
 
             // The name of the operation resource to be deleted.
             string name = "{MY-NAME}";
@@ -531,7 +531,7 @@ namespace StoragetransferSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Get` method:
+            // TODO: Change placeholder below to desired parameter value for the `Get` method:
 
             // The name of the operation resource.
             string name = "{MY-NAME}";
@@ -592,7 +592,7 @@ namespace StoragetransferSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // The value `transferOperations`.
             string name = "{MY-NAME}";
@@ -665,7 +665,7 @@ namespace StoragetransferSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Pause` method:
+            // TODO: Change placeholder below to desired parameter value for the `Pause` method:
 
             // The name of the transfer operation. Required.
             string name = "{MY-NAME}";
@@ -730,7 +730,7 @@ namespace StoragetransferSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `Resume` method:
+            // TODO: Change placeholder below to desired parameter value for the `Resume` method:
 
             // The name of the transfer operation. Required.
             string name = "{MY-NAME}";

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_translate.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_translate.v2.json.baseline
@@ -33,7 +33,7 @@ namespace TranslateSample
             });
 
 
-            // TODO: Change placeholders below to desired parameter values for the `List` method:
+            // TODO: Change placeholder below to desired parameter value for the `List` method:
 
             // The text to detect
             List<string> q = new List<string>();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_adexchangebuyer.v1.4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_adexchangebuyer.v1.4.json.baseline
@@ -17,7 +17,7 @@ getAuth(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `get` method:
+    // TODO: Change placeholder below to desired parameter value for the `get` method:
 
     // The account id
     id: 0,
@@ -103,7 +103,7 @@ getAuth(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `patch` method:
+    // TODO: Change placeholder below to desired parameter value for the `patch` method:
 
     // The account id
     id: 0,
@@ -153,7 +153,7 @@ getAuth(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `update` method:
+    // TODO: Change placeholder below to desired parameter value for the `update` method:
 
     // The account id
     id: 0,
@@ -203,7 +203,7 @@ getAuth(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `get` method:
+    // TODO: Change placeholder below to desired parameter value for the `get` method:
 
     // The account id.
     accountId: 0,
@@ -686,7 +686,7 @@ getAuth(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `delete` method:
+    // TODO: Change placeholder below to desired parameter value for the `delete` method:
 
     // The proposalId to delete deals from.
     proposalId: '{MY-PROPOSAL-ID}',
@@ -736,7 +736,7 @@ getAuth(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `insert` method:
+    // TODO: Change placeholder below to desired parameter value for the `insert` method:
 
     // proposalId for which deals need to be added.
     proposalId: '{MY-PROPOSAL-ID}',
@@ -786,7 +786,7 @@ getAuth(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // The proposalId to get deals for. To search across all proposals specify order_id = '-' as part of
     // the URL.
@@ -833,7 +833,7 @@ getAuth(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `update` method:
+    // TODO: Change placeholder below to desired parameter value for the `update` method:
 
     // The proposalId to edit deals on.
     proposalId: '{MY-PROPOSAL-ID}',
@@ -883,7 +883,7 @@ getAuth(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `insert` method:
+    // TODO: Change placeholder below to desired parameter value for the `insert` method:
 
     // The proposalId to add notes for.
     proposalId: '{MY-PROPOSAL-ID}',
@@ -933,7 +933,7 @@ getAuth(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // The proposalId to get notes for. To search across all proposals specify order_id = '-' as part of
     // the URL.
@@ -980,7 +980,7 @@ getAuth(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `updateproposal` method:
+    // TODO: Change placeholder below to desired parameter value for the `updateproposal` method:
 
     // The private auction id to be updated.
     privateAuctionId: '{MY-PRIVATE-AUCTION-ID}',
@@ -1172,7 +1172,7 @@ getAuth(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `insert` method:
+    // TODO: Change placeholder below to desired parameter value for the `insert` method:
 
     // The account id to insert the pretargeting config for.
     accountId: '',
@@ -1222,7 +1222,7 @@ getAuth(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // The account id to get the pretargeting configs for.
     accountId: '',
@@ -1374,7 +1374,7 @@ getAuth(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `get` method:
+    // TODO: Change placeholder below to desired parameter value for the `get` method:
 
     // The id for the product to get the head revision for.
     productId: '{MY-PRODUCT-ID}',
@@ -1460,7 +1460,7 @@ getAuth(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `get` method:
+    // TODO: Change placeholder below to desired parameter value for the `get` method:
 
     // Id of the proposal to retrieve.
     proposalId: '{MY-PROPOSAL-ID}',
@@ -1649,7 +1649,7 @@ getAuth(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `setupcomplete` method:
+    // TODO: Change placeholder below to desired parameter value for the `setupcomplete` method:
 
     // The proposal id for which the setup is complete
     proposalId: '{MY-PROPOSAL-ID}',
@@ -1750,7 +1750,7 @@ getAuth(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // The accountId of the publisher to get profiles for.
     accountId: 0,

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_appengine.v1beta5.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_appengine.v1beta5.json.baseline
@@ -74,7 +74,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `get` method:
+    // TODO: Change placeholder below to desired parameter value for the `get` method:
 
     // Part of `name`. Name of the application to get. Example: `apps/myapp`.
     appsId: '{MY-APPS-ID}',
@@ -173,7 +173,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // Part of `name`. The resource that owns the locations collection, if applicable.
     appsId: '{MY-APPS-ID}',
@@ -285,7 +285,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // Part of `name`. The name of the operation collection.
     appsId: '{MY-APPS-ID}',
@@ -448,7 +448,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // Part of `name`. Name of the resource requested. Example: `apps/myapp`.
     appsId: '{MY-APPS-ID}',

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_bigquery.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_bigquery.v2.json.baseline
@@ -126,7 +126,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `insert` method:
+    // TODO: Change placeholder below to desired parameter value for the `insert` method:
 
     // Project ID of the new dataset
     projectId: '{MY-PROJECT-ID}',
@@ -178,7 +178,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // Project ID of the datasets to be listed
     projectId: '{MY-PROJECT-ID}',
@@ -502,7 +502,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `insert` method:
+    // TODO: Change placeholder below to desired parameter value for the `insert` method:
 
     // Project ID of the project that will be billed for the job
     projectId: '{MY-PROJECT-ID}',
@@ -561,7 +561,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // Project ID of the jobs to list
     projectId: '{MY-PROJECT-ID}',
@@ -622,7 +622,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `query` method:
+    // TODO: Change placeholder below to desired parameter value for the `query` method:
 
     // Project ID of the project billed for the query
     projectId: '{MY-PROJECT-ID}',

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_cloudbilling.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_cloudbilling.v1.json.baseline
@@ -28,7 +28,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `get` method:
+    // TODO: Change placeholder below to desired parameter value for the `get` method:
 
     // The resource name of the billing account to retrieve. For example,
     // `billingAccounts/012345-567890-ABCDEF`.
@@ -132,7 +132,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // The resource name of the billing account associated with the projects that you want to list. For
     // example, `billingAccounts/012345-567890-ABCDEF`.
@@ -194,7 +194,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `getBillingInfo` method:
+    // TODO: Change placeholder below to desired parameter value for the `getBillingInfo` method:
 
     // The resource name of the project for which billing information is retrieved. For example,
     // `projects/tokyo-rain-123`.
@@ -243,7 +243,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `updateBillingInfo` method:
+    // TODO: Change placeholder below to desired parameter value for the `updateBillingInfo` method:
 
     // The resource name of the project associated with the billing information that you want to update.
     // For example, `projects/tokyo-rain-123`.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_clouddebugger.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_clouddebugger.v2.json.baseline
@@ -28,7 +28,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // Identifies the debuggee.
     debuggeeId: '{MY-DEBUGGEE-ID}',
@@ -275,7 +275,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // ID of the debuggee whose breakpoints to list.
     debuggeeId: '{MY-DEBUGGEE-ID}',
@@ -323,7 +323,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `set` method:
+    // TODO: Change placeholder below to desired parameter value for the `set` method:
 
     // ID of the debuggee where the breakpoint is to be set.
     debuggeeId: '{MY-DEBUGGEE-ID}',

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_cloudmonitoring.v2beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_cloudmonitoring.v2beta2.json.baseline
@@ -28,7 +28,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `create` method:
+    // TODO: Change placeholder below to desired parameter value for the `create` method:
 
     // The project id. The value can be the numeric project ID or string-based project name.
     project: '{MY-PROJECT}',
@@ -131,7 +131,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // The project id. The value can be the numeric project ID or string-based project name.
     project: '{MY-PROJECT}',
@@ -269,7 +269,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `write` method:
+    // TODO: Change placeholder below to desired parameter value for the `write` method:
 
     // The project ID. The value can be the numeric project ID or string-based project name.
     project: '{MY-PROJECT}',

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_cloudresourcemanager.v1beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_cloudresourcemanager.v1beta1.json.baseline
@@ -28,7 +28,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `get` method:
+    // TODO: Change placeholder below to desired parameter value for the `get` method:
 
     // The resource name of the Organization to fetch. Its format is "organizations/[organization_id]". For
     // example, "organizations/1234".
@@ -77,7 +77,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `getIamPolicy` method:
+    // TODO: Change placeholder below to desired parameter value for the `getIamPolicy` method:
 
     // REQUIRED: The resource for which the policy is being requested. `resource` is usually specified as a
     // path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
@@ -186,7 +186,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `setIamPolicy` method:
+    // TODO: Change placeholder below to desired parameter value for the `setIamPolicy` method:
 
     // REQUIRED: The resource for which the policy is being specified. `resource` is usually specified as a
     // path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
@@ -240,7 +240,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `testIamPermissions` method:
+    // TODO: Change placeholder below to desired parameter value for the `testIamPermissions` method:
 
     // REQUIRED: The resource for which the policy detail is being requested. `resource` is usually
     // specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path
@@ -295,7 +295,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `update` method:
+    // TODO: Change placeholder below to desired parameter value for the `update` method:
 
     // Output Only. The resource name of the organization. This is the organization's relative path in the
     // API. Its format is "organizations/[organization_id]". For example, "organizations/1234".
@@ -394,7 +394,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `delete` method:
+    // TODO: Change placeholder below to desired parameter value for the `delete` method:
 
     // The Project ID (for example, `foo-bar-123`). Required.
     projectId: '{MY-PROJECT-ID}',
@@ -438,7 +438,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `get` method:
+    // TODO: Change placeholder below to desired parameter value for the `get` method:
 
     // The Project ID (for example, `my-project-123`). Required.
     projectId: '{MY-PROJECT-ID}',
@@ -486,7 +486,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `getAncestry` method:
+    // TODO: Change placeholder below to desired parameter value for the `getAncestry` method:
 
     // The Project ID (for example, `my-project-123`). Required.
     projectId: '{MY-PROJECT-ID}',
@@ -538,7 +538,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `getIamPolicy` method:
+    // TODO: Change placeholder below to desired parameter value for the `getIamPolicy` method:
 
     // REQUIRED: The resource for which the policy is being requested. `resource` is usually specified as a
     // path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
@@ -647,7 +647,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `setIamPolicy` method:
+    // TODO: Change placeholder below to desired parameter value for the `setIamPolicy` method:
 
     // REQUIRED: The resource for which the policy is being specified. `resource` is usually specified as a
     // path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
@@ -701,7 +701,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `testIamPermissions` method:
+    // TODO: Change placeholder below to desired parameter value for the `testIamPermissions` method:
 
     // REQUIRED: The resource for which the policy detail is being requested. `resource` is usually
     // specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path
@@ -756,7 +756,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `undelete` method:
+    // TODO: Change placeholder below to desired parameter value for the `undelete` method:
 
     // The project ID (for example, `foo-bar-123`). Required.
     projectId: '{MY-PROJECT-ID}',
@@ -804,7 +804,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `update` method:
+    // TODO: Change placeholder below to desired parameter value for the `update` method:
 
     // The project ID (for example, `my-project-123`). Required.
     projectId: '{MY-PROJECT-ID}',

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_cloudtrace.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_cloudtrace.v1.json.baseline
@@ -28,7 +28,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `patchTraces` method:
+    // TODO: Change placeholder below to desired parameter value for the `patchTraces` method:
 
     // ID of the Cloud project where the trace data is stored.
     projectId: '{MY-PROJECT-ID}',
@@ -127,7 +127,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // ID of the Cloud project where the trace data is stored.
     projectId: '{MY-PROJECT-ID}',

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_clouduseraccounts.beta.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_clouduseraccounts.beta.json.baseline
@@ -126,7 +126,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -344,7 +344,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `insert` method:
+    // TODO: Change placeholder below to desired parameter value for the `insert` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -396,7 +396,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -780,7 +780,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `insert` method:
+    // TODO: Change placeholder below to desired parameter value for the `insert` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -832,7 +832,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_compute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_compute.v1.json.baseline
@@ -28,7 +28,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+    // TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -316,7 +316,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+    // TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -874,7 +874,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `insert` method:
+    // TODO: Change placeholder below to desired parameter value for the `insert` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -926,7 +926,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -1097,7 +1097,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+    // TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -1276,7 +1276,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+    // TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -1782,7 +1782,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `insert` method:
+    // TODO: Change placeholder below to desired parameter value for the `insert` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -1834,7 +1834,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -2005,7 +2005,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+    // TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -2453,7 +2453,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `insert` method:
+    // TODO: Change placeholder below to desired parameter value for the `insert` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -2505,7 +2505,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -2668,7 +2668,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `insert` method:
+    // TODO: Change placeholder below to desired parameter value for the `insert` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -2720,7 +2720,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -2836,7 +2836,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+    // TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -2995,7 +2995,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -3158,7 +3158,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `insert` method:
+    // TODO: Change placeholder below to desired parameter value for the `insert` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -3210,7 +3210,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -3483,7 +3483,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `insert` method:
+    // TODO: Change placeholder below to desired parameter value for the `insert` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -3535,7 +3535,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -3808,7 +3808,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `insert` method:
+    // TODO: Change placeholder below to desired parameter value for the `insert` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -3860,7 +3860,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -4239,7 +4239,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `insert` method:
+    // TODO: Change placeholder below to desired parameter value for the `insert` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -4291,7 +4291,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -4410,7 +4410,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+    // TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -5101,7 +5101,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+    // TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -5678,7 +5678,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `insert` method:
+    // TODO: Change placeholder below to desired parameter value for the `insert` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -5730,7 +5730,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -5852,7 +5852,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+    // TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -6932,7 +6932,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+    // TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -7213,7 +7213,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `insert` method:
+    // TODO: Change placeholder below to desired parameter value for the `insert` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -7265,7 +7265,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -7326,7 +7326,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `get` method:
+    // TODO: Change placeholder below to desired parameter value for the `get` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -7374,7 +7374,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `moveDisk` method:
+    // TODO: Change placeholder below to desired parameter value for the `moveDisk` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -7426,7 +7426,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `moveInstance` method:
+    // TODO: Change placeholder below to desired parameter value for the `moveInstance` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -7478,7 +7478,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `setCommonInstanceMetadata` method:
+    // TODO: Change placeholder below to desired parameter value for the `setCommonInstanceMetadata` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -7530,7 +7530,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `setUsageExportBucket` method:
+    // TODO: Change placeholder below to desired parameter value for the `setUsageExportBucket` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -7801,7 +7801,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -7862,7 +7862,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+    // TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -8480,7 +8480,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `insert` method:
+    // TODO: Change placeholder below to desired parameter value for the `insert` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -8532,7 +8532,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -8695,7 +8695,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -8858,7 +8858,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `insert` method:
+    // TODO: Change placeholder below to desired parameter value for the `insert` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -8910,7 +8910,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -8971,7 +8971,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+    // TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -9361,7 +9361,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `insert` method:
+    // TODO: Change placeholder below to desired parameter value for the `insert` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -9413,7 +9413,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -9631,7 +9631,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `insert` method:
+    // TODO: Change placeholder below to desired parameter value for the `insert` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -9683,7 +9683,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -9854,7 +9854,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+    // TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -10258,7 +10258,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+    // TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -10880,7 +10880,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `insert` method:
+    // TODO: Change placeholder below to desired parameter value for the `insert` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -10932,7 +10932,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -11158,7 +11158,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+    // TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -11548,7 +11548,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `insert` method:
+    // TODO: Change placeholder below to desired parameter value for the `insert` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -11655,7 +11655,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -11881,7 +11881,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+    // TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',
@@ -12388,7 +12388,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // Project ID for this request.
     project: '{MY-PROJECT}',

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_dataflow.v1b3.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_dataflow.v1b3.json.baseline
@@ -28,7 +28,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `create` method:
+    // TODO: Change placeholder below to desired parameter value for the `create` method:
 
     // The project which owns the job.
     projectId: '{MY-PROJECT-ID}',
@@ -292,7 +292,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // The project which owns the jobs.
     projectId: '{MY-PROJECT-ID}',
@@ -582,7 +582,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `create` method:
+    // TODO: Change placeholder below to desired parameter value for the `create` method:
 
     // The project which owns the job.
     projectId: '{MY-PROJECT-ID}',
@@ -634,7 +634,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `workerMessages` method:
+    // TODO: Change placeholder below to desired parameter value for the `workerMessages` method:
 
     // The project to send the WorkerMessages to.
     projectId: '{MY-PROJECT-ID}',

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_dataproc.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_dataproc.v1.json.baseline
@@ -652,7 +652,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `cancel` method:
+    // TODO: Change placeholder below to desired parameter value for the `cancel` method:
 
     // The name of the operation resource to be cancelled.
     name: 'projects/{MY-PROJECT}/regions/{MY-REGION}/operations/{MY-OPERATION}',
@@ -696,7 +696,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `delete` method:
+    // TODO: Change placeholder below to desired parameter value for the `delete` method:
 
     // The name of the operation resource to be deleted.
     name: 'projects/{MY-PROJECT}/regions/{MY-REGION}/operations/{MY-OPERATION}',
@@ -740,7 +740,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `get` method:
+    // TODO: Change placeholder below to desired parameter value for the `get` method:
 
     // The name of the operation resource.
     name: 'projects/{MY-PROJECT}/regions/{MY-REGION}/operations/{MY-OPERATION}',
@@ -788,7 +788,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // The name of the operation collection.
     name: '{MY-NAME}',

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_datastore.v1beta3.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_datastore.v1beta3.json.baseline
@@ -28,7 +28,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `allocateIds` method:
+    // TODO: Change placeholder below to desired parameter value for the `allocateIds` method:
 
     // The ID of the project against which to make the request.
     projectId: '{MY-PROJECT-ID}',
@@ -80,7 +80,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `beginTransaction` method:
+    // TODO: Change placeholder below to desired parameter value for the `beginTransaction` method:
 
     // The ID of the project against which to make the request.
     projectId: '{MY-PROJECT-ID}',
@@ -132,7 +132,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `commit` method:
+    // TODO: Change placeholder below to desired parameter value for the `commit` method:
 
     // The ID of the project against which to make the request.
     projectId: '{MY-PROJECT-ID}',
@@ -184,7 +184,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `lookup` method:
+    // TODO: Change placeholder below to desired parameter value for the `lookup` method:
 
     // The ID of the project against which to make the request.
     projectId: '{MY-PROJECT-ID}',
@@ -236,7 +236,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `rollback` method:
+    // TODO: Change placeholder below to desired parameter value for the `rollback` method:
 
     // The ID of the project against which to make the request.
     projectId: '{MY-PROJECT-ID}',
@@ -288,7 +288,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `runQuery` method:
+    // TODO: Change placeholder below to desired parameter value for the `runQuery` method:
 
     // The ID of the project against which to make the request.
     projectId: '{MY-PROJECT-ID}',

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_deploymentmanager.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_deploymentmanager.v2.json.baseline
@@ -185,7 +185,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `insert` method:
+    // TODO: Change placeholder below to desired parameter value for the `insert` method:
 
     // The project ID for this request.
     project: '{MY-PROJECT}',
@@ -237,7 +237,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // The project ID for this request.
     project: '{MY-PROJECT}',
@@ -632,7 +632,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // The project ID for this request.
     project: '{MY-PROJECT}',
@@ -811,7 +811,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // The project ID for this request.
     project: '{MY-PROJECT}',

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_dns.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_dns.v1.json.baseline
@@ -201,7 +201,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `create` method:
+    // TODO: Change placeholder below to desired parameter value for the `create` method:
 
     // Identifies the project addressed by this request.
     project: '{MY-PROJECT}',
@@ -351,7 +351,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // Identifies the project addressed by this request.
     project: '{MY-PROJECT}',
@@ -412,7 +412,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `get` method:
+    // TODO: Change placeholder below to desired parameter value for the `get` method:
 
     // Identifies the project addressed by this request.
     project: '{MY-PROJECT}',

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_logging.v2beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_logging.v2beta1.json.baseline
@@ -188,7 +188,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `delete` method:
+    // TODO: Change placeholder below to desired parameter value for the `delete` method:
 
     // Required. The resource name of the log to delete. Example: `"projects/my-project/logs/syslog"`.
     logName: 'projects/{MY-PROJECT}/logs/{MY-LOG}',
@@ -232,7 +232,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `create` method:
+    // TODO: Change placeholder below to desired parameter value for the `create` method:
 
     // The resource name of the project in which to create the metric. Example: `"projects/my-project-id"`.
     // The new metric must be provided in the request.
@@ -285,7 +285,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `delete` method:
+    // TODO: Change placeholder below to desired parameter value for the `delete` method:
 
     // The resource name of the metric to delete. Example: `"projects/my-project-id/metrics/my-metric-id"`.
     metricName: 'projects/{MY-PROJECT}/metrics/{MY-METRIC}',
@@ -329,7 +329,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `get` method:
+    // TODO: Change placeholder below to desired parameter value for the `get` method:
 
     // The resource name of the desired metric. Example: `"projects/my-project-id/metrics/my-metric-id"`.
     metricName: 'projects/{MY-PROJECT}/metrics/{MY-METRIC}',
@@ -377,7 +377,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // Required. The resource name of the project containing the metrics. Example:
     // `"projects/my-project-id"`.
@@ -439,7 +439,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `update` method:
+    // TODO: Change placeholder below to desired parameter value for the `update` method:
 
     // The resource name of the metric to update. Example: `"projects/my-project-id/metrics/my-metric-id"`.
     // The updated metric must be provided in the request and have the same identifier that is specified in
@@ -493,7 +493,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `create` method:
+    // TODO: Change placeholder below to desired parameter value for the `create` method:
 
     // The resource name of the project in which to create the sink. Example: `"projects/my-project-id"`.
     // The new sink must be provided in the request.
@@ -546,7 +546,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `delete` method:
+    // TODO: Change placeholder below to desired parameter value for the `delete` method:
 
     // The resource name of the sink to delete. Example: `"projects/my-project-id/sinks/my-sink-id"`.
     sinkName: 'projects/{MY-PROJECT}/sinks/{MY-SINK}',
@@ -590,7 +590,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `get` method:
+    // TODO: Change placeholder below to desired parameter value for the `get` method:
 
     // The resource name of the sink to return. Example: `"projects/my-project-id/sinks/my-sink-id"`.
     sinkName: 'projects/{MY-PROJECT}/sinks/{MY-SINK}',
@@ -638,7 +638,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // Required. The resource name of the project containing the sinks. Example:
     // `"projects/my-logging-project"`.
@@ -700,7 +700,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `update` method:
+    // TODO: Change placeholder below to desired parameter value for the `update` method:
 
     // The resource name of the sink to update. Example: `"projects/my-project-id/sinks/my-sink-id"`. The
     // updated sink must be provided in the request and have the same name that is specified in `sinkName`.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_prediction.v1.6.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_prediction.v1.6.json.baseline
@@ -232,7 +232,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `insert` method:
+    // TODO: Change placeholder below to desired parameter value for the `insert` method:
 
     // The project associated with the model.
     project: '{MY-PROJECT}',
@@ -284,7 +284,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // The project associated with the model.
     project: '{MY-PROJECT}',

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_pubsub.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_pubsub.v1.json.baseline
@@ -28,7 +28,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `acknowledge` method:
+    // TODO: Change placeholder below to desired parameter value for the `acknowledge` method:
 
     // The subscription whose message is being acknowledged.
     subscription: 'projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}',
@@ -76,7 +76,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `create` method:
+    // TODO: Change placeholder below to desired parameter value for the `create` method:
 
     // The name of the subscription. It must have the format
     // `"projects/{project}/subscriptions/{subscription}"`. `{subscription}` must start with a letter, and
@@ -132,7 +132,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `delete` method:
+    // TODO: Change placeholder below to desired parameter value for the `delete` method:
 
     // The subscription to delete.
     subscription: 'projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}',
@@ -176,7 +176,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `get` method:
+    // TODO: Change placeholder below to desired parameter value for the `get` method:
 
     // The name of the subscription to get.
     subscription: 'projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}',
@@ -224,7 +224,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `getIamPolicy` method:
+    // TODO: Change placeholder below to desired parameter value for the `getIamPolicy` method:
 
     // REQUIRED: The resource for which the policy is being requested. `resource` is usually specified as a
     // path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
@@ -274,7 +274,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // The name of the cloud project that subscriptions belong to.
     project: 'projects/{MY-PROJECT}',
@@ -335,7 +335,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `modifyAckDeadline` method:
+    // TODO: Change placeholder below to desired parameter value for the `modifyAckDeadline` method:
 
     // The name of the subscription.
     subscription: 'projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}',
@@ -383,7 +383,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `modifyPushConfig` method:
+    // TODO: Change placeholder below to desired parameter value for the `modifyPushConfig` method:
 
     // The name of the subscription.
     subscription: 'projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}',
@@ -431,7 +431,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `pull` method:
+    // TODO: Change placeholder below to desired parameter value for the `pull` method:
 
     // The subscription from which messages should be pulled.
     subscription: 'projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}',
@@ -483,7 +483,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `setIamPolicy` method:
+    // TODO: Change placeholder below to desired parameter value for the `setIamPolicy` method:
 
     // REQUIRED: The resource for which the policy is being specified. `resource` is usually specified as a
     // path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
@@ -537,7 +537,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `testIamPermissions` method:
+    // TODO: Change placeholder below to desired parameter value for the `testIamPermissions` method:
 
     // REQUIRED: The resource for which the policy detail is being requested. `resource` is usually
     // specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path
@@ -592,7 +592,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `create` method:
+    // TODO: Change placeholder below to desired parameter value for the `create` method:
 
     // The name of the topic. It must have the format `"projects/{project}/topics/{topic}"`. `{topic}` must
     // start with a letter, and contain only letters (`[A-Za-z]`), numbers (`[0-9]`), dashes (`-`),
@@ -647,7 +647,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `delete` method:
+    // TODO: Change placeholder below to desired parameter value for the `delete` method:
 
     // Name of the topic to delete.
     topic: 'projects/{MY-PROJECT}/topics/{MY-TOPIC}',
@@ -691,7 +691,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `get` method:
+    // TODO: Change placeholder below to desired parameter value for the `get` method:
 
     // The name of the topic to get.
     topic: 'projects/{MY-PROJECT}/topics/{MY-TOPIC}',
@@ -739,7 +739,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `getIamPolicy` method:
+    // TODO: Change placeholder below to desired parameter value for the `getIamPolicy` method:
 
     // REQUIRED: The resource for which the policy is being requested. `resource` is usually specified as a
     // path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
@@ -789,7 +789,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // The name of the cloud project that topics belong to.
     project: 'projects/{MY-PROJECT}',
@@ -850,7 +850,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `publish` method:
+    // TODO: Change placeholder below to desired parameter value for the `publish` method:
 
     // The messages in the request will be published on this topic.
     topic: 'projects/{MY-PROJECT}/topics/{MY-TOPIC}',
@@ -902,7 +902,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `setIamPolicy` method:
+    // TODO: Change placeholder below to desired parameter value for the `setIamPolicy` method:
 
     // REQUIRED: The resource for which the policy is being specified. `resource` is usually specified as a
     // path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
@@ -956,7 +956,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // The name of the topic that subscriptions are attached to.
     topic: 'projects/{MY-PROJECT}/topics/{MY-TOPIC}',
@@ -1017,7 +1017,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `testIamPermissions` method:
+    // TODO: Change placeholder below to desired parameter value for the `testIamPermissions` method:
 
     // REQUIRED: The resource for which the policy detail is being requested. `resource` is usually
     // specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_sqladmin.v1beta4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_sqladmin.v1beta4.json.baseline
@@ -949,7 +949,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `insert` method:
+    // TODO: Change placeholder below to desired parameter value for the `insert` method:
 
     // Project ID of the project to which the newly created Cloud SQL instances should belong.
     project: '{MY-PROJECT}',
@@ -1001,7 +1001,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // Project ID of the project for which to list Cloud SQL instances.
     project: '{MY-PROJECT}',
@@ -1866,7 +1866,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // Project ID of the project for which to list tiers.
     project: '{MY-PROJECT}',

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_storage.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_storage.v1.json.baseline
@@ -128,7 +128,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `insert` method:
+    // TODO: Change placeholder below to desired parameter value for the `insert` method:
 
     // Name of a bucket.
     bucket: '{MY-BUCKET}',
@@ -180,7 +180,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // Name of a bucket.
     bucket: '{MY-BUCKET}',
@@ -340,7 +340,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `delete` method:
+    // TODO: Change placeholder below to desired parameter value for the `delete` method:
 
     // Name of a bucket.
     bucket: '{MY-BUCKET}',
@@ -384,7 +384,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `get` method:
+    // TODO: Change placeholder below to desired parameter value for the `get` method:
 
     // Name of a bucket.
     bucket: '{MY-BUCKET}',
@@ -432,7 +432,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `insert` method:
+    // TODO: Change placeholder below to desired parameter value for the `insert` method:
 
     // A valid API project identifier.
     project: '{MY-PROJECT}',
@@ -484,7 +484,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // A valid API project identifier.
     project: '{MY-PROJECT}',
@@ -545,7 +545,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `patch` method:
+    // TODO: Change placeholder below to desired parameter value for the `patch` method:
 
     // Name of a bucket.
     bucket: '{MY-BUCKET}',
@@ -597,7 +597,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `update` method:
+    // TODO: Change placeholder below to desired parameter value for the `update` method:
 
     // Name of a bucket.
     bucket: '{MY-BUCKET}',
@@ -791,7 +791,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `insert` method:
+    // TODO: Change placeholder below to desired parameter value for the `insert` method:
 
     // Name of a bucket.
     bucket: '{MY-BUCKET}',
@@ -843,7 +843,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // Name of a bucket.
     bucket: '{MY-BUCKET}',
@@ -1560,7 +1560,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `insert` method:
+    // TODO: Change placeholder below to desired parameter value for the `insert` method:
 
     // Name of the bucket in which to store the new object. Overrides the provided object metadata's bucket
     // value, if any.
@@ -1620,7 +1620,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // Name of the bucket in which to look for objects.
     bucket: '{MY-BUCKET}',
@@ -1858,7 +1858,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `watchAll` method:
+    // TODO: Change placeholder below to desired parameter value for the `watchAll` method:
 
     // Name of the bucket in which to look for objects.
     bucket: '{MY-BUCKET}',

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_storagetransfer.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_storagetransfer.v1.json.baseline
@@ -70,7 +70,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `get` method:
+    // TODO: Change placeholder below to desired parameter value for the `get` method:
 
     // The ID of the Google Developers Console project that the Google service account is associated with.
     // Required.
@@ -165,7 +165,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `get` method:
+    // TODO: Change placeholder below to desired parameter value for the `get` method:
 
     // The job to get. Required.
     jobName: '{MY-JOB-NAME}',
@@ -268,7 +268,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `patch` method:
+    // TODO: Change placeholder below to desired parameter value for the `patch` method:
 
     // The name of job to update. Required.
     jobName: '{MY-JOB-NAME}',
@@ -320,7 +320,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `cancel` method:
+    // TODO: Change placeholder below to desired parameter value for the `cancel` method:
 
     // The name of the operation resource to be cancelled.
     name: '{MY-NAME}',
@@ -364,7 +364,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `delete` method:
+    // TODO: Change placeholder below to desired parameter value for the `delete` method:
 
     // The name of the operation resource to be deleted.
     name: '{MY-NAME}',
@@ -408,7 +408,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `get` method:
+    // TODO: Change placeholder below to desired parameter value for the `get` method:
 
     // The name of the operation resource.
     name: '{MY-NAME}',
@@ -456,7 +456,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `list` method:
+    // TODO: Change placeholder below to desired parameter value for the `list` method:
 
     // The value `transferOperations`.
     name: '{MY-NAME}',
@@ -517,7 +517,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `pause` method:
+    // TODO: Change placeholder below to desired parameter value for the `pause` method:
 
     // The name of the transfer operation. Required.
     name: '{MY-NAME}',
@@ -565,7 +565,7 @@ google.auth.getApplicationDefault(function(err, authClient) {
 
   var request = {
 
-    // TODO: Change placeholders below to desired parameter values for the `resume` method:
+    // TODO: Change placeholder below to desired parameter value for the `resume` method:
 
     // The name of the transfer operation. Required.
     name: '{MY-NAME}',

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_translate.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_translate.v2.json.baseline
@@ -11,7 +11,7 @@ var translate = google.translate('v2');
 
 var request = {
 
-  // TODO: Change placeholders below to desired parameter values for the `list` method:
+  // TODO: Change placeholder below to desired parameter value for the `list` method:
 
   // The text to detect
   q: '',

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_adexchangebuyer.v1.4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_adexchangebuyer.v1.4.json.baseline
@@ -17,7 +17,7 @@ $client = getClient();
 $service = new Google_Service_Adexchangebuyer($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `get` method:
+// TODO: Change placeholder below to desired parameter value for the `get` method:
 
 // The account id
 $id = 0;
@@ -85,7 +85,7 @@ $client = getClient();
 $service = new Google_Service_Adexchangebuyer($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `patch` method:
+// TODO: Change placeholder below to desired parameter value for the `patch` method:
 
 // The account id
 $id = 0;
@@ -126,7 +126,7 @@ $client = getClient();
 $service = new Google_Service_Adexchangebuyer($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `update` method:
+// TODO: Change placeholder below to desired parameter value for the `update` method:
 
 // The account id
 $id = 0;
@@ -167,7 +167,7 @@ $client = getClient();
 $service = new Google_Service_Adexchangebuyer($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `get` method:
+// TODO: Change placeholder below to desired parameter value for the `get` method:
 
 // The account id.
 $accountId = 0;
@@ -556,7 +556,7 @@ $client = getClient();
 $service = new Google_Service_Adexchangebuyer($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `delete` method:
+// TODO: Change placeholder below to desired parameter value for the `delete` method:
 
 // The proposalId to delete deals from.
 $proposalId = '{MY-PROPOSAL-ID}';
@@ -597,7 +597,7 @@ $client = getClient();
 $service = new Google_Service_Adexchangebuyer($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `insert` method:
+// TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 // proposalId for which deals need to be added.
 $proposalId = '{MY-PROPOSAL-ID}';
@@ -638,7 +638,7 @@ $client = getClient();
 $service = new Google_Service_Adexchangebuyer($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listMarketplacedeals` method:
+// TODO: Change placeholder below to desired parameter value for the `listMarketplacedeals` method:
 
 // The proposalId to get deals for. To search across all proposals specify order_id = '-' as part of
 // the URL.
@@ -676,7 +676,7 @@ $client = getClient();
 $service = new Google_Service_Adexchangebuyer($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `update` method:
+// TODO: Change placeholder below to desired parameter value for the `update` method:
 
 // The proposalId to edit deals on.
 $proposalId = '{MY-PROPOSAL-ID}';
@@ -717,7 +717,7 @@ $client = getClient();
 $service = new Google_Service_Adexchangebuyer($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `insert` method:
+// TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 // The proposalId to add notes for.
 $proposalId = '{MY-PROPOSAL-ID}';
@@ -758,7 +758,7 @@ $client = getClient();
 $service = new Google_Service_Adexchangebuyer($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listMarketplacenotes` method:
+// TODO: Change placeholder below to desired parameter value for the `listMarketplacenotes` method:
 
 // The proposalId to get notes for. To search across all proposals specify order_id = '-' as part of
 // the URL.
@@ -796,7 +796,7 @@ $client = getClient();
 $service = new Google_Service_Adexchangebuyer($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `updateproposal` method:
+// TODO: Change placeholder below to desired parameter value for the `updateproposal` method:
 
 // The private auction id to be updated.
 $privateAuctionId = '{MY-PRIVATE-AUCTION-ID}';
@@ -954,7 +954,7 @@ $client = getClient();
 $service = new Google_Service_Adexchangebuyer($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `insert` method:
+// TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 // The account id to insert the pretargeting config for.
 $accountId = '0';
@@ -995,7 +995,7 @@ $client = getClient();
 $service = new Google_Service_Adexchangebuyer($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listPretargetingConfig` method:
+// TODO: Change placeholder below to desired parameter value for the `listPretargetingConfig` method:
 
 // The account id to get the pretargeting configs for.
 $accountId = '0';
@@ -1120,7 +1120,7 @@ $client = getClient();
 $service = new Google_Service_Adexchangebuyer($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `get` method:
+// TODO: Change placeholder below to desired parameter value for the `get` method:
 
 // The id for the product to get the head revision for.
 $productId = '{MY-PRODUCT-ID}';
@@ -1188,7 +1188,7 @@ $client = getClient();
 $service = new Google_Service_Adexchangebuyer($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `get` method:
+// TODO: Change placeholder below to desired parameter value for the `get` method:
 
 // Id of the proposal to retrieve.
 $proposalId = '{MY-PROPOSAL-ID}';
@@ -1341,7 +1341,7 @@ $client = getClient();
 $service = new Google_Service_Adexchangebuyer($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `setupcomplete` method:
+// TODO: Change placeholder below to desired parameter value for the `setupcomplete` method:
 
 // The proposal id for which the setup is complete
 $proposalId = '{MY-PROPOSAL-ID}';
@@ -1425,7 +1425,7 @@ $client = getClient();
 $service = new Google_Service_Adexchangebuyer($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listPubprofiles` method:
+// TODO: Change placeholder below to desired parameter value for the `listPubprofiles` method:
 
 // The accountId of the publisher to get profiles for.
 $accountId = 0;

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_appengine.v1beta5.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_appengine.v1beta5.json.baseline
@@ -63,7 +63,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Appengine($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `get` method:
+// TODO: Change placeholder below to desired parameter value for the `get` method:
 
 // Part of `name`. Name of the application to get. Example: `apps/myapp`.
 $appsId = '{MY-APPS-ID}';
@@ -142,7 +142,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Appengine($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listAppsLocations` method:
+// TODO: Change placeholder below to desired parameter value for the `listAppsLocations` method:
 
 // Part of `name`. The resource that owns the locations collection, if applicable.
 $appsId = '{MY-APPS-ID}';
@@ -228,7 +228,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Appengine($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listAppsOperations` method:
+// TODO: Change placeholder below to desired parameter value for the `listAppsOperations` method:
 
 // Part of `name`. The name of the operation collection.
 $appsId = '{MY-APPS-ID}';
@@ -355,7 +355,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Appengine($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listAppsServices` method:
+// TODO: Change placeholder below to desired parameter value for the `listAppsServices` method:
 
 // Part of `name`. Name of the resource requested. Example: `apps/myapp`.
 $appsId = '{MY-APPS-ID}';

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_bigquery.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_bigquery.v2.json.baseline
@@ -106,7 +106,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Bigquery($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `insert` method:
+// TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 // Project ID of the new dataset
 $projectId = '{MY-PROJECT-ID}';
@@ -148,7 +148,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Bigquery($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listDatasets` method:
+// TODO: Change placeholder below to desired parameter value for the `listDatasets` method:
 
 // Project ID of the datasets to be listed
 $projectId = '{MY-PROJECT-ID}';
@@ -406,7 +406,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Bigquery($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `insert` method:
+// TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 // Project ID of the project that will be billed for the job
 $projectId = '{MY-PROJECT-ID}';
@@ -448,7 +448,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Bigquery($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listJobs` method:
+// TODO: Change placeholder below to desired parameter value for the `listJobs` method:
 
 // Project ID of the jobs to list
 $projectId = '{MY-PROJECT-ID}';
@@ -493,7 +493,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Bigquery($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `query` method:
+// TODO: Change placeholder below to desired parameter value for the `query` method:
 
 // Project ID of the project billed for the query
 $projectId = '{MY-PROJECT-ID}';

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_cloudbilling.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_cloudbilling.v1.json.baseline
@@ -27,7 +27,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Cloudbilling($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `get` method:
+// TODO: Change placeholder below to desired parameter value for the `get` method:
 
 // The resource name of the billing account to retrieve. For example,
 // `billingAccounts/012345-567890-ABCDEF`.
@@ -105,7 +105,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Cloudbilling($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listBillingAccountsProjects` method:
+// TODO: Change placeholder below to desired parameter value for the `listBillingAccountsProjects` method:
 
 // The resource name of the billing account associated with the projects that you want to list. For
 // example, `billingAccounts/012345-567890-ABCDEF`.
@@ -151,7 +151,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Cloudbilling($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `getBillingInfo` method:
+// TODO: Change placeholder below to desired parameter value for the `getBillingInfo` method:
 
 // The resource name of the project for which billing information is retrieved. For example,
 // `projects/tokyo-rain-123`.
@@ -190,7 +190,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Cloudbilling($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `updateBillingInfo` method:
+// TODO: Change placeholder below to desired parameter value for the `updateBillingInfo` method:
 
 // The resource name of the project associated with the billing information that you want to update.
 // For example, `projects/tokyo-rain-123`.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_clouddebugger.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_clouddebugger.v2.json.baseline
@@ -27,7 +27,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudDebugger($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listControllerDebuggeesBreakpoints` method:
+// TODO: Change placeholder below to desired parameter value for the `listControllerDebuggeesBreakpoints` method:
 
 // Identifies the debuggee.
 $debuggeeId = '{MY-DEBUGGEE-ID}';
@@ -225,7 +225,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudDebugger($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listDebuggerDebuggeesBreakpoints` method:
+// TODO: Change placeholder below to desired parameter value for the `listDebuggerDebuggeesBreakpoints` method:
 
 // ID of the debuggee whose breakpoints to list.
 $debuggeeId = '{MY-DEBUGGEE-ID}';
@@ -263,7 +263,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudDebugger($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `set` method:
+// TODO: Change placeholder below to desired parameter value for the `set` method:
 
 // ID of the debuggee where the breakpoint is to be set.
 $debuggeeId = '{MY-DEBUGGEE-ID}';

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_cloudmonitoring.v2beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_cloudmonitoring.v2beta2.json.baseline
@@ -27,7 +27,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudMonitoring($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `create` method:
+// TODO: Change placeholder below to desired parameter value for the `create` method:
 
 // The project id. The value can be the numeric project ID or string-based project name.
 $project = '{MY-PROJECT}';
@@ -110,7 +110,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudMonitoring($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listMetricDescriptors` method:
+// TODO: Change placeholder below to desired parameter value for the `listMetricDescriptors` method:
 
 // The project id. The value can be the numeric project ID or string-based project name.
 $project = '{MY-PROJECT}';
@@ -216,7 +216,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudMonitoring($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `write` method:
+// TODO: Change placeholder below to desired parameter value for the `write` method:
 
 // The project ID. The value can be the numeric project ID or string-based project name.
 $project = '{MY-PROJECT}';

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_cloudresourcemanager.v1beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_cloudresourcemanager.v1beta1.json.baseline
@@ -27,7 +27,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudResourceManager($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `get` method:
+// TODO: Change placeholder below to desired parameter value for the `get` method:
 
 // The resource name of the Organization to fetch. Its format is "organizations/[organization_id]". For
 // example, "organizations/1234".
@@ -66,7 +66,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudResourceManager($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `getIamPolicy` method:
+// TODO: Change placeholder below to desired parameter value for the `getIamPolicy` method:
 
 // REQUIRED: The resource for which the policy is being requested. `resource` is usually specified as a
 // path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
@@ -149,7 +149,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudResourceManager($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `setIamPolicy` method:
+// TODO: Change placeholder below to desired parameter value for the `setIamPolicy` method:
 
 // REQUIRED: The resource for which the policy is being specified. `resource` is usually specified as a
 // path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
@@ -193,7 +193,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudResourceManager($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `testIamPermissions` method:
+// TODO: Change placeholder below to desired parameter value for the `testIamPermissions` method:
 
 // REQUIRED: The resource for which the policy detail is being requested. `resource` is usually
 // specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path
@@ -238,7 +238,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudResourceManager($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `update` method:
+// TODO: Change placeholder below to desired parameter value for the `update` method:
 
 // Output Only. The resource name of the organization. This is the organization's relative path in the
 // API. Its format is "organizations/[organization_id]". For example, "organizations/1234".
@@ -317,7 +317,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudResourceManager($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `delete` method:
+// TODO: Change placeholder below to desired parameter value for the `delete` method:
 
 // The Project ID (for example, `foo-bar-123`). Required.
 $projectId = '{MY-PROJECT-ID}';
@@ -352,7 +352,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudResourceManager($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `get` method:
+// TODO: Change placeholder below to desired parameter value for the `get` method:
 
 // The Project ID (for example, `my-project-123`). Required.
 $projectId = '{MY-PROJECT-ID}';
@@ -390,7 +390,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudResourceManager($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `getAncestry` method:
+// TODO: Change placeholder below to desired parameter value for the `getAncestry` method:
 
 // The Project ID (for example, `my-project-123`). Required.
 $projectId = '{MY-PROJECT-ID}';
@@ -432,7 +432,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudResourceManager($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `getIamPolicy` method:
+// TODO: Change placeholder below to desired parameter value for the `getIamPolicy` method:
 
 // REQUIRED: The resource for which the policy is being requested. `resource` is usually specified as a
 // path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
@@ -515,7 +515,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudResourceManager($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `setIamPolicy` method:
+// TODO: Change placeholder below to desired parameter value for the `setIamPolicy` method:
 
 // REQUIRED: The resource for which the policy is being specified. `resource` is usually specified as a
 // path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
@@ -559,7 +559,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudResourceManager($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `testIamPermissions` method:
+// TODO: Change placeholder below to desired parameter value for the `testIamPermissions` method:
 
 // REQUIRED: The resource for which the policy detail is being requested. `resource` is usually
 // specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path
@@ -604,7 +604,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudResourceManager($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `undelete` method:
+// TODO: Change placeholder below to desired parameter value for the `undelete` method:
 
 // The project ID (for example, `foo-bar-123`). Required.
 $projectId = '{MY-PROJECT-ID}';
@@ -643,7 +643,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudResourceManager($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `update` method:
+// TODO: Change placeholder below to desired parameter value for the `update` method:
 
 // The project ID (for example, `my-project-123`). Required.
 $projectId = '{MY-PROJECT-ID}';

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_cloudtrace.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_cloudtrace.v1.json.baseline
@@ -27,7 +27,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudTrace($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `patchTraces` method:
+// TODO: Change placeholder below to desired parameter value for the `patchTraces` method:
 
 // ID of the Cloud project where the trace data is stored.
 $projectId = '{MY-PROJECT-ID}';
@@ -107,7 +107,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudTrace($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listProjectsTraces` method:
+// TODO: Change placeholder below to desired parameter value for the `listProjectsTraces` method:
 
 // ID of the Cloud project where the trace data is stored.
 $projectId = '{MY-PROJECT-ID}';

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_clouduseraccounts.beta.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_clouduseraccounts.beta.json.baseline
@@ -106,7 +106,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudUserAccounts($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listGlobalAccountsOperations` method:
+// TODO: Change placeholder below to desired parameter value for the `listGlobalAccountsOperations` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -278,7 +278,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudUserAccounts($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `insert` method:
+// TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -320,7 +320,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudUserAccounts($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listGroups` method:
+// TODO: Change placeholder below to desired parameter value for the `listGroups` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -628,7 +628,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudUserAccounts($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `insert` method:
+// TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -670,7 +670,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudUserAccounts($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listUsers` method:
+// TODO: Change placeholder below to desired parameter value for the `listUsers` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_compute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_compute.v1.json.baseline
@@ -27,7 +27,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+// TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -253,7 +253,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+// TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -699,7 +699,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `insert` method:
+// TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -741,7 +741,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listBackendServices` method:
+// TODO: Change placeholder below to desired parameter value for the `listBackendServices` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -876,7 +876,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+// TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -1013,7 +1013,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+// TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -1417,7 +1417,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `insert` method:
+// TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -1459,7 +1459,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listFirewalls` method:
+// TODO: Change placeholder below to desired parameter value for the `listFirewalls` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -1594,7 +1594,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+// TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -1950,7 +1950,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `insert` method:
+// TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -1992,7 +1992,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listGlobalAddresses` method:
+// TODO: Change placeholder below to desired parameter value for the `listGlobalAddresses` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -2119,7 +2119,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `insert` method:
+// TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -2161,7 +2161,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listGlobalForwardingRules` method:
+// TODO: Change placeholder below to desired parameter value for the `listGlobalForwardingRules` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -2251,7 +2251,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+// TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -2375,7 +2375,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listGlobalOperations` method:
+// TODO: Change placeholder below to desired parameter value for the `listGlobalOperations` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -2502,7 +2502,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `insert` method:
+// TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -2544,7 +2544,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listHealthChecks` method:
+// TODO: Change placeholder below to desired parameter value for the `listHealthChecks` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -2761,7 +2761,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `insert` method:
+// TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -2803,7 +2803,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listHttpHealthChecks` method:
+// TODO: Change placeholder below to desired parameter value for the `listHttpHealthChecks` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -3020,7 +3020,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `insert` method:
+// TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -3062,7 +3062,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listHttpsHealthChecks` method:
+// TODO: Change placeholder below to desired parameter value for the `listHttpsHealthChecks` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -3365,7 +3365,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `insert` method:
+// TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -3407,7 +3407,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listImages` method:
+// TODO: Change placeholder below to desired parameter value for the `listImages` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -3500,7 +3500,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+// TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -4059,7 +4059,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+// TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -4518,7 +4518,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `insert` method:
+// TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -4560,7 +4560,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listInstanceTemplates` method:
+// TODO: Change placeholder below to desired parameter value for the `listInstanceTemplates` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -4656,7 +4656,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+// TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -5534,7 +5534,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+// TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -5753,7 +5753,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `insert` method:
+// TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -5795,7 +5795,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listNetworks` method:
+// TODO: Change placeholder below to desired parameter value for the `listNetworks` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -5840,7 +5840,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `get` method:
+// TODO: Change placeholder below to desired parameter value for the `get` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -5878,7 +5878,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `moveDisk` method:
+// TODO: Change placeholder below to desired parameter value for the `moveDisk` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -5920,7 +5920,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `moveInstance` method:
+// TODO: Change placeholder below to desired parameter value for the `moveInstance` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -5962,7 +5962,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `setCommonInstanceMetadata` method:
+// TODO: Change placeholder below to desired parameter value for the `setCommonInstanceMetadata` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -6004,7 +6004,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `setUsageExportBucket` method:
+// TODO: Change placeholder below to desired parameter value for the `setUsageExportBucket` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -6220,7 +6220,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listRegions` method:
+// TODO: Change placeholder below to desired parameter value for the `listRegions` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -6265,7 +6265,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+// TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -6761,7 +6761,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `insert` method:
+// TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -6803,7 +6803,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listRoutes` method:
+// TODO: Change placeholder below to desired parameter value for the `listRoutes` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -6930,7 +6930,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listSnapshots` method:
+// TODO: Change placeholder below to desired parameter value for the `listSnapshots` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -7057,7 +7057,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `insert` method:
+// TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -7099,7 +7099,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listSslCertificates` method:
+// TODO: Change placeholder below to desired parameter value for the `listSslCertificates` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -7144,7 +7144,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+// TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -7452,7 +7452,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `insert` method:
+// TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -7494,7 +7494,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listTargetHttpProxies` method:
+// TODO: Change placeholder below to desired parameter value for the `listTargetHttpProxies` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -7666,7 +7666,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `insert` method:
+// TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -7708,7 +7708,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listTargetHttpsProxies` method:
+// TODO: Change placeholder below to desired parameter value for the `listTargetHttpsProxies` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -7843,7 +7843,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+// TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -8165,7 +8165,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+// TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -8665,7 +8665,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `insert` method:
+// TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -8707,7 +8707,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listTargetSslProxies` method:
+// TODO: Change placeholder below to desired parameter value for the `listTargetSslProxies` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -8887,7 +8887,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+// TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -9195,7 +9195,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `insert` method:
+// TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -9282,7 +9282,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listUrlMaps` method:
+// TODO: Change placeholder below to desired parameter value for the `listUrlMaps` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -9462,7 +9462,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+// TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';
@@ -9862,7 +9862,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Compute($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listZones` method:
+// TODO: Change placeholder below to desired parameter value for the `listZones` method:
 
 // Project ID for this request.
 $project = '{MY-PROJECT}';

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_dataflow.v1b3.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_dataflow.v1b3.json.baseline
@@ -27,7 +27,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Dataflow($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `create` method:
+// TODO: Change placeholder below to desired parameter value for the `create` method:
 
 // The project which owns the job.
 $projectId = '{MY-PROJECT-ID}';
@@ -241,7 +241,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Dataflow($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listProjectsJobs` method:
+// TODO: Change placeholder below to desired parameter value for the `listProjectsJobs` method:
 
 // The project which owns the jobs.
 $projectId = '{MY-PROJECT-ID}';
@@ -469,7 +469,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Dataflow($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `create` method:
+// TODO: Change placeholder below to desired parameter value for the `create` method:
 
 // The project which owns the job.
 $projectId = '{MY-PROJECT-ID}';
@@ -511,7 +511,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Dataflow($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `workerMessages` method:
+// TODO: Change placeholder below to desired parameter value for the `workerMessages` method:
 
 // The project to send the WorkerMessages to.
 $projectId = '{MY-PROJECT-ID}';

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_dataproc.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_dataproc.v1.json.baseline
@@ -530,7 +530,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Dataproc($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `cancel` method:
+// TODO: Change placeholder below to desired parameter value for the `cancel` method:
 
 // The name of the operation resource to be cancelled.
 $name = 'projects/{MY-PROJECT}/regions/{MY-REGION}/operations/{MY-OPERATION}';
@@ -565,7 +565,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Dataproc($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `delete` method:
+// TODO: Change placeholder below to desired parameter value for the `delete` method:
 
 // The name of the operation resource to be deleted.
 $name = 'projects/{MY-PROJECT}/regions/{MY-REGION}/operations/{MY-OPERATION}';
@@ -600,7 +600,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Dataproc($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `get` method:
+// TODO: Change placeholder below to desired parameter value for the `get` method:
 
 // The name of the operation resource.
 $name = 'projects/{MY-PROJECT}/regions/{MY-REGION}/operations/{MY-OPERATION}';
@@ -638,7 +638,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Dataproc($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listProjectsRegionsOperations` method:
+// TODO: Change placeholder below to desired parameter value for the `listProjectsRegionsOperations` method:
 
 // The name of the operation collection.
 $name = '{MY-NAME}';

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_datastore.v1beta3.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_datastore.v1beta3.json.baseline
@@ -27,7 +27,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Datastore($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `allocateIds` method:
+// TODO: Change placeholder below to desired parameter value for the `allocateIds` method:
 
 // The ID of the project against which to make the request.
 $projectId = '{MY-PROJECT-ID}';
@@ -69,7 +69,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Datastore($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `beginTransaction` method:
+// TODO: Change placeholder below to desired parameter value for the `beginTransaction` method:
 
 // The ID of the project against which to make the request.
 $projectId = '{MY-PROJECT-ID}';
@@ -111,7 +111,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Datastore($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `commit` method:
+// TODO: Change placeholder below to desired parameter value for the `commit` method:
 
 // The ID of the project against which to make the request.
 $projectId = '{MY-PROJECT-ID}';
@@ -153,7 +153,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Datastore($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `lookup` method:
+// TODO: Change placeholder below to desired parameter value for the `lookup` method:
 
 // The ID of the project against which to make the request.
 $projectId = '{MY-PROJECT-ID}';
@@ -195,7 +195,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Datastore($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `rollback` method:
+// TODO: Change placeholder below to desired parameter value for the `rollback` method:
 
 // The ID of the project against which to make the request.
 $projectId = '{MY-PROJECT-ID}';
@@ -237,7 +237,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Datastore($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `runQuery` method:
+// TODO: Change placeholder below to desired parameter value for the `runQuery` method:
 
 // The ID of the project against which to make the request.
 $projectId = '{MY-PROJECT-ID}';

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_deploymentmanager.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_deploymentmanager.v2.json.baseline
@@ -154,7 +154,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_DeploymentManager($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `insert` method:
+// TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 // The project ID for this request.
 $project = '{MY-PROJECT}';
@@ -196,7 +196,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_DeploymentManager($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listDeployments` method:
+// TODO: Change placeholder below to desired parameter value for the `listDeployments` method:
 
 // The project ID for this request.
 $project = '{MY-PROJECT}';
@@ -509,7 +509,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_DeploymentManager($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listOperations` method:
+// TODO: Change placeholder below to desired parameter value for the `listOperations` method:
 
 // The project ID for this request.
 $project = '{MY-PROJECT}';
@@ -646,7 +646,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_DeploymentManager($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listTypes` method:
+// TODO: Change placeholder below to desired parameter value for the `listTypes` method:
 
 // The project ID for this request.
 $project = '{MY-PROJECT}';

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_dns.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_dns.v1.json.baseline
@@ -164,7 +164,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Dns($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `create` method:
+// TODO: Change placeholder below to desired parameter value for the `create` method:
 
 // Identifies the project addressed by this request.
 $project = '{MY-PROJECT}';
@@ -285,7 +285,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Dns($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listManagedZones` method:
+// TODO: Change placeholder below to desired parameter value for the `listManagedZones` method:
 
 // Identifies the project addressed by this request.
 $project = '{MY-PROJECT}';
@@ -330,7 +330,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Dns($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `get` method:
+// TODO: Change placeholder below to desired parameter value for the `get` method:
 
 // Identifies the project addressed by this request.
 $project = '{MY-PROJECT}';

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_logging.v2beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_logging.v2beta1.json.baseline
@@ -145,7 +145,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Logging($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `delete` method:
+// TODO: Change placeholder below to desired parameter value for the `delete` method:
 
 // Required. The resource name of the log to delete. Example: `"projects/my-project/logs/syslog"`.
 $logName = 'projects/{MY-PROJECT}/logs/{MY-LOG}';
@@ -180,7 +180,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Logging($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `create` method:
+// TODO: Change placeholder below to desired parameter value for the `create` method:
 
 // The resource name of the project in which to create the metric. Example: `"projects/my-project-id"`.
 // The new metric must be provided in the request.
@@ -223,7 +223,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Logging($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `delete` method:
+// TODO: Change placeholder below to desired parameter value for the `delete` method:
 
 // The resource name of the metric to delete. Example: `"projects/my-project-id/metrics/my-metric-id"`.
 $metricName = 'projects/{MY-PROJECT}/metrics/{MY-METRIC}';
@@ -258,7 +258,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Logging($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `get` method:
+// TODO: Change placeholder below to desired parameter value for the `get` method:
 
 // The resource name of the desired metric. Example: `"projects/my-project-id/metrics/my-metric-id"`.
 $metricName = 'projects/{MY-PROJECT}/metrics/{MY-METRIC}';
@@ -296,7 +296,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Logging($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listProjectsMetrics` method:
+// TODO: Change placeholder below to desired parameter value for the `listProjectsMetrics` method:
 
 // Required. The resource name of the project containing the metrics. Example:
 // `"projects/my-project-id"`.
@@ -342,7 +342,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Logging($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `update` method:
+// TODO: Change placeholder below to desired parameter value for the `update` method:
 
 // The resource name of the metric to update. Example: `"projects/my-project-id/metrics/my-metric-id"`.
 // The updated metric must be provided in the request and have the same identifier that is specified in
@@ -386,7 +386,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Logging($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `create` method:
+// TODO: Change placeholder below to desired parameter value for the `create` method:
 
 // The resource name of the project in which to create the sink. Example: `"projects/my-project-id"`.
 // The new sink must be provided in the request.
@@ -429,7 +429,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Logging($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `delete` method:
+// TODO: Change placeholder below to desired parameter value for the `delete` method:
 
 // The resource name of the sink to delete. Example: `"projects/my-project-id/sinks/my-sink-id"`.
 $sinkName = 'projects/{MY-PROJECT}/sinks/{MY-SINK}';
@@ -464,7 +464,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Logging($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `get` method:
+// TODO: Change placeholder below to desired parameter value for the `get` method:
 
 // The resource name of the sink to return. Example: `"projects/my-project-id/sinks/my-sink-id"`.
 $sinkName = 'projects/{MY-PROJECT}/sinks/{MY-SINK}';
@@ -502,7 +502,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Logging($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listProjectsSinks` method:
+// TODO: Change placeholder below to desired parameter value for the `listProjectsSinks` method:
 
 // Required. The resource name of the project containing the sinks. Example:
 // `"projects/my-logging-project"`.
@@ -548,7 +548,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Logging($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `update` method:
+// TODO: Change placeholder below to desired parameter value for the `update` method:
 
 // The resource name of the sink to update. Example: `"projects/my-project-id/sinks/my-sink-id"`. The
 // updated sink must be provided in the request and have the same name that is specified in `sinkName`.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_prediction.v1.6.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_prediction.v1.6.json.baseline
@@ -192,7 +192,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Prediction($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `insert` method:
+// TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 // The project associated with the model.
 $project = '{MY-PROJECT}';
@@ -234,7 +234,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Prediction($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listTrainedmodels` method:
+// TODO: Change placeholder below to desired parameter value for the `listTrainedmodels` method:
 
 // The project associated with the model.
 $project = '{MY-PROJECT}';

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_pubsub.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_pubsub.v1.json.baseline
@@ -27,7 +27,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Pubsub($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `acknowledge` method:
+// TODO: Change placeholder below to desired parameter value for the `acknowledge` method:
 
 // The subscription whose message is being acknowledged.
 $subscription = 'projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}';
@@ -66,7 +66,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Pubsub($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `create` method:
+// TODO: Change placeholder below to desired parameter value for the `create` method:
 
 // The name of the subscription. It must have the format
 // `"projects/{project}/subscriptions/{subscription}"`. `{subscription}` must start with a letter, and
@@ -112,7 +112,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Pubsub($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `delete` method:
+// TODO: Change placeholder below to desired parameter value for the `delete` method:
 
 // The subscription to delete.
 $subscription = 'projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}';
@@ -147,7 +147,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Pubsub($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `get` method:
+// TODO: Change placeholder below to desired parameter value for the `get` method:
 
 // The name of the subscription to get.
 $subscription = 'projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}';
@@ -185,7 +185,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Pubsub($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `getIamPolicy` method:
+// TODO: Change placeholder below to desired parameter value for the `getIamPolicy` method:
 
 // REQUIRED: The resource for which the policy is being requested. `resource` is usually specified as a
 // path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
@@ -225,7 +225,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Pubsub($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listProjectsSubscriptions` method:
+// TODO: Change placeholder below to desired parameter value for the `listProjectsSubscriptions` method:
 
 // The name of the cloud project that subscriptions belong to.
 $project = 'projects/{MY-PROJECT}';
@@ -270,7 +270,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Pubsub($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `modifyAckDeadline` method:
+// TODO: Change placeholder below to desired parameter value for the `modifyAckDeadline` method:
 
 // The name of the subscription.
 $subscription = 'projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}';
@@ -309,7 +309,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Pubsub($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `modifyPushConfig` method:
+// TODO: Change placeholder below to desired parameter value for the `modifyPushConfig` method:
 
 // The name of the subscription.
 $subscription = 'projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}';
@@ -348,7 +348,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Pubsub($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `pull` method:
+// TODO: Change placeholder below to desired parameter value for the `pull` method:
 
 // The subscription from which messages should be pulled.
 $subscription = 'projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}';
@@ -390,7 +390,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Pubsub($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `setIamPolicy` method:
+// TODO: Change placeholder below to desired parameter value for the `setIamPolicy` method:
 
 // REQUIRED: The resource for which the policy is being specified. `resource` is usually specified as a
 // path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
@@ -434,7 +434,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Pubsub($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `testIamPermissions` method:
+// TODO: Change placeholder below to desired parameter value for the `testIamPermissions` method:
 
 // REQUIRED: The resource for which the policy detail is being requested. `resource` is usually
 // specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path
@@ -479,7 +479,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Pubsub($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `create` method:
+// TODO: Change placeholder below to desired parameter value for the `create` method:
 
 // The name of the topic. It must have the format `"projects/{project}/topics/{topic}"`. `{topic}` must
 // start with a letter, and contain only letters (`[A-Za-z]`), numbers (`[0-9]`), dashes (`-`),
@@ -524,7 +524,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Pubsub($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `delete` method:
+// TODO: Change placeholder below to desired parameter value for the `delete` method:
 
 // Name of the topic to delete.
 $topic = 'projects/{MY-PROJECT}/topics/{MY-TOPIC}';
@@ -559,7 +559,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Pubsub($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `get` method:
+// TODO: Change placeholder below to desired parameter value for the `get` method:
 
 // The name of the topic to get.
 $topic = 'projects/{MY-PROJECT}/topics/{MY-TOPIC}';
@@ -597,7 +597,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Pubsub($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `getIamPolicy` method:
+// TODO: Change placeholder below to desired parameter value for the `getIamPolicy` method:
 
 // REQUIRED: The resource for which the policy is being requested. `resource` is usually specified as a
 // path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
@@ -637,7 +637,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Pubsub($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listProjectsTopics` method:
+// TODO: Change placeholder below to desired parameter value for the `listProjectsTopics` method:
 
 // The name of the cloud project that topics belong to.
 $project = 'projects/{MY-PROJECT}';
@@ -682,7 +682,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Pubsub($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `publish` method:
+// TODO: Change placeholder below to desired parameter value for the `publish` method:
 
 // The messages in the request will be published on this topic.
 $topic = 'projects/{MY-PROJECT}/topics/{MY-TOPIC}';
@@ -724,7 +724,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Pubsub($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `setIamPolicy` method:
+// TODO: Change placeholder below to desired parameter value for the `setIamPolicy` method:
 
 // REQUIRED: The resource for which the policy is being specified. `resource` is usually specified as a
 // path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
@@ -768,7 +768,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Pubsub($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listProjectsTopicsSubscriptions` method:
+// TODO: Change placeholder below to desired parameter value for the `listProjectsTopicsSubscriptions` method:
 
 // The name of the topic that subscriptions are attached to.
 $topic = 'projects/{MY-PROJECT}/topics/{MY-TOPIC}';
@@ -813,7 +813,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Pubsub($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `testIamPermissions` method:
+// TODO: Change placeholder below to desired parameter value for the `testIamPermissions` method:
 
 // REQUIRED: The resource for which the policy detail is being requested. `resource` is usually
 // specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_sqladmin.v1beta4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_sqladmin.v1beta4.json.baseline
@@ -772,7 +772,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_SQLAdmin($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `insert` method:
+// TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 // Project ID of the project to which the newly created Cloud SQL instances should belong.
 $project = '{MY-PROJECT}';
@@ -814,7 +814,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_SQLAdmin($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listInstances` method:
+// TODO: Change placeholder below to desired parameter value for the `listInstances` method:
 
 // Project ID of the project for which to list Cloud SQL instances.
 $project = '{MY-PROJECT}';
@@ -1507,7 +1507,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_SQLAdmin($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listTiers` method:
+// TODO: Change placeholder below to desired parameter value for the `listTiers` method:
 
 // Project ID of the project for which to list tiers.
 $project = '{MY-PROJECT}';

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_storage.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_storage.v1.json.baseline
@@ -108,7 +108,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storage($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `insert` method:
+// TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 // Name of a bucket.
 $bucket = '{MY-BUCKET}';
@@ -150,7 +150,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storage($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listBucketAccessControls` method:
+// TODO: Change placeholder below to desired parameter value for the `listBucketAccessControls` method:
 
 // Name of a bucket.
 $bucket = '{MY-BUCKET}';
@@ -280,7 +280,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storage($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `delete` method:
+// TODO: Change placeholder below to desired parameter value for the `delete` method:
 
 // Name of a bucket.
 $bucket = '{MY-BUCKET}';
@@ -315,7 +315,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storage($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `get` method:
+// TODO: Change placeholder below to desired parameter value for the `get` method:
 
 // Name of a bucket.
 $bucket = '{MY-BUCKET}';
@@ -353,7 +353,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storage($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `insert` method:
+// TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 // A valid API project identifier.
 $project = '{MY-PROJECT}';
@@ -395,7 +395,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storage($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listBuckets` method:
+// TODO: Change placeholder below to desired parameter value for the `listBuckets` method:
 
 // A valid API project identifier.
 $project = '{MY-PROJECT}';
@@ -440,7 +440,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storage($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `patch` method:
+// TODO: Change placeholder below to desired parameter value for the `patch` method:
 
 // Name of a bucket.
 $bucket = '{MY-BUCKET}';
@@ -482,7 +482,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storage($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `update` method:
+// TODO: Change placeholder below to desired parameter value for the `update` method:
 
 // Name of a bucket.
 $bucket = '{MY-BUCKET}';
@@ -638,7 +638,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storage($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `insert` method:
+// TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 // Name of a bucket.
 $bucket = '{MY-BUCKET}';
@@ -680,7 +680,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storage($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listDefaultObjectAccessControls` method:
+// TODO: Change placeholder below to desired parameter value for the `listDefaultObjectAccessControls` method:
 
 // Name of a bucket.
 $bucket = '{MY-BUCKET}';
@@ -1269,7 +1269,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storage($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `insert` method:
+// TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 // Name of the bucket in which to store the new object. Overrides the provided object metadata's bucket
 // value, if any.
@@ -1312,7 +1312,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storage($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listObjects` method:
+// TODO: Change placeholder below to desired parameter value for the `listObjects` method:
 
 // Name of the bucket in which to look for objects.
 $bucket = '{MY-BUCKET}';
@@ -1504,7 +1504,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storage($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `watchAll` method:
+// TODO: Change placeholder below to desired parameter value for the `watchAll` method:
 
 // Name of the bucket in which to look for objects.
 $bucket = '{MY-BUCKET}';

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_storagetransfer.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_storagetransfer.v1.json.baseline
@@ -59,7 +59,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storagetransfer($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `get` method:
+// TODO: Change placeholder below to desired parameter value for the `get` method:
 
 // The ID of the Google Developers Console project that the Google service account is associated with.
 // Required.
@@ -134,7 +134,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storagetransfer($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `get` method:
+// TODO: Change placeholder below to desired parameter value for the `get` method:
 
 // The job to get. Required.
 $jobName = '{MY-JOB-NAME}';
@@ -211,7 +211,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storagetransfer($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `patch` method:
+// TODO: Change placeholder below to desired parameter value for the `patch` method:
 
 // The name of job to update. Required.
 $jobName = '{MY-JOB-NAME}';
@@ -253,7 +253,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storagetransfer($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `cancel` method:
+// TODO: Change placeholder below to desired parameter value for the `cancel` method:
 
 // The name of the operation resource to be cancelled.
 $name = '{MY-NAME}';
@@ -288,7 +288,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storagetransfer($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `delete` method:
+// TODO: Change placeholder below to desired parameter value for the `delete` method:
 
 // The name of the operation resource to be deleted.
 $name = '{MY-NAME}';
@@ -323,7 +323,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storagetransfer($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `get` method:
+// TODO: Change placeholder below to desired parameter value for the `get` method:
 
 // The name of the operation resource.
 $name = '{MY-NAME}';
@@ -361,7 +361,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storagetransfer($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listTransferOperations` method:
+// TODO: Change placeholder below to desired parameter value for the `listTransferOperations` method:
 
 // The value `transferOperations`.
 $name = '{MY-NAME}';
@@ -406,7 +406,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storagetransfer($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `pause` method:
+// TODO: Change placeholder below to desired parameter value for the `pause` method:
 
 // The name of the transfer operation. Required.
 $name = '{MY-NAME}';
@@ -445,7 +445,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storagetransfer($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `resume` method:
+// TODO: Change placeholder below to desired parameter value for the `resume` method:
 
 // The name of the transfer operation. Required.
 $name = '{MY-NAME}';

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_translate.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_translate.v2.json.baseline
@@ -21,7 +21,7 @@ $client->setDeveloperKey('{MY-API-KEY}')
 $service = new Google_Service_Translate($client);
 
 
-// TODO: Change placeholders below to desired parameter values for the `listDetections` method:
+// TODO: Change placeholder below to desired parameter value for the `listDetections` method:
 
 // The text to detect
 $q = [];

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_adexchangebuyer.v1.4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_adexchangebuyer.v1.4.json.baseline
@@ -23,7 +23,7 @@ credentials = None
 service = discovery.build('adexchangebuyer', 'v1.4', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `get` method:
+# TODO: Change placeholder below to desired parameter value for the `get` method:
 
 # The account id
 id = 0
@@ -87,7 +87,7 @@ credentials = None
 service = discovery.build('adexchangebuyer', 'v1.4', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `patch` method:
+# TODO: Change placeholder below to desired parameter value for the `patch` method:
 
 # The account id
 id = 0
@@ -127,7 +127,7 @@ credentials = None
 service = discovery.build('adexchangebuyer', 'v1.4', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `update` method:
+# TODO: Change placeholder below to desired parameter value for the `update` method:
 
 # The account id
 id = 0
@@ -167,7 +167,7 @@ credentials = None
 service = discovery.build('adexchangebuyer', 'v1.4', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `get` method:
+# TODO: Change placeholder below to desired parameter value for the `get` method:
 
 # The account id.
 accountId = 0
@@ -533,7 +533,7 @@ credentials = None
 service = discovery.build('adexchangebuyer', 'v1.4', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `delete` method:
+# TODO: Change placeholder below to desired parameter value for the `delete` method:
 
 # The proposalId to delete deals from.
 proposalId = '{MY-PROPOSAL-ID}'
@@ -573,7 +573,7 @@ credentials = None
 service = discovery.build('adexchangebuyer', 'v1.4', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert` method:
+# TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 # proposalId for which deals need to be added.
 proposalId = '{MY-PROPOSAL-ID}'
@@ -613,7 +613,7 @@ credentials = None
 service = discovery.build('adexchangebuyer', 'v1.4', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # The proposalId to get deals for. To search across all proposals specify order_id = '-' as part of
 # the URL.
@@ -649,7 +649,7 @@ credentials = None
 service = discovery.build('adexchangebuyer', 'v1.4', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `update` method:
+# TODO: Change placeholder below to desired parameter value for the `update` method:
 
 # The proposalId to edit deals on.
 proposalId = '{MY-PROPOSAL-ID}'
@@ -689,7 +689,7 @@ credentials = None
 service = discovery.build('adexchangebuyer', 'v1.4', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert` method:
+# TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 # The proposalId to add notes for.
 proposalId = '{MY-PROPOSAL-ID}'
@@ -729,7 +729,7 @@ credentials = None
 service = discovery.build('adexchangebuyer', 'v1.4', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # The proposalId to get notes for. To search across all proposals specify order_id = '-' as part of
 # the URL.
@@ -763,7 +763,7 @@ credentials = None
 service = discovery.build('adexchangebuyer', 'v1.4', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `updateproposal` method:
+# TODO: Change placeholder below to desired parameter value for the `updateproposal` method:
 
 # The private auction id to be updated.
 privateAuctionId = '{MY-PRIVATE-AUCTION-ID}'
@@ -912,7 +912,7 @@ credentials = None
 service = discovery.build('adexchangebuyer', 'v1.4', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert` method:
+# TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 # The account id to insert the pretargeting config for.
 accountId = str(0L)
@@ -952,7 +952,7 @@ credentials = None
 service = discovery.build('adexchangebuyer', 'v1.4', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # The account id to get the pretargeting configs for.
 accountId = str(0L)
@@ -1073,7 +1073,7 @@ credentials = None
 service = discovery.build('adexchangebuyer', 'v1.4', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `get` method:
+# TODO: Change placeholder below to desired parameter value for the `get` method:
 
 # The id for the product to get the head revision for.
 productId = '{MY-PRODUCT-ID}'
@@ -1137,7 +1137,7 @@ credentials = None
 service = discovery.build('adexchangebuyer', 'v1.4', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `get` method:
+# TODO: Change placeholder below to desired parameter value for the `get` method:
 
 # Id of the proposal to retrieve.
 proposalId = '{MY-PROPOSAL-ID}'
@@ -1282,7 +1282,7 @@ credentials = None
 service = discovery.build('adexchangebuyer', 'v1.4', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `setupcomplete` method:
+# TODO: Change placeholder below to desired parameter value for the `setupcomplete` method:
 
 # The proposal id for which the setup is complete
 proposalId = '{MY-PROPOSAL-ID}'
@@ -1363,7 +1363,7 @@ credentials = None
 service = discovery.build('adexchangebuyer', 'v1.4', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # The accountId of the publisher to get profiles for.
 accountId = 0

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_appengine.v1beta5.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_appengine.v1beta5.json.baseline
@@ -63,7 +63,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('appengine', 'v1beta5', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `get` method:
+# TODO: Change placeholder below to desired parameter value for the `get` method:
 
 # Part of `name`. Name of the application to get. Example: `apps/myapp`.
 appsId = '{MY-APPS-ID}'
@@ -142,7 +142,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('appengine', 'v1beta5', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # Part of `name`. The resource that owns the locations collection, if applicable.
 appsId = '{MY-APPS-ID}'
@@ -226,7 +226,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('appengine', 'v1beta5', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # Part of `name`. The name of the operation collection.
 appsId = '{MY-APPS-ID}'
@@ -351,7 +351,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('appengine', 'v1beta5', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # Part of `name`. Name of the resource requested. Example: `apps/myapp`.
 appsId = '{MY-APPS-ID}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_bigquery.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_bigquery.v2.json.baseline
@@ -103,7 +103,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('bigquery', 'v2', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert` method:
+# TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 # Project ID of the new dataset
 projectId = '{MY-PROJECT-ID}'
@@ -146,7 +146,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('bigquery', 'v2', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # Project ID of the datasets to be listed
 projectId = '{MY-PROJECT-ID}'
@@ -404,7 +404,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('bigquery', 'v2', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert` method:
+# TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 # Project ID of the project that will be billed for the job
 projectId = '{MY-PROJECT-ID}'
@@ -447,7 +447,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('bigquery', 'v2', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # Project ID of the jobs to list
 projectId = '{MY-PROJECT-ID}'
@@ -490,7 +490,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('bigquery', 'v2', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `query` method:
+# TODO: Change placeholder below to desired parameter value for the `query` method:
 
 # Project ID of the project billed for the query
 projectId = '{MY-PROJECT-ID}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_cloudbilling.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_cloudbilling.v1.json.baseline
@@ -26,7 +26,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('cloudbilling', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `get` method:
+# TODO: Change placeholder below to desired parameter value for the `get` method:
 
 # The resource name of the billing account to retrieve. For example,
 # `billingAccounts/012345-567890-ABCDEF`.
@@ -102,7 +102,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('cloudbilling', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # The resource name of the billing account associated with the projects that you want to list. For
 # example, `billingAccounts/012345-567890-ABCDEF`.
@@ -146,7 +146,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('cloudbilling', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `getBillingInfo` method:
+# TODO: Change placeholder below to desired parameter value for the `getBillingInfo` method:
 
 # The resource name of the project for which billing information is retrieved. For example,
 # `projects/tokyo-rain-123`.
@@ -185,7 +185,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('cloudbilling', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `updateBillingInfo` method:
+# TODO: Change placeholder below to desired parameter value for the `updateBillingInfo` method:
 
 # The resource name of the project associated with the billing information that you want to update.
 # For example, `projects/tokyo-rain-123`.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_clouddebugger.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_clouddebugger.v2.json.baseline
@@ -26,7 +26,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('clouddebugger', 'v2', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # Identifies the debuggee.
 debuggeeId = '{MY-DEBUGGEE-ID}'
@@ -224,7 +224,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('clouddebugger', 'v2', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # ID of the debuggee whose breakpoints to list.
 debuggeeId = '{MY-DEBUGGEE-ID}'
@@ -262,7 +262,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('clouddebugger', 'v2', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `set` method:
+# TODO: Change placeholder below to desired parameter value for the `set` method:
 
 # ID of the debuggee where the breakpoint is to be set.
 debuggeeId = '{MY-DEBUGGEE-ID}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_cloudmonitoring.v2beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_cloudmonitoring.v2beta2.json.baseline
@@ -26,7 +26,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('cloudmonitoring', 'v2beta2', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `create` method:
+# TODO: Change placeholder below to desired parameter value for the `create` method:
 
 # The project id. The value can be the numeric project ID or string-based project name.
 project = '{MY-PROJECT}'
@@ -110,7 +110,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('cloudmonitoring', 'v2beta2', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # The project id. The value can be the numeric project ID or string-based project name.
 project = '{MY-PROJECT}'
@@ -204,7 +204,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('cloudmonitoring', 'v2beta2', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `write` method:
+# TODO: Change placeholder below to desired parameter value for the `write` method:
 
 # The project ID. The value can be the numeric project ID or string-based project name.
 project = '{MY-PROJECT}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_cloudresourcemanager.v1beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_cloudresourcemanager.v1beta1.json.baseline
@@ -26,7 +26,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('cloudresourcemanager', 'v1beta1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `get` method:
+# TODO: Change placeholder below to desired parameter value for the `get` method:
 
 # The resource name of the Organization to fetch. Its format is "organizations/[organization_id]". For
 # example, "organizations/1234".
@@ -65,7 +65,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('cloudresourcemanager', 'v1beta1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `getIamPolicy` method:
+# TODO: Change placeholder below to desired parameter value for the `getIamPolicy` method:
 
 # REQUIRED: The resource for which the policy is being requested. `resource` is usually specified as a
 # path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
@@ -147,7 +147,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('cloudresourcemanager', 'v1beta1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `setIamPolicy` method:
+# TODO: Change placeholder below to desired parameter value for the `setIamPolicy` method:
 
 # REQUIRED: The resource for which the policy is being specified. `resource` is usually specified as a
 # path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
@@ -192,7 +192,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('cloudresourcemanager', 'v1beta1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `testIamPermissions` method:
+# TODO: Change placeholder below to desired parameter value for the `testIamPermissions` method:
 
 # REQUIRED: The resource for which the policy detail is being requested. `resource` is usually
 # specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path
@@ -238,7 +238,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('cloudresourcemanager', 'v1beta1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `update` method:
+# TODO: Change placeholder below to desired parameter value for the `update` method:
 
 # Output Only. The resource name of the organization. This is the organization's relative path in the
 # API. Its format is "organizations/[organization_id]". For example, "organizations/1234".
@@ -317,7 +317,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('cloudresourcemanager', 'v1beta1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `delete` method:
+# TODO: Change placeholder below to desired parameter value for the `delete` method:
 
 # The Project ID (for example, `foo-bar-123`). Required.
 projectId = '{MY-PROJECT-ID}'
@@ -352,7 +352,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('cloudresourcemanager', 'v1beta1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `get` method:
+# TODO: Change placeholder below to desired parameter value for the `get` method:
 
 # The Project ID (for example, `my-project-123`). Required.
 projectId = '{MY-PROJECT-ID}'
@@ -390,7 +390,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('cloudresourcemanager', 'v1beta1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `getAncestry` method:
+# TODO: Change placeholder below to desired parameter value for the `getAncestry` method:
 
 # The Project ID (for example, `my-project-123`). Required.
 projectId = '{MY-PROJECT-ID}'
@@ -433,7 +433,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('cloudresourcemanager', 'v1beta1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `getIamPolicy` method:
+# TODO: Change placeholder below to desired parameter value for the `getIamPolicy` method:
 
 # REQUIRED: The resource for which the policy is being requested. `resource` is usually specified as a
 # path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
@@ -515,7 +515,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('cloudresourcemanager', 'v1beta1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `setIamPolicy` method:
+# TODO: Change placeholder below to desired parameter value for the `setIamPolicy` method:
 
 # REQUIRED: The resource for which the policy is being specified. `resource` is usually specified as a
 # path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
@@ -560,7 +560,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('cloudresourcemanager', 'v1beta1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `testIamPermissions` method:
+# TODO: Change placeholder below to desired parameter value for the `testIamPermissions` method:
 
 # REQUIRED: The resource for which the policy detail is being requested. `resource` is usually
 # specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path
@@ -604,7 +604,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('cloudresourcemanager', 'v1beta1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `undelete` method:
+# TODO: Change placeholder below to desired parameter value for the `undelete` method:
 
 # The project ID (for example, `foo-bar-123`). Required.
 projectId = '{MY-PROJECT-ID}'
@@ -644,7 +644,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('cloudresourcemanager', 'v1beta1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `update` method:
+# TODO: Change placeholder below to desired parameter value for the `update` method:
 
 # The project ID (for example, `my-project-123`). Required.
 projectId = '{MY-PROJECT-ID}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_cloudtrace.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_cloudtrace.v1.json.baseline
@@ -24,7 +24,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('cloudtrace', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `patchTraces` method:
+# TODO: Change placeholder below to desired parameter value for the `patchTraces` method:
 
 # ID of the Cloud project where the trace data is stored.
 projectId = '{MY-PROJECT-ID}'
@@ -105,7 +105,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('cloudtrace', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # ID of the Cloud project where the trace data is stored.
 projectId = '{MY-PROJECT-ID}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_clouduseraccounts.beta.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_clouduseraccounts.beta.json.baseline
@@ -103,7 +103,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -274,7 +274,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert` method:
+# TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -317,7 +317,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -625,7 +625,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert` method:
+# TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -668,7 +668,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('clouduseraccounts', 'beta', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_compute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_compute.v1.json.baseline
@@ -26,7 +26,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+# TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -249,7 +249,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+# TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -695,7 +695,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert` method:
+# TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -738,7 +738,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -873,7 +873,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+# TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -1006,7 +1006,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+# TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -1409,7 +1409,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert` method:
+# TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -1452,7 +1452,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -1587,7 +1587,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+# TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -1941,7 +1941,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert` method:
+# TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -1984,7 +1984,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -2109,7 +2109,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert` method:
+# TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -2152,7 +2152,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -2241,7 +2241,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+# TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -2361,7 +2361,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -2486,7 +2486,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert` method:
+# TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -2529,7 +2529,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -2746,7 +2746,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert` method:
+# TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -2789,7 +2789,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -3006,7 +3006,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert` method:
+# TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -3049,7 +3049,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -3353,7 +3353,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert` method:
+# TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -3396,7 +3396,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -3488,7 +3488,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+# TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -4049,7 +4049,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+# TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -4506,7 +4506,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert` method:
+# TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -4549,7 +4549,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -4644,7 +4644,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+# TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -5525,7 +5525,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+# TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -5740,7 +5740,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert` method:
+# TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -5783,7 +5783,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -5826,7 +5826,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `get` method:
+# TODO: Change placeholder below to desired parameter value for the `get` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -5864,7 +5864,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `moveDisk` method:
+# TODO: Change placeholder below to desired parameter value for the `moveDisk` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -5907,7 +5907,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `moveInstance` method:
+# TODO: Change placeholder below to desired parameter value for the `moveInstance` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -5950,7 +5950,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `setCommonInstanceMetadata` method:
+# TODO: Change placeholder below to desired parameter value for the `setCommonInstanceMetadata` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -5993,7 +5993,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `setUsageExportBucket` method:
+# TODO: Change placeholder below to desired parameter value for the `setUsageExportBucket` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -6206,7 +6206,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -6249,7 +6249,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+# TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -6745,7 +6745,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert` method:
+# TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -6788,7 +6788,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -6913,7 +6913,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -7038,7 +7038,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert` method:
+# TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -7081,7 +7081,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -7124,7 +7124,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+# TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -7429,7 +7429,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert` method:
+# TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -7472,7 +7472,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -7643,7 +7643,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert` method:
+# TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -7686,7 +7686,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -7821,7 +7821,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+# TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -8142,7 +8142,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+# TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -8643,7 +8643,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert` method:
+# TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -8686,7 +8686,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -8867,7 +8867,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+# TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -9172,7 +9172,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert` method:
+# TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -9261,7 +9261,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -9442,7 +9442,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `aggregatedList` method:
+# TODO: Change placeholder below to desired parameter value for the `aggregatedList` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -9835,7 +9835,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('compute', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_dataflow.v1b3.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_dataflow.v1b3.json.baseline
@@ -26,7 +26,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('dataflow', 'v1b3', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `create` method:
+# TODO: Change placeholder below to desired parameter value for the `create` method:
 
 # The project which owns the job.
 projectId = '{MY-PROJECT-ID}'
@@ -243,7 +243,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('dataflow', 'v1b3', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # The project which owns the jobs.
 projectId = '{MY-PROJECT-ID}'
@@ -470,7 +470,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('dataflow', 'v1b3', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `create` method:
+# TODO: Change placeholder below to desired parameter value for the `create` method:
 
 # The project which owns the job.
 projectId = '{MY-PROJECT-ID}'
@@ -513,7 +513,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('dataflow', 'v1b3', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `workerMessages` method:
+# TODO: Change placeholder below to desired parameter value for the `workerMessages` method:
 
 # The project to send the WorkerMessages to.
 projectId = '{MY-PROJECT-ID}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_dataproc.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_dataproc.v1.json.baseline
@@ -526,7 +526,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('dataproc', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `cancel` method:
+# TODO: Change placeholder below to desired parameter value for the `cancel` method:
 
 # The name of the operation resource to be cancelled.
 name = 'projects/{MY-PROJECT}/regions/{MY-REGION}/operations/{MY-OPERATION}'
@@ -559,7 +559,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('dataproc', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `delete` method:
+# TODO: Change placeholder below to desired parameter value for the `delete` method:
 
 # The name of the operation resource to be deleted.
 name = 'projects/{MY-PROJECT}/regions/{MY-REGION}/operations/{MY-OPERATION}'
@@ -594,7 +594,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('dataproc', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `get` method:
+# TODO: Change placeholder below to desired parameter value for the `get` method:
 
 # The name of the operation resource.
 name = 'projects/{MY-PROJECT}/regions/{MY-REGION}/operations/{MY-OPERATION}'
@@ -632,7 +632,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('dataproc', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # The name of the operation collection.
 name = '{MY-NAME}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_datastore.v1beta3.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_datastore.v1beta3.json.baseline
@@ -26,7 +26,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('datastore', 'v1beta3', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `allocateIds` method:
+# TODO: Change placeholder below to desired parameter value for the `allocateIds` method:
 
 # The ID of the project against which to make the request.
 projectId = '{MY-PROJECT-ID}'
@@ -69,7 +69,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('datastore', 'v1beta3', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `beginTransaction` method:
+# TODO: Change placeholder below to desired parameter value for the `beginTransaction` method:
 
 # The ID of the project against which to make the request.
 projectId = '{MY-PROJECT-ID}'
@@ -112,7 +112,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('datastore', 'v1beta3', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `commit` method:
+# TODO: Change placeholder below to desired parameter value for the `commit` method:
 
 # The ID of the project against which to make the request.
 projectId = '{MY-PROJECT-ID}'
@@ -155,7 +155,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('datastore', 'v1beta3', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `lookup` method:
+# TODO: Change placeholder below to desired parameter value for the `lookup` method:
 
 # The ID of the project against which to make the request.
 projectId = '{MY-PROJECT-ID}'
@@ -198,7 +198,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('datastore', 'v1beta3', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `rollback` method:
+# TODO: Change placeholder below to desired parameter value for the `rollback` method:
 
 # The ID of the project against which to make the request.
 projectId = '{MY-PROJECT-ID}'
@@ -241,7 +241,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('datastore', 'v1beta3', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `runQuery` method:
+# TODO: Change placeholder below to desired parameter value for the `runQuery` method:
 
 # The ID of the project against which to make the request.
 projectId = '{MY-PROJECT-ID}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_deploymentmanager.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_deploymentmanager.v2.json.baseline
@@ -154,7 +154,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('deploymentmanager', 'v2', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert` method:
+# TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 # The project ID for this request.
 project = '{MY-PROJECT}'
@@ -197,7 +197,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('deploymentmanager', 'v2', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # The project ID for this request.
 project = '{MY-PROJECT}'
@@ -509,7 +509,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('deploymentmanager', 'v2', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # The project ID for this request.
 project = '{MY-PROJECT}'
@@ -642,7 +642,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('deploymentmanager', 'v2', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # The project ID for this request.
 project = '{MY-PROJECT}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_dns.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_dns.v1.json.baseline
@@ -162,7 +162,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('dns', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `create` method:
+# TODO: Change placeholder below to desired parameter value for the `create` method:
 
 # Identifies the project addressed by this request.
 project = '{MY-PROJECT}'
@@ -282,7 +282,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('dns', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # Identifies the project addressed by this request.
 project = '{MY-PROJECT}'
@@ -325,7 +325,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('dns', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `get` method:
+# TODO: Change placeholder below to desired parameter value for the `get` method:
 
 # Identifies the project addressed by this request.
 project = '{MY-PROJECT}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_logging.v2beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_logging.v2beta1.json.baseline
@@ -140,7 +140,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('logging', 'v2beta1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `delete` method:
+# TODO: Change placeholder below to desired parameter value for the `delete` method:
 
 # Required. The resource name of the log to delete. Example: `"projects/my-project/logs/syslog"`.
 logName = 'projects/{MY-PROJECT}/logs/{MY-LOG}'
@@ -175,7 +175,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('logging', 'v2beta1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `create` method:
+# TODO: Change placeholder below to desired parameter value for the `create` method:
 
 # The resource name of the project in which to create the metric. Example: `"projects/my-project-id"`.
 # The new metric must be provided in the request.
@@ -217,7 +217,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('logging', 'v2beta1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `delete` method:
+# TODO: Change placeholder below to desired parameter value for the `delete` method:
 
 # The resource name of the metric to delete. Example: `"projects/my-project-id/metrics/my-metric-id"`.
 metricName = 'projects/{MY-PROJECT}/metrics/{MY-METRIC}'
@@ -252,7 +252,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('logging', 'v2beta1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `get` method:
+# TODO: Change placeholder below to desired parameter value for the `get` method:
 
 # The resource name of the desired metric. Example: `"projects/my-project-id/metrics/my-metric-id"`.
 metricName = 'projects/{MY-PROJECT}/metrics/{MY-METRIC}'
@@ -290,7 +290,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('logging', 'v2beta1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # Required. The resource name of the project containing the metrics. Example:
 # `"projects/my-project-id"`.
@@ -334,7 +334,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('logging', 'v2beta1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `update` method:
+# TODO: Change placeholder below to desired parameter value for the `update` method:
 
 # The resource name of the metric to update. Example: `"projects/my-project-id/metrics/my-metric-id"`.
 # The updated metric must be provided in the request and have the same identifier that is specified in
@@ -379,7 +379,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('logging', 'v2beta1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `create` method:
+# TODO: Change placeholder below to desired parameter value for the `create` method:
 
 # The resource name of the project in which to create the sink. Example: `"projects/my-project-id"`.
 # The new sink must be provided in the request.
@@ -421,7 +421,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('logging', 'v2beta1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `delete` method:
+# TODO: Change placeholder below to desired parameter value for the `delete` method:
 
 # The resource name of the sink to delete. Example: `"projects/my-project-id/sinks/my-sink-id"`.
 sinkName = 'projects/{MY-PROJECT}/sinks/{MY-SINK}'
@@ -456,7 +456,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('logging', 'v2beta1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `get` method:
+# TODO: Change placeholder below to desired parameter value for the `get` method:
 
 # The resource name of the sink to return. Example: `"projects/my-project-id/sinks/my-sink-id"`.
 sinkName = 'projects/{MY-PROJECT}/sinks/{MY-SINK}'
@@ -494,7 +494,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('logging', 'v2beta1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # Required. The resource name of the project containing the sinks. Example:
 # `"projects/my-logging-project"`.
@@ -538,7 +538,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('logging', 'v2beta1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `update` method:
+# TODO: Change placeholder below to desired parameter value for the `update` method:
 
 # The resource name of the sink to update. Example: `"projects/my-project-id/sinks/my-sink-id"`. The
 # updated sink must be provided in the request and have the same name that is specified in `sinkName`.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_prediction.v1.6.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_prediction.v1.6.json.baseline
@@ -190,7 +190,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('prediction', 'v1.6', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert` method:
+# TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 # The project associated with the model.
 project = '{MY-PROJECT}'
@@ -233,7 +233,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('prediction', 'v1.6', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # The project associated with the model.
 project = '{MY-PROJECT}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_pubsub.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_pubsub.v1.json.baseline
@@ -24,7 +24,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('pubsub', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `acknowledge` method:
+# TODO: Change placeholder below to desired parameter value for the `acknowledge` method:
 
 # The subscription whose message is being acknowledged.
 subscription = 'projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}'
@@ -64,7 +64,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('pubsub', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `create` method:
+# TODO: Change placeholder below to desired parameter value for the `create` method:
 
 # The name of the subscription. It must have the format
 # `"projects/{project}/subscriptions/{subscription}"`. `{subscription}` must start with a letter, and
@@ -109,7 +109,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('pubsub', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `delete` method:
+# TODO: Change placeholder below to desired parameter value for the `delete` method:
 
 # The subscription to delete.
 subscription = 'projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}'
@@ -144,7 +144,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('pubsub', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `get` method:
+# TODO: Change placeholder below to desired parameter value for the `get` method:
 
 # The name of the subscription to get.
 subscription = 'projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}'
@@ -182,7 +182,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('pubsub', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `getIamPolicy` method:
+# TODO: Change placeholder below to desired parameter value for the `getIamPolicy` method:
 
 # REQUIRED: The resource for which the policy is being requested. `resource` is usually specified as a
 # path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
@@ -222,7 +222,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('pubsub', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # The name of the cloud project that subscriptions belong to.
 project = 'projects/{MY-PROJECT}'
@@ -263,7 +263,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('pubsub', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `modifyAckDeadline` method:
+# TODO: Change placeholder below to desired parameter value for the `modifyAckDeadline` method:
 
 # The name of the subscription.
 subscription = 'projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}'
@@ -301,7 +301,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('pubsub', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `modifyPushConfig` method:
+# TODO: Change placeholder below to desired parameter value for the `modifyPushConfig` method:
 
 # The name of the subscription.
 subscription = 'projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}'
@@ -341,7 +341,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('pubsub', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `pull` method:
+# TODO: Change placeholder below to desired parameter value for the `pull` method:
 
 # The subscription from which messages should be pulled.
 subscription = 'projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}'
@@ -384,7 +384,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('pubsub', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `setIamPolicy` method:
+# TODO: Change placeholder below to desired parameter value for the `setIamPolicy` method:
 
 # REQUIRED: The resource for which the policy is being specified. `resource` is usually specified as a
 # path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
@@ -429,7 +429,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('pubsub', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `testIamPermissions` method:
+# TODO: Change placeholder below to desired parameter value for the `testIamPermissions` method:
 
 # REQUIRED: The resource for which the policy detail is being requested. `resource` is usually
 # specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path
@@ -475,7 +475,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('pubsub', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `create` method:
+# TODO: Change placeholder below to desired parameter value for the `create` method:
 
 # The name of the topic. It must have the format `"projects/{project}/topics/{topic}"`. `{topic}` must
 # start with a letter, and contain only letters (`[A-Za-z]`), numbers (`[0-9]`), dashes (`-`),
@@ -519,7 +519,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('pubsub', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `delete` method:
+# TODO: Change placeholder below to desired parameter value for the `delete` method:
 
 # Name of the topic to delete.
 topic = 'projects/{MY-PROJECT}/topics/{MY-TOPIC}'
@@ -554,7 +554,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('pubsub', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `get` method:
+# TODO: Change placeholder below to desired parameter value for the `get` method:
 
 # The name of the topic to get.
 topic = 'projects/{MY-PROJECT}/topics/{MY-TOPIC}'
@@ -592,7 +592,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('pubsub', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `getIamPolicy` method:
+# TODO: Change placeholder below to desired parameter value for the `getIamPolicy` method:
 
 # REQUIRED: The resource for which the policy is being requested. `resource` is usually specified as a
 # path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
@@ -632,7 +632,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('pubsub', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # The name of the cloud project that topics belong to.
 project = 'projects/{MY-PROJECT}'
@@ -675,7 +675,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('pubsub', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `publish` method:
+# TODO: Change placeholder below to desired parameter value for the `publish` method:
 
 # The messages in the request will be published on this topic.
 topic = 'projects/{MY-PROJECT}/topics/{MY-TOPIC}'
@@ -718,7 +718,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('pubsub', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `setIamPolicy` method:
+# TODO: Change placeholder below to desired parameter value for the `setIamPolicy` method:
 
 # REQUIRED: The resource for which the policy is being specified. `resource` is usually specified as a
 # path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
@@ -763,7 +763,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('pubsub', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # The name of the topic that subscriptions are attached to.
 topic = 'projects/{MY-PROJECT}/topics/{MY-TOPIC}'
@@ -806,7 +806,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('pubsub', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `testIamPermissions` method:
+# TODO: Change placeholder below to desired parameter value for the `testIamPermissions` method:
 
 # REQUIRED: The resource for which the policy detail is being requested. `resource` is usually
 # specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_sqladmin.v1beta4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_sqladmin.v1beta4.json.baseline
@@ -777,7 +777,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert` method:
+# TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 # Project ID of the project to which the newly created Cloud SQL instances should belong.
 project = '{MY-PROJECT}'
@@ -820,7 +820,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # Project ID of the project for which to list Cloud SQL instances.
 project = '{MY-PROJECT}'
@@ -1514,7 +1514,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('sqladmin', 'v1beta4', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # Project ID of the project for which to list tiers.
 project = '{MY-PROJECT}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_storage.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_storage.v1.json.baseline
@@ -105,7 +105,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('storage', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert` method:
+# TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 # Name of a bucket.
 bucket = '{MY-BUCKET}'
@@ -148,7 +148,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('storage', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # Name of a bucket.
 bucket = '{MY-BUCKET}'
@@ -278,7 +278,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('storage', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `delete` method:
+# TODO: Change placeholder below to desired parameter value for the `delete` method:
 
 # Name of a bucket.
 bucket = '{MY-BUCKET}'
@@ -313,7 +313,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('storage', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `get` method:
+# TODO: Change placeholder below to desired parameter value for the `get` method:
 
 # Name of a bucket.
 bucket = '{MY-BUCKET}'
@@ -351,7 +351,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('storage', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert` method:
+# TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 # A valid API project identifier.
 project = '{MY-PROJECT}'
@@ -394,7 +394,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('storage', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # A valid API project identifier.
 project = '{MY-PROJECT}'
@@ -437,7 +437,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('storage', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `patch` method:
+# TODO: Change placeholder below to desired parameter value for the `patch` method:
 
 # Name of a bucket.
 bucket = '{MY-BUCKET}'
@@ -480,7 +480,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('storage', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `update` method:
+# TODO: Change placeholder below to desired parameter value for the `update` method:
 
 # Name of a bucket.
 bucket = '{MY-BUCKET}'
@@ -634,7 +634,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('storage', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert` method:
+# TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 # Name of a bucket.
 bucket = '{MY-BUCKET}'
@@ -677,7 +677,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('storage', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # Name of a bucket.
 bucket = '{MY-BUCKET}'
@@ -1269,7 +1269,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('storage', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert` method:
+# TODO: Change placeholder below to desired parameter value for the `insert` method:
 
 # Name of the bucket in which to store the new object. Overrides the provided object metadata's bucket
 # value, if any.
@@ -1313,7 +1313,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('storage', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # Name of the bucket in which to look for objects.
 bucket = '{MY-BUCKET}'
@@ -1506,7 +1506,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('storage', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `watchAll` method:
+# TODO: Change placeholder below to desired parameter value for the `watchAll` method:
 
 # Name of the bucket in which to look for objects.
 bucket = '{MY-BUCKET}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_storagetransfer.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_storagetransfer.v1.json.baseline
@@ -58,7 +58,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('storagetransfer', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `get` method:
+# TODO: Change placeholder below to desired parameter value for the `get` method:
 
 # The ID of the Google Developers Console project that the Google service account is associated with.
 # Required.
@@ -134,7 +134,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('storagetransfer', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `get` method:
+# TODO: Change placeholder below to desired parameter value for the `get` method:
 
 # The job to get. Required.
 jobName = '{MY-JOB-NAME}'
@@ -209,7 +209,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('storagetransfer', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `patch` method:
+# TODO: Change placeholder below to desired parameter value for the `patch` method:
 
 # The name of job to update. Required.
 jobName = '{MY-JOB-NAME}'
@@ -250,7 +250,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('storagetransfer', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `cancel` method:
+# TODO: Change placeholder below to desired parameter value for the `cancel` method:
 
 # The name of the operation resource to be cancelled.
 name = '{MY-NAME}'
@@ -283,7 +283,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('storagetransfer', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `delete` method:
+# TODO: Change placeholder below to desired parameter value for the `delete` method:
 
 # The name of the operation resource to be deleted.
 name = '{MY-NAME}'
@@ -318,7 +318,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('storagetransfer', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `get` method:
+# TODO: Change placeholder below to desired parameter value for the `get` method:
 
 # The name of the operation resource.
 name = '{MY-NAME}'
@@ -356,7 +356,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('storagetransfer', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # The value `transferOperations`.
 name = '{MY-NAME}'
@@ -397,7 +397,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('storagetransfer', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `pause` method:
+# TODO: Change placeholder below to desired parameter value for the `pause` method:
 
 # The name of the transfer operation. Required.
 name = '{MY-NAME}'
@@ -435,7 +435,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('storagetransfer', 'v1', credentials=credentials)
 
 
-# TODO: Change placeholders below to desired parameter values for the `resume` method:
+# TODO: Change placeholder below to desired parameter value for the `resume` method:
 
 # The name of the transfer operation. Required.
 name = '{MY-NAME}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_translate.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_translate.v2.json.baseline
@@ -17,7 +17,7 @@ from googleapiclient import discovery
 service = discovery.build('translate', 'v2', developerKey='{MY-API-KEY}')
 
 
-# TODO: Change placeholders below to desired parameter values for the `list` method:
+# TODO: Change placeholder below to desired parameter value for the `list` method:
 
 # The text to detect
 q = ''

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_adexchangebuyer.v1.4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_adexchangebuyer.v1.4.json.baseline
@@ -19,7 +19,7 @@ service = Google::Apis::AdexchangebuyerV1_4::AdexchangebuyerService.new
 service.authorization = nil
 
 
-# TODO: Change placeholders below to desired parameter values for the `get_account` method:
+# TODO: Change placeholder below to desired parameter value for the `get_account` method:
 
 # The account id
 id = 0
@@ -75,7 +75,7 @@ service = Google::Apis::AdexchangebuyerV1_4::AdexchangebuyerService.new
 service.authorization = nil
 
 
-# TODO: Change placeholders below to desired parameter values for the `patch_account` method:
+# TODO: Change placeholder below to desired parameter value for the `patch_account` method:
 
 # The account id
 id = 0
@@ -110,7 +110,7 @@ service = Google::Apis::AdexchangebuyerV1_4::AdexchangebuyerService.new
 service.authorization = nil
 
 
-# TODO: Change placeholders below to desired parameter values for the `update_account` method:
+# TODO: Change placeholder below to desired parameter value for the `update_account` method:
 
 # The account id
 id = 0
@@ -145,7 +145,7 @@ service = Google::Apis::AdexchangebuyerV1_4::AdexchangebuyerService.new
 service.authorization = nil
 
 
-# TODO: Change placeholders below to desired parameter values for the `get_billing_info` method:
+# TODO: Change placeholder below to desired parameter value for the `get_billing_info` method:
 
 # The account id.
 account_id = 0
@@ -471,7 +471,7 @@ service = Google::Apis::AdexchangebuyerV1_4::AdexchangebuyerService.new
 service.authorization = nil
 
 
-# TODO: Change placeholders below to desired parameter values for the `delete_marketplacedeal_order_deals` method:
+# TODO: Change placeholder below to desired parameter value for the `delete_marketplacedeal_order_deals` method:
 
 # The proposalId to delete deals from.
 proposal_id = '{MY-PROPOSAL-ID}'
@@ -506,7 +506,7 @@ service = Google::Apis::AdexchangebuyerV1_4::AdexchangebuyerService.new
 service.authorization = nil
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert_marketplacedeal` method:
+# TODO: Change placeholder below to desired parameter value for the `insert_marketplacedeal` method:
 
 # proposalId for which deals need to be added.
 proposal_id = '{MY-PROPOSAL-ID}'
@@ -541,7 +541,7 @@ service = Google::Apis::AdexchangebuyerV1_4::AdexchangebuyerService.new
 service.authorization = nil
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_marketplacedeals` method:
+# TODO: Change placeholder below to desired parameter value for the `list_marketplacedeals` method:
 
 # The proposalId to get deals for. To search across all proposals specify order_id = '-' as part of
 # the URL.
@@ -573,7 +573,7 @@ service = Google::Apis::AdexchangebuyerV1_4::AdexchangebuyerService.new
 service.authorization = nil
 
 
-# TODO: Change placeholders below to desired parameter values for the `update_marketplacedeal` method:
+# TODO: Change placeholder below to desired parameter value for the `update_marketplacedeal` method:
 
 # The proposalId to edit deals on.
 proposal_id = '{MY-PROPOSAL-ID}'
@@ -608,7 +608,7 @@ service = Google::Apis::AdexchangebuyerV1_4::AdexchangebuyerService.new
 service.authorization = nil
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert_marketplacenote` method:
+# TODO: Change placeholder below to desired parameter value for the `insert_marketplacenote` method:
 
 # The proposalId to add notes for.
 proposal_id = '{MY-PROPOSAL-ID}'
@@ -643,7 +643,7 @@ service = Google::Apis::AdexchangebuyerV1_4::AdexchangebuyerService.new
 service.authorization = nil
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_marketplacenotes` method:
+# TODO: Change placeholder below to desired parameter value for the `list_marketplacenotes` method:
 
 # The proposalId to get notes for. To search across all proposals specify order_id = '-' as part of
 # the URL.
@@ -675,7 +675,7 @@ service = Google::Apis::AdexchangebuyerV1_4::AdexchangebuyerService.new
 service.authorization = nil
 
 
-# TODO: Change placeholders below to desired parameter values for the `update_marketplace_private_auction_proposal` method:
+# TODO: Change placeholder below to desired parameter value for the `update_marketplace_private_auction_proposal` method:
 
 # The private auction id to be updated.
 private_auction_id = '{MY-PRIVATE-AUCTION-ID}'
@@ -809,7 +809,7 @@ service = Google::Apis::AdexchangebuyerV1_4::AdexchangebuyerService.new
 service.authorization = nil
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert_pretargeting_config` method:
+# TODO: Change placeholder below to desired parameter value for the `insert_pretargeting_config` method:
 
 # The account id to insert the pretargeting config for.
 account_id = ''
@@ -844,7 +844,7 @@ service = Google::Apis::AdexchangebuyerV1_4::AdexchangebuyerService.new
 service.authorization = nil
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_pretargeting_configs` method:
+# TODO: Change placeholder below to desired parameter value for the `list_pretargeting_configs` method:
 
 # The account id to get the pretargeting configs for.
 account_id = ''
@@ -951,7 +951,7 @@ service = Google::Apis::AdexchangebuyerV1_4::AdexchangebuyerService.new
 service.authorization = nil
 
 
-# TODO: Change placeholders below to desired parameter values for the `get_product` method:
+# TODO: Change placeholder below to desired parameter value for the `get_product` method:
 
 # The id for the product to get the head revision for.
 product_id = '{MY-PRODUCT-ID}'
@@ -1007,7 +1007,7 @@ service = Google::Apis::AdexchangebuyerV1_4::AdexchangebuyerService.new
 service.authorization = nil
 
 
-# TODO: Change placeholders below to desired parameter values for the `get_proposal` method:
+# TODO: Change placeholder below to desired parameter value for the `get_proposal` method:
 
 # Id of the proposal to retrieve.
 proposal_id = '{MY-PROPOSAL-ID}'
@@ -1136,7 +1136,7 @@ service = Google::Apis::AdexchangebuyerV1_4::AdexchangebuyerService.new
 service.authorization = nil
 
 
-# TODO: Change placeholders below to desired parameter values for the `proposal_setup_complete` method:
+# TODO: Change placeholder below to desired parameter value for the `proposal_setup_complete` method:
 
 # The proposal id for which the setup is complete
 proposal_id = '{MY-PROPOSAL-ID}'
@@ -1208,7 +1208,7 @@ service = Google::Apis::AdexchangebuyerV1_4::AdexchangebuyerService.new
 service.authorization = nil
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_pub_profiles` method:
+# TODO: Change placeholder below to desired parameter value for the `list_pub_profiles` method:
 
 # The accountId of the publisher to get profiles for.
 account_id = 0

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_appengine.v1beta5.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_appengine.v1beta5.json.baseline
@@ -58,7 +58,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `get_app` method:
+# TODO: Change placeholder below to desired parameter value for the `get_app` method:
 
 # Part of `name`. Name of the application to get. Example: `apps/myapp`.
 apps_id = '{MY-APPS-ID}'
@@ -133,7 +133,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_app_locations` method:
+# TODO: Change placeholder below to desired parameter value for the `list_app_locations` method:
 
 # Part of `name`. The resource that owns the locations collection, if applicable.
 apps_id = '{MY-APPS-ID}'
@@ -212,7 +212,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_app_operations` method:
+# TODO: Change placeholder below to desired parameter value for the `list_app_operations` method:
 
 # Part of `name`. The name of the operation collection.
 apps_id = '{MY-APPS-ID}'
@@ -330,7 +330,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_app_services` method:
+# TODO: Change placeholder below to desired parameter value for the `list_app_services` method:
 
 # Part of `name`. Name of the resource requested. Example: `apps/myapp`.
 apps_id = '{MY-APPS-ID}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_bigquery.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_bigquery.v2.json.baseline
@@ -99,7 +99,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert_dataset` method:
+# TODO: Change placeholder below to desired parameter value for the `insert_dataset` method:
 
 # Project ID of the new dataset
 project_id = '{MY-PROJECT-ID}'
@@ -139,7 +139,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_datasets` method:
+# TODO: Change placeholder below to desired parameter value for the `list_datasets` method:
 
 # Project ID of the datasets to be listed
 project_id = '{MY-PROJECT-ID}'
@@ -382,7 +382,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert_job` method:
+# TODO: Change placeholder below to desired parameter value for the `insert_job` method:
 
 # Project ID of the project that will be billed for the job
 project_id = '{MY-PROJECT-ID}'
@@ -422,7 +422,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_jobs` method:
+# TODO: Change placeholder below to desired parameter value for the `list_jobs` method:
 
 # Project ID of the jobs to list
 project_id = '{MY-PROJECT-ID}'
@@ -462,7 +462,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `query_job` method:
+# TODO: Change placeholder below to desired parameter value for the `query_job` method:
 
 # Project ID of the project billed for the query
 project_id = '{MY-PROJECT-ID}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_cloudbilling.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_cloudbilling.v1.json.baseline
@@ -24,7 +24,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `get_billing_account` method:
+# TODO: Change placeholder below to desired parameter value for the `get_billing_account` method:
 
 # The resource name of the billing account to retrieve. For example,
 # `billingAccounts/012345-567890-ABCDEF`.
@@ -95,7 +95,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_billing_account_projects` method:
+# TODO: Change placeholder below to desired parameter value for the `list_billing_account_projects` method:
 
 # The resource name of the billing account associated with the projects that you want to list. For
 # example, `billingAccounts/012345-567890-ABCDEF`.
@@ -136,7 +136,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `get_project_billing_info` method:
+# TODO: Change placeholder below to desired parameter value for the `get_project_billing_info` method:
 
 # The resource name of the project for which billing information is retrieved. For example,
 # `projects/tokyo-rain-123`.
@@ -173,7 +173,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `update_project_billing_info` method:
+# TODO: Change placeholder below to desired parameter value for the `update_project_billing_info` method:
 
 # The resource name of the project associated with the billing information that you want to update.
 # For example, `projects/tokyo-rain-123`.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_clouddebugger.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_clouddebugger.v2.json.baseline
@@ -24,7 +24,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_controller_debuggee_breakpoints` method:
+# TODO: Change placeholder below to desired parameter value for the `list_controller_debuggee_breakpoints` method:
 
 # Identifies the debuggee.
 debuggee_id = '{MY-DEBUGGEE-ID}'
@@ -212,7 +212,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_debugger_debuggee_breakpoints` method:
+# TODO: Change placeholder below to desired parameter value for the `list_debugger_debuggee_breakpoints` method:
 
 # ID of the debuggee whose breakpoints to list.
 debuggee_id = '{MY-DEBUGGEE-ID}'
@@ -248,7 +248,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `set_debugger_debuggee_breakpoint` method:
+# TODO: Change placeholder below to desired parameter value for the `set_debugger_debuggee_breakpoint` method:
 
 # ID of the debuggee where the breakpoint is to be set.
 debuggee_id = '{MY-DEBUGGEE-ID}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_cloudmonitoring.v2beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_cloudmonitoring.v2beta2.json.baseline
@@ -24,7 +24,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `create_metric_descriptor` method:
+# TODO: Change placeholder below to desired parameter value for the `create_metric_descriptor` method:
 
 # The project id. The value can be the numeric project ID or string-based project name.
 project = '{MY-PROJECT}'
@@ -103,7 +103,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_metric_descriptors` method:
+# TODO: Change placeholder below to desired parameter value for the `list_metric_descriptors` method:
 
 # The project id. The value can be the numeric project ID or string-based project name.
 project = '{MY-PROJECT}'
@@ -199,7 +199,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `write_timeseries` method:
+# TODO: Change placeholder below to desired parameter value for the `write_timeseries` method:
 
 # The project ID. The value can be the numeric project ID or string-based project name.
 project = '{MY-PROJECT}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_cloudresourcemanager.v1beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_cloudresourcemanager.v1beta1.json.baseline
@@ -24,7 +24,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `get_organization` method:
+# TODO: Change placeholder below to desired parameter value for the `get_organization` method:
 
 # The resource name of the Organization to fetch. Its format is "organizations/[organization_id]". For
 # example, "organizations/1234".
@@ -61,7 +61,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `get_organization_iam_policy` method:
+# TODO: Change placeholder below to desired parameter value for the `get_organization_iam_policy` method:
 
 # REQUIRED: The resource for which the policy is being requested. `resource` is usually specified as a
 # path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
@@ -137,7 +137,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `set_organization_iam_policy` method:
+# TODO: Change placeholder below to desired parameter value for the `set_organization_iam_policy` method:
 
 # REQUIRED: The resource for which the policy is being specified. `resource` is usually specified as a
 # path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
@@ -179,7 +179,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `test_organization_iam_permissions` method:
+# TODO: Change placeholder below to desired parameter value for the `test_organization_iam_permissions` method:
 
 # REQUIRED: The resource for which the policy detail is being requested. `resource` is usually
 # specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path
@@ -222,7 +222,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `update_organization` method:
+# TODO: Change placeholder below to desired parameter value for the `update_organization` method:
 
 # Output Only. The resource name of the organization. This is the organization's relative path in the
 # API. Its format is "organizations/[organization_id]". For example, "organizations/1234".
@@ -297,7 +297,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `delete_project` method:
+# TODO: Change placeholder below to desired parameter value for the `delete_project` method:
 
 # The Project ID (for example, `foo-bar-123`). Required.
 project_id = '{MY-PROJECT-ID}'
@@ -330,7 +330,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `get_project` method:
+# TODO: Change placeholder below to desired parameter value for the `get_project` method:
 
 # The Project ID (for example, `my-project-123`). Required.
 project_id = '{MY-PROJECT-ID}'
@@ -366,7 +366,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `get_project_ancestry` method:
+# TODO: Change placeholder below to desired parameter value for the `get_project_ancestry` method:
 
 # The Project ID (for example, `my-project-123`). Required.
 project_id = '{MY-PROJECT-ID}'
@@ -406,7 +406,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `get_project_iam_policy` method:
+# TODO: Change placeholder below to desired parameter value for the `get_project_iam_policy` method:
 
 # REQUIRED: The resource for which the policy is being requested. `resource` is usually specified as a
 # path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
@@ -482,7 +482,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `set_project_iam_policy` method:
+# TODO: Change placeholder below to desired parameter value for the `set_project_iam_policy` method:
 
 # REQUIRED: The resource for which the policy is being specified. `resource` is usually specified as a
 # path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
@@ -524,7 +524,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `test_project_iam_permissions` method:
+# TODO: Change placeholder below to desired parameter value for the `test_project_iam_permissions` method:
 
 # REQUIRED: The resource for which the policy detail is being requested. `resource` is usually
 # specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path
@@ -567,7 +567,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `undelete_project` method:
+# TODO: Change placeholder below to desired parameter value for the `undelete_project` method:
 
 # The project ID (for example, `foo-bar-123`). Required.
 project_id = '{MY-PROJECT-ID}'
@@ -604,7 +604,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `update_project` method:
+# TODO: Change placeholder below to desired parameter value for the `update_project` method:
 
 # The project ID (for example, `my-project-123`). Required.
 project_id = '{MY-PROJECT-ID}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_cloudtrace.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_cloudtrace.v1.json.baseline
@@ -24,7 +24,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `patch_project_traces` method:
+# TODO: Change placeholder below to desired parameter value for the `patch_project_traces` method:
 
 # ID of the Cloud project where the trace data is stored.
 project_id = '{MY-PROJECT-ID}'
@@ -100,7 +100,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_project_traces` method:
+# TODO: Change placeholder below to desired parameter value for the `list_project_traces` method:
 
 # ID of the Cloud project where the trace data is stored.
 project_id = '{MY-PROJECT-ID}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_clouduseraccounts.beta.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_clouduseraccounts.beta.json.baseline
@@ -99,7 +99,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_global_accounts_operations` method:
+# TODO: Change placeholder below to desired parameter value for the `list_global_accounts_operations` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -260,7 +260,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert_group` method:
+# TODO: Change placeholder below to desired parameter value for the `insert_group` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -300,7 +300,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_groups` method:
+# TODO: Change placeholder below to desired parameter value for the `list_groups` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -591,7 +591,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert_user` method:
+# TODO: Change placeholder below to desired parameter value for the `insert_user` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -631,7 +631,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_users` method:
+# TODO: Change placeholder below to desired parameter value for the `list_users` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_compute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_compute.v1.json.baseline
@@ -24,7 +24,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_aggregated_addresses` method:
+# TODO: Change placeholder below to desired parameter value for the `list_aggregated_addresses` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -234,7 +234,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_aggregated_autoscalers` method:
+# TODO: Change placeholder below to desired parameter value for the `list_aggregated_autoscalers` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -654,7 +654,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert_backend_service` method:
+# TODO: Change placeholder below to desired parameter value for the `insert_backend_service` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -694,7 +694,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_backend_services` method:
+# TODO: Change placeholder below to desired parameter value for the `list_backend_services` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -820,7 +820,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_aggregated_disk_types` method:
+# TODO: Change placeholder below to desired parameter value for the `list_aggregated_disk_types` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -945,7 +945,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_aggregated_disk` method:
+# TODO: Change placeholder below to desired parameter value for the `list_aggregated_disk` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -1325,7 +1325,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert_firewall` method:
+# TODO: Change placeholder below to desired parameter value for the `insert_firewall` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -1365,7 +1365,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_firewalls` method:
+# TODO: Change placeholder below to desired parameter value for the `list_firewalls` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -1491,7 +1491,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_aggregated_forwarding_rules` method:
+# TODO: Change placeholder below to desired parameter value for the `list_aggregated_forwarding_rules` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -1825,7 +1825,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert_global_address` method:
+# TODO: Change placeholder below to desired parameter value for the `insert_global_address` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -1865,7 +1865,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_global_addresses` method:
+# TODO: Change placeholder below to desired parameter value for the `list_global_addresses` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -1983,7 +1983,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert_global_forwarding_rule` method:
+# TODO: Change placeholder below to desired parameter value for the `insert_global_forwarding_rule` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -2023,7 +2023,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_global_forwarding_rules` method:
+# TODO: Change placeholder below to desired parameter value for the `list_global_forwarding_rules` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -2106,7 +2106,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_aggregated_global_operation` method:
+# TODO: Change placeholder below to desired parameter value for the `list_aggregated_global_operation` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -2221,7 +2221,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_global_operations` method:
+# TODO: Change placeholder below to desired parameter value for the `list_global_operations` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -2339,7 +2339,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert_health_check` method:
+# TODO: Change placeholder below to desired parameter value for the `insert_health_check` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -2379,7 +2379,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_health_checks` method:
+# TODO: Change placeholder below to desired parameter value for the `list_health_checks` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -2583,7 +2583,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert_http_health_check` method:
+# TODO: Change placeholder below to desired parameter value for the `insert_http_health_check` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -2623,7 +2623,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_http_health_checks` method:
+# TODO: Change placeholder below to desired parameter value for the `list_http_health_checks` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -2827,7 +2827,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert_https_health_check` method:
+# TODO: Change placeholder below to desired parameter value for the `insert_https_health_check` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -2867,7 +2867,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_https_health_checks` method:
+# TODO: Change placeholder below to desired parameter value for the `list_https_health_checks` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -3153,7 +3153,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert_image` method:
+# TODO: Change placeholder below to desired parameter value for the `insert_image` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -3193,7 +3193,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_images` method:
+# TODO: Change placeholder below to desired parameter value for the `list_images` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -3279,7 +3279,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_aggregated_instance_group_managers` method:
+# TODO: Change placeholder below to desired parameter value for the `list_aggregated_instance_group_managers` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -3808,7 +3808,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_aggregated_instance_groups` method:
+# TODO: Change placeholder below to desired parameter value for the `list_aggregated_instance_groups` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -4238,7 +4238,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert_instance_template` method:
+# TODO: Change placeholder below to desired parameter value for the `insert_instance_template` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -4278,7 +4278,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_instance_templates` method:
+# TODO: Change placeholder below to desired parameter value for the `list_instance_templates` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -4367,7 +4367,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_aggregated_instances` method:
+# TODO: Change placeholder below to desired parameter value for the `list_aggregated_instances` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -5201,7 +5201,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_aggregated_machine_types` method:
+# TODO: Change placeholder below to desired parameter value for the `list_aggregated_machine_types` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -5404,7 +5404,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert_network` method:
+# TODO: Change placeholder below to desired parameter value for the `insert_network` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -5444,7 +5444,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_networks` method:
+# TODO: Change placeholder below to desired parameter value for the `list_networks` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -5484,7 +5484,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `get_project` method:
+# TODO: Change placeholder below to desired parameter value for the `get_project` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -5520,7 +5520,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `move_disk` method:
+# TODO: Change placeholder below to desired parameter value for the `move_disk` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -5560,7 +5560,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `move_instance` method:
+# TODO: Change placeholder below to desired parameter value for the `move_instance` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -5600,7 +5600,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `set_common_instance_metadata` method:
+# TODO: Change placeholder below to desired parameter value for the `set_common_instance_metadata` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -5640,7 +5640,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `set_usage_export_bucket` method:
+# TODO: Change placeholder below to desired parameter value for the `set_usage_export_bucket` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -5843,7 +5843,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_regions` method:
+# TODO: Change placeholder below to desired parameter value for the `list_regions` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -5883,7 +5883,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `aggregated_router_list` method:
+# TODO: Change placeholder below to desired parameter value for the `aggregated_router_list` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -6351,7 +6351,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert_route` method:
+# TODO: Change placeholder below to desired parameter value for the `insert_route` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -6391,7 +6391,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_routes` method:
+# TODO: Change placeholder below to desired parameter value for the `list_routes` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -6509,7 +6509,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_snapshots` method:
+# TODO: Change placeholder below to desired parameter value for the `list_snapshots` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -6627,7 +6627,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert_ssl_certificate` method:
+# TODO: Change placeholder below to desired parameter value for the `insert_ssl_certificate` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -6667,7 +6667,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_ssl_certificates` method:
+# TODO: Change placeholder below to desired parameter value for the `list_ssl_certificates` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -6707,7 +6707,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `aggregated_subnetwork_list` method:
+# TODO: Change placeholder below to desired parameter value for the `aggregated_subnetwork_list` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -6995,7 +6995,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert_target_http_proxy` method:
+# TODO: Change placeholder below to desired parameter value for the `insert_target_http_proxy` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -7035,7 +7035,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_target_http_proxies` method:
+# TODO: Change placeholder below to desired parameter value for the `list_target_http_proxies` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -7196,7 +7196,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert_target_https_proxy` method:
+# TODO: Change placeholder below to desired parameter value for the `insert_target_https_proxy` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -7236,7 +7236,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_target_https_proxies` method:
+# TODO: Change placeholder below to desired parameter value for the `list_target_https_proxies` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -7362,7 +7362,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_aggregated_target_instance` method:
+# TODO: Change placeholder below to desired parameter value for the `list_aggregated_target_instance` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -7664,7 +7664,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_aggregated_target_pools` method:
+# TODO: Change placeholder below to desired parameter value for the `list_aggregated_target_pools` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -8136,7 +8136,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert_target_ssl_proxy` method:
+# TODO: Change placeholder below to desired parameter value for the `insert_target_ssl_proxy` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -8176,7 +8176,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_target_ssl_proxies` method:
+# TODO: Change placeholder below to desired parameter value for the `list_target_ssl_proxies` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -8345,7 +8345,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_aggregated_target_vpn_gateways` method:
+# TODO: Change placeholder below to desired parameter value for the `list_aggregated_target_vpn_gateways` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -8633,7 +8633,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert_url_map` method:
+# TODO: Change placeholder below to desired parameter value for the `insert_url_map` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -8716,7 +8716,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_url_maps` method:
+# TODO: Change placeholder below to desired parameter value for the `list_url_maps` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -8885,7 +8885,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_aggregated_vpn_tunnel` method:
+# TODO: Change placeholder below to desired parameter value for the `list_aggregated_vpn_tunnel` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'
@@ -9258,7 +9258,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_zones` method:
+# TODO: Change placeholder below to desired parameter value for the `list_zones` method:
 
 # Project ID for this request.
 project = '{MY-PROJECT}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_dataflow.v1b3.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_dataflow.v1b3.json.baseline
@@ -24,7 +24,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `create_project_job` method:
+# TODO: Change placeholder below to desired parameter value for the `create_project_job` method:
 
 # The project which owns the job.
 project_id = '{MY-PROJECT-ID}'
@@ -228,7 +228,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_project_jobs` method:
+# TODO: Change placeholder below to desired parameter value for the `list_project_jobs` method:
 
 # The project which owns the jobs.
 project_id = '{MY-PROJECT-ID}'
@@ -440,7 +440,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `create_job_from_template` method:
+# TODO: Change placeholder below to desired parameter value for the `create_job_from_template` method:
 
 # The project which owns the job.
 project_id = '{MY-PROJECT-ID}'
@@ -480,7 +480,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `worker_project_messages` method:
+# TODO: Change placeholder below to desired parameter value for the `worker_project_messages` method:
 
 # The project to send the WorkerMessages to.
 project_id = '{MY-PROJECT-ID}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_dataproc.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_dataproc.v1.json.baseline
@@ -499,7 +499,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `cancel_operation` method:
+# TODO: Change placeholder below to desired parameter value for the `cancel_operation` method:
 
 # The name of the operation resource to be cancelled.
 name = 'projects/{MY-PROJECT}/regions/{MY-REGION}/operations/{MY-OPERATION}'
@@ -532,7 +532,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `delete_operation` method:
+# TODO: Change placeholder below to desired parameter value for the `delete_operation` method:
 
 # The name of the operation resource to be deleted.
 name = 'projects/{MY-PROJECT}/regions/{MY-REGION}/operations/{MY-OPERATION}'
@@ -565,7 +565,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `get_operation` method:
+# TODO: Change placeholder below to desired parameter value for the `get_operation` method:
 
 # The name of the operation resource.
 name = 'projects/{MY-PROJECT}/regions/{MY-REGION}/operations/{MY-OPERATION}'
@@ -601,7 +601,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_operations` method:
+# TODO: Change placeholder below to desired parameter value for the `list_operations` method:
 
 # The name of the operation collection.
 name = '{MY-NAME}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_datastore.v1beta3.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_datastore.v1beta3.json.baseline
@@ -24,7 +24,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `allocate_project_ids` method:
+# TODO: Change placeholder below to desired parameter value for the `allocate_project_ids` method:
 
 # The ID of the project against which to make the request.
 project_id = '{MY-PROJECT-ID}'
@@ -64,7 +64,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `begin_project_transaction` method:
+# TODO: Change placeholder below to desired parameter value for the `begin_project_transaction` method:
 
 # The ID of the project against which to make the request.
 project_id = '{MY-PROJECT-ID}'
@@ -104,7 +104,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `commit_project` method:
+# TODO: Change placeholder below to desired parameter value for the `commit_project` method:
 
 # The ID of the project against which to make the request.
 project_id = '{MY-PROJECT-ID}'
@@ -144,7 +144,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `lookup_project` method:
+# TODO: Change placeholder below to desired parameter value for the `lookup_project` method:
 
 # The ID of the project against which to make the request.
 project_id = '{MY-PROJECT-ID}'
@@ -184,7 +184,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `rollback_project` method:
+# TODO: Change placeholder below to desired parameter value for the `rollback_project` method:
 
 # The ID of the project against which to make the request.
 project_id = '{MY-PROJECT-ID}'
@@ -224,7 +224,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `run_project_query` method:
+# TODO: Change placeholder below to desired parameter value for the `run_project_query` method:
 
 # The ID of the project against which to make the request.
 project_id = '{MY-PROJECT-ID}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_deploymentmanager.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_deploymentmanager.v2.json.baseline
@@ -145,7 +145,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert_deployment` method:
+# TODO: Change placeholder below to desired parameter value for the `insert_deployment` method:
 
 # The project ID for this request.
 project = '{MY-PROJECT}'
@@ -185,7 +185,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_deployments` method:
+# TODO: Change placeholder below to desired parameter value for the `list_deployments` method:
 
 # The project ID for this request.
 project = '{MY-PROJECT}'
@@ -478,7 +478,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_operations` method:
+# TODO: Change placeholder below to desired parameter value for the `list_operations` method:
 
 # The project ID for this request.
 project = '{MY-PROJECT}'
@@ -603,7 +603,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_types` method:
+# TODO: Change placeholder below to desired parameter value for the `list_types` method:
 
 # The project ID for this request.
 project = '{MY-PROJECT}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_dns.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_dns.v1.json.baseline
@@ -152,7 +152,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `create_managed_zone` method:
+# TODO: Change placeholder below to desired parameter value for the `create_managed_zone` method:
 
 # Identifies the project addressed by this request.
 project = '{MY-PROJECT}'
@@ -267,7 +267,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_managed_zones` method:
+# TODO: Change placeholder below to desired parameter value for the `list_managed_zones` method:
 
 # Identifies the project addressed by this request.
 project = '{MY-PROJECT}'
@@ -307,7 +307,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `get_project` method:
+# TODO: Change placeholder below to desired parameter value for the `get_project` method:
 
 # Identifies the project addressed by this request.
 project = '{MY-PROJECT}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_logging.v2beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_logging.v2beta1.json.baseline
@@ -130,7 +130,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `delete_log` method:
+# TODO: Change placeholder below to desired parameter value for the `delete_log` method:
 
 # Required. The resource name of the log to delete. Example: `"projects/my-project/logs/syslog"`.
 log_name = 'projects/{MY-PROJECT}/logs/{MY-LOG}'
@@ -163,7 +163,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `create_project_metric` method:
+# TODO: Change placeholder below to desired parameter value for the `create_project_metric` method:
 
 # The resource name of the project in which to create the metric. Example: `"projects/my-project-id"`.
 # The new metric must be provided in the request.
@@ -204,7 +204,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `delete_project_metric` method:
+# TODO: Change placeholder below to desired parameter value for the `delete_project_metric` method:
 
 # The resource name of the metric to delete. Example: `"projects/my-project-id/metrics/my-metric-id"`.
 metric_name = 'projects/{MY-PROJECT}/metrics/{MY-METRIC}'
@@ -237,7 +237,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `get_project_metric` method:
+# TODO: Change placeholder below to desired parameter value for the `get_project_metric` method:
 
 # The resource name of the desired metric. Example: `"projects/my-project-id/metrics/my-metric-id"`.
 metric_name = 'projects/{MY-PROJECT}/metrics/{MY-METRIC}'
@@ -273,7 +273,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_project_metrics` method:
+# TODO: Change placeholder below to desired parameter value for the `list_project_metrics` method:
 
 # Required. The resource name of the project containing the metrics. Example:
 # `"projects/my-project-id"`.
@@ -314,7 +314,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `update_project_metric` method:
+# TODO: Change placeholder below to desired parameter value for the `update_project_metric` method:
 
 # The resource name of the metric to update. Example: `"projects/my-project-id/metrics/my-metric-id"`.
 # The updated metric must be provided in the request and have the same identifier that is specified in
@@ -356,7 +356,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `create_project_sink` method:
+# TODO: Change placeholder below to desired parameter value for the `create_project_sink` method:
 
 # The resource name of the project in which to create the sink. Example: `"projects/my-project-id"`.
 # The new sink must be provided in the request.
@@ -397,7 +397,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `delete_project_sink` method:
+# TODO: Change placeholder below to desired parameter value for the `delete_project_sink` method:
 
 # The resource name of the sink to delete. Example: `"projects/my-project-id/sinks/my-sink-id"`.
 sink_name = 'projects/{MY-PROJECT}/sinks/{MY-SINK}'
@@ -430,7 +430,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `get_project_sink` method:
+# TODO: Change placeholder below to desired parameter value for the `get_project_sink` method:
 
 # The resource name of the sink to return. Example: `"projects/my-project-id/sinks/my-sink-id"`.
 sink_name = 'projects/{MY-PROJECT}/sinks/{MY-SINK}'
@@ -466,7 +466,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_project_sinks` method:
+# TODO: Change placeholder below to desired parameter value for the `list_project_sinks` method:
 
 # Required. The resource name of the project containing the sinks. Example:
 # `"projects/my-logging-project"`.
@@ -507,7 +507,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `update_project_sink` method:
+# TODO: Change placeholder below to desired parameter value for the `update_project_sink` method:
 
 # The resource name of the sink to update. Example: `"projects/my-project-id/sinks/my-sink-id"`. The
 # updated sink must be provided in the request and have the same name that is specified in `sinkName`.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_prediction.v1.6.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_prediction.v1.6.json.baseline
@@ -181,7 +181,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert_trained_model` method:
+# TODO: Change placeholder below to desired parameter value for the `insert_trained_model` method:
 
 # The project associated with the model.
 project = '{MY-PROJECT}'
@@ -221,7 +221,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_trained_models` method:
+# TODO: Change placeholder below to desired parameter value for the `list_trained_models` method:
 
 # The project associated with the model.
 project = '{MY-PROJECT}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_pubsub.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_pubsub.v1.json.baseline
@@ -24,7 +24,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `acknowledge_subscription` method:
+# TODO: Change placeholder below to desired parameter value for the `acknowledge_subscription` method:
 
 # The subscription whose message is being acknowledged.
 subscription = 'projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}'
@@ -61,7 +61,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `create_subscription` method:
+# TODO: Change placeholder below to desired parameter value for the `create_subscription` method:
 
 # The name of the subscription. It must have the format
 # `"projects/{project}/subscriptions/{subscription}"`. `{subscription}` must start with a letter, and
@@ -105,7 +105,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `delete_subscription` method:
+# TODO: Change placeholder below to desired parameter value for the `delete_subscription` method:
 
 # The subscription to delete.
 subscription = 'projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}'
@@ -138,7 +138,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `get_subscription` method:
+# TODO: Change placeholder below to desired parameter value for the `get_subscription` method:
 
 # The name of the subscription to get.
 subscription = 'projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}'
@@ -174,7 +174,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `get_project_subscription_iam_policy` method:
+# TODO: Change placeholder below to desired parameter value for the `get_project_subscription_iam_policy` method:
 
 # REQUIRED: The resource for which the policy is being requested. `resource` is usually specified as a
 # path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
@@ -212,7 +212,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_subscriptions` method:
+# TODO: Change placeholder below to desired parameter value for the `list_subscriptions` method:
 
 # The name of the cloud project that subscriptions belong to.
 project = 'projects/{MY-PROJECT}'
@@ -252,7 +252,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `modify_subscription_ack_deadline` method:
+# TODO: Change placeholder below to desired parameter value for the `modify_subscription_ack_deadline` method:
 
 # The name of the subscription.
 subscription = 'projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}'
@@ -289,7 +289,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `modify_subscription_push_config` method:
+# TODO: Change placeholder below to desired parameter value for the `modify_subscription_push_config` method:
 
 # The name of the subscription.
 subscription = 'projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}'
@@ -326,7 +326,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `pull_subscription` method:
+# TODO: Change placeholder below to desired parameter value for the `pull_subscription` method:
 
 # The subscription from which messages should be pulled.
 subscription = 'projects/{MY-PROJECT}/subscriptions/{MY-SUBSCRIPTION}'
@@ -366,7 +366,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `set_subscription_iam_policy` method:
+# TODO: Change placeholder below to desired parameter value for the `set_subscription_iam_policy` method:
 
 # REQUIRED: The resource for which the policy is being specified. `resource` is usually specified as a
 # path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
@@ -408,7 +408,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `test_subscription_iam_permissions` method:
+# TODO: Change placeholder below to desired parameter value for the `test_subscription_iam_permissions` method:
 
 # REQUIRED: The resource for which the policy detail is being requested. `resource` is usually
 # specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path
@@ -451,7 +451,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `create_topic` method:
+# TODO: Change placeholder below to desired parameter value for the `create_topic` method:
 
 # The name of the topic. It must have the format `"projects/{project}/topics/{topic}"`. `{topic}` must
 # start with a letter, and contain only letters (`[A-Za-z]`), numbers (`[0-9]`), dashes (`-`),
@@ -494,7 +494,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `delete_topic` method:
+# TODO: Change placeholder below to desired parameter value for the `delete_topic` method:
 
 # Name of the topic to delete.
 topic = 'projects/{MY-PROJECT}/topics/{MY-TOPIC}'
@@ -527,7 +527,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `get_topic` method:
+# TODO: Change placeholder below to desired parameter value for the `get_topic` method:
 
 # The name of the topic to get.
 topic = 'projects/{MY-PROJECT}/topics/{MY-TOPIC}'
@@ -563,7 +563,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `get_project_topic_iam_policy` method:
+# TODO: Change placeholder below to desired parameter value for the `get_project_topic_iam_policy` method:
 
 # REQUIRED: The resource for which the policy is being requested. `resource` is usually specified as a
 # path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
@@ -601,7 +601,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_topics` method:
+# TODO: Change placeholder below to desired parameter value for the `list_topics` method:
 
 # The name of the cloud project that topics belong to.
 project = 'projects/{MY-PROJECT}'
@@ -641,7 +641,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `publish_topic` method:
+# TODO: Change placeholder below to desired parameter value for the `publish_topic` method:
 
 # The messages in the request will be published on this topic.
 topic = 'projects/{MY-PROJECT}/topics/{MY-TOPIC}'
@@ -681,7 +681,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `set_topic_iam_policy` method:
+# TODO: Change placeholder below to desired parameter value for the `set_topic_iam_policy` method:
 
 # REQUIRED: The resource for which the policy is being specified. `resource` is usually specified as a
 # path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path specified in
@@ -723,7 +723,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_topic_subscriptions` method:
+# TODO: Change placeholder below to desired parameter value for the `list_topic_subscriptions` method:
 
 # The name of the topic that subscriptions are attached to.
 topic = 'projects/{MY-PROJECT}/topics/{MY-TOPIC}'
@@ -763,7 +763,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `test_topic_iam_permissions` method:
+# TODO: Change placeholder below to desired parameter value for the `test_topic_iam_permissions` method:
 
 # REQUIRED: The resource for which the policy detail is being requested. `resource` is usually
 # specified as a path, such as `projects/*project*/zones/*zone*/disks/*disk*`. The format for the path

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_sqladmin.v1beta4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_sqladmin.v1beta4.json.baseline
@@ -732,7 +732,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert_instance` method:
+# TODO: Change placeholder below to desired parameter value for the `insert_instance` method:
 
 # Project ID of the project to which the newly created Cloud SQL instances should belong.
 project = '{MY-PROJECT}'
@@ -772,7 +772,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_instances` method:
+# TODO: Change placeholder below to desired parameter value for the `list_instances` method:
 
 # Project ID of the project for which to list Cloud SQL instances.
 project = '{MY-PROJECT}'
@@ -1427,7 +1427,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_tiers` method:
+# TODO: Change placeholder below to desired parameter value for the `list_tiers` method:
 
 # Project ID of the project for which to list tiers.
 project = '{MY-PROJECT}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_storage.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_storage.v1.json.baseline
@@ -101,7 +101,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert_bucket_access_control` method:
+# TODO: Change placeholder below to desired parameter value for the `insert_bucket_access_control` method:
 
 # Name of a bucket.
 bucket = '{MY-BUCKET}'
@@ -141,7 +141,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_bucket_access_controls` method:
+# TODO: Change placeholder below to desired parameter value for the `list_bucket_access_controls` method:
 
 # Name of a bucket.
 bucket = '{MY-BUCKET}'
@@ -265,7 +265,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `delete_bucket` method:
+# TODO: Change placeholder below to desired parameter value for the `delete_bucket` method:
 
 # Name of a bucket.
 bucket = '{MY-BUCKET}'
@@ -298,7 +298,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `get_bucket` method:
+# TODO: Change placeholder below to desired parameter value for the `get_bucket` method:
 
 # Name of a bucket.
 bucket = '{MY-BUCKET}'
@@ -334,7 +334,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert_bucket` method:
+# TODO: Change placeholder below to desired parameter value for the `insert_bucket` method:
 
 # A valid API project identifier.
 project = '{MY-PROJECT}'
@@ -374,7 +374,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_buckets` method:
+# TODO: Change placeholder below to desired parameter value for the `list_buckets` method:
 
 # A valid API project identifier.
 project = '{MY-PROJECT}'
@@ -414,7 +414,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `patch_bucket` method:
+# TODO: Change placeholder below to desired parameter value for the `patch_bucket` method:
 
 # Name of a bucket.
 bucket = '{MY-BUCKET}'
@@ -454,7 +454,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `update_bucket` method:
+# TODO: Change placeholder below to desired parameter value for the `update_bucket` method:
 
 # Name of a bucket.
 bucket = '{MY-BUCKET}'
@@ -602,7 +602,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert_default_object_access_control` method:
+# TODO: Change placeholder below to desired parameter value for the `insert_default_object_access_control` method:
 
 # Name of a bucket.
 bucket = '{MY-BUCKET}'
@@ -642,7 +642,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_default_object_access_controls` method:
+# TODO: Change placeholder below to desired parameter value for the `list_default_object_access_controls` method:
 
 # Name of a bucket.
 bucket = '{MY-BUCKET}'
@@ -1205,7 +1205,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `insert_object` method:
+# TODO: Change placeholder below to desired parameter value for the `insert_object` method:
 
 # Name of the bucket in which to store the new object. Overrides the provided object metadata's bucket
 # value, if any.
@@ -1246,7 +1246,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_objects` method:
+# TODO: Change placeholder below to desired parameter value for the `list_objects` method:
 
 # Name of the bucket in which to look for objects.
 bucket = '{MY-BUCKET}'
@@ -1427,7 +1427,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `watch_all_objects` method:
+# TODO: Change placeholder below to desired parameter value for the `watch_all_objects` method:
 
 # Name of the bucket in which to look for objects.
 bucket = '{MY-BUCKET}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_storagetransfer.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_storagetransfer.v1.json.baseline
@@ -54,7 +54,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `get_google_service_account` method:
+# TODO: Change placeholder below to desired parameter value for the `get_google_service_account` method:
 
 # The ID of the Google Developers Console project that the Google service account is associated with.
 # Required.
@@ -125,7 +125,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `get_transfer_job` method:
+# TODO: Change placeholder below to desired parameter value for the `get_transfer_job` method:
 
 # The job to get. Required.
 job_name = '{MY-JOB-NAME}'
@@ -195,7 +195,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `patch_transfer_job` method:
+# TODO: Change placeholder below to desired parameter value for the `patch_transfer_job` method:
 
 # The name of job to update. Required.
 job_name = '{MY-JOB-NAME}'
@@ -235,7 +235,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `cancel_transfer_operation` method:
+# TODO: Change placeholder below to desired parameter value for the `cancel_transfer_operation` method:
 
 # The name of the operation resource to be cancelled.
 name = '{MY-NAME}'
@@ -268,7 +268,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `delete_transfer_operation` method:
+# TODO: Change placeholder below to desired parameter value for the `delete_transfer_operation` method:
 
 # The name of the operation resource to be deleted.
 name = '{MY-NAME}'
@@ -301,7 +301,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `get_transfer_operation` method:
+# TODO: Change placeholder below to desired parameter value for the `get_transfer_operation` method:
 
 # The name of the operation resource.
 name = '{MY-NAME}'
@@ -337,7 +337,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_transfer_operations` method:
+# TODO: Change placeholder below to desired parameter value for the `list_transfer_operations` method:
 
 # The value `transferOperations`.
 name = '{MY-NAME}'
@@ -377,7 +377,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `pause_transfer_operation` method:
+# TODO: Change placeholder below to desired parameter value for the `pause_transfer_operation` method:
 
 # The name of the transfer operation. Required.
 name = '{MY-NAME}'
@@ -414,7 +414,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 
-# TODO: Change placeholders below to desired parameter values for the `resume_transfer_operation` method:
+# TODO: Change placeholder below to desired parameter value for the `resume_transfer_operation` method:
 
 # The name of the transfer operation. Required.
 name = '{MY-NAME}'

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_translate.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_translate.v2.json.baseline
@@ -15,7 +15,7 @@ service = Google::Apis::TranslateV2::TranslateService.new
 service.key = '{MY-API-KEY}'
 
 
-# TODO: Change placeholders below to desired parameter values for the `list_detections` method:
+# TODO: Change placeholder below to desired parameter value for the `list_detections` method:
 
 # The text to detect
 q = []


### PR DESCRIPTION
Add feature omitted for non-Java languages in earlier PR
https://github.com/googleapis/toolkit/pull/487.

Not needed for Go due to alternative placeholder comment
formatting (motivated by gofmt prohibition of multiple consecutive blank
lines).