### PR TITLE
Remove beta stub creation method

### DIFF
--- a/src/main/resources/com/google/api/codegen/py/main.snip
+++ b/src/main/resources/com/google/api/codegen/py/main.snip
@@ -239,7 +239,7 @@
                         stubModule = importHandler.fileToModule(stubInterface.getFile()), \
                         stubService = stubInterface.getSimpleName
                     self.{@stubName} = config.create_stub(
-                        {@stubModule}.beta_create_{@stubService}_stub,
+                        {@stubModule}.{@stubService}Stub,
                         service_path,
                         port,
                         ssl_creds=ssl_creds,

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
@@ -261,7 +261,7 @@ class LibraryServiceApi(object):
             bundle_descriptors=self._BUNDLE_DESCRIPTORS,
             page_descriptors=self._PAGE_DESCRIPTORS)
         self.library_service_stub = config.create_stub(
-            library_pb2.beta_create_LibraryService_stub,
+            library_pb2.LibraryServiceStub,
             service_path,
             port,
             ssl_creds=ssl_creds,
@@ -269,7 +269,7 @@ class LibraryServiceApi(object):
             metadata_transformer=metadata_transformer,
             scopes=scopes)
         self.labeler_stub = config.create_stub(
-            tagger_pb2.beta_create_Labeler_stub,
+            tagger_pb2.LabelerStub,
             service_path,
             port,
             ssl_creds=ssl_creds,

--- a/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
@@ -261,7 +261,7 @@ class LibraryServiceApi(object):
             bundle_descriptors=self._BUNDLE_DESCRIPTORS,
             page_descriptors=self._PAGE_DESCRIPTORS)
         self.library_service_stub = config.create_stub(
-            library_pb2.beta_create_LibraryService_stub,
+            library_pb2.LibraryServiceStub,
             service_path,
             port,
             ssl_creds=ssl_creds,
@@ -269,7 +269,7 @@ class LibraryServiceApi(object):
             metadata_transformer=metadata_transformer,
             scopes=scopes)
         self.labeler_stub = config.create_stub(
-            tagger_pb2.beta_create_Labeler_stub,
+            tagger_pb2.LabelerStub,
             service_path,
             port,
             ssl_creds=ssl_creds,

--- a/src/test/java/com/google/api/codegen/testdata/python_main_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_main_no_path_templates.baseline
@@ -108,7 +108,7 @@ class NoTemplatesAPIServiceApi(object):
             config.STATUS_CODE_NAMES,
             kwargs={'metadata': metadata})
         self.no_templates_api_service_stub = config.create_stub(
-            no_path_templates_pb2.beta_create_NoTemplatesAPIService_stub,
+            no_path_templates_pb2.NoTemplatesAPIServiceStub,
             service_path,
             port,
             ssl_creds=ssl_creds,


### PR DESCRIPTION
This was previously done in #483 but was accidentally reverted in #470 