### PR TITLE
Resolve name clashes between Python enums

### DIFF
--- a/src/main/java/com/google/api/codegen/py/PythonContextCommon.java
+++ b/src/main/java/com/google/api/codegen/py/PythonContextCommon.java
@@ -14,14 +14,10 @@
  */
 package com.google.api.codegen.py;
 
-import com.google.api.tools.framework.model.Model;
-import com.google.api.tools.framework.model.TypeRef;
-import com.google.common.base.Predicate;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 import java.util.List;
 
 /**
@@ -39,17 +35,6 @@ public class PythonContextCommon {
       return name + "_";
     }
     return name;
-  }
-
-  public Iterable<TypeRef> getEnumTypes(Model model) {
-    return Iterables.filter(
-        model.getSymbolTable().getDeclaredTypes(),
-        new Predicate<TypeRef>() {
-          @Override
-          public boolean apply(TypeRef type) {
-            return type.isEnum() && type.getEnumType().isReachable();
-          }
-        });
   }
 
   /*

--- a/src/main/java/com/google/api/codegen/py/PythonEnumSymbolTable.java
+++ b/src/main/java/com/google/api/codegen/py/PythonEnumSymbolTable.java
@@ -1,0 +1,78 @@
+/* Copyright 2016 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.py;
+
+import com.google.api.tools.framework.model.EnumType;
+import com.google.api.tools.framework.model.Model;
+import com.google.api.tools.framework.model.ProtoElement;
+import com.google.api.tools.framework.model.TypeRef;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * A symbol table mapping proto enum values to their Pythonic aliases. Handles disambiguation of
+ * enums that share the same proto simple name.
+ */
+public class PythonEnumSymbolTable {
+  private final BiMap<EnumType, String> enums;
+  private final Set<String> blacklist;
+
+  public PythonEnumSymbolTable(Model model) {
+    enums = HashBiMap.create();
+    blacklist = new HashSet<>();
+    for (TypeRef type : model.getSymbolTable().getDeclaredTypes()) {
+      if (type.isEnum() && type.getEnumType().isReachable()) {
+        addEnum(type.getEnumType(), type.getEnumType().getSimpleName());
+      }
+    }
+  }
+
+  /** Gets all reachable enum types. */
+  public Iterable<EnumType> getEnums() {
+    return enums.keySet();
+  }
+
+  /** Gets the Pythonic alias corresponding to a given enum type. */
+  public String lookupName(EnumType type) {
+    return enums.get(type);
+  }
+
+  private void addEnum(EnumType type, String name) {
+    if (enums.inverse().containsKey(name)) {
+      blacklist.add(name); // remove the ambiguous name from circulation
+      EnumType oldType = enums.inverse().remove(name);
+      addEnum(oldType, disambiguate(oldType, name));
+      addEnum(type, disambiguate(type, name));
+
+    } else if (blacklist.contains(name)) {
+      addEnum(type, disambiguate(type, name));
+
+    } else {
+      enums.put(type, name);
+    }
+  }
+
+  private String disambiguate(EnumType type, String currentName) {
+    ProtoElement parent = type.getParent();
+    StringBuilder newName = new StringBuilder(type.getSimpleName());
+    while (newName.length() <= currentName.length() && parent != null) {
+      newName.insert(0, parent.getSimpleName());
+      parent = parent.getParent();
+    }
+    return newName.toString();
+  }
+}

--- a/src/main/java/com/google/api/codegen/py/PythonGapicContext.java
+++ b/src/main/java/com/google/api/codegen/py/PythonGapicContext.java
@@ -147,8 +147,8 @@ public class PythonGapicContext extends GapicContext {
     return typeComment(field.getType(), importHandler);
   }
 
-  private String enumClassName(EnumType enumType) {
-    return "enums." + pythonCommon.wrapIfKeywordOrBuiltIn(enumType.getSimpleName());
+  private String enumClassName(EnumType enumType, PythonEnumSymbolTable enumTable) {
+    return "enums." + pythonCommon.wrapIfKeywordOrBuiltIn(enumTable.lookupName(enumType));
   }
 
   private String typeComment(TypeRef type, PythonImportHandler importHandler) {
@@ -159,7 +159,7 @@ public class PythonGapicContext extends GapicContext {
         return "enum :class:`"
             + getApiConfig().getPackageName()
             + "."
-            + enumClassName(type.getEnumType())
+            + enumClassName(type.getEnumType(), importHandler.getEnumTable())
             + "`";
       default:
         if (type.isPrimitive()) {
@@ -364,9 +364,8 @@ public class PythonGapicContext extends GapicContext {
       case TYPE_ENUM:
         Preconditions.checkArgument(
             type.getEnumType().getValues().size() > 0, "enum must have a value");
-        // TODO:multiple enums of same name?
         return "enums."
-            + type.getEnumType().getSimpleName()
+            + importHandler.getEnumTable().lookupName(type.getEnumType())
             + "."
             + type.getEnumType().getValues().get(0).getSimpleName();
       default:

--- a/src/main/java/com/google/api/codegen/py/PythonImportHandler.java
+++ b/src/main/java/com/google/api/codegen/py/PythonImportHandler.java
@@ -47,8 +47,13 @@ public class PythonImportHandler {
    */
   private final BiMap<ProtoFile, String> fileImports = HashBiMap.create();
 
+  private final PythonEnumSymbolTable enumTable;
+
   /** This constructor is for the main imports of a generated service file */
-  public PythonImportHandler(Interface service, ApiConfig apiConfig) {
+  public PythonImportHandler(
+      Interface service, ApiConfig apiConfig, PythonEnumSymbolTable enumTable) {
+    this.enumTable = enumTable;
+
     // Add non-service-specific imports.
     addImportStandard("json");
     addImportStandard("os");
@@ -61,7 +66,7 @@ public class PythonImportHandler {
     addImportExternal("google.gax", "path_template");
 
     // only if add enum import if there are enums
-    if (!Iterables.isEmpty(new PythonContextCommon().getEnumTypes(service.getModel()))) {
+    if (!Iterables.isEmpty(enumTable.getEnums())) {
       addImportLocal(apiConfig.getPackageName(), "enums");
     }
 
@@ -87,7 +92,8 @@ public class PythonImportHandler {
   }
 
   /** This constructor is used for doc messages. */
-  public PythonImportHandler(ProtoFile file) {
+  public PythonImportHandler(ProtoFile file, PythonEnumSymbolTable enumTable) {
+    this.enumTable = enumTable;
     for (MessageType message : file.getMessages()) {
       for (Field field : message.getMessageFields()) {
         MessageType messageType = field.getType().getMessageType();
@@ -105,7 +111,13 @@ public class PythonImportHandler {
   }
 
   // Independent import handler to support fragment generation from discovery sources
-  public PythonImportHandler() {}
+  public PythonImportHandler() {
+    enumTable = null;
+  }
+
+  public PythonEnumSymbolTable getEnumTable() {
+    return enumTable;
+  }
 
   /**
    * Returns the path to a proto element. If fullyQualified is false, returns the fully qualified

--- a/src/main/java/com/google/api/codegen/py/PythonImportHandler.java
+++ b/src/main/java/com/google/api/codegen/py/PythonImportHandler.java
@@ -26,7 +26,6 @@ import com.google.api.tools.framework.model.ProtoFile;
 import com.google.common.base.Strings;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
-import com.google.common.collect.Iterables;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -47,13 +46,8 @@ public class PythonImportHandler {
    */
   private final BiMap<ProtoFile, String> fileImports = HashBiMap.create();
 
-  private final PythonEnumSymbolTable enumTable;
-
   /** This constructor is for the main imports of a generated service file */
-  public PythonImportHandler(
-      Interface service, ApiConfig apiConfig, PythonEnumSymbolTable enumTable) {
-    this.enumTable = enumTable;
-
+  public PythonImportHandler(Interface service, ApiConfig apiConfig, boolean importEnums) {
     // Add non-service-specific imports.
     addImportStandard("json");
     addImportStandard("os");
@@ -66,7 +60,7 @@ public class PythonImportHandler {
     addImportExternal("google.gax", "path_template");
 
     // only if add enum import if there are enums
-    if (!Iterables.isEmpty(enumTable.getEnums())) {
+    if (importEnums) {
       addImportLocal(apiConfig.getPackageName(), "enums");
     }
 
@@ -92,8 +86,7 @@ public class PythonImportHandler {
   }
 
   /** This constructor is used for doc messages. */
-  public PythonImportHandler(ProtoFile file, PythonEnumSymbolTable enumTable) {
-    this.enumTable = enumTable;
+  public PythonImportHandler(ProtoFile file) {
     for (MessageType message : file.getMessages()) {
       for (Field field : message.getMessageFields()) {
         MessageType messageType = field.getType().getMessageType();
@@ -111,13 +104,7 @@ public class PythonImportHandler {
   }
 
   // Independent import handler to support fragment generation from discovery sources
-  public PythonImportHandler() {
-    enumTable = null;
-  }
-
-  public PythonEnumSymbolTable getEnumTable() {
-    return enumTable;
-  }
+  public PythonImportHandler() {}
 
   /**
    * Returns the path to a proto element. If fullyQualified is false, returns the fully qualified

--- a/src/main/java/com/google/api/codegen/py/PythonInterfaceInitializer.java
+++ b/src/main/java/com/google/api/codegen/py/PythonInterfaceInitializer.java
@@ -17,10 +17,12 @@ package com.google.api.codegen.py;
 import com.google.api.codegen.ApiConfig;
 import com.google.api.tools.framework.model.Interface;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
 
 public class PythonInterfaceInitializer implements PythonSnippetSetInputInitializer<Interface> {
 
   private final ApiConfig apiConfig;
+  private PythonEnumSymbolTable enumTable = null;
 
   public PythonInterfaceInitializer(ApiConfig apiConfig) {
     this.apiConfig = apiConfig;
@@ -28,11 +30,17 @@ public class PythonInterfaceInitializer implements PythonSnippetSetInputInitiali
 
   @Override
   public PythonImportHandler getImportHandler(Interface iface) {
-    return new PythonImportHandler(iface, apiConfig, new PythonEnumSymbolTable(iface.getModel()));
+    if (enumTable == null) {
+      enumTable = new PythonEnumSymbolTable(iface.getModel());
+    }
+    return new PythonImportHandler(iface, apiConfig, !Iterables.isEmpty(enumTable.getEnums()));
   }
 
   @Override
   public ImmutableMap<String, Object> getGlobalMap(Interface iface) {
-    return ImmutableMap.of("pyproto", (Object) new PythonProtoElements());
+    if (enumTable == null) {
+      enumTable = new PythonEnumSymbolTable(iface.getModel());
+    }
+    return ImmutableMap.of("pyproto", (Object) new PythonProtoElements(), "enumTable", enumTable);
   }
 }

--- a/src/main/java/com/google/api/codegen/py/PythonInterfaceInitializer.java
+++ b/src/main/java/com/google/api/codegen/py/PythonInterfaceInitializer.java
@@ -28,7 +28,7 @@ public class PythonInterfaceInitializer implements PythonSnippetSetInputInitiali
 
   @Override
   public PythonImportHandler getImportHandler(Interface iface) {
-    return new PythonImportHandler(iface, apiConfig);
+    return new PythonImportHandler(iface, apiConfig, new PythonEnumSymbolTable(iface.getModel()));
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/py/PythonProtoFileInitializer.java
+++ b/src/main/java/com/google/api/codegen/py/PythonProtoFileInitializer.java
@@ -21,7 +21,7 @@ public class PythonProtoFileInitializer implements PythonSnippetSetInputInitiali
 
   @Override
   public PythonImportHandler getImportHandler(ProtoFile file) {
-    return new PythonImportHandler(file);
+    return new PythonImportHandler(file, new PythonEnumSymbolTable(file.getModel()));
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/py/PythonProtoFileInitializer.java
+++ b/src/main/java/com/google/api/codegen/py/PythonProtoFileInitializer.java
@@ -21,11 +21,12 @@ public class PythonProtoFileInitializer implements PythonSnippetSetInputInitiali
 
   @Override
   public PythonImportHandler getImportHandler(ProtoFile file) {
-    return new PythonImportHandler(file, new PythonEnumSymbolTable(file.getModel()));
+    return new PythonImportHandler(file);
   }
 
   @Override
   public ImmutableMap<String, Object> getGlobalMap(ProtoFile file) {
-    return ImmutableMap.of("file", (Object) file);
+    return ImmutableMap.of(
+        "file", (Object) file, "enumTable", new PythonEnumSymbolTable(file.getModel()));
   }
 }

--- a/src/main/resources/com/google/api/codegen/py/enum.snip
+++ b/src/main/resources/com/google/api/codegen/py/enum.snip
@@ -62,7 +62,7 @@
 @end
 
 @private enumSection(enum)
-    class {@context.python.wrapIfKeywordOrBuiltIn(importHandler.getEnumTable.lookupName(enum))}(object):
+    class {@context.python.wrapIfKeywordOrBuiltIn(enumTable.lookupName(enum))}(object):
         {@enumComments(enum)}
         @join value : enum.getValues
             {@context.python.wrapIfKeywordOrBuiltIn(value.getSimpleName)} = {@value.getNumber}
@@ -70,7 +70,7 @@
 @end
 
 @private enumConstants()
-    @join enum : importHandler.getEnumTable.getEnums on BREAK.add(BREAK).add(BREAK)
+    @join enum : enumTable.getEnums on BREAK.add(BREAK).add(BREAK)
         {@enumSection(enum)}
     @end
 @end

--- a/src/main/resources/com/google/api/codegen/py/enum.snip
+++ b/src/main/resources/com/google/api/codegen/py/enum.snip
@@ -62,7 +62,7 @@
 @end
 
 @private enumSection(enum)
-    class {@context.python.wrapIfKeywordOrBuiltIn(enum.getSimpleName)}(object):
+    class {@context.python.wrapIfKeywordOrBuiltIn(importHandler.getEnumTable.lookupName(enum))}(object):
         {@enumComments(enum)}
         @join value : enum.getValues
             {@context.python.wrapIfKeywordOrBuiltIn(value.getSimpleName)} = {@value.getNumber}
@@ -70,7 +70,7 @@
 @end
 
 @private enumConstants()
-    @join type : context.python.getEnumTypes(context.getModel) on BREAK.add(BREAK).add(BREAK)
-        {@enumSection(type.getEnumType)}
+    @join enum : importHandler.getEnumTable.getEnums on BREAK.add(BREAK).add(BREAK)
+        {@enumSection(enum)}
     @end
 @end

--- a/src/main/resources/com/google/api/codegen/py/main.snip
+++ b/src/main/resources/com/google/api/codegen/py/main.snip
@@ -353,7 +353,7 @@
 
 @private methodComments(service, method)
   @let descriptionComments = context.methodDescriptionComments(method), \
-       signatureComments = context.methodSignatureComments(service, method, importHandler)
+       signatureComments = context.methodSignatureComments(service, method, importHandler, enumTable)
     """
     @join comment : descriptionComments
       {@comment}
@@ -383,7 +383,7 @@
 @private methodSample(service, method)
   @let apiConfig = context.getApiConfig, \
        apiName = context.getApiWrapperName(service), \
-       returnType = context.returnTypeOrEmpty(method, importHandler), \
+       returnType = context.returnTypeOrEmpty(method, importHandler, enumTable), \
        fields = context.getRequiredFields(service, method), \
        builder = context.newDocConfigBuilder \
          .setInterface(service) \
@@ -501,7 +501,7 @@
             @if {@context.isDefaultValueMutable(field)}
                 {@paramName}=None
             @else
-                {@paramName}={@context.defaultValue(field, importHandler)}
+                {@paramName}={@context.defaultValue(field, importHandler, enumTable)}
             @end
         @end
     @end
@@ -511,7 +511,7 @@
     @join field : params if {@context.isDefaultValueMutable(field)} on BREAK
         @let paramName = {@context.python.wrapIfKeywordOrBuiltIn(field.getSimpleName())}
             if {@paramName} is None:
-                {@paramName} = {@context.defaultValue(field, importHandler)}
+                {@paramName} = {@context.defaultValue(field, importHandler, enumTable)}
         @end
     @end
 @end

--- a/src/main/resources/com/google/api/codegen/py/message.snip
+++ b/src/main/resources/com/google/api/codegen/py/message.snip
@@ -44,7 +44,7 @@
 @end
 
 @private messageComments(message)
-    @join comment : context.messageComments(message, importHandler)
+    @join comment : context.messageComments(message, importHandler, enumTable)
         {@comment}
     @end
 @end

--- a/src/main/resources/com/google/api/codegen/py/method_sample.snip
+++ b/src/main/resources/com/google/api/codegen/py/method_sample.snip
@@ -125,7 +125,7 @@
         {@formatResourceFunctionArgs(metadata.getCollectionConfig)}\
       )
     @else
-      {@context.defaultValue(line.getType, importHandler)}
+      {@context.defaultValue(line.getType, importHandler, enumTable)}
     @end
   @end
 @end

--- a/src/test/java/com/google/api/codegen/testdata/library.proto
+++ b/src/test/java/com/google/api/codegen/testdata/library.proto
@@ -191,10 +191,29 @@ message SomeMessage {
   int32 field = 1;
 
   SomeMessage2 field2 = 2;
+
+  // Tests service with two enums of the same simple name
+  enum Alignment {
+    GOOD = 0;
+    NEUTRAL = 1;
+    EVIL = 2;
+  }
+
+  Alignment alignment = 3;
 }
 
 message SomeMessage2 {
   int32 field1 = 1;
+
+  // Another enum with duplicated simple name
+  enum Alignment {
+    FLUSH_LEFT = 0;
+    FLUSH_RIGHT = 1;
+    CENTERED = 2;
+    JUSTIFIED = 3;
+  }
+
+  Alignment format = 2;
 }
 
 // A Shelf contains a collection of books with a theme.

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_doc_message_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_doc_message_library.baseline
@@ -756,21 +756,69 @@ var Book = {
  * @property {Object} field2
  *   This object should have the same structure as [SomeMessage2]{@link SomeMessage2}
  *
+ * @property {number} alignment
+ *   The number should be among the values of [Alignment]{@link Alignment}
+ *
  * @class
  * @see [google.example.library.v1.SomeMessage definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var SomeMessage = {
   // This is for documentation. Actual contents will be loaded by gRPC.
+
+  /**
+   * Tests service with two enums of the same simple name
+   *
+   * @enum {number}
+   */
+  Alignment: {
+    /**
+     * Tests service with two enums of the same simple name
+     */  GOOD: 0,
+
+    /**
+     * Tests service with two enums of the same simple name
+     */  NEUTRAL: 1,
+
+    /**
+     * Tests service with two enums of the same simple name
+     */  EVIL: 2
+  }
 };
 
 /**
  * @property {number} field1
+ *
+ * @property {number} format
+ *   The number should be among the values of [Alignment]{@link Alignment}
  *
  * @class
  * @see [google.example.library.v1.SomeMessage2 definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var SomeMessage2 = {
   // This is for documentation. Actual contents will be loaded by gRPC.
+
+  /**
+   * Another enum with duplicated simple name
+   *
+   * @enum {number}
+   */
+  Alignment: {
+    /**
+     * Another enum with duplicated simple name
+     */  FLUSH_LEFT: 0,
+
+    /**
+     * Another enum with duplicated simple name
+     */  FLUSH_RIGHT: 1,
+
+    /**
+     * Another enum with duplicated simple name
+     */  CENTERED: 2,
+
+    /**
+     * Another enum with duplicated simple name
+     */  JUSTIFIED: 3
+  }
 };
 
 /**

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_enum_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_enum_library.baseline
@@ -55,6 +55,36 @@ class Rating(object):
     BAD = 1
 
 
+class SomeMessageAlignment(object):
+    """
+    Tests service with two enums of the same simple name
+
+    Attributes:
+      GOOD (int)
+      NEUTRAL (int)
+      EVIL (int)
+    """
+    GOOD = 0
+    NEUTRAL = 1
+    EVIL = 2
+
+
+class SomeMessage2Alignment(object):
+    """
+    Another enum with duplicated simple name
+
+    Attributes:
+      FLUSH_LEFT (int)
+      FLUSH_RIGHT (int)
+      CENTERED (int)
+      JUSTIFIED (int)
+    """
+    FLUSH_LEFT = 0
+    FLUSH_RIGHT = 1
+    CENTERED = 2
+    JUSTIFIED = 3
+
+
 class Stage(object):
     """
     Attributes:

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_message_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_message_library.baseline
@@ -653,6 +653,7 @@ class SomeMessage(object):
     Attributes:
       field (int)
       field2 (:class:`google.example.library.v1.library_pb2.SomeMessage2`)
+      alignment (enum :class:`google.cloud.gapic.example.library.v1.enums.SomeMessageAlignment`)
 
     """
     pass
@@ -662,6 +663,7 @@ class SomeMessage2(object):
     """
     Attributes:
       field1 (int)
+      format (enum :class:`google.cloud.gapic.example.library.v1.enums.SomeMessage2Alignment`)
 
     """
     pass

--- a/src/test/java/com/google/api/codegen/testdata/python_enum_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_enum_library.baseline
@@ -55,6 +55,36 @@ class Rating(object):
     BAD = 1
 
 
+class SomeMessageAlignment(object):
+    """
+    Tests service with two enums of the same simple name
+
+    Attributes:
+      GOOD (int)
+      NEUTRAL (int)
+      EVIL (int)
+    """
+    GOOD = 0
+    NEUTRAL = 1
+    EVIL = 2
+
+
+class SomeMessage2Alignment(object):
+    """
+    Another enum with duplicated simple name
+
+    Attributes:
+      FLUSH_LEFT (int)
+      FLUSH_RIGHT (int)
+      CENTERED (int)
+      JUSTIFIED (int)
+    """
+    FLUSH_LEFT = 0
+    FLUSH_RIGHT = 1
+    CENTERED = 2
+    JUSTIFIED = 3
+
+
 class Stage(object):
     """
     Attributes:

--- a/src/test/java/com/google/api/codegen/testdata/ruby_doc_message_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_doc_message_library.baseline
@@ -647,11 +647,35 @@ module Google
         #   @return [Integer]
         # @!attribute [rw] field2
         #   @return [Google::Example::Library::V1::SomeMessage2]
-        class SomeMessage; end
+        # @!attribute [rw] alignment
+        #   @return [Google::Example::Library::V1::SomeMessage::Alignment]
+        class SomeMessage
+          # Tests service with two enums of the same simple name
+          module Alignment
+            GOOD = 0
+
+            NEUTRAL = 1
+
+            EVIL = 2
+          end
+        end
 
         # @!attribute [rw] field1
         #   @return [Integer]
-        class SomeMessage2; end
+        # @!attribute [rw] format
+        #   @return [Google::Example::Library::V1::SomeMessage2::Alignment]
+        class SomeMessage2
+          # Another enum with duplicated simple name
+          module Alignment
+            FLUSH_LEFT = 0
+
+            FLUSH_RIGHT = 1
+
+            CENTERED = 2
+
+            JUSTIFIED = 3
+          end
+        end
 
         # A Shelf contains a collection of books with a theme.
         # @!attribute [rw] name


### PR DESCRIPTION
Introduces a symbol table for enums that handles disambiguation logic.
Previously, the enum simple name was always used. If an API contained
multiple enums with a common simple name, this could lead to name
clashes.

Fixes #511