### PR TITLE
Add temporary hack to resolve Go import path in google/api

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/go/GoModelTypeNameConverter.java
+++ b/src/main/java/com/google/api/codegen/transformer/go/GoModelTypeNameConverter.java
@@ -148,6 +148,23 @@ public class GoModelTypeNameConverter implements ModelTypeNameConverter {
       pointerPrefix = "*";
     }
 
+    // TODO(pongad): Remove this atrocious hack after resolving
+    // https://github.com/googleapis/googleapis/issues/161 .
+    // Context: The structure of Go "google.golang.org/genproto/googleapis/api" directory is different from
+    // the way proto files are laid out in https://github.com/googleapis/googleapis/tree/master/google/api .
+    // These files therefore needs the `go_package` option so we can generate import paths properly.
+    // This is the workaround until that can happen.
+    if (importPath.equals("google.golang.org/genproto/googleapis/api")
+        && (elemName.equals("MetricDescriptor") || elemName.equals("Metric"))) {
+      importPath = "google.golang.org/genproto/googleapis/api/metric";
+      localName = "metricpb";
+    } else if (importPath.equals("google.golang.org/genproto/googleapis/api")
+        && (elemName.equals("MonitoredResourceDescriptor")
+            || elemName.equals("MonitoredResource"))) {
+      importPath = "google.golang.org/genproto/googleapis/api/monitoredres";
+      localName = "monitoredrespb";
+    }
+
     return new TypeName(
         Joiner.on(";").join(importPath, localName, elemName, pointerPrefix),
         pointerPrefix + localName + "." + elemName);


### PR DESCRIPTION
Types in protobuf package google.api is laid out differently in Go.
The proto files defining these types will need `go_package` option
so that we can generate imports properly.

This commit introduce a hack so that we can generate services while
waiting for this option to be added.