### PR TITLE
Fix unused import in Go discovery sample gen

### DIFF
--- a/src/main/resources/com/google/api/codegen/go/discovery_fragment.snip
+++ b/src/main/resources/com/google/api/codegen/go/discovery_fragment.snip
@@ -38,7 +38,9 @@
       @if authType != "APPLICATION_DEFAULT_CREDENTIALS"
         "errors"
       @end
-      "fmt"
+      @if not(context.isResponseEmpty(method))
+        "fmt"
+      @end
       "log"
       @if authType != "APPLICATION_DEFAULT_CREDENTIALS"
         "net/http"

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_adexchangebuyer.v1.4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_adexchangebuyer.v1.4.json.baseline
@@ -528,7 +528,6 @@ package main
 
 import (
   "errors"
-  "fmt"
   "log"
   "net/http"
 
@@ -757,7 +756,6 @@ package main
 
 import (
   "errors"
-  "fmt"
   "log"
   "net/http"
 
@@ -1164,7 +1162,6 @@ package main
 
 import (
   "errors"
-  "fmt"
   "log"
   "net/http"
 
@@ -1282,7 +1279,6 @@ package main
 
 import (
   "errors"
-  "fmt"
   "log"
   "net/http"
 
@@ -1976,7 +1972,6 @@ package main
 
 import (
   "errors"
-  "fmt"
   "log"
   "net/http"
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_bigquery.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_bigquery.v2.json.baseline
@@ -14,7 +14,6 @@ package main
 //    project directory.
 
 import (
-  "fmt"
   "log"
 
   "golang.org/x/net/context"
@@ -867,7 +866,6 @@ package main
 //    project directory.
 
 import (
-  "fmt"
   "log"
 
   "golang.org/x/net/context"

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_clouduseraccounts.beta.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_clouduseraccounts.beta.json.baseline
@@ -14,7 +14,6 @@ package main
 //    project directory.
 
 import (
-  "fmt"
   "log"
 
   "golang.org/x/net/context"

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_compute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_compute.v1.json.baseline
@@ -2987,7 +2987,6 @@ package main
 //    project directory.
 
 import (
-  "fmt"
   "log"
 
   "golang.org/x/net/context"
@@ -7946,7 +7945,6 @@ package main
 //    project directory.
 
 import (
-  "fmt"
   "log"
 
   "golang.org/x/net/context"
@@ -12737,7 +12735,6 @@ package main
 //    project directory.
 
 import (
-  "fmt"
   "log"
 
   "golang.org/x/net/context"

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_dns.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_dns.v1.json.baseline
@@ -249,7 +249,6 @@ package main
 //    project directory.
 
 import (
-  "fmt"
   "log"
 
   "golang.org/x/net/context"

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_prediction.v1.6.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_prediction.v1.6.json.baseline
@@ -130,7 +130,6 @@ package main
 //    project directory.
 
 import (
-  "fmt"
   "log"
 
   "golang.org/x/net/context"

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_storage.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_storage.v1.json.baseline
@@ -14,7 +14,6 @@ package main
 //    project directory.
 
 import (
-  "fmt"
   "log"
 
   "golang.org/x/net/context"
@@ -354,7 +353,6 @@ package main
 //    project directory.
 
 import (
-  "fmt"
   "log"
 
   "golang.org/x/net/context"
@@ -677,7 +675,6 @@ package main
 //    project directory.
 
 import (
-  "fmt"
   "log"
 
   "golang.org/x/net/context"
@@ -726,7 +723,6 @@ package main
 //    project directory.
 
 import (
-  "fmt"
   "log"
 
   "golang.org/x/net/context"
@@ -1066,7 +1062,6 @@ package main
 //    project directory.
 
 import (
-  "fmt"
   "log"
 
   "golang.org/x/net/context"
@@ -1569,7 +1564,6 @@ package main
 //    project directory.
 
 import (
-  "fmt"
   "log"
 
   "golang.org/x/net/context"

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_taskqueue.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_taskqueue.v1beta2.json.baseline
@@ -70,7 +70,6 @@ package main
 
 import (
   "errors"
-  "fmt"
   "log"
   "net/http"
 


### PR DESCRIPTION
Change to template means "fmt" is no longer used when response is
empty.