### PR TITLE
Remove unreliable print dependency in C# discovery sample gen

### DIFF
--- a/src/main/resources/com/google/api/codegen/csharp/discovery_fragment.snip
+++ b/src/main/resources/com/google/api/codegen/csharp/discovery_fragment.snip
@@ -219,16 +219,10 @@
   @end
 @end
 
-# Unlike placeholders for other languages, this placeholder does not pretty-print output.
-# This seems to require a third-party library like Json.NET: https://www.nuget.org/packages/newtonsoft.json/
 @private print(element)
-    @let JavaScriptSerializer = context.using("System.Web.Script.Serialization.JavaScriptSerializer")
-        Console.WriteLine(new {@JavaScriptSerializer}().Serialize({@element}));
-    @end
+    Console.WriteLine({@element});
 @end
 
 @private printEntry(entry)
-    @let JavaScriptSerializer = context.using("System.Web.Script.Serialization.JavaScriptSerializer")
-        Console.WriteLine("[" + {@entry}.Key + "] = " + new {@JavaScriptSerializer}().Serialize({@entry}.Value));
-    @end
+    Console.WriteLine("[" + {@entry}.Key + "] = " + {@entry}.Value);
 @end

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_adexchangebuyer.v1.4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_adexchangebuyer.v1.4.json.baseline
@@ -12,7 +12,6 @@ using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
 
@@ -45,7 +44,7 @@ namespace AdExchangeBuyerSample
             // Data.Account response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
 
         public static UserCredential GetCredential() {
@@ -71,7 +70,6 @@ using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
 
@@ -97,7 +95,7 @@ namespace AdExchangeBuyerSample
             // Data.AccountsList response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
 
         public static UserCredential GetCredential() {
@@ -123,7 +121,6 @@ using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
 
@@ -160,7 +157,7 @@ namespace AdExchangeBuyerSample
             // Data.Account response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
 
         public static UserCredential GetCredential() {
@@ -186,7 +183,6 @@ using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
 
@@ -223,7 +219,7 @@ namespace AdExchangeBuyerSample
             // Data.Account response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
 
         public static UserCredential GetCredential() {
@@ -249,7 +245,6 @@ using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
 
@@ -282,7 +277,7 @@ namespace AdExchangeBuyerSample
             // Data.BillingInfo response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
 
         public static UserCredential GetCredential() {
@@ -308,7 +303,6 @@ using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
 
@@ -334,7 +328,7 @@ namespace AdExchangeBuyerSample
             // Data.BillingInfoList response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
 
         public static UserCredential GetCredential() {
@@ -360,7 +354,6 @@ using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
 
@@ -396,7 +389,7 @@ namespace AdExchangeBuyerSample
             // Data.Budget response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
 
         public static UserCredential GetCredential() {
@@ -422,7 +415,6 @@ using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
 
@@ -462,7 +454,7 @@ namespace AdExchangeBuyerSample
             // Data.Budget response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
 
         public static UserCredential GetCredential() {
@@ -488,7 +480,6 @@ using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
 
@@ -528,7 +519,7 @@ namespace AdExchangeBuyerSample
             // Data.Budget response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
 
         public static UserCredential GetCredential() {
@@ -613,7 +604,6 @@ using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
 
@@ -649,7 +639,7 @@ namespace AdExchangeBuyerSample
             // Data.Creative response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
 
         public static UserCredential GetCredential() {
@@ -675,7 +665,6 @@ using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
 
@@ -705,7 +694,7 @@ namespace AdExchangeBuyerSample
             // Data.Creative response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
 
         public static UserCredential GetCredential() {
@@ -731,7 +720,6 @@ using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
 
@@ -766,7 +754,7 @@ namespace AdExchangeBuyerSample
                 foreach (Data.Creative creative in response.Items)
                 {
                     // TODO: Change code below to process each `creative` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(creative));
+                    Console.WriteLine(creative);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -854,7 +842,6 @@ using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
 
@@ -891,7 +878,7 @@ namespace AdExchangeBuyerSample
             // Data.DeleteOrderDealsResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
 
         public static UserCredential GetCredential() {
@@ -917,7 +904,6 @@ using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
 
@@ -954,7 +940,7 @@ namespace AdExchangeBuyerSample
             // Data.AddOrderDealsResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
 
         public static UserCredential GetCredential() {
@@ -980,7 +966,6 @@ using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
 
@@ -1014,7 +999,7 @@ namespace AdExchangeBuyerSample
             // Data.GetOrderDealsResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
 
         public static UserCredential GetCredential() {
@@ -1040,7 +1025,6 @@ using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
 
@@ -1077,7 +1061,7 @@ namespace AdExchangeBuyerSample
             // Data.EditAllOrderDealsResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
 
         public static UserCredential GetCredential() {
@@ -1103,7 +1087,6 @@ using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
 
@@ -1140,7 +1123,7 @@ namespace AdExchangeBuyerSample
             // Data.AddOrderNotesResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
 
         public static UserCredential GetCredential() {
@@ -1166,7 +1149,6 @@ using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
 
@@ -1200,7 +1182,7 @@ namespace AdExchangeBuyerSample
             // Data.GetOrderNotesResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
 
         public static UserCredential GetCredential() {
@@ -1285,7 +1267,6 @@ using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
 
@@ -1324,7 +1305,7 @@ namespace AdExchangeBuyerSample
             // Data.PerformanceReportList response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
 
         public static UserCredential GetCredential() {
@@ -1406,7 +1387,6 @@ using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
 
@@ -1442,7 +1422,7 @@ namespace AdExchangeBuyerSample
             // Data.PretargetingConfig response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
 
         public static UserCredential GetCredential() {
@@ -1468,7 +1448,6 @@ using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
 
@@ -1505,7 +1484,7 @@ namespace AdExchangeBuyerSample
             // Data.PretargetingConfig response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
 
         public static UserCredential GetCredential() {
@@ -1531,7 +1510,6 @@ using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
 
@@ -1564,7 +1542,7 @@ namespace AdExchangeBuyerSample
             // Data.PretargetingConfigList response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
 
         public static UserCredential GetCredential() {
@@ -1590,7 +1568,6 @@ using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
 
@@ -1630,7 +1607,7 @@ namespace AdExchangeBuyerSample
             // Data.PretargetingConfig response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
 
         public static UserCredential GetCredential() {
@@ -1656,7 +1633,6 @@ using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
 
@@ -1696,7 +1672,7 @@ namespace AdExchangeBuyerSample
             // Data.PretargetingConfig response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
 
         public static UserCredential GetCredential() {
@@ -1722,7 +1698,6 @@ using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
 
@@ -1755,7 +1730,7 @@ namespace AdExchangeBuyerSample
             // Data.Product response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
 
         public static UserCredential GetCredential() {
@@ -1781,7 +1756,6 @@ using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
 
@@ -1807,7 +1781,7 @@ namespace AdExchangeBuyerSample
             // Data.GetOffersResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
 
         public static UserCredential GetCredential() {
@@ -1833,7 +1807,6 @@ using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
 
@@ -1866,7 +1839,7 @@ namespace AdExchangeBuyerSample
             // Data.Proposal response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
 
         public static UserCredential GetCredential() {
@@ -1892,7 +1865,6 @@ using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
 
@@ -1922,7 +1894,7 @@ namespace AdExchangeBuyerSample
             // Data.CreateOrdersResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
 
         public static UserCredential GetCredential() {
@@ -1948,7 +1920,6 @@ using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
 
@@ -1994,7 +1965,7 @@ namespace AdExchangeBuyerSample
             // Data.Proposal response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
 
         public static UserCredential GetCredential() {
@@ -2020,7 +1991,6 @@ using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
 
@@ -2046,7 +2016,7 @@ namespace AdExchangeBuyerSample
             // Data.GetOrdersResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
 
         public static UserCredential GetCredential() {
@@ -2125,7 +2095,6 @@ using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
 
@@ -2171,7 +2140,7 @@ namespace AdExchangeBuyerSample
             // Data.Proposal response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
 
         public static UserCredential GetCredential() {
@@ -2197,7 +2166,6 @@ using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
 
@@ -2230,7 +2198,7 @@ namespace AdExchangeBuyerSample
             // Data.GetPublisherProfilesByAccountIdResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
 
         public static UserCredential GetCredential() {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_appengine.v1beta5.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_appengine.v1beta5.json.baseline
@@ -16,7 +16,6 @@ using Google.Apis.Appengine.v1beta5;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Appengine.v1beta5.Data;
 
@@ -53,7 +52,7 @@ namespace AppengineSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -74,7 +73,6 @@ using Google.Apis.Appengine.v1beta5;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Appengine.v1beta5.Data;
 
@@ -114,7 +112,7 @@ namespace AppengineSample
             // Data.Application response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -135,7 +133,6 @@ using Google.Apis.Appengine.v1beta5;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Appengine.v1beta5.Data;
 
@@ -178,7 +175,7 @@ namespace AppengineSample
             // Data.Location response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -199,7 +196,6 @@ using Google.Apis.Appengine.v1beta5;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Appengine.v1beta5.Data;
 
@@ -248,7 +244,7 @@ namespace AppengineSample
                 foreach (Data.Location location in response.Locations)
                 {
                     // TODO: Change code below to process each `location` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(location));
+                    Console.WriteLine(location);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -272,7 +268,6 @@ using Google.Apis.Appengine.v1beta5;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Appengine.v1beta5.Data;
 
@@ -315,7 +310,7 @@ namespace AppengineSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -336,7 +331,6 @@ using Google.Apis.Appengine.v1beta5;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Appengine.v1beta5.Data;
 
@@ -385,7 +379,7 @@ namespace AppengineSample
                 foreach (Data.Operation operation in response.Operations)
                 {
                     // TODO: Change code below to process each `operation` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(operation));
+                    Console.WriteLine(operation);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -409,7 +403,6 @@ using Google.Apis.Appengine.v1beta5;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Appengine.v1beta5.Data;
 
@@ -452,7 +445,7 @@ namespace AppengineSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -473,7 +466,6 @@ using Google.Apis.Appengine.v1beta5;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Appengine.v1beta5.Data;
 
@@ -516,7 +508,7 @@ namespace AppengineSample
             // Data.Service response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -537,7 +529,6 @@ using Google.Apis.Appengine.v1beta5;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Appengine.v1beta5.Data;
 
@@ -586,7 +577,7 @@ namespace AppengineSample
                 foreach (Data.Service service in response.Services)
                 {
                     // TODO: Change code below to process each `service` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(service));
+                    Console.WriteLine(service);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -610,7 +601,6 @@ using Google.Apis.Appengine.v1beta5;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Appengine.v1beta5.Data;
 
@@ -657,7 +647,7 @@ namespace AppengineSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -678,7 +668,6 @@ using Google.Apis.Appengine.v1beta5;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Appengine.v1beta5.Data;
 
@@ -725,7 +714,7 @@ namespace AppengineSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -746,7 +735,6 @@ using Google.Apis.Appengine.v1beta5;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Appengine.v1beta5.Data;
 
@@ -792,7 +780,7 @@ namespace AppengineSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -813,7 +801,6 @@ using Google.Apis.Appengine.v1beta5;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Appengine.v1beta5.Data;
 
@@ -859,7 +846,7 @@ namespace AppengineSample
             // Data.Version response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -880,7 +867,6 @@ using Google.Apis.Appengine.v1beta5;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Appengine.v1beta5.Data;
 
@@ -934,7 +920,7 @@ namespace AppengineSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -955,7 +941,6 @@ using Google.Apis.Appengine.v1beta5;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Appengine.v1beta5.Data;
 
@@ -1005,7 +990,7 @@ namespace AppengineSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -1026,7 +1011,6 @@ using Google.Apis.Appengine.v1beta5;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Appengine.v1beta5.Data;
 
@@ -1076,7 +1060,7 @@ namespace AppengineSample
             // Data.Instance response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -1097,7 +1081,6 @@ using Google.Apis.Appengine.v1beta5;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Appengine.v1beta5.Data;
 
@@ -1152,7 +1135,7 @@ namespace AppengineSample
                 foreach (Data.Instance instance in response.Instances)
                 {
                     // TODO: Change code below to process each `instance` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(instance));
+                    Console.WriteLine(instance);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -1176,7 +1159,6 @@ using Google.Apis.Appengine.v1beta5;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Appengine.v1beta5.Data;
 
@@ -1228,7 +1210,7 @@ namespace AppengineSample
                 foreach (Data.Version version in response.Versions)
                 {
                     // TODO: Change code below to process each `version` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(version));
+                    Console.WriteLine(version);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -1252,7 +1234,6 @@ using Google.Apis.Appengine.v1beta5;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Appengine.v1beta5.Data;
 
@@ -1302,7 +1283,7 @@ namespace AppengineSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_bigquery.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_bigquery.v2.json.baseline
@@ -74,7 +74,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Bigquery.v2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Bigquery.v2.Data;
 
@@ -117,7 +116,7 @@ namespace BigquerySample
             // Data.Dataset response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -138,7 +137,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Bigquery.v2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Bigquery.v2.Data;
 
@@ -182,7 +180,7 @@ namespace BigquerySample
             // Data.Dataset response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -203,7 +201,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Bigquery.v2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Bigquery.v2.Data;
 
@@ -252,7 +249,7 @@ namespace BigquerySample
                 foreach (Data.DatasetList.Datasets datasets in response.Datasets)
                 {
                     // TODO: Change code below to process each `datasets` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(datasets));
+                    Console.WriteLine(datasets);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -276,7 +273,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Bigquery.v2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Bigquery.v2.Data;
 
@@ -323,7 +319,7 @@ namespace BigquerySample
             // Data.Dataset response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -344,7 +340,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Bigquery.v2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Bigquery.v2.Data;
 
@@ -391,7 +386,7 @@ namespace BigquerySample
             // Data.Dataset response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -412,7 +407,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Bigquery.v2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Bigquery.v2.Data;
 
@@ -455,7 +449,7 @@ namespace BigquerySample
             // Data.JobCancelResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -476,7 +470,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Bigquery.v2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Bigquery.v2.Data;
 
@@ -519,7 +512,7 @@ namespace BigquerySample
             // Data.Job response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -540,7 +533,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Bigquery.v2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Bigquery.v2.Data;
 
@@ -583,7 +575,7 @@ namespace BigquerySample
             // Data.GetQueryResultsResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -604,7 +596,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Bigquery.v2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Bigquery.v2.Data;
 
@@ -652,7 +643,7 @@ namespace BigquerySample
             // Data.Job response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -673,7 +664,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Bigquery.v2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Bigquery.v2.Data;
 
@@ -722,7 +712,7 @@ namespace BigquerySample
                 foreach (Data.JobList.Jobs jobs in response.Jobs)
                 {
                     // TODO: Change code below to process each `jobs` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(jobs));
+                    Console.WriteLine(jobs);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -746,7 +736,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Bigquery.v2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Bigquery.v2.Data;
 
@@ -790,7 +779,7 @@ namespace BigquerySample
             // Data.QueryResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -811,7 +800,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Bigquery.v2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Bigquery.v2.Data;
 
@@ -853,7 +841,7 @@ namespace BigquerySample
                 foreach (Data.ProjectList.Projects projects in response.Projects)
                 {
                     // TODO: Change code below to process each `projects` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(projects));
+                    Console.WriteLine(projects);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -877,7 +865,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Bigquery.v2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Bigquery.v2.Data;
 
@@ -927,7 +914,7 @@ namespace BigquerySample
             // Data.TableDataInsertAllResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -948,7 +935,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Bigquery.v2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Bigquery.v2.Data;
 
@@ -994,7 +980,7 @@ namespace BigquerySample
             // Data.TableDataList response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -1076,7 +1062,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Bigquery.v2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Bigquery.v2.Data;
 
@@ -1122,7 +1107,7 @@ namespace BigquerySample
             // Data.Table response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -1143,7 +1128,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Bigquery.v2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Bigquery.v2.Data;
 
@@ -1190,7 +1174,7 @@ namespace BigquerySample
             // Data.Table response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -1211,7 +1195,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Bigquery.v2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Bigquery.v2.Data;
 
@@ -1263,7 +1246,7 @@ namespace BigquerySample
                 foreach (Data.TableList.Tables tables in response.Tables)
                 {
                     // TODO: Change code below to process each `tables` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(tables));
+                    Console.WriteLine(tables);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -1287,7 +1270,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Bigquery.v2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Bigquery.v2.Data;
 
@@ -1337,7 +1319,7 @@ namespace BigquerySample
             // Data.Table response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -1358,7 +1340,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Bigquery.v2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Bigquery.v2.Data;
 
@@ -1408,7 +1389,7 @@ namespace BigquerySample
             // Data.Table response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_cloudbilling.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_cloudbilling.v1.json.baseline
@@ -16,7 +16,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Cloudbilling.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Cloudbilling.v1.Data;
 
@@ -57,7 +56,7 @@ namespace CloudbillingSample
             // Data.BillingAccount response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -78,7 +77,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Cloudbilling.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Cloudbilling.v1.Data;
 
@@ -120,7 +118,7 @@ namespace CloudbillingSample
                 foreach (Data.BillingAccount billingAccount in response.BillingAccounts)
                 {
                     // TODO: Change code below to process each `billingAccount` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(billingAccount));
+                    Console.WriteLine(billingAccount);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -144,7 +142,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Cloudbilling.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Cloudbilling.v1.Data;
 
@@ -194,7 +191,7 @@ namespace CloudbillingSample
                 foreach (Data.ProjectBillingInfo projectBillingInfo in response.ProjectBillingInfo)
                 {
                     // TODO: Change code below to process each `projectBillingInfo` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(projectBillingInfo));
+                    Console.WriteLine(projectBillingInfo);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -218,7 +215,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Cloudbilling.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Cloudbilling.v1.Data;
 
@@ -259,7 +255,7 @@ namespace CloudbillingSample
             // Data.ProjectBillingInfo response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -280,7 +276,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Cloudbilling.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Cloudbilling.v1.Data;
 
@@ -325,7 +320,7 @@ namespace CloudbillingSample
             // Data.ProjectBillingInfo response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_clouddebugger.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_clouddebugger.v2.json.baseline
@@ -16,7 +16,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudDebugger.v2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudDebugger.v2.Data;
 
@@ -56,7 +55,7 @@ namespace CloudDebuggerSample
             // Data.ListActiveBreakpointsResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -77,7 +76,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudDebugger.v2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudDebugger.v2.Data;
 
@@ -124,7 +122,7 @@ namespace CloudDebuggerSample
             // Data.UpdateActiveBreakpointResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -145,7 +143,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudDebugger.v2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudDebugger.v2.Data;
 
@@ -182,7 +179,7 @@ namespace CloudDebuggerSample
             // Data.RegisterDebuggeeResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -203,7 +200,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudDebugger.v2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudDebugger.v2.Data;
 
@@ -246,7 +242,7 @@ namespace CloudDebuggerSample
             // Data.Empty response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -267,7 +263,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudDebugger.v2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudDebugger.v2.Data;
 
@@ -310,7 +305,7 @@ namespace CloudDebuggerSample
             // Data.GetBreakpointResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -331,7 +326,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudDebugger.v2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudDebugger.v2.Data;
 
@@ -371,7 +365,7 @@ namespace CloudDebuggerSample
             // Data.ListBreakpointsResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -392,7 +386,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudDebugger.v2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudDebugger.v2.Data;
 
@@ -436,7 +429,7 @@ namespace CloudDebuggerSample
             // Data.SetBreakpointResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -457,7 +450,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudDebugger.v2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudDebugger.v2.Data;
 
@@ -490,7 +482,7 @@ namespace CloudDebuggerSample
             // Data.ListDebuggeesResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_cloudmonitoring.v2beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_cloudmonitoring.v2beta2.json.baseline
@@ -16,7 +16,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudMonitoring.v2beta2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudMonitoring.v2beta2.Data;
 
@@ -60,7 +59,7 @@ namespace CloudMonitoringSample
             // Data.MetricDescriptor response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -81,7 +80,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudMonitoring.v2beta2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudMonitoring.v2beta2.Data;
 
@@ -124,7 +122,7 @@ namespace CloudMonitoringSample
             // Data.DeleteMetricDescriptorResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -145,7 +143,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudMonitoring.v2beta2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudMonitoring.v2beta2.Data;
 
@@ -198,7 +195,7 @@ namespace CloudMonitoringSample
                 foreach (Data.MetricDescriptor metricDescriptor in response.Metrics)
                 {
                     // TODO: Change code below to process each `metricDescriptor` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(metricDescriptor));
+                    Console.WriteLine(metricDescriptor);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -222,7 +219,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudMonitoring.v2beta2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudMonitoring.v2beta2.Data;
 
@@ -283,7 +279,7 @@ namespace CloudMonitoringSample
                 foreach (Data.Timeseries timeseries in response.Timeseries)
                 {
                     // TODO: Change code below to process each `timeseries` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(timeseries));
+                    Console.WriteLine(timeseries);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -307,7 +303,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudMonitoring.v2beta2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudMonitoring.v2beta2.Data;
 
@@ -351,7 +346,7 @@ namespace CloudMonitoringSample
             // Data.WriteTimeseriesResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -372,7 +367,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudMonitoring.v2beta2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudMonitoring.v2beta2.Data;
 
@@ -433,7 +427,7 @@ namespace CloudMonitoringSample
                 foreach (Data.TimeseriesDescriptor timeseriesDescriptor in response.Timeseries)
                 {
                     // TODO: Change code below to process each `timeseriesDescriptor` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(timeseriesDescriptor));
+                    Console.WriteLine(timeseriesDescriptor);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_cloudresourcemanager.v1beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_cloudresourcemanager.v1beta1.json.baseline
@@ -16,7 +16,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudResourceManager.v1beta1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudResourceManager.v1beta1.Data;
 
@@ -57,7 +56,7 @@ namespace CloudResourceManagerSample
             // Data.Organization response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -78,7 +77,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudResourceManager.v1beta1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudResourceManager.v1beta1.Data;
 
@@ -124,7 +122,7 @@ namespace CloudResourceManagerSample
             // Data.Policy response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -145,7 +143,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudResourceManager.v1beta1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudResourceManager.v1beta1.Data;
 
@@ -187,7 +184,7 @@ namespace CloudResourceManagerSample
                 foreach (Data.Organization organization in response.Organizations)
                 {
                     // TODO: Change code below to process each `organization` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(organization));
+                    Console.WriteLine(organization);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -211,7 +208,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudResourceManager.v1beta1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudResourceManager.v1beta1.Data;
 
@@ -257,7 +253,7 @@ namespace CloudResourceManagerSample
             // Data.Policy response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -278,7 +274,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudResourceManager.v1beta1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudResourceManager.v1beta1.Data;
 
@@ -325,7 +320,7 @@ namespace CloudResourceManagerSample
             // Data.TestIamPermissionsResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -346,7 +341,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudResourceManager.v1beta1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudResourceManager.v1beta1.Data;
 
@@ -391,7 +385,7 @@ namespace CloudResourceManagerSample
             // Data.Organization response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -412,7 +406,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudResourceManager.v1beta1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudResourceManager.v1beta1.Data;
 
@@ -449,7 +442,7 @@ namespace CloudResourceManagerSample
             // Data.Project response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -470,7 +463,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudResourceManager.v1beta1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudResourceManager.v1beta1.Data;
 
@@ -510,7 +502,7 @@ namespace CloudResourceManagerSample
             // Data.Empty response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -531,7 +523,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudResourceManager.v1beta1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudResourceManager.v1beta1.Data;
 
@@ -571,7 +562,7 @@ namespace CloudResourceManagerSample
             // Data.Project response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -592,7 +583,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudResourceManager.v1beta1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudResourceManager.v1beta1.Data;
 
@@ -636,7 +626,7 @@ namespace CloudResourceManagerSample
             // Data.GetAncestryResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -657,7 +647,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudResourceManager.v1beta1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudResourceManager.v1beta1.Data;
 
@@ -703,7 +692,7 @@ namespace CloudResourceManagerSample
             // Data.Policy response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -724,7 +713,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudResourceManager.v1beta1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudResourceManager.v1beta1.Data;
 
@@ -766,7 +754,7 @@ namespace CloudResourceManagerSample
                 foreach (Data.Project project in response.Projects)
                 {
                     // TODO: Change code below to process each `project` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(project));
+                    Console.WriteLine(project);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -790,7 +778,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudResourceManager.v1beta1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudResourceManager.v1beta1.Data;
 
@@ -836,7 +823,7 @@ namespace CloudResourceManagerSample
             // Data.Policy response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -857,7 +844,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudResourceManager.v1beta1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudResourceManager.v1beta1.Data;
 
@@ -904,7 +890,7 @@ namespace CloudResourceManagerSample
             // Data.TestIamPermissionsResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -925,7 +911,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudResourceManager.v1beta1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudResourceManager.v1beta1.Data;
 
@@ -969,7 +954,7 @@ namespace CloudResourceManagerSample
             // Data.Empty response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -990,7 +975,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudResourceManager.v1beta1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudResourceManager.v1beta1.Data;
 
@@ -1034,7 +1018,7 @@ namespace CloudResourceManagerSample
             // Data.Project response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_cloudtrace.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_cloudtrace.v1.json.baseline
@@ -16,7 +16,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudTrace.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudTrace.v1.Data;
 
@@ -60,7 +59,7 @@ namespace CloudTraceSample
             // Data.Empty response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -81,7 +80,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudTrace.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudTrace.v1.Data;
 
@@ -124,7 +122,7 @@ namespace CloudTraceSample
             // Data.Trace response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -145,7 +143,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudTrace.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudTrace.v1.Data;
 
@@ -194,7 +191,7 @@ namespace CloudTraceSample
                 foreach (Data.Trace trace in response.Traces)
                 {
                     // TODO: Change code below to process each `trace` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(trace));
+                    Console.WriteLine(trace);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_clouduseraccounts.beta.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_clouduseraccounts.beta.json.baseline
@@ -74,7 +74,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudUserAccounts.beta;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudUserAccounts.beta.Data;
 
@@ -117,7 +116,7 @@ namespace CloudUserAccountsSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -138,7 +137,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudUserAccounts.beta;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudUserAccounts.beta.Data;
 
@@ -187,7 +185,7 @@ namespace CloudUserAccountsSample
                 foreach (Data.Operation operation in response.Items)
                 {
                     // TODO: Change code below to process each `operation` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(operation));
+                    Console.WriteLine(operation);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -211,7 +209,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudUserAccounts.beta;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudUserAccounts.beta.Data;
 
@@ -258,7 +255,7 @@ namespace CloudUserAccountsSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -279,7 +276,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudUserAccounts.beta;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudUserAccounts.beta.Data;
 
@@ -322,7 +318,7 @@ namespace CloudUserAccountsSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -343,7 +339,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudUserAccounts.beta;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudUserAccounts.beta.Data;
 
@@ -386,7 +381,7 @@ namespace CloudUserAccountsSample
             // Data.Group response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -407,7 +402,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudUserAccounts.beta;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudUserAccounts.beta.Data;
 
@@ -451,7 +445,7 @@ namespace CloudUserAccountsSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -472,7 +466,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudUserAccounts.beta;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudUserAccounts.beta.Data;
 
@@ -521,7 +514,7 @@ namespace CloudUserAccountsSample
                 foreach (Data.Group group_ in response.Items)
                 {
                     // TODO: Change code below to process each `group_` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(group_));
+                    Console.WriteLine(group_);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -545,7 +538,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudUserAccounts.beta;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudUserAccounts.beta.Data;
 
@@ -592,7 +584,7 @@ namespace CloudUserAccountsSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -613,7 +605,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudUserAccounts.beta;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudUserAccounts.beta.Data;
 
@@ -662,7 +653,7 @@ namespace CloudUserAccountsSample
             // Data.LinuxGetAuthorizedKeysViewResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -683,7 +674,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudUserAccounts.beta;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudUserAccounts.beta.Data;
 
@@ -729,7 +719,7 @@ namespace CloudUserAccountsSample
             // Data.LinuxGetLinuxAccountViewsResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -750,7 +740,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudUserAccounts.beta;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudUserAccounts.beta.Data;
 
@@ -797,7 +786,7 @@ namespace CloudUserAccountsSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -818,7 +807,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudUserAccounts.beta;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudUserAccounts.beta.Data;
 
@@ -861,7 +849,7 @@ namespace CloudUserAccountsSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -882,7 +870,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudUserAccounts.beta;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudUserAccounts.beta.Data;
 
@@ -925,7 +912,7 @@ namespace CloudUserAccountsSample
             // Data.User response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -946,7 +933,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudUserAccounts.beta;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudUserAccounts.beta.Data;
 
@@ -990,7 +976,7 @@ namespace CloudUserAccountsSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -1011,7 +997,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudUserAccounts.beta;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudUserAccounts.beta.Data;
 
@@ -1060,7 +1045,7 @@ namespace CloudUserAccountsSample
                 foreach (Data.User user in response.Items)
                 {
                     // TODO: Change code below to process each `user` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(user));
+                    Console.WriteLine(user);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -1084,7 +1069,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudUserAccounts.beta;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.CloudUserAccounts.beta.Data;
 
@@ -1131,7 +1115,7 @@ namespace CloudUserAccountsSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_compute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_compute.v1.json.baseline
@@ -17,7 +17,6 @@ using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -66,7 +65,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.AddressesScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine("[" + item.Key + "] = " + new JavaScriptSerializer().Serialize(item.Value));
+                    Console.WriteLine("[" + item.Key + "] = " + item.Value);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -90,7 +89,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -136,7 +134,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -157,7 +155,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -203,7 +200,7 @@ namespace ComputeSample
             // Data.Address response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -224,7 +221,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -271,7 +267,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -292,7 +288,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -344,7 +339,7 @@ namespace ComputeSample
                 foreach (Data.Address address in response.Items)
                 {
                     // TODO: Change code below to process each `address` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(address));
+                    Console.WriteLine(address);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -369,7 +364,6 @@ using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -418,7 +412,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.AutoscalersScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine("[" + item.Key + "] = " + new JavaScriptSerializer().Serialize(item.Value));
+                    Console.WriteLine("[" + item.Key + "] = " + item.Value);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -442,7 +436,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -488,7 +481,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -509,7 +502,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -555,7 +547,7 @@ namespace ComputeSample
             // Data.Autoscaler response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -576,7 +568,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -623,7 +614,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -644,7 +635,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -696,7 +686,7 @@ namespace ComputeSample
                 foreach (Data.Autoscaler autoscaler in response.Items)
                 {
                     // TODO: Change code below to process each `autoscaler` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(autoscaler));
+                    Console.WriteLine(autoscaler);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -720,7 +710,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -770,7 +759,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -791,7 +780,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -838,7 +826,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -859,7 +847,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -902,7 +889,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -923,7 +910,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -966,7 +952,7 @@ namespace ComputeSample
             // Data.BackendService response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -987,7 +973,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -1034,7 +1019,7 @@ namespace ComputeSample
             // Data.BackendServiceGroupHealth response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -1055,7 +1040,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -1099,7 +1083,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -1120,7 +1104,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -1169,7 +1152,7 @@ namespace ComputeSample
                 foreach (Data.BackendService backendService in response.Items)
                 {
                     // TODO: Change code below to process each `backendService` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(backendService));
+                    Console.WriteLine(backendService);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -1193,7 +1176,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -1240,7 +1222,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -1261,7 +1243,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -1308,7 +1289,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -1330,7 +1311,6 @@ using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -1379,7 +1359,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.DiskTypesScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine("[" + item.Key + "] = " + new JavaScriptSerializer().Serialize(item.Value));
+                    Console.WriteLine("[" + item.Key + "] = " + item.Value);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -1403,7 +1383,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -1449,7 +1428,7 @@ namespace ComputeSample
             // Data.DiskType response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -1470,7 +1449,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -1522,7 +1500,7 @@ namespace ComputeSample
                 foreach (Data.DiskType diskType in response.Items)
                 {
                     // TODO: Change code below to process each `diskType` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(diskType));
+                    Console.WriteLine(diskType);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -1547,7 +1525,6 @@ using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -1596,7 +1573,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.DisksScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine("[" + item.Key + "] = " + new JavaScriptSerializer().Serialize(item.Value));
+                    Console.WriteLine("[" + item.Key + "] = " + item.Value);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -1620,7 +1597,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -1670,7 +1646,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -1691,7 +1667,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -1737,7 +1712,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -1758,7 +1733,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -1804,7 +1778,7 @@ namespace ComputeSample
             // Data.Disk response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -1825,7 +1799,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -1872,7 +1845,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -1893,7 +1866,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -1945,7 +1917,7 @@ namespace ComputeSample
                 foreach (Data.Disk disk in response.Items)
                 {
                     // TODO: Change code below to process each `disk` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(disk));
+                    Console.WriteLine(disk);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -1969,7 +1941,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -2019,7 +1990,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -2040,7 +2011,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -2083,7 +2053,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -2104,7 +2074,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -2147,7 +2116,7 @@ namespace ComputeSample
             // Data.Firewall response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -2168,7 +2137,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -2212,7 +2180,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -2233,7 +2201,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -2282,7 +2249,7 @@ namespace ComputeSample
                 foreach (Data.Firewall firewall in response.Items)
                 {
                     // TODO: Change code below to process each `firewall` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(firewall));
+                    Console.WriteLine(firewall);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -2306,7 +2273,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -2353,7 +2319,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -2374,7 +2340,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -2421,7 +2386,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -2443,7 +2408,6 @@ using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -2492,7 +2456,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.ForwardingRulesScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine("[" + item.Key + "] = " + new JavaScriptSerializer().Serialize(item.Value));
+                    Console.WriteLine("[" + item.Key + "] = " + item.Value);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -2516,7 +2480,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -2562,7 +2525,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -2583,7 +2546,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -2629,7 +2591,7 @@ namespace ComputeSample
             // Data.ForwardingRule response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -2650,7 +2612,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -2697,7 +2658,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -2718,7 +2679,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -2770,7 +2730,7 @@ namespace ComputeSample
                 foreach (Data.ForwardingRule forwardingRule in response.Items)
                 {
                     // TODO: Change code below to process each `forwardingRule` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(forwardingRule));
+                    Console.WriteLine(forwardingRule);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -2794,7 +2754,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -2844,7 +2803,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -2865,7 +2824,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -2908,7 +2866,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -2929,7 +2887,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -2972,7 +2929,7 @@ namespace ComputeSample
             // Data.Address response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -2993,7 +2950,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -3037,7 +2993,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -3058,7 +3014,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -3107,7 +3062,7 @@ namespace ComputeSample
                 foreach (Data.Address address in response.Items)
                 {
                     // TODO: Change code below to process each `address` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(address));
+                    Console.WriteLine(address);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -3131,7 +3086,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -3174,7 +3128,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -3195,7 +3149,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -3238,7 +3191,7 @@ namespace ComputeSample
             // Data.ForwardingRule response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -3259,7 +3212,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -3303,7 +3255,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -3324,7 +3276,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -3373,7 +3324,7 @@ namespace ComputeSample
                 foreach (Data.ForwardingRule forwardingRule in response.Items)
                 {
                     // TODO: Change code below to process each `forwardingRule` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(forwardingRule));
+                    Console.WriteLine(forwardingRule);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -3397,7 +3348,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -3444,7 +3394,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -3466,7 +3416,6 @@ using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -3515,7 +3464,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.OperationsScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine("[" + item.Key + "] = " + new JavaScriptSerializer().Serialize(item.Value));
+                    Console.WriteLine("[" + item.Key + "] = " + item.Value);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -3597,7 +3546,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -3640,7 +3588,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -3661,7 +3609,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -3710,7 +3657,7 @@ namespace ComputeSample
                 foreach (Data.Operation operation in response.Items)
                 {
                     // TODO: Change code below to process each `operation` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(operation));
+                    Console.WriteLine(operation);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -3734,7 +3681,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -3777,7 +3723,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -3798,7 +3744,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -3841,7 +3786,7 @@ namespace ComputeSample
             // Data.HealthCheck response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -3862,7 +3807,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -3906,7 +3850,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -3927,7 +3871,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -3976,7 +3919,7 @@ namespace ComputeSample
                 foreach (Data.HealthCheck healthCheck in response.Items)
                 {
                     // TODO: Change code below to process each `healthCheck` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(healthCheck));
+                    Console.WriteLine(healthCheck);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -4000,7 +3943,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -4047,7 +3989,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -4068,7 +4010,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -4115,7 +4056,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -4136,7 +4077,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -4179,7 +4119,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -4200,7 +4140,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -4243,7 +4182,7 @@ namespace ComputeSample
             // Data.HttpHealthCheck response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -4264,7 +4203,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -4308,7 +4246,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -4329,7 +4267,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -4378,7 +4315,7 @@ namespace ComputeSample
                 foreach (Data.HttpHealthCheck httpHealthCheck in response.Items)
                 {
                     // TODO: Change code below to process each `httpHealthCheck` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(httpHealthCheck));
+                    Console.WriteLine(httpHealthCheck);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -4402,7 +4339,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -4449,7 +4385,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -4470,7 +4406,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -4517,7 +4452,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -4538,7 +4473,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -4581,7 +4515,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -4602,7 +4536,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -4645,7 +4578,7 @@ namespace ComputeSample
             // Data.HttpsHealthCheck response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -4666,7 +4599,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -4710,7 +4642,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -4731,7 +4663,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -4780,7 +4711,7 @@ namespace ComputeSample
                 foreach (Data.HttpsHealthCheck httpsHealthCheck in response.Items)
                 {
                     // TODO: Change code below to process each `httpsHealthCheck` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(httpsHealthCheck));
+                    Console.WriteLine(httpsHealthCheck);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -4804,7 +4735,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -4851,7 +4781,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -4872,7 +4802,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -4919,7 +4848,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -4940,7 +4869,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -4983,7 +4911,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -5004,7 +4932,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -5051,7 +4978,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -5072,7 +4999,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -5115,7 +5041,7 @@ namespace ComputeSample
             // Data.Image response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -5136,7 +5062,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -5179,7 +5104,7 @@ namespace ComputeSample
             // Data.Image response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -5200,7 +5125,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -5244,7 +5168,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -5265,7 +5189,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -5314,7 +5237,7 @@ namespace ComputeSample
                 foreach (Data.Image image in response.Items)
                 {
                     // TODO: Change code below to process each `image` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(image));
+                    Console.WriteLine(image);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -5338,7 +5261,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -5388,7 +5310,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -5410,7 +5332,6 @@ using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -5459,7 +5380,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.InstanceGroupManagersScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine("[" + item.Key + "] = " + new JavaScriptSerializer().Serialize(item.Value));
+                    Console.WriteLine("[" + item.Key + "] = " + item.Value);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -5483,7 +5404,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -5529,7 +5449,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -5550,7 +5470,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -5600,7 +5519,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -5621,7 +5540,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -5667,7 +5585,7 @@ namespace ComputeSample
             // Data.InstanceGroupManager response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -5688,7 +5606,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -5735,7 +5652,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -5756,7 +5673,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -5808,7 +5724,7 @@ namespace ComputeSample
                 foreach (Data.InstanceGroupManager instanceGroupManager in response.Items)
                 {
                     // TODO: Change code below to process each `instanceGroupManager` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(instanceGroupManager));
+                    Console.WriteLine(instanceGroupManager);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -5832,7 +5748,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -5878,7 +5793,7 @@ namespace ComputeSample
             // Data.InstanceGroupManagersListManagedInstancesResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -5899,7 +5814,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -5949,7 +5863,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -5970,7 +5884,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -6021,7 +5934,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -6042,7 +5955,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -6092,7 +6004,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -6113,7 +6025,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -6163,7 +6074,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -6184,7 +6095,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -6234,7 +6144,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -6256,7 +6166,6 @@ using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -6305,7 +6214,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.InstanceGroupsScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine("[" + item.Key + "] = " + new JavaScriptSerializer().Serialize(item.Value));
+                    Console.WriteLine("[" + item.Key + "] = " + item.Value);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -6329,7 +6238,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -6375,7 +6283,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -6396,7 +6304,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -6442,7 +6349,7 @@ namespace ComputeSample
             // Data.InstanceGroup response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -6463,7 +6370,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -6510,7 +6416,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -6531,7 +6437,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -6583,7 +6488,7 @@ namespace ComputeSample
                 foreach (Data.InstanceGroup instanceGroup in response.Items)
                 {
                     // TODO: Change code below to process each `instanceGroup` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(instanceGroup));
+                    Console.WriteLine(instanceGroup);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -6607,7 +6512,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -6666,7 +6570,7 @@ namespace ComputeSample
                 foreach (Data.InstanceWithNamedPorts instanceWithNamedPorts in response.Items)
                 {
                     // TODO: Change code below to process each `instanceWithNamedPorts` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(instanceWithNamedPorts));
+                    Console.WriteLine(instanceWithNamedPorts);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -6690,7 +6594,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -6740,7 +6643,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -6761,7 +6664,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -6811,7 +6713,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -6832,7 +6734,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -6875,7 +6776,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -6896,7 +6797,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -6939,7 +6839,7 @@ namespace ComputeSample
             // Data.InstanceTemplate response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -6960,7 +6860,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -7004,7 +6903,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -7025,7 +6924,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -7074,7 +6972,7 @@ namespace ComputeSample
                 foreach (Data.InstanceTemplate instanceTemplate in response.Items)
                 {
                     // TODO: Change code below to process each `instanceTemplate` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(instanceTemplate));
+                    Console.WriteLine(instanceTemplate);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -7098,7 +6996,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -7151,7 +7048,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -7173,7 +7070,6 @@ using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -7222,7 +7118,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.InstancesScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine("[" + item.Key + "] = " + new JavaScriptSerializer().Serialize(item.Value));
+                    Console.WriteLine("[" + item.Key + "] = " + item.Value);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -7246,7 +7142,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -7296,7 +7191,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -7317,7 +7212,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -7363,7 +7257,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -7384,7 +7278,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -7436,7 +7329,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -7457,7 +7350,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -7506,7 +7398,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -7527,7 +7419,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -7573,7 +7464,7 @@ namespace ComputeSample
             // Data.Instance response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -7594,7 +7485,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -7640,7 +7530,7 @@ namespace ComputeSample
             // Data.SerialPortOutput response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -7661,7 +7551,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -7708,7 +7597,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -7729,7 +7618,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -7781,7 +7669,7 @@ namespace ComputeSample
                 foreach (Data.Instance instance in response.Items)
                 {
                     // TODO: Change code below to process each `instance` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(instance));
+                    Console.WriteLine(instance);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -7805,7 +7693,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -7851,7 +7738,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -7872,7 +7759,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -7924,7 +7810,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -7945,7 +7831,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -7995,7 +7880,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -8016,7 +7901,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -8066,7 +7950,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -8087,7 +7971,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -8137,7 +8020,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -8158,7 +8041,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -8208,7 +8090,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -8229,7 +8111,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -8275,7 +8156,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -8296,7 +8177,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -8346,7 +8226,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -8367,7 +8247,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -8413,7 +8292,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -8434,7 +8313,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -8477,7 +8355,7 @@ namespace ComputeSample
             // Data.License response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -8499,7 +8377,6 @@ using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -8548,7 +8425,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.MachineTypesScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine("[" + item.Key + "] = " + new JavaScriptSerializer().Serialize(item.Value));
+                    Console.WriteLine("[" + item.Key + "] = " + item.Value);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -8572,7 +8449,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -8618,7 +8494,7 @@ namespace ComputeSample
             // Data.MachineType response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -8639,7 +8515,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -8691,7 +8566,7 @@ namespace ComputeSample
                 foreach (Data.MachineType machineType in response.Items)
                 {
                     // TODO: Change code below to process each `machineType` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(machineType));
+                    Console.WriteLine(machineType);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -8715,7 +8590,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -8758,7 +8632,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -8779,7 +8653,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -8822,7 +8695,7 @@ namespace ComputeSample
             // Data.Network response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -8843,7 +8716,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -8887,7 +8759,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -8908,7 +8780,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -8957,7 +8828,7 @@ namespace ComputeSample
                 foreach (Data.Network network in response.Items)
                 {
                     // TODO: Change code below to process each `network` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(network));
+                    Console.WriteLine(network);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -8981,7 +8852,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -9021,7 +8891,7 @@ namespace ComputeSample
             // Data.Project response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -9042,7 +8912,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -9086,7 +8955,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -9107,7 +8976,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -9151,7 +9019,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -9172,7 +9040,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -9216,7 +9083,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -9237,7 +9104,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -9281,7 +9147,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -9363,7 +9229,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -9409,7 +9274,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -9430,7 +9295,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -9482,7 +9346,7 @@ namespace ComputeSample
                 foreach (Data.Operation operation in response.Items)
                 {
                     // TODO: Change code below to process each `operation` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(operation));
+                    Console.WriteLine(operation);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -9506,7 +9370,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -9549,7 +9412,7 @@ namespace ComputeSample
             // Data.Region response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -9570,7 +9433,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -9619,7 +9481,7 @@ namespace ComputeSample
                 foreach (Data.Region region in response.Items)
                 {
                     // TODO: Change code below to process each `region` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(region));
+                    Console.WriteLine(region);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -9644,7 +9506,6 @@ using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -9693,7 +9554,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.RoutersScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine("[" + item.Key + "] = " + new JavaScriptSerializer().Serialize(item.Value));
+                    Console.WriteLine("[" + item.Key + "] = " + item.Value);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -9717,7 +9578,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -9763,7 +9623,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -9784,7 +9644,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -9830,7 +9689,7 @@ namespace ComputeSample
             // Data.Router response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -9851,7 +9710,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -9897,7 +9755,7 @@ namespace ComputeSample
             // Data.RouterStatusResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -9918,7 +9776,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -9965,7 +9822,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -9986,7 +9843,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -10038,7 +9894,7 @@ namespace ComputeSample
                 foreach (Data.Router router in response.Items)
                 {
                     // TODO: Change code below to process each `router` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(router));
+                    Console.WriteLine(router);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -10062,7 +9918,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -10112,7 +9967,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -10133,7 +9988,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -10183,7 +10037,7 @@ namespace ComputeSample
             // Data.RoutersPreviewResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -10204,7 +10058,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -10254,7 +10107,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -10275,7 +10128,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -10318,7 +10170,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -10339,7 +10191,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -10382,7 +10233,7 @@ namespace ComputeSample
             // Data.Route response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -10403,7 +10254,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -10447,7 +10297,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -10468,7 +10318,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -10517,7 +10366,7 @@ namespace ComputeSample
                 foreach (Data.Route route in response.Items)
                 {
                     // TODO: Change code below to process each `route` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(route));
+                    Console.WriteLine(route);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -10541,7 +10390,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -10584,7 +10432,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -10605,7 +10453,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -10648,7 +10495,7 @@ namespace ComputeSample
             // Data.Snapshot response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -10669,7 +10516,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -10718,7 +10564,7 @@ namespace ComputeSample
                 foreach (Data.Snapshot snapshot in response.Items)
                 {
                     // TODO: Change code below to process each `snapshot` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(snapshot));
+                    Console.WriteLine(snapshot);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -10742,7 +10588,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -10785,7 +10630,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -10806,7 +10651,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -10849,7 +10693,7 @@ namespace ComputeSample
             // Data.SslCertificate response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -10870,7 +10714,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -10914,7 +10757,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -10935,7 +10778,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -10984,7 +10826,7 @@ namespace ComputeSample
                 foreach (Data.SslCertificate sslCertificate in response.Items)
                 {
                     // TODO: Change code below to process each `sslCertificate` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(sslCertificate));
+                    Console.WriteLine(sslCertificate);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -11009,7 +10851,6 @@ using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -11058,7 +10899,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.SubnetworksScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine("[" + item.Key + "] = " + new JavaScriptSerializer().Serialize(item.Value));
+                    Console.WriteLine("[" + item.Key + "] = " + item.Value);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -11082,7 +10923,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -11128,7 +10968,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -11149,7 +10989,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -11195,7 +11034,7 @@ namespace ComputeSample
             // Data.Subnetwork response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -11216,7 +11055,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -11263,7 +11101,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -11284,7 +11122,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -11336,7 +11173,7 @@ namespace ComputeSample
                 foreach (Data.Subnetwork subnetwork in response.Items)
                 {
                     // TODO: Change code below to process each `subnetwork` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(subnetwork));
+                    Console.WriteLine(subnetwork);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -11360,7 +11197,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -11403,7 +11239,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -11424,7 +11260,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -11467,7 +11302,7 @@ namespace ComputeSample
             // Data.TargetHttpProxy response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -11488,7 +11323,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -11532,7 +11366,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -11553,7 +11387,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -11602,7 +11435,7 @@ namespace ComputeSample
                 foreach (Data.TargetHttpProxy targetHttpProxy in response.Items)
                 {
                     // TODO: Change code below to process each `targetHttpProxy` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(targetHttpProxy));
+                    Console.WriteLine(targetHttpProxy);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -11626,7 +11459,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -11673,7 +11505,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -11694,7 +11526,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -11737,7 +11568,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -11758,7 +11589,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -11801,7 +11631,7 @@ namespace ComputeSample
             // Data.TargetHttpsProxy response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -11822,7 +11652,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -11866,7 +11695,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -11887,7 +11716,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -11936,7 +11764,7 @@ namespace ComputeSample
                 foreach (Data.TargetHttpsProxy targetHttpsProxy in response.Items)
                 {
                     // TODO: Change code below to process each `targetHttpsProxy` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(targetHttpsProxy));
+                    Console.WriteLine(targetHttpsProxy);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -11960,7 +11788,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -12007,7 +11834,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -12028,7 +11855,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -12075,7 +11901,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -12097,7 +11923,6 @@ using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -12146,7 +11971,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.TargetInstancesScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine("[" + item.Key + "] = " + new JavaScriptSerializer().Serialize(item.Value));
+                    Console.WriteLine("[" + item.Key + "] = " + item.Value);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -12170,7 +11995,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -12216,7 +12040,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -12237,7 +12061,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -12283,7 +12106,7 @@ namespace ComputeSample
             // Data.TargetInstance response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -12304,7 +12127,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -12351,7 +12173,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -12372,7 +12194,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -12424,7 +12245,7 @@ namespace ComputeSample
                 foreach (Data.TargetInstance targetInstance in response.Items)
                 {
                     // TODO: Change code below to process each `targetInstance` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(targetInstance));
+                    Console.WriteLine(targetInstance);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -12448,7 +12269,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -12498,7 +12318,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -12519,7 +12339,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -12569,7 +12388,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -12591,7 +12410,6 @@ using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -12640,7 +12458,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.TargetPoolsScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine("[" + item.Key + "] = " + new JavaScriptSerializer().Serialize(item.Value));
+                    Console.WriteLine("[" + item.Key + "] = " + item.Value);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -12664,7 +12482,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -12710,7 +12527,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -12731,7 +12548,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -12777,7 +12593,7 @@ namespace ComputeSample
             // Data.TargetPool response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -12798,7 +12614,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -12848,7 +12663,7 @@ namespace ComputeSample
             // Data.TargetPoolInstanceHealth response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -12869,7 +12684,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -12916,7 +12730,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -12937,7 +12751,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -12989,7 +12802,7 @@ namespace ComputeSample
                 foreach (Data.TargetPool targetPool in response.Items)
                 {
                     // TODO: Change code below to process each `targetPool` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(targetPool));
+                    Console.WriteLine(targetPool);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -13013,7 +12826,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -13063,7 +12875,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -13084,7 +12896,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -13134,7 +12945,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -13155,7 +12966,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -13205,7 +13015,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -13226,7 +13036,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -13269,7 +13078,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -13290,7 +13099,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -13333,7 +13141,7 @@ namespace ComputeSample
             // Data.TargetSslProxy response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -13354,7 +13162,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -13398,7 +13205,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -13419,7 +13226,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -13468,7 +13274,7 @@ namespace ComputeSample
                 foreach (Data.TargetSslProxy targetSslProxy in response.Items)
                 {
                     // TODO: Change code below to process each `targetSslProxy` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(targetSslProxy));
+                    Console.WriteLine(targetSslProxy);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -13492,7 +13298,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -13539,7 +13344,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -13560,7 +13365,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -13607,7 +13411,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -13628,7 +13432,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -13675,7 +13478,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -13697,7 +13500,6 @@ using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -13746,7 +13548,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.TargetVpnGatewaysScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine("[" + item.Key + "] = " + new JavaScriptSerializer().Serialize(item.Value));
+                    Console.WriteLine("[" + item.Key + "] = " + item.Value);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -13770,7 +13572,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -13816,7 +13617,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -13837,7 +13638,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -13883,7 +13683,7 @@ namespace ComputeSample
             // Data.TargetVpnGateway response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -13904,7 +13704,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -13951,7 +13750,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -13972,7 +13771,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -14024,7 +13822,7 @@ namespace ComputeSample
                 foreach (Data.TargetVpnGateway targetVpnGateway in response.Items)
                 {
                     // TODO: Change code below to process each `targetVpnGateway` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(targetVpnGateway));
+                    Console.WriteLine(targetVpnGateway);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -14048,7 +13846,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -14091,7 +13888,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -14112,7 +13909,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -14155,7 +13951,7 @@ namespace ComputeSample
             // Data.UrlMap response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -14176,7 +13972,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -14220,7 +14015,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -14241,7 +14036,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -14288,7 +14082,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -14309,7 +14103,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -14358,7 +14151,7 @@ namespace ComputeSample
                 foreach (Data.UrlMap urlMap in response.Items)
                 {
                     // TODO: Change code below to process each `urlMap` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(urlMap));
+                    Console.WriteLine(urlMap);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -14382,7 +14175,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -14429,7 +14221,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -14450,7 +14242,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -14497,7 +14288,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -14518,7 +14309,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -14565,7 +14355,7 @@ namespace ComputeSample
             // Data.UrlMapsValidateResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -14587,7 +14377,6 @@ using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -14636,7 +14425,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.VpnTunnelsScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine("[" + item.Key + "] = " + new JavaScriptSerializer().Serialize(item.Value));
+                    Console.WriteLine("[" + item.Key + "] = " + item.Value);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -14660,7 +14449,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -14706,7 +14494,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -14727,7 +14515,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -14773,7 +14560,7 @@ namespace ComputeSample
             // Data.VpnTunnel response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -14794,7 +14581,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -14841,7 +14627,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -14862,7 +14648,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -14914,7 +14699,7 @@ namespace ComputeSample
                 foreach (Data.VpnTunnel vpnTunnel in response.Items)
                 {
                     // TODO: Change code below to process each `vpnTunnel` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(vpnTunnel));
+                    Console.WriteLine(vpnTunnel);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -14999,7 +14784,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -15045,7 +14829,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -15066,7 +14850,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -15118,7 +14901,7 @@ namespace ComputeSample
                 foreach (Data.Operation operation in response.Items)
                 {
                     // TODO: Change code below to process each `operation` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(operation));
+                    Console.WriteLine(operation);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -15142,7 +14925,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -15185,7 +14967,7 @@ namespace ComputeSample
             // Data.Zone response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -15206,7 +14988,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Compute.v1.Data;
 
@@ -15255,7 +15036,7 @@ namespace ComputeSample
                 foreach (Data.Zone zone in response.Items)
                 {
                     // TODO: Change code below to process each `zone` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(zone));
+                    Console.WriteLine(zone);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_container.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_container.v1.json.baseline
@@ -16,7 +16,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Container.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Container.v1.Data;
 
@@ -65,7 +64,7 @@ namespace ContainerSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -86,7 +85,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Container.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Container.v1.Data;
 
@@ -134,7 +132,7 @@ namespace ContainerSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -155,7 +153,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Container.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Container.v1.Data;
 
@@ -203,7 +200,7 @@ namespace ContainerSample
             // Data.Cluster response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -224,7 +221,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Container.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Container.v1.Data;
 
@@ -269,7 +265,7 @@ namespace ContainerSample
             // Data.ListClustersResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -290,7 +286,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Container.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Container.v1.Data;
 
@@ -342,7 +337,7 @@ namespace ContainerSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -363,7 +358,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Container.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Container.v1.Data;
 
@@ -414,7 +408,7 @@ namespace ContainerSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -435,7 +429,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Container.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Container.v1.Data;
 
@@ -486,7 +479,7 @@ namespace ContainerSample
             // Data.NodePool response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -507,7 +500,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Container.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Container.v1.Data;
 
@@ -555,7 +547,7 @@ namespace ContainerSample
             // Data.ListNodePoolsResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -576,7 +568,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Container.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Container.v1.Data;
 
@@ -628,7 +619,7 @@ namespace ContainerSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -649,7 +640,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Container.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Container.v1.Data;
 
@@ -694,7 +684,7 @@ namespace ContainerSample
             // Data.ServerConfig response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -715,7 +705,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Container.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Container.v1.Data;
 
@@ -763,7 +752,7 @@ namespace ContainerSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -784,7 +773,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Container.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Container.v1.Data;
 
@@ -829,7 +817,7 @@ namespace ContainerSample
             // Data.ListOperationsResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_dataflow.v1b3.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_dataflow.v1b3.json.baseline
@@ -16,7 +16,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataflow.v1b3;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Dataflow.v1b3.Data;
 
@@ -60,7 +59,7 @@ namespace DataflowSample
             // Data.Job response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -81,7 +80,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataflow.v1b3;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Dataflow.v1b3.Data;
 
@@ -128,7 +126,7 @@ namespace DataflowSample
             // Data.GetDebugConfigResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -149,7 +147,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataflow.v1b3;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Dataflow.v1b3.Data;
 
@@ -196,7 +193,7 @@ namespace DataflowSample
             // Data.SendDebugCaptureResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -217,7 +214,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataflow.v1b3;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Dataflow.v1b3.Data;
 
@@ -260,7 +256,7 @@ namespace DataflowSample
             // Data.Job response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -281,7 +277,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataflow.v1b3;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Dataflow.v1b3.Data;
 
@@ -324,7 +319,7 @@ namespace DataflowSample
             // Data.JobMetrics response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -345,7 +340,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataflow.v1b3;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Dataflow.v1b3.Data;
 
@@ -394,7 +388,7 @@ namespace DataflowSample
                 foreach (Data.Job job in response.Jobs)
                 {
                     // TODO: Change code below to process each `job` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(job));
+                    Console.WriteLine(job);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -418,7 +412,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataflow.v1b3;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Dataflow.v1b3.Data;
 
@@ -470,7 +463,7 @@ namespace DataflowSample
                 foreach (Data.JobMessage jobMessage in response.JobMessages)
                 {
                     // TODO: Change code below to process each `jobMessage` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(jobMessage));
+                    Console.WriteLine(jobMessage);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -494,7 +487,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataflow.v1b3;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Dataflow.v1b3.Data;
 
@@ -541,7 +533,7 @@ namespace DataflowSample
             // Data.Job response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -562,7 +554,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataflow.v1b3;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Dataflow.v1b3.Data;
 
@@ -609,7 +600,7 @@ namespace DataflowSample
             // Data.LeaseWorkItemResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -630,7 +621,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataflow.v1b3;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Dataflow.v1b3.Data;
 
@@ -677,7 +667,7 @@ namespace DataflowSample
             // Data.ReportWorkItemStatusResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -698,7 +688,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataflow.v1b3;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Dataflow.v1b3.Data;
 
@@ -742,7 +731,7 @@ namespace DataflowSample
             // Data.Job response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -763,7 +752,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataflow.v1b3;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Dataflow.v1b3.Data;
 
@@ -807,7 +795,7 @@ namespace DataflowSample
             // Data.SendWorkerMessagesResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_dataproc.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_dataproc.v1.json.baseline
@@ -16,7 +16,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataproc.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Dataproc.v1.Data;
 
@@ -63,7 +62,7 @@ namespace DataprocSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -84,7 +83,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataproc.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Dataproc.v1.Data;
 
@@ -130,7 +128,7 @@ namespace DataprocSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -151,7 +149,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataproc.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Dataproc.v1.Data;
 
@@ -201,7 +198,7 @@ namespace DataprocSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -222,7 +219,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataproc.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Dataproc.v1.Data;
 
@@ -268,7 +264,7 @@ namespace DataprocSample
             // Data.Cluster response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -289,7 +285,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataproc.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Dataproc.v1.Data;
 
@@ -341,7 +336,7 @@ namespace DataprocSample
                 foreach (Data.Cluster cluster in response.Clusters)
                 {
                     // TODO: Change code below to process each `cluster` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(cluster));
+                    Console.WriteLine(cluster);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -365,7 +360,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataproc.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Dataproc.v1.Data;
 
@@ -415,7 +409,7 @@ namespace DataprocSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -436,7 +430,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataproc.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Dataproc.v1.Data;
 
@@ -486,7 +479,7 @@ namespace DataprocSample
             // Data.Job response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -507,7 +500,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataproc.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Dataproc.v1.Data;
 
@@ -553,7 +545,7 @@ namespace DataprocSample
             // Data.Empty response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -574,7 +566,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataproc.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Dataproc.v1.Data;
 
@@ -620,7 +611,7 @@ namespace DataprocSample
             // Data.Job response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -641,7 +632,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataproc.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Dataproc.v1.Data;
 
@@ -693,7 +683,7 @@ namespace DataprocSample
                 foreach (Data.Job job in response.Jobs)
                 {
                     // TODO: Change code below to process each `job` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(job));
+                    Console.WriteLine(job);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -717,7 +707,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataproc.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Dataproc.v1.Data;
 
@@ -764,7 +753,7 @@ namespace DataprocSample
             // Data.Job response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -785,7 +774,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataproc.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Dataproc.v1.Data;
 
@@ -825,7 +813,7 @@ namespace DataprocSample
             // Data.Empty response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -846,7 +834,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataproc.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Dataproc.v1.Data;
 
@@ -886,7 +873,7 @@ namespace DataprocSample
             // Data.Empty response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -907,7 +894,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataproc.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Dataproc.v1.Data;
 
@@ -947,7 +933,7 @@ namespace DataprocSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -968,7 +954,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataproc.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Dataproc.v1.Data;
 
@@ -1017,7 +1002,7 @@ namespace DataprocSample
                 foreach (Data.Operation operation in response.Operations)
                 {
                     // TODO: Change code below to process each `operation` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(operation));
+                    Console.WriteLine(operation);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_datastore.v1beta3.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_datastore.v1beta3.json.baseline
@@ -16,7 +16,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Datastore.v1beta3;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Datastore.v1beta3.Data;
 
@@ -60,7 +59,7 @@ namespace DatastoreSample
             // Data.AllocateIdsResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -81,7 +80,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Datastore.v1beta3;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Datastore.v1beta3.Data;
 
@@ -125,7 +123,7 @@ namespace DatastoreSample
             // Data.BeginTransactionResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -146,7 +144,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Datastore.v1beta3;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Datastore.v1beta3.Data;
 
@@ -190,7 +187,7 @@ namespace DatastoreSample
             // Data.CommitResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -211,7 +208,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Datastore.v1beta3;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Datastore.v1beta3.Data;
 
@@ -255,7 +251,7 @@ namespace DatastoreSample
             // Data.LookupResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -276,7 +272,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Datastore.v1beta3;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Datastore.v1beta3.Data;
 
@@ -320,7 +315,7 @@ namespace DatastoreSample
             // Data.RollbackResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -341,7 +336,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Datastore.v1beta3;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Datastore.v1beta3.Data;
 
@@ -385,7 +379,7 @@ namespace DatastoreSample
             // Data.RunQueryResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_deploymentmanager.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_deploymentmanager.v2.json.baseline
@@ -16,7 +16,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.DeploymentManager.v2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.DeploymentManager.v2.Data;
 
@@ -63,7 +62,7 @@ namespace DeploymentManagerSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -84,7 +83,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.DeploymentManager.v2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.DeploymentManager.v2.Data;
 
@@ -127,7 +125,7 @@ namespace DeploymentManagerSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -148,7 +146,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.DeploymentManager.v2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.DeploymentManager.v2.Data;
 
@@ -191,7 +188,7 @@ namespace DeploymentManagerSample
             // Data.Deployment response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -212,7 +209,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.DeploymentManager.v2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.DeploymentManager.v2.Data;
 
@@ -256,7 +252,7 @@ namespace DeploymentManagerSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -277,7 +273,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.DeploymentManager.v2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.DeploymentManager.v2.Data;
 
@@ -326,7 +321,7 @@ namespace DeploymentManagerSample
                 foreach (Data.Deployment deployment in response.Deployments)
                 {
                     // TODO: Change code below to process each `deployment` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(deployment));
+                    Console.WriteLine(deployment);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -350,7 +345,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.DeploymentManager.v2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.DeploymentManager.v2.Data;
 
@@ -397,7 +391,7 @@ namespace DeploymentManagerSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -418,7 +412,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.DeploymentManager.v2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.DeploymentManager.v2.Data;
 
@@ -465,7 +458,7 @@ namespace DeploymentManagerSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -486,7 +479,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.DeploymentManager.v2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.DeploymentManager.v2.Data;
 
@@ -533,7 +525,7 @@ namespace DeploymentManagerSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -554,7 +546,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.DeploymentManager.v2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.DeploymentManager.v2.Data;
 
@@ -600,7 +591,7 @@ namespace DeploymentManagerSample
             // Data.Manifest response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -621,7 +612,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.DeploymentManager.v2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.DeploymentManager.v2.Data;
 
@@ -673,7 +663,7 @@ namespace DeploymentManagerSample
                 foreach (Data.Manifest manifest in response.Manifests)
                 {
                     // TODO: Change code below to process each `manifest` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(manifest));
+                    Console.WriteLine(manifest);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -697,7 +687,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.DeploymentManager.v2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.DeploymentManager.v2.Data;
 
@@ -740,7 +729,7 @@ namespace DeploymentManagerSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -761,7 +750,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.DeploymentManager.v2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.DeploymentManager.v2.Data;
 
@@ -810,7 +798,7 @@ namespace DeploymentManagerSample
                 foreach (Data.Operation operation in response.Operations)
                 {
                     // TODO: Change code below to process each `operation` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(operation));
+                    Console.WriteLine(operation);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -834,7 +822,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.DeploymentManager.v2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.DeploymentManager.v2.Data;
 
@@ -880,7 +867,7 @@ namespace DeploymentManagerSample
             // Data.Resource response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -901,7 +888,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.DeploymentManager.v2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.DeploymentManager.v2.Data;
 
@@ -953,7 +939,7 @@ namespace DeploymentManagerSample
                 foreach (Data.Resource resource in response.Resources)
                 {
                     // TODO: Change code below to process each `resource` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(resource));
+                    Console.WriteLine(resource);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -977,7 +963,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.DeploymentManager.v2;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.DeploymentManager.v2.Data;
 
@@ -1026,7 +1011,7 @@ namespace DeploymentManagerSample
                 foreach (Data.Type type in response.Types)
                 {
                     // TODO: Change code below to process each `type` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(type));
+                    Console.WriteLine(type);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_dns.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_dns.v1.json.baseline
@@ -16,7 +16,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dns.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Dns.v1.Data;
 
@@ -63,7 +62,7 @@ namespace DnsSample
             // Data.Change response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -84,7 +83,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dns.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Dns.v1.Data;
 
@@ -130,7 +128,7 @@ namespace DnsSample
             // Data.Change response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -151,7 +149,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dns.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Dns.v1.Data;
 
@@ -203,7 +200,7 @@ namespace DnsSample
                 foreach (Data.Change change in response.Changes)
                 {
                     // TODO: Change code below to process each `change` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(change));
+                    Console.WriteLine(change);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -227,7 +224,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dns.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Dns.v1.Data;
 
@@ -271,7 +267,7 @@ namespace DnsSample
             // Data.ManagedZone response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -350,7 +346,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dns.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Dns.v1.Data;
 
@@ -393,7 +388,7 @@ namespace DnsSample
             // Data.ManagedZone response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -414,7 +409,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dns.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Dns.v1.Data;
 
@@ -463,7 +457,7 @@ namespace DnsSample
                 foreach (Data.ManagedZone managedZone in response.ManagedZones)
                 {
                     // TODO: Change code below to process each `managedZone` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(managedZone));
+                    Console.WriteLine(managedZone);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -487,7 +481,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dns.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Dns.v1.Data;
 
@@ -527,7 +520,7 @@ namespace DnsSample
             // Data.Project response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -548,7 +541,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dns.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Dns.v1.Data;
 
@@ -600,7 +592,7 @@ namespace DnsSample
                 foreach (Data.ResourceRecordSet resourceRecordSet in response.Rrsets)
                 {
                     // TODO: Change code below to process each `resourceRecordSet` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(resourceRecordSet));
+                    Console.WriteLine(resourceRecordSet);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_logging.v2beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_logging.v2beta1.json.baseline
@@ -16,7 +16,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Logging.v2beta1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Logging.v2beta1.Data;
 
@@ -62,7 +61,7 @@ namespace LoggingSample
                 foreach (Data.LogEntry logEntry in response.Entries)
                 {
                     // TODO: Change code below to process each `logEntry` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(logEntry));
+                    Console.WriteLine(logEntry);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -86,7 +85,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Logging.v2beta1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Logging.v2beta1.Data;
 
@@ -123,7 +121,7 @@ namespace LoggingSample
             // Data.WriteLogEntriesResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -144,7 +142,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Logging.v2beta1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Logging.v2beta1.Data;
 
@@ -186,7 +183,7 @@ namespace LoggingSample
                 foreach (Data.MonitoredResourceDescriptor monitoredResourceDescriptor in response.ResourceDescriptors)
                 {
                     // TODO: Change code below to process each `monitoredResourceDescriptor` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(monitoredResourceDescriptor));
+                    Console.WriteLine(monitoredResourceDescriptor);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -210,7 +207,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Logging.v2beta1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Logging.v2beta1.Data;
 
@@ -250,7 +246,7 @@ namespace LoggingSample
             // Data.Empty response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -271,7 +267,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Logging.v2beta1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Logging.v2beta1.Data;
 
@@ -316,7 +311,7 @@ namespace LoggingSample
             // Data.LogMetric response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -337,7 +332,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Logging.v2beta1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Logging.v2beta1.Data;
 
@@ -377,7 +371,7 @@ namespace LoggingSample
             // Data.Empty response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -398,7 +392,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Logging.v2beta1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Logging.v2beta1.Data;
 
@@ -438,7 +431,7 @@ namespace LoggingSample
             // Data.LogMetric response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -459,7 +452,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Logging.v2beta1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Logging.v2beta1.Data;
 
@@ -509,7 +501,7 @@ namespace LoggingSample
                 foreach (Data.LogMetric logMetric in response.Metrics)
                 {
                     // TODO: Change code below to process each `logMetric` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(logMetric));
+                    Console.WriteLine(logMetric);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -533,7 +525,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Logging.v2beta1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Logging.v2beta1.Data;
 
@@ -579,7 +570,7 @@ namespace LoggingSample
             // Data.LogMetric response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -600,7 +591,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Logging.v2beta1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Logging.v2beta1.Data;
 
@@ -645,7 +635,7 @@ namespace LoggingSample
             // Data.LogSink response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -666,7 +656,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Logging.v2beta1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Logging.v2beta1.Data;
 
@@ -706,7 +695,7 @@ namespace LoggingSample
             // Data.Empty response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -727,7 +716,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Logging.v2beta1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Logging.v2beta1.Data;
 
@@ -767,7 +755,7 @@ namespace LoggingSample
             // Data.LogSink response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -788,7 +776,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Logging.v2beta1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Logging.v2beta1.Data;
 
@@ -838,7 +825,7 @@ namespace LoggingSample
                 foreach (Data.LogSink logSink in response.Sinks)
                 {
                     // TODO: Change code below to process each `logSink` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(logSink));
+                    Console.WriteLine(logSink);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -862,7 +849,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Logging.v2beta1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Logging.v2beta1.Data;
 
@@ -908,7 +894,7 @@ namespace LoggingSample
             // Data.LogSink response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_prediction.v1.6.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_prediction.v1.6.json.baseline
@@ -16,7 +16,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Prediction.v1_6;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Prediction.v1_6.Data;
 
@@ -63,7 +62,7 @@ namespace PredictionSample
             // Data.Output response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -84,7 +83,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Prediction.v1_6;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Prediction.v1_6.Data;
 
@@ -127,7 +125,7 @@ namespace PredictionSample
             // Data.Analyze response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -206,7 +204,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Prediction.v1_6;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Prediction.v1_6.Data;
 
@@ -249,7 +246,7 @@ namespace PredictionSample
             // Data.Insert2 response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -270,7 +267,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Prediction.v1_6;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Prediction.v1_6.Data;
 
@@ -314,7 +310,7 @@ namespace PredictionSample
             // Data.Insert2 response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -335,7 +331,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Prediction.v1_6;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Prediction.v1_6.Data;
 
@@ -384,7 +379,7 @@ namespace PredictionSample
                 foreach (Data.Insert2 insert2 in response.Items)
                 {
                     // TODO: Change code below to process each `insert2` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(insert2));
+                    Console.WriteLine(insert2);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -408,7 +403,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Prediction.v1_6;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Prediction.v1_6.Data;
 
@@ -455,7 +449,7 @@ namespace PredictionSample
             // Data.Output response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -476,7 +470,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Prediction.v1_6;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Prediction.v1_6.Data;
 
@@ -523,7 +516,7 @@ namespace PredictionSample
             // Data.Insert2 response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_pubsub.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_pubsub.v1.json.baseline
@@ -16,7 +16,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Pubsub.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Pubsub.v1.Data;
 
@@ -60,7 +59,7 @@ namespace PubsubSample
             // Data.Empty response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -81,7 +80,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Pubsub.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Pubsub.v1.Data;
 
@@ -129,7 +127,7 @@ namespace PubsubSample
             // Data.Subscription response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -150,7 +148,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Pubsub.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Pubsub.v1.Data;
 
@@ -190,7 +187,7 @@ namespace PubsubSample
             // Data.Empty response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -211,7 +208,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Pubsub.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Pubsub.v1.Data;
 
@@ -251,7 +247,7 @@ namespace PubsubSample
             // Data.Subscription response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -272,7 +268,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Pubsub.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Pubsub.v1.Data;
 
@@ -314,7 +309,7 @@ namespace PubsubSample
             // Data.Policy response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -335,7 +330,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Pubsub.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Pubsub.v1.Data;
 
@@ -384,7 +378,7 @@ namespace PubsubSample
                 foreach (Data.Subscription subscription in response.Subscriptions)
                 {
                     // TODO: Change code below to process each `subscription` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(subscription));
+                    Console.WriteLine(subscription);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -408,7 +402,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Pubsub.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Pubsub.v1.Data;
 
@@ -452,7 +445,7 @@ namespace PubsubSample
             // Data.Empty response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -473,7 +466,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Pubsub.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Pubsub.v1.Data;
 
@@ -517,7 +509,7 @@ namespace PubsubSample
             // Data.Empty response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -538,7 +530,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Pubsub.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Pubsub.v1.Data;
 
@@ -582,7 +573,7 @@ namespace PubsubSample
             // Data.PullResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -603,7 +594,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Pubsub.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Pubsub.v1.Data;
 
@@ -649,7 +639,7 @@ namespace PubsubSample
             // Data.Policy response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -670,7 +660,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Pubsub.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Pubsub.v1.Data;
 
@@ -717,7 +706,7 @@ namespace PubsubSample
             // Data.TestIamPermissionsResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -738,7 +727,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Pubsub.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Pubsub.v1.Data;
 
@@ -785,7 +773,7 @@ namespace PubsubSample
             // Data.Topic response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -806,7 +794,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Pubsub.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Pubsub.v1.Data;
 
@@ -846,7 +833,7 @@ namespace PubsubSample
             // Data.Empty response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -867,7 +854,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Pubsub.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Pubsub.v1.Data;
 
@@ -907,7 +893,7 @@ namespace PubsubSample
             // Data.Topic response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -928,7 +914,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Pubsub.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Pubsub.v1.Data;
 
@@ -970,7 +955,7 @@ namespace PubsubSample
             // Data.Policy response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -991,7 +976,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Pubsub.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Pubsub.v1.Data;
 
@@ -1040,7 +1024,7 @@ namespace PubsubSample
                 foreach (Data.Topic topic in response.Topics)
                 {
                     // TODO: Change code below to process each `topic` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(topic));
+                    Console.WriteLine(topic);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -1064,7 +1048,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Pubsub.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Pubsub.v1.Data;
 
@@ -1108,7 +1091,7 @@ namespace PubsubSample
             // Data.PublishResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -1129,7 +1112,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Pubsub.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Pubsub.v1.Data;
 
@@ -1175,7 +1157,7 @@ namespace PubsubSample
             // Data.Policy response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -1196,7 +1178,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Pubsub.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Pubsub.v1.Data;
 
@@ -1245,7 +1226,7 @@ namespace PubsubSample
                 foreach (string string_ in response.Subscriptions)
                 {
                     // TODO: Change code below to process each `string_` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(string_));
+                    Console.WriteLine(string_);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -1269,7 +1250,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Pubsub.v1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Pubsub.v1.Data;
 
@@ -1316,7 +1296,7 @@ namespace PubsubSample
             // Data.TestIamPermissionsResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_replicapoolupdater.v1beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_replicapoolupdater.v1beta1.json.baseline
@@ -16,7 +16,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Replicapoolupdater.v1beta1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Replicapoolupdater.v1beta1.Data;
 
@@ -62,7 +61,7 @@ namespace ReplicapoolupdaterSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -83,7 +82,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Replicapoolupdater.v1beta1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Replicapoolupdater.v1beta1.Data;
 
@@ -129,7 +127,7 @@ namespace ReplicapoolupdaterSample
             // Data.RollingUpdate response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -150,7 +148,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Replicapoolupdater.v1beta1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Replicapoolupdater.v1beta1.Data;
 
@@ -197,7 +194,7 @@ namespace ReplicapoolupdaterSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -218,7 +215,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Replicapoolupdater.v1beta1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Replicapoolupdater.v1beta1.Data;
 
@@ -270,7 +266,7 @@ namespace ReplicapoolupdaterSample
                 foreach (Data.RollingUpdate rollingUpdate in response.Items)
                 {
                     // TODO: Change code below to process each `rollingUpdate` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(rollingUpdate));
+                    Console.WriteLine(rollingUpdate);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -294,7 +290,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Replicapoolupdater.v1beta1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Replicapoolupdater.v1beta1.Data;
 
@@ -349,7 +344,7 @@ namespace ReplicapoolupdaterSample
                 foreach (Data.InstanceUpdate instanceUpdate in response.Items)
                 {
                     // TODO: Change code below to process each `instanceUpdate` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(instanceUpdate));
+                    Console.WriteLine(instanceUpdate);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -373,7 +368,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Replicapoolupdater.v1beta1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Replicapoolupdater.v1beta1.Data;
 
@@ -419,7 +413,7 @@ namespace ReplicapoolupdaterSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -440,7 +434,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Replicapoolupdater.v1beta1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Replicapoolupdater.v1beta1.Data;
 
@@ -486,7 +479,7 @@ namespace ReplicapoolupdaterSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -507,7 +500,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Replicapoolupdater.v1beta1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Replicapoolupdater.v1beta1.Data;
 
@@ -553,7 +545,7 @@ namespace ReplicapoolupdaterSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -574,7 +566,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Replicapoolupdater.v1beta1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Replicapoolupdater.v1beta1.Data;
 
@@ -620,7 +611,7 @@ namespace ReplicapoolupdaterSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -641,7 +632,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Replicapoolupdater.v1beta1;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Replicapoolupdater.v1beta1.Data;
 
@@ -693,7 +683,7 @@ namespace ReplicapoolupdaterSample
                 foreach (Data.Operation operation in response.Items)
                 {
                     // TODO: Change code below to process each `operation` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(operation));
+                    Console.WriteLine(operation);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_sqladmin.v1beta4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_sqladmin.v1beta4.json.baseline
@@ -16,7 +16,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.SQLAdmin.v1beta4.Data;
 
@@ -62,7 +61,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -83,7 +82,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.SQLAdmin.v1beta4.Data;
 
@@ -129,7 +127,7 @@ namespace SQLAdminSample
             // Data.BackupRun response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -150,7 +148,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.SQLAdmin.v1beta4.Data;
 
@@ -197,7 +194,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -218,7 +215,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.SQLAdmin.v1beta4.Data;
 
@@ -270,7 +266,7 @@ namespace SQLAdminSample
                 foreach (Data.BackupRun backupRun in response.Items)
                 {
                     // TODO: Change code below to process each `backupRun` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(backupRun));
+                    Console.WriteLine(backupRun);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -294,7 +290,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.SQLAdmin.v1beta4.Data;
 
@@ -340,7 +335,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -361,7 +356,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.SQLAdmin.v1beta4.Data;
 
@@ -407,7 +401,7 @@ namespace SQLAdminSample
             // Data.Database response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -428,7 +422,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.SQLAdmin.v1beta4.Data;
 
@@ -475,7 +468,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -496,7 +489,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.SQLAdmin.v1beta4.Data;
 
@@ -539,7 +531,7 @@ namespace SQLAdminSample
             // Data.DatabasesListResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -560,7 +552,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.SQLAdmin.v1beta4.Data;
 
@@ -610,7 +601,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -631,7 +622,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.SQLAdmin.v1beta4.Data;
 
@@ -681,7 +671,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -702,7 +692,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.SQLAdmin.v1beta4.Data;
 
@@ -735,7 +724,7 @@ namespace SQLAdminSample
             // Data.FlagsListResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -756,7 +745,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.SQLAdmin.v1beta4.Data;
 
@@ -803,7 +791,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -824,7 +812,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.SQLAdmin.v1beta4.Data;
 
@@ -867,7 +854,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -888,7 +875,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.SQLAdmin.v1beta4.Data;
 
@@ -935,7 +921,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -956,7 +942,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.SQLAdmin.v1beta4.Data;
 
@@ -1003,7 +988,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -1024,7 +1009,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.SQLAdmin.v1beta4.Data;
 
@@ -1067,7 +1051,7 @@ namespace SQLAdminSample
             // Data.DatabaseInstance response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -1088,7 +1072,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.SQLAdmin.v1beta4.Data;
 
@@ -1135,7 +1118,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -1156,7 +1139,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.SQLAdmin.v1beta4.Data;
 
@@ -1200,7 +1182,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -1221,7 +1203,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.SQLAdmin.v1beta4.Data;
 
@@ -1270,7 +1251,7 @@ namespace SQLAdminSample
                 foreach (Data.DatabaseInstance databaseInstance in response.Items)
                 {
                     // TODO: Change code below to process each `databaseInstance` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(databaseInstance));
+                    Console.WriteLine(databaseInstance);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -1294,7 +1275,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.SQLAdmin.v1beta4.Data;
 
@@ -1341,7 +1321,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -1362,7 +1342,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.SQLAdmin.v1beta4.Data;
 
@@ -1405,7 +1384,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -1426,7 +1405,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.SQLAdmin.v1beta4.Data;
 
@@ -1469,7 +1447,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -1490,7 +1468,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.SQLAdmin.v1beta4.Data;
 
@@ -1533,7 +1510,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -1554,7 +1531,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.SQLAdmin.v1beta4.Data;
 
@@ -1601,7 +1577,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -1622,7 +1598,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.SQLAdmin.v1beta4.Data;
 
@@ -1665,7 +1640,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -1686,7 +1661,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.SQLAdmin.v1beta4.Data;
 
@@ -1729,7 +1703,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -1750,7 +1724,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.SQLAdmin.v1beta4.Data;
 
@@ -1797,7 +1770,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -1818,7 +1791,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.SQLAdmin.v1beta4.Data;
 
@@ -1861,7 +1833,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -1882,7 +1854,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.SQLAdmin.v1beta4.Data;
 
@@ -1934,7 +1905,7 @@ namespace SQLAdminSample
                 foreach (Data.Operation operation in response.Items)
                 {
                     // TODO: Change code below to process each `operation` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(operation));
+                    Console.WriteLine(operation);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -1958,7 +1929,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.SQLAdmin.v1beta4.Data;
 
@@ -2005,7 +1975,7 @@ namespace SQLAdminSample
             // Data.SslCert response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -2026,7 +1996,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.SQLAdmin.v1beta4.Data;
 
@@ -2072,7 +2041,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -2093,7 +2062,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.SQLAdmin.v1beta4.Data;
 
@@ -2139,7 +2107,7 @@ namespace SQLAdminSample
             // Data.SslCert response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -2160,7 +2128,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.SQLAdmin.v1beta4.Data;
 
@@ -2207,7 +2174,7 @@ namespace SQLAdminSample
             // Data.SslCertsInsertResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -2228,7 +2195,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.SQLAdmin.v1beta4.Data;
 
@@ -2271,7 +2237,7 @@ namespace SQLAdminSample
             // Data.SslCertsListResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -2292,7 +2258,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.SQLAdmin.v1beta4.Data;
 
@@ -2332,7 +2297,7 @@ namespace SQLAdminSample
             // Data.TiersListResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -2353,7 +2318,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.SQLAdmin.v1beta4.Data;
 
@@ -2402,7 +2366,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -2423,7 +2387,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.SQLAdmin.v1beta4.Data;
 
@@ -2470,7 +2433,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -2491,7 +2454,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.SQLAdmin.v1beta4.Data;
 
@@ -2534,7 +2496,7 @@ namespace SQLAdminSample
             // Data.UsersListResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -2555,7 +2517,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.SQLAdmin.v1beta4.Data;
 
@@ -2608,7 +2569,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_storage.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_storage.v1.json.baseline
@@ -75,7 +75,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Storage.v1.Data;
 
@@ -119,7 +118,7 @@ namespace StorageSample
             // Data.BucketAccessControl response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -140,7 +139,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Storage.v1.Data;
 
@@ -184,7 +182,7 @@ namespace StorageSample
             // Data.BucketAccessControl response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -205,7 +203,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Storage.v1.Data;
 
@@ -245,7 +242,7 @@ namespace StorageSample
             // Data.BucketAccessControls response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -266,7 +263,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Storage.v1.Data;
 
@@ -314,7 +310,7 @@ namespace StorageSample
             // Data.BucketAccessControl response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -335,7 +331,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Storage.v1.Data;
 
@@ -383,7 +378,7 @@ namespace StorageSample
             // Data.BucketAccessControl response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -459,7 +454,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Storage.v1.Data;
 
@@ -499,7 +493,7 @@ namespace StorageSample
             // Data.Bucket response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -520,7 +514,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Storage.v1.Data;
 
@@ -564,7 +557,7 @@ namespace StorageSample
             // Data.Bucket response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -585,7 +578,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Storage.v1.Data;
 
@@ -634,7 +626,7 @@ namespace StorageSample
                 foreach (Data.Bucket bucket in response.Items)
                 {
                     // TODO: Change code below to process each `bucket` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(bucket));
+                    Console.WriteLine(bucket);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -658,7 +650,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Storage.v1.Data;
 
@@ -702,7 +693,7 @@ namespace StorageSample
             // Data.Bucket response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -723,7 +714,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Storage.v1.Data;
 
@@ -767,7 +757,7 @@ namespace StorageSample
             // Data.Bucket response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -901,7 +891,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Storage.v1.Data;
 
@@ -945,7 +934,7 @@ namespace StorageSample
             // Data.ObjectAccessControl response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -966,7 +955,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Storage.v1.Data;
 
@@ -1010,7 +998,7 @@ namespace StorageSample
             // Data.ObjectAccessControl response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -1031,7 +1019,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Storage.v1.Data;
 
@@ -1071,7 +1058,7 @@ namespace StorageSample
             // Data.ObjectAccessControls response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -1092,7 +1079,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Storage.v1.Data;
 
@@ -1140,7 +1126,7 @@ namespace StorageSample
             // Data.ObjectAccessControl response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -1161,7 +1147,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Storage.v1.Data;
 
@@ -1209,7 +1194,7 @@ namespace StorageSample
             // Data.ObjectAccessControl response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -1293,7 +1278,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Storage.v1.Data;
 
@@ -1341,7 +1325,7 @@ namespace StorageSample
             // Data.ObjectAccessControl response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -1362,7 +1346,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Storage.v1.Data;
 
@@ -1410,7 +1393,7 @@ namespace StorageSample
             // Data.ObjectAccessControl response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -1431,7 +1414,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Storage.v1.Data;
 
@@ -1475,7 +1457,7 @@ namespace StorageSample
             // Data.ObjectAccessControls response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -1496,7 +1478,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Storage.v1.Data;
 
@@ -1548,7 +1529,7 @@ namespace StorageSample
             // Data.ObjectAccessControl response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -1569,7 +1550,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Storage.v1.Data;
 
@@ -1621,7 +1601,7 @@ namespace StorageSample
             // Data.ObjectAccessControl response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -1642,7 +1622,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Storage.v1.Data;
 
@@ -1690,7 +1669,7 @@ namespace StorageSample
             // Data.Object response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -1711,7 +1690,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Storage.v1.Data;
 
@@ -1768,7 +1746,7 @@ namespace StorageSample
             // Data.Object response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -1848,7 +1826,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Storage.v1.Data;
 
@@ -1892,7 +1869,7 @@ namespace StorageSample
             // Data.Object response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -1913,7 +1890,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Storage.v1.Data;
 
@@ -1962,7 +1938,7 @@ namespace StorageSample
             // Data.Object response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -1983,7 +1959,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Storage.v1.Data;
 
@@ -2032,7 +2007,7 @@ namespace StorageSample
                 foreach (Data.Object object_ in response.Items)
                 {
                     // TODO: Change code below to process each `object_` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(object_));
+                    Console.WriteLine(object_);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -2056,7 +2031,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Storage.v1.Data;
 
@@ -2104,7 +2078,7 @@ namespace StorageSample
             // Data.Object response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -2125,7 +2099,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Storage.v1.Data;
 
@@ -2182,7 +2155,7 @@ namespace StorageSample
             // Data.RewriteResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -2203,7 +2176,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Storage.v1.Data;
 
@@ -2251,7 +2223,7 @@ namespace StorageSample
             // Data.Object response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -2272,7 +2244,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Storage.v1.Data;
 
@@ -2316,7 +2287,7 @@ namespace StorageSample
             // Data.Channel response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_storagetransfer.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_storagetransfer.v1.json.baseline
@@ -16,7 +16,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storagetransfer.v1;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Storagetransfer.v1.Data;
 
@@ -49,7 +48,7 @@ namespace StoragetransferSample
             // Data.GoogleServiceAccount response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -70,7 +69,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storagetransfer.v1;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Storagetransfer.v1.Data;
 
@@ -111,7 +109,7 @@ namespace StoragetransferSample
             // Data.GoogleServiceAccount response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -132,7 +130,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storagetransfer.v1;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Storagetransfer.v1.Data;
 
@@ -169,7 +166,7 @@ namespace StoragetransferSample
             // Data.TransferJob response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -190,7 +187,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storagetransfer.v1;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Storagetransfer.v1.Data;
 
@@ -230,7 +226,7 @@ namespace StoragetransferSample
             // Data.TransferJob response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -251,7 +247,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storagetransfer.v1;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Storagetransfer.v1.Data;
 
@@ -293,7 +288,7 @@ namespace StoragetransferSample
                 foreach (Data.TransferJob transferJob in response.TransferJobs)
                 {
                     // TODO: Change code below to process each `transferJob` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(transferJob));
+                    Console.WriteLine(transferJob);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -317,7 +312,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storagetransfer.v1;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Storagetransfer.v1.Data;
 
@@ -361,7 +355,7 @@ namespace StoragetransferSample
             // Data.TransferJob response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -382,7 +376,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storagetransfer.v1;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Storagetransfer.v1.Data;
 
@@ -422,7 +415,7 @@ namespace StoragetransferSample
             // Data.Empty response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -443,7 +436,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storagetransfer.v1;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Storagetransfer.v1.Data;
 
@@ -483,7 +475,7 @@ namespace StoragetransferSample
             // Data.Empty response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -504,7 +496,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storagetransfer.v1;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Storagetransfer.v1.Data;
 
@@ -544,7 +535,7 @@ namespace StoragetransferSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -565,7 +556,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storagetransfer.v1;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Storagetransfer.v1.Data;
 
@@ -614,7 +604,7 @@ namespace StoragetransferSample
                 foreach (Data.Operation operation in response.Operations)
                 {
                     // TODO: Change code below to process each `operation` resource:
-                    Console.WriteLine(new JavaScriptSerializer().Serialize(operation));
+                    Console.WriteLine(operation);
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -638,7 +628,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storagetransfer.v1;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Storagetransfer.v1.Data;
 
@@ -682,7 +671,7 @@ namespace StoragetransferSample
             // Data.Empty response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -703,7 +692,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storagetransfer.v1;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Storagetransfer.v1.Data;
 
@@ -747,7 +735,7 @@ namespace StoragetransferSample
             // Data.Empty response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_taskqueue.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_taskqueue.v1beta2.json.baseline
@@ -12,7 +12,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Taskqueue.v1beta2;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Taskqueue.v1beta2.Data;
 
@@ -48,7 +47,7 @@ namespace TaskqueueSample
             // Data.TaskQueue response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
 
         public static UserCredential GetCredential() {
@@ -135,7 +134,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Taskqueue.v1beta2;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Taskqueue.v1beta2.Data;
 
@@ -174,7 +172,7 @@ namespace TaskqueueSample
             // Data.Task response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
 
         public static UserCredential GetCredential() {
@@ -201,7 +199,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Taskqueue.v1beta2;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Taskqueue.v1beta2.Data;
 
@@ -241,7 +238,7 @@ namespace TaskqueueSample
             // Data.Task response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
 
         public static UserCredential GetCredential() {
@@ -268,7 +265,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Taskqueue.v1beta2;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Taskqueue.v1beta2.Data;
 
@@ -310,7 +306,7 @@ namespace TaskqueueSample
             // Data.Tasks response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
 
         public static UserCredential GetCredential() {
@@ -337,7 +333,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Taskqueue.v1beta2;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Taskqueue.v1beta2.Data;
 
@@ -373,7 +368,7 @@ namespace TaskqueueSample
             // Data.Tasks2 response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
 
         public static UserCredential GetCredential() {
@@ -400,7 +395,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Taskqueue.v1beta2;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Taskqueue.v1beta2.Data;
 
@@ -446,7 +440,7 @@ namespace TaskqueueSample
             // Data.Task response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
 
         public static UserCredential GetCredential() {
@@ -473,7 +467,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Taskqueue.v1beta2;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Taskqueue.v1beta2.Data;
 
@@ -519,7 +512,7 @@ namespace TaskqueueSample
             // Data.Task response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
 
         public static UserCredential GetCredential() {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_translate.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_translate.v2.json.baseline
@@ -13,7 +13,6 @@ using Google.Apis.Services;
 using Google.Apis.Translate.v2;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Translate.v2.Data;
 
@@ -46,7 +45,7 @@ namespace TranslateSample
             // Data.DetectionsListResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -63,7 +62,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Translate.v2;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Translate.v2.Data;
 
@@ -89,7 +87,7 @@ namespace TranslateSample
             // Data.LanguagesListResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }
@@ -107,7 +105,6 @@ using Google.Apis.Services;
 using Google.Apis.Translate.v2;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Translate.v2.Data;
 
@@ -143,7 +140,7 @@ namespace TranslateSample
             // Data.TranslationsListResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_vision.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_vision.v1.json.baseline
@@ -16,7 +16,6 @@ using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Vision.v1;
 using System.Threading.Tasks;
-using System.Web.Script.Serialization;
 
 using Data = Google.Apis.Vision.v1.Data;
 
@@ -53,7 +52,7 @@ namespace VisionSample
             // Data.BatchAnnotateImagesResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(new JavaScriptSerializer().Serialize(response));
+            Console.WriteLine(response);
         }
     }
 }


### PR DESCRIPTION
It appears some versions of .NET do not include System.Web.Script
namespace by default:
http://stackoverflow.com/questions/13035192/error-cs0234-the-type-or-namespace-name-script-does-not-exist-in-the-namespac?noredirect=1