### PR TITLE
Go: Fix iterator

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/PageStreamingTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/PageStreamingTransformer.java
@@ -94,9 +94,13 @@ public class PageStreamingTransformer {
 
     TypeRef tokenType = pageStreaming.getResponseTokenField().getType();
     desc.tokenTypeName(typeTable.getAndSaveNicknameFor(tokenType));
-
     desc.defaultTokenValue(context.getTypeTable().getZeroValueAndSaveNicknameFor(tokenType));
-    desc.resourceZeroValue(context.getTypeTable().getZeroValueAndSaveNicknameFor(resourceType));
+
+    // The resource fields are "repeated" in the proto.
+    // We `makeOptional` so that we get the zero value of the resource,
+    // not the zero value of the array/list of resources.
+    desc.resourceZeroValue(
+        context.getTypeTable().getZeroValueAndSaveNicknameFor(resourceType.makeOptional()));
 
     desc.requestTokenSetFunction(
         namer.getFieldSetFunctionName(featureConfig, pageStreaming.getRequestTokenField()));

--- a/src/main/resources/com/google/api/codegen/go/main.snip
+++ b/src/main/resources/com/google/api/codegen/go/main.snip
@@ -190,7 +190,7 @@
         ctx = metadata.NewContext(ctx, c.metadata)
         it := &{@method.responseTypeName}{}
 
-        fetch := func(pageSize int, pageToken string) (string, err) {
+        fetch := func(pageSize int, pageToken string) (string, error) {
             var resp {@method.listMethod.responseObjectTypeName}
             req.PageToken = pageToken
             if pageSize > math.MaxInt32 {
@@ -244,6 +244,7 @@
         it.items = it.items[1:]
         return item, nil
     }
+
 @end
 
 @private pathTemplateParams(args)

--- a/src/test/java/com/google/api/codegen/testdata/go_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_main_library.baseline
@@ -249,7 +249,7 @@ func (c *Client) ListShelves(ctx context.Context, req *librarypb.ListShelvesRequ
     ctx = metadata.NewContext(ctx, c.metadata)
     it := &ShelfIterator{}
 
-    fetch := func(pageSize int, pageToken string) (string, err) {
+    fetch := func(pageSize int, pageToken string) (string, error) {
         var resp *librarypb.ListShelvesResponse
         req.PageToken = pageToken
         if pageSize > math.MaxInt32 {
@@ -357,7 +357,7 @@ func (c *Client) ListBooks(ctx context.Context, req *librarypb.ListBooksRequest)
     ctx = metadata.NewContext(ctx, c.metadata)
     it := &BookIterator{}
 
-    fetch := func(pageSize int, pageToken string) (string, err) {
+    fetch := func(pageSize int, pageToken string) (string, error) {
         var resp *librarypb.ListBooksResponse
         req.PageToken = pageToken
         if pageSize > math.MaxInt32 {
@@ -433,7 +433,7 @@ func (c *Client) ListStrings(ctx context.Context, req *librarypb.ListStringsRequ
     ctx = metadata.NewContext(ctx, c.metadata)
     it := &StringIterator{}
 
-    fetch := func(pageSize int, pageToken string) (string, err) {
+    fetch := func(pageSize int, pageToken string) (string, error) {
         var resp *librarypb.ListStringsResponse
         req.PageToken = pageToken
         if pageSize > math.MaxInt32 {
@@ -505,7 +505,7 @@ func (c *Client) FindRelatedBooks(ctx context.Context, req *librarypb.FindRelate
     ctx = metadata.NewContext(ctx, c.metadata)
     it := &StringIterator{}
 
-    fetch := func(pageSize int, pageToken string) (string, err) {
+    fetch := func(pageSize int, pageToken string) (string, error) {
         var resp *librarypb.FindRelatedBooksResponse
         req.PageToken = pageToken
         if pageSize > math.MaxInt32 {
@@ -566,28 +566,6 @@ func (c *Client) AddLabel(ctx context.Context, req *taggerpb.AddLabelRequest) (*
 }
 
 
-// ShelfIterator manages a stream of *librarypb.Shelf.
-type ShelfIterator struct {
-    items    []*librarypb.Shelf
-    pageInfo *iterator.PageInfo
-    nextFunc func() error
-}
-
-// PageInfo supports pagination. See the google.golang.org/api/iterator package for details.
-func (it *ShelfIterator) PageInfo() *iterator.PageInfo {
-    return it.pageInfo
-}
-
-// Next returns the next result. Its second return value is iterator.Done if there are no more
-// results. Once Next returns Done, all subsequent calls will return Done.
-func (it *ShelfIterator) Next() (*librarypb.Shelf, error) {
-    if err := it.nextFunc(); err != nil {
-        return nil, err
-    }
-    item := it.items[0]
-    it.items = it.items[1:]
-    return item, nil
-}
 // BookIterator manages a stream of *librarypb.Book.
 type BookIterator struct {
     items    []*librarypb.Book
@@ -610,6 +588,30 @@ func (it *BookIterator) Next() (*librarypb.Book, error) {
     it.items = it.items[1:]
     return item, nil
 }
+
+// ShelfIterator manages a stream of *librarypb.Shelf.
+type ShelfIterator struct {
+    items    []*librarypb.Shelf
+    pageInfo *iterator.PageInfo
+    nextFunc func() error
+}
+
+// PageInfo supports pagination. See the google.golang.org/api/iterator package for details.
+func (it *ShelfIterator) PageInfo() *iterator.PageInfo {
+    return it.pageInfo
+}
+
+// Next returns the next result. Its second return value is iterator.Done if there are no more
+// results. Once Next returns Done, all subsequent calls will return Done.
+func (it *ShelfIterator) Next() (*librarypb.Shelf, error) {
+    if err := it.nextFunc(); err != nil {
+        return nil, err
+    }
+    item := it.items[0]
+    it.items = it.items[1:]
+    return item, nil
+}
+
 // StringIterator manages a stream of string.
 type StringIterator struct {
     items    []string
@@ -626,31 +628,10 @@ func (it *StringIterator) PageInfo() *iterator.PageInfo {
 // results. Once Next returns Done, all subsequent calls will return Done.
 func (it *StringIterator) Next() (string, error) {
     if err := it.nextFunc(); err != nil {
-        return nil, err
+        return "", err
     }
     item := it.items[0]
     it.items = it.items[1:]
     return item, nil
 }
-// StringIterator manages a stream of string.
-type StringIterator struct {
-    items    []string
-    pageInfo *iterator.PageInfo
-    nextFunc func() error
-}
 
-// PageInfo supports pagination. See the google.golang.org/api/iterator package for details.
-func (it *StringIterator) PageInfo() *iterator.PageInfo {
-    return it.pageInfo
-}
-
-// Next returns the next result. Its second return value is iterator.Done if there are no more
-// results. Once Next returns Done, all subsequent calls will return Done.
-func (it *StringIterator) Next() (string, error) {
-    if err := it.nextFunc(); err != nil {
-        return nil, err
-    }
-    item := it.items[0]
-    it.items = it.items[1:]
-    return item, nil
-}


### PR DESCRIPTION
This commit fixes a few iterator issues.
- There was duplicate iterators if more than one method paginates over
  the same resource types. Iterators are now deduped.
- The iterator over strings mistakenly tried to return nil.
  Zero values now work properly.
- Iterators declared return type "err" instead of "error".
  This is now fixed.