### PR TITLE
Even more style changes to Java discovery samplegen

### DIFF
--- a/src/main/java/com/google/api/codegen/discovery/config/ApiaryConfigToSampleConfigConverter.java
+++ b/src/main/java/com/google/api/codegen/discovery/config/ApiaryConfigToSampleConfigConverter.java
@@ -142,19 +142,24 @@ public class ApiaryConfigToSampleConfigConverter {
    * Creates a field.
    */
   private FieldInfo createFieldInfo(Field field, Type containerType, Method method) {
-    String exampleFormat = "";
+    String example = "";
     TypeInfo typeInfo = createTypeInfo(field, method);
     if (typeInfo.kind() == Field.Kind.TYPE_STRING) {
-      // If a field pattern exists, use it. Otherwise, get the string format.
-      exampleFormat = apiaryConfig.getFieldPattern().get(containerType.getName(), field.getName());
-      if (Strings.isNullOrEmpty(exampleFormat)) {
-        exampleFormat = apiaryConfig.getStringFormat(containerType.getName(), field.getName());
+      String fieldPattern =
+          apiaryConfig.getFieldPattern().get(containerType.getName(), field.getName());
+      String stringFormat = apiaryConfig.getStringFormat(containerType.getName(), field.getName());
+      example = typeNameGenerator.getFieldPatternExample(fieldPattern);
+      if (!Strings.isNullOrEmpty(example)) {
+        // Generates an example of the format: `ex: "projects/my-project/logs/my-log"`
+        example = "ex: " + example;
+      } else {
+        example = typeNameGenerator.getStringFormatExample(stringFormat);
       }
     }
     return FieldInfo.newBuilder()
         .name(field.getName())
         .type(typeInfo)
-        .example(typeNameGenerator.getExample(exampleFormat))
+        .example(example)
         .description(
             Strings.nullToEmpty(
                 apiaryConfig.getDescription(method.getRequestTypeUrl(), field.getName())))

--- a/src/main/java/com/google/api/codegen/discovery/config/ApiaryConfigToSampleConfigConverter.java
+++ b/src/main/java/com/google/api/codegen/discovery/config/ApiaryConfigToSampleConfigConverter.java
@@ -25,6 +25,7 @@ import org.apache.commons.lang3.StringUtils;
 import com.google.api.codegen.ApiaryConfig;
 import com.google.api.codegen.DiscoveryImporter;
 import com.google.api.codegen.discovery.DefaultString;
+import com.google.api.codegen.util.Name;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.Field;
@@ -71,11 +72,13 @@ public class ApiaryConfigToSampleConfigConverter {
     for (Method method : this.methods) {
       methods.put(method.getName(), createMethod(method));
     }
+    String apiTypeName = typeNameGenerator.getApiTypeName(apiName);
     return SampleConfig.newBuilder()
         .apiTitle(apiaryConfig.getApiTitle())
         .apiName(apiName)
         .apiVersion(apiVersion)
-        .apiTypeName(typeNameGenerator.getApiTypeName(apiName))
+        .apiTypeName(apiTypeName)
+        .lowerCamelApiTypeName(Name.upperCamel(apiTypeName).toLowerCamel())
         .packagePrefix(typeNameGenerator.getPackagePrefix(apiName, apiVersion))
         .methods(methods)
         .authType(apiaryConfig.getAuthType())
@@ -132,7 +135,9 @@ public class ApiaryConfigToSampleConfigConverter {
             .responseType(responseType)
             .isPageStreaming(isPageStreaming)
             .pageStreamingResourceField(pageStreamingResourceField)
+            .isPageStreamingResourceSetterInRequestBody(false)
             .hasMediaUpload(apiaryConfig.getMediaUpload().contains(method.getName()))
+            .hasMediaDownload(apiaryConfig.getMediaDownload().contains(method.getName()))
             .authScopes(apiaryConfig.getAuthScopes(method.getName()))
             .build();
     return methodInfo;

--- a/src/main/java/com/google/api/codegen/discovery/config/FieldInfo.java
+++ b/src/main/java/com/google/api/codegen/discovery/config/FieldInfo.java
@@ -38,16 +38,10 @@ public abstract class FieldInfo {
   public abstract TypeInfo type();
 
   /**
-   * Returns the placeholder value of the field, or empty string if none.
+   * Returns the example value of the field, or empty string if none.
    */
-  @JsonProperty("placeholder")
-  public abstract String placeholder();
-
-  /**
-   * Returns true if the placeholder contains more than one placeholder value.
-   */
-  @JsonProperty("isPlaceholderSingular")
-  public abstract boolean isPlaceholderSingular();
+  @JsonProperty("example")
+  public abstract String example();
 
   /**
    * Returns the description of the field.
@@ -68,11 +62,8 @@ public abstract class FieldInfo {
     @JsonProperty("type")
     public abstract Builder type(TypeInfo val);
 
-    @JsonProperty("placeholder")
-    public abstract Builder placeholder(String val);
-
-    @JsonProperty("isPlaceholderSingular")
-    public abstract Builder isPlaceholderSingular(boolean val);
+    @JsonProperty("example")
+    public abstract Builder example(String val);
 
     @JsonProperty("description")
     public abstract Builder description(String val);

--- a/src/main/java/com/google/api/codegen/discovery/config/MethodInfo.java
+++ b/src/main/java/com/google/api/codegen/discovery/config/MethodInfo.java
@@ -105,10 +105,26 @@ public abstract class MethodInfo {
   public abstract FieldInfo pageStreamingResourceField();
 
   /**
+   * Returns true if the request body contains the page streaming resource setter.
+   *
+   * Provided to support a workaround for the logging.entries.list method in
+   * Java, where the request body, instead of the request, contains the page
+   * streaming resource setter.
+   */
+  @JsonProperty("isPageStreamingResourceSetterInRequestBody")
+  public abstract boolean isPageStreamingResourceSetterInRequestBody();
+
+  /**
    * Returns true if the method supports media upload.
    */
   @JsonProperty("hasMediaUpload")
   public abstract boolean hasMediaUpload();
+
+  /**
+   * Returns true if the method supports media download.
+   */
+  @JsonProperty("hasMediaDownload")
+  public abstract boolean hasMediaDownload();
 
   /**
    * Returns a list of the method's accepted authentication scopes.
@@ -147,8 +163,14 @@ public abstract class MethodInfo {
     @JsonProperty("pageStreamingResourceField")
     public abstract Builder pageStreamingResourceField(FieldInfo val);
 
+    @JsonProperty("isPageStreamingResourceSetterInRequestBody")
+    public abstract Builder isPageStreamingResourceSetterInRequestBody(boolean val);
+
     @JsonProperty("hasMediaUpload")
     public abstract Builder hasMediaUpload(boolean val);
+
+    @JsonProperty("hasMediaDownload")
+    public abstract Builder hasMediaDownload(boolean val);
 
     @JsonProperty("authScopes")
     public abstract Builder authScopes(List<String> val);

--- a/src/main/java/com/google/api/codegen/discovery/config/SampleConfig.java
+++ b/src/main/java/com/google/api/codegen/discovery/config/SampleConfig.java
@@ -88,17 +88,6 @@ public abstract class SampleConfig {
   public abstract String apiTypeName();
 
   /**
-   * Returns the lower-camel formatted API type name.
-   *
-   * This is mostly for utility for overrides where apiTypeName is used to
-   * generate a variable name, and the automatically generated lower-camel
-   * format is wrong.
-   * For example: "SQLAdmin" to "sQLAdmin"
-   */
-  @JsonProperty("lowerCamelApiTypeName")
-  public abstract String lowerCamelApiTypeName();
-
-  /**
    * Returns the language specific package prefix for API types.
    */
   @JsonProperty("packagePrefix")
@@ -140,9 +129,6 @@ public abstract class SampleConfig {
 
     @JsonProperty("apiTypeName")
     public abstract Builder apiTypeName(String val);
-
-    @JsonProperty("lowerCamelApiTypeName")
-    public abstract Builder lowerCamelApiTypeName(String val);
 
     @JsonProperty("packagePrefix")
     public abstract Builder packagePrefix(String val);

--- a/src/main/java/com/google/api/codegen/discovery/config/SampleConfig.java
+++ b/src/main/java/com/google/api/codegen/discovery/config/SampleConfig.java
@@ -88,6 +88,17 @@ public abstract class SampleConfig {
   public abstract String apiTypeName();
 
   /**
+   * Returns the lower-camel formatted API type name.
+   *
+   * This is mostly for utility for overrides where apiTypeName is used to
+   * generate a variable name, and the automatically generated lower-camel
+   * format is wrong.
+   * For example: "SQLAdmin" to "sQLAdmin"
+   */
+  @JsonProperty("lowerCamelApiTypeName")
+  public abstract String lowerCamelApiTypeName();
+
+  /**
    * Returns the language specific package prefix for API types.
    */
   @JsonProperty("packagePrefix")
@@ -129,6 +140,9 @@ public abstract class SampleConfig {
 
     @JsonProperty("apiTypeName")
     public abstract Builder apiTypeName(String val);
+
+    @JsonProperty("lowerCamelApiTypeName")
+    public abstract Builder lowerCamelApiTypeName(String val);
 
     @JsonProperty("packagePrefix")
     public abstract Builder packagePrefix(String val);

--- a/src/main/java/com/google/api/codegen/discovery/config/TypeNameGenerator.java
+++ b/src/main/java/com/google/api/codegen/discovery/config/TypeNameGenerator.java
@@ -55,7 +55,20 @@ public interface TypeNameGenerator {
   public String getSubpackage(boolean isRequest);
 
   /**
-   * Returns an example value for a field with the given format.
+   * Returns an example demonstrating the given string format or an empty
+   * string if format is unrecognized.
+   *
+   * If not the empty string, the returned value will be enclosed within the
+   * correct language-specific quotes.
    */
-  public String getExample(String format);
+  public String getStringFormatExample(String format);
+
+  /**
+   * Returns an example demonstrating the given field pattern or an empty
+   * string if pattern is invalid.
+   *
+   * If not the empty string, the returned value will be enclosed within the
+   * correct language-specific quotes.
+   */
+  public String getFieldPatternExample(String pattern);
 }

--- a/src/main/java/com/google/api/codegen/discovery/config/TypeNameGenerator.java
+++ b/src/main/java/com/google/api/codegen/discovery/config/TypeNameGenerator.java
@@ -16,8 +16,6 @@ package com.google.api.codegen.discovery.config;
 
 import java.util.List;
 
-import com.google.protobuf.Field.Kind;
-
 /**
  * Generates language specific names for types and package paths.
  *
@@ -57,7 +55,7 @@ public interface TypeNameGenerator {
   public String getSubpackage(boolean isRequest);
 
   /**
-   * Returns the language formatted representation of value given kind.
+   * Returns an example value for a field with the given format.
    */
-  public String formatValue(String value, Kind kind);
+  public String getExample(String format);
 }

--- a/src/main/java/com/google/api/codegen/discovery/config/java/JavaTypeNameGenerator.java
+++ b/src/main/java/com/google/api/codegen/discovery/config/java/JavaTypeNameGenerator.java
@@ -17,10 +17,11 @@ package com.google.api.codegen.discovery.config.java;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.google.api.client.util.Strings;
+import com.google.api.codegen.discovery.DefaultString;
 import com.google.api.codegen.discovery.config.TypeNameGenerator;
 import com.google.api.codegen.util.Name;
 import com.google.common.base.Joiner;
-import com.google.protobuf.Field;
 
 public class JavaTypeNameGenerator implements TypeNameGenerator {
 
@@ -61,12 +62,23 @@ public class JavaTypeNameGenerator implements TypeNameGenerator {
   }
 
   @Override
-  public String formatValue(String value, Field.Kind kind) {
-    switch (kind) {
-      case TYPE_STRING:
-        return "\"" + value + "\"";
-      default:
-        throw new IllegalArgumentException("unsupported kind: " + kind.toString());
+  public String getExample(String format) {
+    if (Strings.isNullOrEmpty(format)) {
+      return "";
     }
+    switch (format) {
+      case "byte":
+        return "Base64-encoded string of bytes: see http://tools.ietf.org/html/rfc4648";
+      case "date":
+        return "\"YYYY-MM-DD\": see java.text.SimpleDateFormat";
+      case "date-time":
+        return "\"YYYY-MM-DDThh:mm:ss.fffZ\": see com.google.api.client.util.DateTime.toStringRfc3339()";
+    }
+    // Returns "" if format is invalid.
+    String def = DefaultString.getNonTrivialPlaceholder(format);
+    if (Strings.isNullOrEmpty(def)) {
+      return "";
+    }
+    return String.format("ex: \"%s\"", def);
   }
 }

--- a/src/main/java/com/google/api/codegen/discovery/config/java/JavaTypeNameGenerator.java
+++ b/src/main/java/com/google/api/codegen/discovery/config/java/JavaTypeNameGenerator.java
@@ -62,7 +62,7 @@ public class JavaTypeNameGenerator implements TypeNameGenerator {
   }
 
   @Override
-  public String getExample(String format) {
+  public String getStringFormatExample(String format) {
     if (Strings.isNullOrEmpty(format)) {
       return "";
     }
@@ -73,12 +73,17 @@ public class JavaTypeNameGenerator implements TypeNameGenerator {
         return "\"YYYY-MM-DD\": see java.text.SimpleDateFormat";
       case "date-time":
         return "\"YYYY-MM-DDThh:mm:ss.fffZ\": see com.google.api.client.util.DateTime.toStringRfc3339()";
+      default:
+        return "";
     }
-    // Returns "" if format is invalid.
-    String def = DefaultString.getNonTrivialPlaceholder(format);
+  }
+
+  @Override
+  public String getFieldPatternExample(String pattern) {
+    String def = DefaultString.getNonTrivialPlaceholder(pattern);
     if (Strings.isNullOrEmpty(def)) {
       return "";
     }
-    return String.format("ex: \"%s\"", def);
+    return String.format("\"%s\"", def);
   }
 }

--- a/src/main/java/com/google/api/codegen/discovery/transformer/SampleNamer.java
+++ b/src/main/java/com/google/api/codegen/discovery/transformer/SampleNamer.java
@@ -38,9 +38,8 @@ public class SampleNamer extends NameFormatterDelegator {
   /**
    * Returns the variable name of the service.
    */
-  public String getServiceVarName(String lowerCamelApiTypeName) {
-    return localVarName(
-        Name.lowerCamel(Name.lowerCamel(lowerCamelApiTypeName).toLowerCamel(), "service"));
+  public String getServiceVarName(String apiTypeName) {
+    return localVarName(Name.upperCamel(apiTypeName, "Service"));
   }
 
   /**
@@ -94,7 +93,6 @@ public class SampleNamer extends NameFormatterDelegator {
    * Returns the name of the createService function.
    */
   public String createServiceFuncName(String apiTypeName) {
-    return publicMethodName(
-        Name.lowerCamel("create", Name.upperCamel(apiTypeName).toLowerCamel(), "service"));
+    return publicMethodName(Name.upperCamel("Create", apiTypeName, "Service"));
   }
 }

--- a/src/main/java/com/google/api/codegen/discovery/transformer/SampleNamer.java
+++ b/src/main/java/com/google/api/codegen/discovery/transformer/SampleNamer.java
@@ -38,8 +38,9 @@ public class SampleNamer extends NameFormatterDelegator {
   /**
    * Returns the variable name of the service.
    */
-  public String getServiceVarName(String apiTypeName) {
-    return localVarName(Name.lowerCamel(Name.upperCamel(apiTypeName).toLowerCamel(), "service"));
+  public String getServiceVarName(String lowerCamelApiTypeName) {
+    return localVarName(
+        Name.lowerCamel(Name.lowerCamel(lowerCamelApiTypeName).toLowerCamel(), "service"));
   }
 
   /**
@@ -87,5 +88,13 @@ public class SampleNamer extends NameFormatterDelegator {
    */
   public String getResponseVarName() {
     return localVarName(Name.lowerCamel("response"));
+  }
+
+  /**
+   * Returns the name of the createService function.
+   */
+  public String createServiceFuncName(String apiTypeName) {
+    return publicMethodName(
+        Name.lowerCamel("create", Name.upperCamel(apiTypeName).toLowerCamel(), "service"));
   }
 }

--- a/src/main/java/com/google/api/codegen/discovery/transformer/java/JavaSampleMethodToViewTransformer.java
+++ b/src/main/java/com/google/api/codegen/discovery/transformer/java/JavaSampleMethodToViewTransformer.java
@@ -87,8 +87,7 @@ public class JavaSampleMethodToViewTransformer implements SampleMethodToViewTran
 
     SampleBodyView.Builder sampleBodyView = SampleBodyView.newBuilder();
     sampleBodyView.serviceVarName(
-        symbolTable.getNewSymbol(
-            sampleNamer.getServiceVarName(sampleConfig.lowerCamelApiTypeName())));
+        symbolTable.getNewSymbol(sampleNamer.getServiceVarName(sampleConfig.apiTypeName())));
     sampleBodyView.serviceTypeName(
         sampleTypeTable.getAndSaveNicknameForServiceType(sampleConfig.apiTypeName()));
     sampleBodyView.methodVerb(methodInfo.verb());
@@ -172,16 +171,14 @@ public class JavaSampleMethodToViewTransformer implements SampleMethodToViewTran
   public SampleFieldView generateSampleField(
       Entry<String, FieldInfo> field, SampleTypeTable sampleTypeTable, SymbolTable symbolTable) {
     TypeInfo typeInfo = field.getValue().type();
-    String defaultValue = field.getValue().placeholder();
-    if (Strings.isNullOrEmpty(defaultValue)) {
-      defaultValue = sampleTypeTable.getZeroValueAndSaveNicknameFor(typeInfo);
-    }
+    String defaultValue = sampleTypeTable.getZeroValueAndSaveNicknameFor(typeInfo);
+    String example = field.getValue().example();
     return SampleFieldView.newBuilder()
         .name(symbolTable.getNewSymbol(field.getKey()))
         .typeName(sampleTypeTable.getAndSaveNicknameFor(typeInfo))
         .defaultValue(defaultValue)
+        .example(example)
         .description(field.getValue().description())
-        .isPlaceholderSingular(field.getValue().isPlaceholderSingular())
         .build();
   }
 

--- a/src/main/java/com/google/api/codegen/discovery/transformer/java/JavaSampleTypeNameConverter.java
+++ b/src/main/java/com/google/api/codegen/discovery/transformer/java/JavaSampleTypeNameConverter.java
@@ -89,8 +89,9 @@ class JavaSampleTypeNameConverter implements SampleTypeNameConverter {
   @Override
   public TypeName getRequestTypeName(String apiTypeName, TypeInfo typeInfo) {
     MessageTypeInfo type = typeInfo.message();
-    return typeNameConverter.getTypeName(
-        Joiner.on('.').join(packagePrefix(type.subpackage()), apiTypeName, type.typeName()));
+    return new TypeName(
+        Joiner.on('.').join(packagePrefix(type.subpackage()), apiTypeName, type.typeName()),
+        Joiner.on('.').join(apiTypeName, type.typeName()));
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/discovery/viewmodel/SampleBodyView.java
+++ b/src/main/java/com/google/api/codegen/discovery/viewmodel/SampleBodyView.java
@@ -59,7 +59,11 @@ public abstract class SampleBodyView {
 
   public abstract boolean isResourceMap();
 
+  public abstract boolean isResourceSetterInRequestBody();
+
   public abstract boolean hasMediaUpload();
+
+  public abstract boolean hasMediaDownload();
 
   public abstract AuthType authType();
 
@@ -68,6 +72,8 @@ public abstract class SampleBodyView {
   public abstract List<String> authScopes();
 
   public abstract boolean isAuthScopesSingular();
+
+  public abstract String createServiceFuncName();
 
   public static Builder newBuilder() {
     return new AutoValue_SampleBodyView.Builder();
@@ -114,7 +120,11 @@ public abstract class SampleBodyView {
 
     public abstract Builder isResourceMap(boolean val);
 
+    public abstract Builder isResourceSetterInRequestBody(boolean val);
+
     public abstract Builder hasMediaUpload(boolean val);
+
+    public abstract Builder hasMediaDownload(boolean val);
 
     public abstract Builder authType(AuthType val);
 
@@ -123,6 +133,8 @@ public abstract class SampleBodyView {
     public abstract Builder authScopes(List<String> val);
 
     public abstract Builder isAuthScopesSingular(boolean val);
+
+    public abstract Builder createServiceFuncName(String val);
 
     public abstract SampleBodyView build();
   }

--- a/src/main/java/com/google/api/codegen/discovery/viewmodel/SampleFieldView.java
+++ b/src/main/java/com/google/api/codegen/discovery/viewmodel/SampleFieldView.java
@@ -25,9 +25,9 @@ public abstract class SampleFieldView {
 
   public abstract String defaultValue();
 
-  public abstract String description();
+  public abstract String example();
 
-  public abstract boolean isPlaceholderSingular();
+  public abstract String description();
 
   public static Builder newBuilder() {
     return new AutoValue_SampleFieldView.Builder();
@@ -42,9 +42,9 @@ public abstract class SampleFieldView {
 
     public abstract Builder defaultValue(String val);
 
-    public abstract Builder description(String val);
+    public abstract Builder example(String val);
 
-    public abstract Builder isPlaceholderSingular(boolean val);
+    public abstract Builder description(String val);
 
     public abstract SampleFieldView build();
   }

--- a/src/main/java/com/google/api/codegen/util/CommonAcronyms.java
+++ b/src/main/java/com/google/api/codegen/util/CommonAcronyms.java
@@ -28,7 +28,13 @@ import java.util.List;
  */
 public class CommonAcronyms {
   private static final ImmutableSet<String> ACRONYMS =
-      ImmutableSet.<String>builder().add("IAM").add("HTTP").add("XML").add("API").build();
+      ImmutableSet.<String>builder()
+          .add("IAM")
+          .add("HTTP")
+          .add("XML")
+          .add("API")
+          .add("SQL")
+          .build();
 
   /**
    * Represents the notion of whether a name piece is normal or an upper-case acronym.

--- a/src/main/java/com/google/api/codegen/util/SymbolTable.java
+++ b/src/main/java/com/google/api/codegen/util/SymbolTable.java
@@ -30,6 +30,23 @@ public class SymbolTable {
   private final Set<String> symbolTable = new HashSet<>();
 
   /**
+   * Returns a new SymbolTable seeded with all the words in seed.
+   *
+   * For example, if seed is {"int"}, a subsequent call to {@link
+   * #getNewSymbol(String)} for "int" will return "int2".
+   *
+   * The behavior of the returned SymbolTable is guaranteed if used with
+   * {@link #getNewSymbol(String)}, but not with {@link #getNewSymbol(Name)}.
+   */
+  public static SymbolTable fromSeed(Set<String> seed) {
+    SymbolTable symbolTable = new SymbolTable();
+    for (String s : seed) {
+      symbolTable.getNewSymbol(s);
+    }
+    return symbolTable;
+  }
+
+  /**
    * Returns a unique name, with a numeric suffix in case of conflicts.
    *
    * Not guaranteed to work as expected if used in combination with {@link

--- a/src/main/java/com/google/api/codegen/util/java/JavaTypeTable.java
+++ b/src/main/java/com/google/api/codegen/util/java/JavaTypeTable.java
@@ -23,6 +23,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 
 import java.util.Collections;
@@ -174,4 +175,62 @@ public class JavaTypeTable implements TypeTable {
     implicitImports.put(name, yes);
     return yes;
   }
+
+  public static final ImmutableSet<String> RESERVED_IDENTIFIER_SET =
+      ImmutableSet.<String>builder()
+          .add(
+              "abstract",
+              "assert",
+              "boolean",
+              "break",
+              "byte",
+              "case",
+              "catch",
+              "char",
+              "class",
+              "const",
+              "continue",
+              "default",
+              "do",
+              "double",
+              "else",
+              "enum",
+              "extends",
+              "false",
+              "final",
+              "finally",
+              "float",
+              "for",
+              "goto",
+              "if",
+              "implements",
+              "import",
+              "instanceof",
+              "int",
+              "interface",
+              "long",
+              "native",
+              "new",
+              "null",
+              "package",
+              "private",
+              "protected",
+              "public",
+              "return",
+              "short",
+              "static",
+              "strictfp",
+              "super",
+              "switch",
+              "synchronized",
+              "this",
+              "throw",
+              "throws",
+              "transient",
+              "true",
+              "try",
+              "void",
+              "volatile",
+              "while")
+          .build();
 }

--- a/src/main/resources/com/google/api/codegen/java/sample.snip
+++ b/src/main/resources/com/google/api/codegen/java/sample.snip
@@ -1,11 +1,11 @@
-@snippet generate(sampleClass)
-  /*
+@snippet generate(class)
+  /**
    * BEFORE RUNNING:
    * ---------------
-   * 1. If not already done, enable the {@sampleClass.apiTitle}
+   * 1. If not already done, enable the {@class.apiTitle}
    *    and check the quota for your project at
-   *    https://console.developers.google.com/apis/api/{@sampleClass.apiName}
-   @switch sampleClass.body.authType
+   *    https://console.developers.google.com/apis/api/{@class.apiName}
+   @switch class.body.authType
    @case "APPLICATION_DEFAULT_CREDENTIALS"
      * 2. This sample uses Application Default Credentials for authentication.
      *    If not already done, install the gcloud CLI from
@@ -14,30 +14,28 @@
      * 3. Install the Java client library on Maven or Gradle. Check installation
      *    instructions at https://github.com/google/google-api-java-client.
      *    On other build systems, you can add the jar files to your project from
-     *    https://developers.google.com/resources/api-libraries/download/{@sampleClass.apiName}/{@sampleClass.apiVersion}/java
+     *    https://developers.google.com/resources/api-libraries/download/{@class.apiName}/{@class.apiVersion}/java
    @default
      * 2. Install the Java client library on Maven or Gradle. Check installation
      *    instructions at https://github.com/google/google-api-java-client.
      *    On other build systems, you can add the jar files to your project from
-     *    https://developers.google.com/resources/api-libraries/download/{@sampleClass.apiName}/{@sampleClass.apiVersion}/java
+     *    https://developers.google.com/resources/api-libraries/download/{@class.apiName}/{@class.apiVersion}/java
    @end
    */
-  @join import : sampleClass.imports
+  @join import : class.imports
     import {@import};
   @end
 
-  public class {@sampleClass.className} {
-    {@runFunc(sampleClass.body)}
+  public class {@class.className} {
+    {@mainFunc(class.body)}
 
-    {@createServiceFunc(sampleClass.body)}
-
-    {@mainFunc(sampleClass)}
+    {@createServiceFunc(class.body)}
   }
 @end
 
-@private runFunc(sampleBody)
-  public void run() throws IOException, GeneralSecurityException {
-    @join field : sampleBody.fields if sampleBody.fields
+@private mainFunc(body)
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
+    @join field : body.fields if body.fields
       @if field.description
         @join line : util.getDocLines(field.description, 100)
           // {@line}
@@ -45,102 +43,101 @@
 
 
       @end
-      {@field.typeName} {@field.name} = {@field.defaultValue}; {@placeholderTodo(field.isPlaceholderSingular)}
+      {@field.typeName} {@field.name} = {@field.defaultValue};  {@placeholderTodo(field.isPlaceholderSingular)}
 
     @end
-    @if sampleBody.hasInputRequest
-      // TODO: Assign values to desired fields of `{@sampleBody.requestBodyVarName}`.
-      @if sampleBody.methodVerb == "PATCH"
+    @if body.hasInputRequest
+      // TODO: Assign values to desired fields of `{@body.requestBodyVarName}`.
+      @if body.methodVerb == "PATCH"
         // Only assigned fields will be changed.
       @end
-      {@sampleBody.requestBodyTypeName} {@sampleBody.requestBodyVarName} = new {@sampleBody.requestBodyTypeName}();
+      {@body.requestBodyTypeName} {@body.requestBodyVarName} = new {@body.requestBodyTypeName}();
 
     @end
-    @if sampleBody.hasMediaUpload
+    @if body.hasMediaUpload
       // TODO: Add desired media content for upload. For more information, see:
       // https://developers.google.com/api-client-library/java/google-api-java-client/media-upload
 
     @end
-    {@sampleBody.serviceTypeName} {@sampleBody.serviceVarName} = createService();
-    {@sampleBody.requestTypeName} {@sampleBody.requestVarName} = {@sampleBody.serviceVarName}.{@callChain(sampleBody.methodNameComponents)}({@paramList(sampleBody.fieldVarNames)});
+    {@body.serviceTypeName} {@body.serviceVarName} = {@body.createServiceFuncName}();
+    {@body.requestTypeName} {@body.requestVarName} = {@body.serviceVarName}.{@callChain(body.methodNameComponents)}({@paramList(body.fieldVarNames)});
+    @if {@body.hasMediaDownload()}
 
-    @if sampleBody.isPageStreaming
-      {@sampleBody.responseTypeName} {@sampleBody.responseVarName};
+      // TODO: Download media content if desired. For more information, see:
+      // https://developers.google.com/api-client-library/java/google-api-java-client/media-download
+    @end
+
+    @if body.isPageStreaming
+      {@body.responseTypeName} {@body.responseVarName};
       do {
-        {@sampleBody.responseVarName} = {@sampleBody.requestVarName}.execute();
-        if ({@sampleBody.responseVarName}.{@sampleBody.resourceGetterName}() == null) {
+        {@body.responseVarName} = {@body.requestVarName}.execute();
+        if ({@body.responseVarName}.{@body.resourceGetterName}() == null) {
           continue;
         }
-        @if sampleBody.isResourceMap
-          for ({@sampleBody.resourceTypeName} {@sampleBody.resourceVarName} : response.{@sampleBody.resourceGetterName}().entrySet()) {
-            // TODO: Change code below to process each `{@sampleBody.resourceVarName}` entry:
-            System.out.println({@sampleBody.resourceVarName}.getKey() + ": " + {@sampleBody.resourceVarName}.getValue());
+        @if body.isResourceMap
+          for ({@body.resourceTypeName} {@body.resourceVarName} : response.{@body.resourceGetterName}().entrySet()) {
+            // TODO: Change code below to process each `{@body.resourceVarName}` entry:
+            System.out.println({@body.resourceVarName}.getKey() + ": " + {@body.resourceVarName}.getValue());
           }
         @else
-          for ({@sampleBody.resourceTypeName} {@sampleBody.resourceVarName} : response.{@sampleBody.resourceGetterName}()) {
-            // TODO: Change code below to process each `{@sampleBody.resourceVarName}` resource:
-            System.out.println({@sampleBody.resourceVarName});
+          for ({@body.resourceTypeName} {@body.resourceVarName} : response.{@body.resourceGetterName}()) {
+            // TODO: Change code below to process each `{@body.resourceVarName}` resource:
+            System.out.println({@body.resourceVarName});
           }
         @end
-      } while ({@sampleBody.responseVarName}.getNextPageToken() != null);
+        @if body.isResourceSetterInRequestBody
+          {@body.requestBodyVarName}.setPageToken({@body.responseVarName()}.getNextPageToken());
+        @else
+          {@body.requestVarName}.setPageToken({@body.responseVarName()}.getNextPageToken());
+        @end
+      } while ({@body.responseVarName}.getNextPageToken() != null);
     @else
-      @if sampleBody.hasOutput
-        {@sampleBody.responseTypeName} {@sampleBody.responseVarName} = {@sampleBody.requestVarName}.execute();
-        System.out.println({@sampleBody.responseVarName});
+      @if body.hasOutput
+        {@body.responseTypeName} {@body.responseVarName} = {@body.requestVarName}.execute();
+
+        // TODO: Change code below to process the `response` object:
+        System.out.println({@body.responseVarName});
       @else
-        {@sampleBody.requestVarName}.execute();
+        {@body.requestVarName}.execute();
       @end
     @end
   }
 @end
 
-@private createServiceFunc(sampleBody)
-  public {@sampleBody.serviceTypeName} createService() throws IOException, GeneralSecurityException {
+@private createServiceFunc(body)
+  public static {@body.serviceTypeName} {@body.createServiceFuncName}() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    @switch sampleBody.authType
+    @switch body.authType
     @case "OAUTH_3L"
-      // TODO: Change placeholder below to generate authentication credentials.
-      // See: {@sampleBody.authInstructionsUrl}
+      // TODO: Change placeholder below to generate authentication credentials, see:
+      // {@body.authInstructionsUrl}
       //
-      @if sampleBody.isAuthScopesSingular
+      @if body.isAuthScopesSingular
         // Authorize using the following scope:
       @else
         // Authorize using one of the following scopes:
       @end
-      @join scope : sampleBody.authScopes
+      @join scope : body.authScopes
         //    {@scope}
       @end
       GoogleCredential credential = null;
     @case "API_KEY"
       // TODO: Change placeholder below to generate authentication credentials.
-      // See: {@sampleBody.authInstructionsUrl}
+      // See: {@body.authInstructionsUrl}
       GoogleCredential credential = null;
     @default
       GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
       if (credential.createScopedRequired()) {
         credential =
             credential.createScoped(Arrays.asList("https://www.googleapis.com/auth/cloud-platform"));
       }
     @end
 
-    return new {@sampleBody.serviceTypeName}.Builder(httpTransport, jsonFactory, credential)
+    return new {@body.serviceTypeName}.Builder(httpTransport, jsonFactory, credential)
         .setApplicationName("Google Cloud Platform Sample")
         .build();
-  }
-@end
-
-@private mainFunc(sampleClass)
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new {@sampleClass.className}().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
   }
 @end
 

--- a/src/main/resources/com/google/api/codegen/java/sample.snip
+++ b/src/main/resources/com/google/api/codegen/java/sample.snip
@@ -43,7 +43,10 @@
 
 
       @end
-      {@field.typeName} {@field.name} = {@field.defaultValue};  {@placeholderTodo(field.isPlaceholderSingular)}
+      {@field.typeName} {@field.name} = {@field.defaultValue};  // TODO: Update placeholder value.
+      @if field.example
+        // {@field.example}
+      @end
 
     @end
     @if body.hasInputRequest
@@ -55,7 +58,7 @@
 
     @end
     @if body.hasMediaUpload
-      // TODO: Add desired media content for upload. For more information, see:
+      // TODO: Add desired media content for upload. See:
       // https://developers.google.com/api-client-library/java/google-api-java-client/media-upload
 
     @end
@@ -63,7 +66,7 @@
     {@body.requestTypeName} {@body.requestVarName} = {@body.serviceVarName}.{@callChain(body.methodNameComponents)}({@paramList(body.fieldVarNames)});
     @if {@body.hasMediaDownload()}
 
-      // TODO: Download media content if desired. For more information, see:
+      // TODO: Download media content if desired. See:
       // https://developers.google.com/api-client-library/java/google-api-java-client/media-download
     @end
 
@@ -111,7 +114,7 @@
 
     @switch body.authType
     @case "OAUTH_3L"
-      // TODO: Change placeholder below to generate authentication credentials, see:
+      // TODO: Change placeholder below to generate authentication credentials. See:
       // {@body.authInstructionsUrl}
       //
       @if body.isAuthScopesSingular
@@ -150,13 +153,5 @@
 @private paramList(fieldVarNames)
   @join fieldVarName : fieldVarNames on ", "
     {@fieldVarName}
-  @end
-@end
-
-@private placeholderTodo(isSingular)
-  @if isSingular
-    // TODO: Update placeholder value.
-  @else
-    // TODO: Update placeholder values.
   @end
 @end

--- a/src/test/java/com/google/api/codegen/discovery/DefaultStringTest.java
+++ b/src/test/java/com/google/api/codegen/discovery/DefaultStringTest.java
@@ -35,7 +35,7 @@ public class DefaultStringTest {
     def2 = DefaultString.getNonTrivialPlaceholder("^projects/[^/]*$");
     sample = DefaultString.getSample("pubsub", "project", "^projects/[^/]*$");
     Truth.assertThat(def).isEqualTo("projects/{MY-PROJECT}");
-    Truth.assertThat(def2).isEqualTo("projects/{MY-PROJECT}");
+    Truth.assertThat(def2).isEqualTo("projects/my-project");
     Truth.assertThat(sample).isEqualTo("");
 
     def = DefaultString.getPlaceholder("bar", null);
@@ -58,7 +58,7 @@ public class DefaultStringTest {
         };
 
     for (String s : invalid) {
-      Truth.assertThat(DefaultString.forPattern(s)).isNull();
+      Truth.assertThat(DefaultString.forPattern(s, "{MY-%s}", true)).isNull();
     }
   }
 
@@ -74,7 +74,8 @@ public class DefaultStringTest {
             .build();
 
     for (Map.Entry<String, String> entry : tests.entrySet()) {
-      Truth.assertThat(DefaultString.forPattern(entry.getKey())).isEqualTo(entry.getValue());
+      Truth.assertThat(DefaultString.forPattern(entry.getKey(), "{MY-%s}", true))
+          .isEqualTo(entry.getValue());
     }
   }
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/logging.v2beta1.json.overrides
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/logging.v2beta1.json.overrides
@@ -1,5 +1,10 @@
 {
   "java": {
-    "packagePrefix": "com.google.api.services.logging.v2beta1"
+    "packagePrefix": "com.google.api.services.logging.v2beta1",
+    "methods": {
+      "logging.entries.list": {
+        "isPageStreamingResourceSetterInRequestBody": true
+      }
+    }
   }
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/mvvm_java/java_adexchangebuyer.v1.4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/mvvm_java/java_adexchangebuyer.v1.4.json.baseline
@@ -1,5 +1,5 @@
 
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -16,29 +16,30 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.adexchangebuyer.AdExchangeBuyer;
-import com.google.api.services.adexchangebuyer.AdExchangeBuyer.Accounts.Get;
 import com.google.api.services.adexchangebuyer.model.Account;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
 public class AdExchangeBuyerExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The account id
-    int id = 0; // TODO: Update placeholder value.
+    int id = 0;  // TODO: Update placeholder value.
 
-    AdExchangeBuyer adExchangeBuyerService = createService();
-    Get request = adExchangeBuyerService.accounts().get(id);
+    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Accounts.Get request = adexchangebuyerService.accounts().get(id);
 
     Account response = request.execute();
+
+    // TODO: Change code below to process the `response` object:
     System.out.println(response);
   }
 
-  public AdExchangeBuyer createService() throws IOException, GeneralSecurityException {
+  public static AdExchangeBuyer createAdExchangeBuyerService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials.
-    // See: https://foo.com/bar
+    // TODO: Change placeholder below to generate authentication credentials, see:
+    // https://foo.com/bar
     //
     // Authorize using the following scope:
     //    https://www.googleapis.com/auth/adexchange.buyer
@@ -48,18 +49,8 @@ public class AdExchangeBuyerExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new AdExchangeBuyerExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -76,26 +67,27 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.adexchangebuyer.AdExchangeBuyer;
-import com.google.api.services.adexchangebuyer.AdExchangeBuyer.Accounts.List;
 import com.google.api.services.adexchangebuyer.model.AccountsList;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
 public class AdExchangeBuyerExample {
-  public void run() throws IOException, GeneralSecurityException {
-    AdExchangeBuyer adExchangeBuyerService = createService();
-    List request = adExchangeBuyerService.accounts().list();
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
+    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Accounts.List request = adexchangebuyerService.accounts().list();
 
     AccountsList response = request.execute();
+
+    // TODO: Change code below to process the `response` object:
     System.out.println(response);
   }
 
-  public AdExchangeBuyer createService() throws IOException, GeneralSecurityException {
+  public static AdExchangeBuyer createAdExchangeBuyerService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials.
-    // See: https://foo.com/bar
+    // TODO: Change placeholder below to generate authentication credentials, see:
+    // https://foo.com/bar
     //
     // Authorize using the following scope:
     //    https://www.googleapis.com/auth/adexchange.buyer
@@ -105,18 +97,8 @@ public class AdExchangeBuyerExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new AdExchangeBuyerExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -133,33 +115,34 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.adexchangebuyer.AdExchangeBuyer;
-import com.google.api.services.adexchangebuyer.AdExchangeBuyer.Accounts.Patch;
 import com.google.api.services.adexchangebuyer.model.Account;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
 public class AdExchangeBuyerExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The account id
-    int id = 0; // TODO: Update placeholder value.
+    int id = 0;  // TODO: Update placeholder value.
 
     // TODO: Assign values to desired fields of `requestBody`.
     // Only assigned fields will be changed.
     Account requestBody = new Account();
 
-    AdExchangeBuyer adExchangeBuyerService = createService();
-    Patch request = adExchangeBuyerService.accounts().patch(id, requestBody);
+    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Accounts.Patch request = adexchangebuyerService.accounts().patch(id, requestBody);
 
     Account response = request.execute();
+
+    // TODO: Change code below to process the `response` object:
     System.out.println(response);
   }
 
-  public AdExchangeBuyer createService() throws IOException, GeneralSecurityException {
+  public static AdExchangeBuyer createAdExchangeBuyerService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials.
-    // See: https://foo.com/bar
+    // TODO: Change placeholder below to generate authentication credentials, see:
+    // https://foo.com/bar
     //
     // Authorize using the following scope:
     //    https://www.googleapis.com/auth/adexchange.buyer
@@ -169,18 +152,8 @@ public class AdExchangeBuyerExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new AdExchangeBuyerExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -197,32 +170,33 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.adexchangebuyer.AdExchangeBuyer;
-import com.google.api.services.adexchangebuyer.AdExchangeBuyer.Accounts.Update;
 import com.google.api.services.adexchangebuyer.model.Account;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
 public class AdExchangeBuyerExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The account id
-    int id = 0; // TODO: Update placeholder value.
+    int id = 0;  // TODO: Update placeholder value.
 
     // TODO: Assign values to desired fields of `requestBody`.
     Account requestBody = new Account();
 
-    AdExchangeBuyer adExchangeBuyerService = createService();
-    Update request = adExchangeBuyerService.accounts().update(id, requestBody);
+    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Accounts.Update request = adexchangebuyerService.accounts().update(id, requestBody);
 
     Account response = request.execute();
+
+    // TODO: Change code below to process the `response` object:
     System.out.println(response);
   }
 
-  public AdExchangeBuyer createService() throws IOException, GeneralSecurityException {
+  public static AdExchangeBuyer createAdExchangeBuyerService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials.
-    // See: https://foo.com/bar
+    // TODO: Change placeholder below to generate authentication credentials, see:
+    // https://foo.com/bar
     //
     // Authorize using the following scope:
     //    https://www.googleapis.com/auth/adexchange.buyer
@@ -232,18 +206,8 @@ public class AdExchangeBuyerExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new AdExchangeBuyerExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -260,29 +224,30 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.adexchangebuyer.AdExchangeBuyer;
-import com.google.api.services.adexchangebuyer.AdExchangeBuyer.BillingInfo.Get;
 import com.google.api.services.adexchangebuyer.model.BillingInfo;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
 public class AdExchangeBuyerExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The account id.
-    int accountId = 0; // TODO: Update placeholder value.
+    int accountId = 0;  // TODO: Update placeholder value.
 
-    AdExchangeBuyer adExchangeBuyerService = createService();
-    Get request = adExchangeBuyerService.billingInfo().get(accountId);
+    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.BillingInfo.Get request = adexchangebuyerService.billingInfo().get(accountId);
 
     BillingInfo response = request.execute();
+
+    // TODO: Change code below to process the `response` object:
     System.out.println(response);
   }
 
-  public AdExchangeBuyer createService() throws IOException, GeneralSecurityException {
+  public static AdExchangeBuyer createAdExchangeBuyerService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials.
-    // See: https://foo.com/bar
+    // TODO: Change placeholder below to generate authentication credentials, see:
+    // https://foo.com/bar
     //
     // Authorize using the following scope:
     //    https://www.googleapis.com/auth/adexchange.buyer
@@ -292,18 +257,8 @@ public class AdExchangeBuyerExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new AdExchangeBuyerExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -320,26 +275,27 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.adexchangebuyer.AdExchangeBuyer;
-import com.google.api.services.adexchangebuyer.AdExchangeBuyer.BillingInfo.List;
 import com.google.api.services.adexchangebuyer.model.BillingInfoList;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
 public class AdExchangeBuyerExample {
-  public void run() throws IOException, GeneralSecurityException {
-    AdExchangeBuyer adExchangeBuyerService = createService();
-    List request = adExchangeBuyerService.billingInfo().list();
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
+    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.BillingInfo.List request = adexchangebuyerService.billingInfo().list();
 
     BillingInfoList response = request.execute();
+
+    // TODO: Change code below to process the `response` object:
     System.out.println(response);
   }
 
-  public AdExchangeBuyer createService() throws IOException, GeneralSecurityException {
+  public static AdExchangeBuyer createAdExchangeBuyerService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials.
-    // See: https://foo.com/bar
+    // TODO: Change placeholder below to generate authentication credentials, see:
+    // https://foo.com/bar
     //
     // Authorize using the following scope:
     //    https://www.googleapis.com/auth/adexchange.buyer
@@ -349,18 +305,8 @@ public class AdExchangeBuyerExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new AdExchangeBuyerExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -377,32 +323,33 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.adexchangebuyer.AdExchangeBuyer;
-import com.google.api.services.adexchangebuyer.AdExchangeBuyer.Budget.Get;
 import com.google.api.services.adexchangebuyer.model.Budget;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
 public class AdExchangeBuyerExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The account id to get the budget information for.
-    long accountId = 0L; // TODO: Update placeholder value.
+    long accountId = 0L;  // TODO: Update placeholder value.
 
     // The billing id to get the budget information for.
-    long billingId = 0L; // TODO: Update placeholder value.
+    long billingId = 0L;  // TODO: Update placeholder value.
 
-    AdExchangeBuyer adExchangeBuyerService = createService();
-    Get request = adExchangeBuyerService.budget().get(accountId, billingId);
+    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Budget.Get request = adexchangebuyerService.budget().get(accountId, billingId);
 
     Budget response = request.execute();
+
+    // TODO: Change code below to process the `response` object:
     System.out.println(response);
   }
 
-  public AdExchangeBuyer createService() throws IOException, GeneralSecurityException {
+  public static AdExchangeBuyer createAdExchangeBuyerService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials.
-    // See: https://foo.com/bar
+    // TODO: Change placeholder below to generate authentication credentials, see:
+    // https://foo.com/bar
     //
     // Authorize using the following scope:
     //    https://www.googleapis.com/auth/adexchange.buyer
@@ -412,18 +359,8 @@ public class AdExchangeBuyerExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new AdExchangeBuyerExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -440,36 +377,37 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.adexchangebuyer.AdExchangeBuyer;
-import com.google.api.services.adexchangebuyer.AdExchangeBuyer.Budget.Patch;
 import com.google.api.services.adexchangebuyer.model.Budget;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
 public class AdExchangeBuyerExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The account id associated with the budget being updated.
-    long accountId = 0L; // TODO: Update placeholder value.
+    long accountId = 0L;  // TODO: Update placeholder value.
 
     // The billing id associated with the budget being updated.
-    long billingId = 0L; // TODO: Update placeholder value.
+    long billingId = 0L;  // TODO: Update placeholder value.
 
     // TODO: Assign values to desired fields of `requestBody`.
     // Only assigned fields will be changed.
     Budget requestBody = new Budget();
 
-    AdExchangeBuyer adExchangeBuyerService = createService();
-    Patch request = adExchangeBuyerService.budget().patch(accountId, billingId, requestBody);
+    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Budget.Patch request = adexchangebuyerService.budget().patch(accountId, billingId, requestBody);
 
     Budget response = request.execute();
+
+    // TODO: Change code below to process the `response` object:
     System.out.println(response);
   }
 
-  public AdExchangeBuyer createService() throws IOException, GeneralSecurityException {
+  public static AdExchangeBuyer createAdExchangeBuyerService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials.
-    // See: https://foo.com/bar
+    // TODO: Change placeholder below to generate authentication credentials, see:
+    // https://foo.com/bar
     //
     // Authorize using the following scope:
     //    https://www.googleapis.com/auth/adexchange.buyer
@@ -479,18 +417,8 @@ public class AdExchangeBuyerExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new AdExchangeBuyerExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -507,35 +435,36 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.adexchangebuyer.AdExchangeBuyer;
-import com.google.api.services.adexchangebuyer.AdExchangeBuyer.Budget.Update;
 import com.google.api.services.adexchangebuyer.model.Budget;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
 public class AdExchangeBuyerExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The account id associated with the budget being updated.
-    long accountId = 0L; // TODO: Update placeholder value.
+    long accountId = 0L;  // TODO: Update placeholder value.
 
     // The billing id associated with the budget being updated.
-    long billingId = 0L; // TODO: Update placeholder value.
+    long billingId = 0L;  // TODO: Update placeholder value.
 
     // TODO: Assign values to desired fields of `requestBody`.
     Budget requestBody = new Budget();
 
-    AdExchangeBuyer adExchangeBuyerService = createService();
-    Update request = adExchangeBuyerService.budget().update(accountId, billingId, requestBody);
+    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Budget.Update request = adexchangebuyerService.budget().update(accountId, billingId, requestBody);
 
     Budget response = request.execute();
+
+    // TODO: Change code below to process the `response` object:
     System.out.println(response);
   }
 
-  public AdExchangeBuyer createService() throws IOException, GeneralSecurityException {
+  public static AdExchangeBuyer createAdExchangeBuyerService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials.
-    // See: https://foo.com/bar
+    // TODO: Change placeholder below to generate authentication credentials, see:
+    // https://foo.com/bar
     //
     // Authorize using the following scope:
     //    https://www.googleapis.com/auth/adexchange.buyer
@@ -545,18 +474,8 @@ public class AdExchangeBuyerExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new AdExchangeBuyerExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -573,33 +492,32 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.adexchangebuyer.AdExchangeBuyer;
-import com.google.api.services.adexchangebuyer.AdExchangeBuyer.Creatives.AddDeal;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
 public class AdExchangeBuyerExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The id for the account that will serve this creative.
-    int accountId = 0; // TODO: Update placeholder value.
+    int accountId = 0;  // TODO: Update placeholder value.
 
     // The buyer-specific id for this creative.
-    String buyerCreativeId = ""; // TODO: Update placeholder value.
+    String buyerCreativeId = "";  // TODO: Update placeholder value.
 
     // The id of the deal id to associate with this creative.
-    long dealId = 0L; // TODO: Update placeholder value.
+    long dealId = 0L;  // TODO: Update placeholder value.
 
-    AdExchangeBuyer adExchangeBuyerService = createService();
-    AddDeal request = adExchangeBuyerService.creatives().addDeal(accountId, buyerCreativeId, dealId);
+    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Creatives.AddDeal request = adexchangebuyerService.creatives().addDeal(accountId, buyerCreativeId, dealId);
 
     request.execute();
   }
 
-  public AdExchangeBuyer createService() throws IOException, GeneralSecurityException {
+  public static AdExchangeBuyer createAdExchangeBuyerService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials.
-    // See: https://foo.com/bar
+    // TODO: Change placeholder below to generate authentication credentials, see:
+    // https://foo.com/bar
     //
     // Authorize using the following scope:
     //    https://www.googleapis.com/auth/adexchange.buyer
@@ -609,18 +527,8 @@ public class AdExchangeBuyerExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new AdExchangeBuyerExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -637,32 +545,33 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.adexchangebuyer.AdExchangeBuyer;
-import com.google.api.services.adexchangebuyer.AdExchangeBuyer.Creatives.Get;
 import com.google.api.services.adexchangebuyer.model.Creative;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
 public class AdExchangeBuyerExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The id for the account that will serve this creative.
-    int accountId = 0; // TODO: Update placeholder value.
+    int accountId = 0;  // TODO: Update placeholder value.
 
     // The buyer-specific id for this creative.
-    String buyerCreativeId = ""; // TODO: Update placeholder value.
+    String buyerCreativeId = "";  // TODO: Update placeholder value.
 
-    AdExchangeBuyer adExchangeBuyerService = createService();
-    Get request = adExchangeBuyerService.creatives().get(accountId, buyerCreativeId);
+    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Creatives.Get request = adexchangebuyerService.creatives().get(accountId, buyerCreativeId);
 
     Creative response = request.execute();
+
+    // TODO: Change code below to process the `response` object:
     System.out.println(response);
   }
 
-  public AdExchangeBuyer createService() throws IOException, GeneralSecurityException {
+  public static AdExchangeBuyer createAdExchangeBuyerService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials.
-    // See: https://foo.com/bar
+    // TODO: Change placeholder below to generate authentication credentials, see:
+    // https://foo.com/bar
     //
     // Authorize using the following scope:
     //    https://www.googleapis.com/auth/adexchange.buyer
@@ -672,18 +581,8 @@ public class AdExchangeBuyerExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new AdExchangeBuyerExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -700,29 +599,30 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.adexchangebuyer.AdExchangeBuyer;
-import com.google.api.services.adexchangebuyer.AdExchangeBuyer.Creatives.Insert;
 import com.google.api.services.adexchangebuyer.model.Creative;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
 public class AdExchangeBuyerExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // TODO: Assign values to desired fields of `requestBody`.
     Creative requestBody = new Creative();
 
-    AdExchangeBuyer adExchangeBuyerService = createService();
-    Insert request = adExchangeBuyerService.creatives().insert(requestBody);
+    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Creatives.Insert request = adexchangebuyerService.creatives().insert(requestBody);
 
     Creative response = request.execute();
+
+    // TODO: Change code below to process the `response` object:
     System.out.println(response);
   }
 
-  public AdExchangeBuyer createService() throws IOException, GeneralSecurityException {
+  public static AdExchangeBuyer createAdExchangeBuyerService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials.
-    // See: https://foo.com/bar
+    // TODO: Change placeholder below to generate authentication credentials, see:
+    // https://foo.com/bar
     //
     // Authorize using the following scope:
     //    https://www.googleapis.com/auth/adexchange.buyer
@@ -732,18 +632,8 @@ public class AdExchangeBuyerExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new AdExchangeBuyerExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -760,16 +650,15 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.adexchangebuyer.AdExchangeBuyer;
-import com.google.api.services.adexchangebuyer.AdExchangeBuyer.Creatives.List;
 import com.google.api.services.adexchangebuyer.model.Creative;
 import com.google.api.services.adexchangebuyer.model.CreativesList;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
 public class AdExchangeBuyerExample {
-  public void run() throws IOException, GeneralSecurityException {
-    AdExchangeBuyer adExchangeBuyerService = createService();
-    List request = adExchangeBuyerService.creatives().list();
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
+    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Creatives.List request = adexchangebuyerService.creatives().list();
 
     CreativesList response;
     do {
@@ -781,15 +670,16 @@ public class AdExchangeBuyerExample {
         // TODO: Change code below to process each `creative` resource:
         System.out.println(creative);
       }
+      request.setPageToken(response.getNextPageToken());
     } while (response.getNextPageToken() != null);
   }
 
-  public AdExchangeBuyer createService() throws IOException, GeneralSecurityException {
+  public static AdExchangeBuyer createAdExchangeBuyerService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials.
-    // See: https://foo.com/bar
+    // TODO: Change placeholder below to generate authentication credentials, see:
+    // https://foo.com/bar
     //
     // Authorize using the following scope:
     //    https://www.googleapis.com/auth/adexchange.buyer
@@ -799,18 +689,8 @@ public class AdExchangeBuyerExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new AdExchangeBuyerExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -827,33 +707,32 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.adexchangebuyer.AdExchangeBuyer;
-import com.google.api.services.adexchangebuyer.AdExchangeBuyer.Creatives.RemoveDeal;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
 public class AdExchangeBuyerExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The id for the account that will serve this creative.
-    int accountId = 0; // TODO: Update placeholder value.
+    int accountId = 0;  // TODO: Update placeholder value.
 
     // The buyer-specific id for this creative.
-    String buyerCreativeId = ""; // TODO: Update placeholder value.
+    String buyerCreativeId = "";  // TODO: Update placeholder value.
 
     // The id of the deal id to disassociate with this creative.
-    long dealId = 0L; // TODO: Update placeholder value.
+    long dealId = 0L;  // TODO: Update placeholder value.
 
-    AdExchangeBuyer adExchangeBuyerService = createService();
-    RemoveDeal request = adExchangeBuyerService.creatives().removeDeal(accountId, buyerCreativeId, dealId);
+    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Creatives.RemoveDeal request = adexchangebuyerService.creatives().removeDeal(accountId, buyerCreativeId, dealId);
 
     request.execute();
   }
 
-  public AdExchangeBuyer createService() throws IOException, GeneralSecurityException {
+  public static AdExchangeBuyer createAdExchangeBuyerService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials.
-    // See: https://foo.com/bar
+    // TODO: Change placeholder below to generate authentication credentials, see:
+    // https://foo.com/bar
     //
     // Authorize using the following scope:
     //    https://www.googleapis.com/auth/adexchange.buyer
@@ -863,18 +742,8 @@ public class AdExchangeBuyerExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new AdExchangeBuyerExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -891,33 +760,34 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.adexchangebuyer.AdExchangeBuyer;
-import com.google.api.services.adexchangebuyer.AdExchangeBuyer.Marketplacedeals.Delete;
 import com.google.api.services.adexchangebuyer.model.DeleteOrderDealsRequest;
 import com.google.api.services.adexchangebuyer.model.DeleteOrderDealsResponse;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
 public class AdExchangeBuyerExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The proposalId to delete deals from.
-    String proposalId = ""; // TODO: Update placeholder value.
+    String proposalId = "";  // TODO: Update placeholder value.
 
     // TODO: Assign values to desired fields of `requestBody`.
     DeleteOrderDealsRequest requestBody = new DeleteOrderDealsRequest();
 
-    AdExchangeBuyer adExchangeBuyerService = createService();
-    Delete request = adExchangeBuyerService.marketplacedeals().delete(proposalId, requestBody);
+    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Marketplacedeals.Delete request = adexchangebuyerService.marketplacedeals().delete(proposalId, requestBody);
 
     DeleteOrderDealsResponse response = request.execute();
+
+    // TODO: Change code below to process the `response` object:
     System.out.println(response);
   }
 
-  public AdExchangeBuyer createService() throws IOException, GeneralSecurityException {
+  public static AdExchangeBuyer createAdExchangeBuyerService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials.
-    // See: https://foo.com/bar
+    // TODO: Change placeholder below to generate authentication credentials, see:
+    // https://foo.com/bar
     //
     // Authorize using the following scope:
     //    https://www.googleapis.com/auth/adexchange.buyer
@@ -927,18 +797,8 @@ public class AdExchangeBuyerExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new AdExchangeBuyerExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -955,33 +815,34 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.adexchangebuyer.AdExchangeBuyer;
-import com.google.api.services.adexchangebuyer.AdExchangeBuyer.Marketplacedeals.Insert;
 import com.google.api.services.adexchangebuyer.model.AddOrderDealsRequest;
 import com.google.api.services.adexchangebuyer.model.AddOrderDealsResponse;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
 public class AdExchangeBuyerExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // proposalId for which deals need to be added.
-    String proposalId = ""; // TODO: Update placeholder value.
+    String proposalId = "";  // TODO: Update placeholder value.
 
     // TODO: Assign values to desired fields of `requestBody`.
     AddOrderDealsRequest requestBody = new AddOrderDealsRequest();
 
-    AdExchangeBuyer adExchangeBuyerService = createService();
-    Insert request = adExchangeBuyerService.marketplacedeals().insert(proposalId, requestBody);
+    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Marketplacedeals.Insert request = adexchangebuyerService.marketplacedeals().insert(proposalId, requestBody);
 
     AddOrderDealsResponse response = request.execute();
+
+    // TODO: Change code below to process the `response` object:
     System.out.println(response);
   }
 
-  public AdExchangeBuyer createService() throws IOException, GeneralSecurityException {
+  public static AdExchangeBuyer createAdExchangeBuyerService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials.
-    // See: https://foo.com/bar
+    // TODO: Change placeholder below to generate authentication credentials, see:
+    // https://foo.com/bar
     //
     // Authorize using the following scope:
     //    https://www.googleapis.com/auth/adexchange.buyer
@@ -991,18 +852,8 @@ public class AdExchangeBuyerExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new AdExchangeBuyerExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -1019,30 +870,31 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.adexchangebuyer.AdExchangeBuyer;
-import com.google.api.services.adexchangebuyer.AdExchangeBuyer.Marketplacedeals.List;
 import com.google.api.services.adexchangebuyer.model.GetOrderDealsResponse;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
 public class AdExchangeBuyerExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The proposalId to get deals for. To search across all proposals specify order_id = '-' as part of
     // the URL.
-    String proposalId = ""; // TODO: Update placeholder value.
+    String proposalId = "";  // TODO: Update placeholder value.
 
-    AdExchangeBuyer adExchangeBuyerService = createService();
-    List request = adExchangeBuyerService.marketplacedeals().list(proposalId);
+    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Marketplacedeals.List request = adexchangebuyerService.marketplacedeals().list(proposalId);
 
     GetOrderDealsResponse response = request.execute();
+
+    // TODO: Change code below to process the `response` object:
     System.out.println(response);
   }
 
-  public AdExchangeBuyer createService() throws IOException, GeneralSecurityException {
+  public static AdExchangeBuyer createAdExchangeBuyerService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials.
-    // See: https://foo.com/bar
+    // TODO: Change placeholder below to generate authentication credentials, see:
+    // https://foo.com/bar
     //
     // Authorize using the following scope:
     //    https://www.googleapis.com/auth/adexchange.buyer
@@ -1052,18 +904,8 @@ public class AdExchangeBuyerExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new AdExchangeBuyerExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -1080,33 +922,34 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.adexchangebuyer.AdExchangeBuyer;
-import com.google.api.services.adexchangebuyer.AdExchangeBuyer.Marketplacedeals.Update;
 import com.google.api.services.adexchangebuyer.model.EditAllOrderDealsRequest;
 import com.google.api.services.adexchangebuyer.model.EditAllOrderDealsResponse;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
 public class AdExchangeBuyerExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The proposalId to edit deals on.
-    String proposalId = ""; // TODO: Update placeholder value.
+    String proposalId = "";  // TODO: Update placeholder value.
 
     // TODO: Assign values to desired fields of `requestBody`.
     EditAllOrderDealsRequest requestBody = new EditAllOrderDealsRequest();
 
-    AdExchangeBuyer adExchangeBuyerService = createService();
-    Update request = adExchangeBuyerService.marketplacedeals().update(proposalId, requestBody);
+    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Marketplacedeals.Update request = adexchangebuyerService.marketplacedeals().update(proposalId, requestBody);
 
     EditAllOrderDealsResponse response = request.execute();
+
+    // TODO: Change code below to process the `response` object:
     System.out.println(response);
   }
 
-  public AdExchangeBuyer createService() throws IOException, GeneralSecurityException {
+  public static AdExchangeBuyer createAdExchangeBuyerService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials.
-    // See: https://foo.com/bar
+    // TODO: Change placeholder below to generate authentication credentials, see:
+    // https://foo.com/bar
     //
     // Authorize using the following scope:
     //    https://www.googleapis.com/auth/adexchange.buyer
@@ -1116,18 +959,8 @@ public class AdExchangeBuyerExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new AdExchangeBuyerExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -1144,33 +977,34 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.adexchangebuyer.AdExchangeBuyer;
-import com.google.api.services.adexchangebuyer.AdExchangeBuyer.Marketplacenotes.Insert;
 import com.google.api.services.adexchangebuyer.model.AddOrderNotesRequest;
 import com.google.api.services.adexchangebuyer.model.AddOrderNotesResponse;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
 public class AdExchangeBuyerExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The proposalId to add notes for.
-    String proposalId = ""; // TODO: Update placeholder value.
+    String proposalId = "";  // TODO: Update placeholder value.
 
     // TODO: Assign values to desired fields of `requestBody`.
     AddOrderNotesRequest requestBody = new AddOrderNotesRequest();
 
-    AdExchangeBuyer adExchangeBuyerService = createService();
-    Insert request = adExchangeBuyerService.marketplacenotes().insert(proposalId, requestBody);
+    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Marketplacenotes.Insert request = adexchangebuyerService.marketplacenotes().insert(proposalId, requestBody);
 
     AddOrderNotesResponse response = request.execute();
+
+    // TODO: Change code below to process the `response` object:
     System.out.println(response);
   }
 
-  public AdExchangeBuyer createService() throws IOException, GeneralSecurityException {
+  public static AdExchangeBuyer createAdExchangeBuyerService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials.
-    // See: https://foo.com/bar
+    // TODO: Change placeholder below to generate authentication credentials, see:
+    // https://foo.com/bar
     //
     // Authorize using the following scope:
     //    https://www.googleapis.com/auth/adexchange.buyer
@@ -1180,18 +1014,8 @@ public class AdExchangeBuyerExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new AdExchangeBuyerExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -1208,30 +1032,31 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.adexchangebuyer.AdExchangeBuyer;
-import com.google.api.services.adexchangebuyer.AdExchangeBuyer.Marketplacenotes.List;
 import com.google.api.services.adexchangebuyer.model.GetOrderNotesResponse;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
 public class AdExchangeBuyerExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The proposalId to get notes for. To search across all proposals specify order_id = '-' as part of
     // the URL.
-    String proposalId = ""; // TODO: Update placeholder value.
+    String proposalId = "";  // TODO: Update placeholder value.
 
-    AdExchangeBuyer adExchangeBuyerService = createService();
-    List request = adExchangeBuyerService.marketplacenotes().list(proposalId);
+    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Marketplacenotes.List request = adexchangebuyerService.marketplacenotes().list(proposalId);
 
     GetOrderNotesResponse response = request.execute();
+
+    // TODO: Change code below to process the `response` object:
     System.out.println(response);
   }
 
-  public AdExchangeBuyer createService() throws IOException, GeneralSecurityException {
+  public static AdExchangeBuyer createAdExchangeBuyerService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials.
-    // See: https://foo.com/bar
+    // TODO: Change placeholder below to generate authentication credentials, see:
+    // https://foo.com/bar
     //
     // Authorize using the following scope:
     //    https://www.googleapis.com/auth/adexchange.buyer
@@ -1241,18 +1066,8 @@ public class AdExchangeBuyerExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new AdExchangeBuyerExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -1269,31 +1084,30 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.adexchangebuyer.AdExchangeBuyer;
-import com.google.api.services.adexchangebuyer.AdExchangeBuyer.Marketplaceprivateauction.Updateproposal;
 import com.google.api.services.adexchangebuyer.model.UpdatePrivateAuctionProposalRequest;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
 public class AdExchangeBuyerExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The private auction id to be updated.
-    String privateAuctionId = ""; // TODO: Update placeholder value.
+    String privateAuctionId = "";  // TODO: Update placeholder value.
 
     // TODO: Assign values to desired fields of `requestBody`.
     UpdatePrivateAuctionProposalRequest requestBody = new UpdatePrivateAuctionProposalRequest();
 
-    AdExchangeBuyer adExchangeBuyerService = createService();
-    Updateproposal request = adExchangeBuyerService.marketplaceprivateauction().updateproposal(privateAuctionId, requestBody);
+    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Marketplaceprivateauction.Updateproposal request = adexchangebuyerService.marketplaceprivateauction().updateproposal(privateAuctionId, requestBody);
 
     request.execute();
   }
 
-  public AdExchangeBuyer createService() throws IOException, GeneralSecurityException {
+  public static AdExchangeBuyer createAdExchangeBuyerService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials.
-    // See: https://foo.com/bar
+    // TODO: Change placeholder below to generate authentication credentials, see:
+    // https://foo.com/bar
     //
     // Authorize using the following scope:
     //    https://www.googleapis.com/auth/adexchange.buyer
@@ -1303,18 +1117,8 @@ public class AdExchangeBuyerExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new AdExchangeBuyerExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -1331,35 +1135,36 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.adexchangebuyer.AdExchangeBuyer;
-import com.google.api.services.adexchangebuyer.AdExchangeBuyer.PerformanceReport.List;
 import com.google.api.services.adexchangebuyer.model.PerformanceReportList;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
 public class AdExchangeBuyerExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The account id to get the reports.
-    long accountId = 0L; // TODO: Update placeholder value.
+    long accountId = 0L;  // TODO: Update placeholder value.
 
     // The end time of the report in ISO 8601 timestamp format using UTC.
-    String endDateTime = ""; // TODO: Update placeholder value.
+    String endDateTime = "";  // TODO: Update placeholder value.
 
     // The start time of the report in ISO 8601 timestamp format using UTC.
-    String startDateTime = ""; // TODO: Update placeholder value.
+    String startDateTime = "";  // TODO: Update placeholder value.
 
-    AdExchangeBuyer adExchangeBuyerService = createService();
-    List request = adExchangeBuyerService.performanceReport().list(accountId, endDateTime, startDateTime);
+    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.PerformanceReport.List request = adexchangebuyerService.performanceReport().list(accountId, endDateTime, startDateTime);
 
     PerformanceReportList response = request.execute();
+
+    // TODO: Change code below to process the `response` object:
     System.out.println(response);
   }
 
-  public AdExchangeBuyer createService() throws IOException, GeneralSecurityException {
+  public static AdExchangeBuyer createAdExchangeBuyerService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials.
-    // See: https://foo.com/bar
+    // TODO: Change placeholder below to generate authentication credentials, see:
+    // https://foo.com/bar
     //
     // Authorize using the following scope:
     //    https://www.googleapis.com/auth/adexchange.buyer
@@ -1369,18 +1174,8 @@ public class AdExchangeBuyerExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new AdExchangeBuyerExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -1397,30 +1192,29 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.adexchangebuyer.AdExchangeBuyer;
-import com.google.api.services.adexchangebuyer.AdExchangeBuyer.PretargetingConfig.Delete;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
 public class AdExchangeBuyerExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The account id to delete the pretargeting config for.
-    long accountId = 0L; // TODO: Update placeholder value.
+    long accountId = 0L;  // TODO: Update placeholder value.
 
     // The specific id of the configuration to delete.
-    long configId = 0L; // TODO: Update placeholder value.
+    long configId = 0L;  // TODO: Update placeholder value.
 
-    AdExchangeBuyer adExchangeBuyerService = createService();
-    Delete request = adExchangeBuyerService.pretargetingConfig().delete(accountId, configId);
+    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.PretargetingConfig.Delete request = adexchangebuyerService.pretargetingConfig().delete(accountId, configId);
 
     request.execute();
   }
 
-  public AdExchangeBuyer createService() throws IOException, GeneralSecurityException {
+  public static AdExchangeBuyer createAdExchangeBuyerService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials.
-    // See: https://foo.com/bar
+    // TODO: Change placeholder below to generate authentication credentials, see:
+    // https://foo.com/bar
     //
     // Authorize using the following scope:
     //    https://www.googleapis.com/auth/adexchange.buyer
@@ -1430,18 +1224,8 @@ public class AdExchangeBuyerExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new AdExchangeBuyerExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -1458,32 +1242,33 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.adexchangebuyer.AdExchangeBuyer;
-import com.google.api.services.adexchangebuyer.AdExchangeBuyer.PretargetingConfig.Get;
 import com.google.api.services.adexchangebuyer.model.PretargetingConfig;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
 public class AdExchangeBuyerExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The account id to get the pretargeting config for.
-    long accountId = 0L; // TODO: Update placeholder value.
+    long accountId = 0L;  // TODO: Update placeholder value.
 
     // The specific id of the configuration to retrieve.
-    long configId = 0L; // TODO: Update placeholder value.
+    long configId = 0L;  // TODO: Update placeholder value.
 
-    AdExchangeBuyer adExchangeBuyerService = createService();
-    Get request = adExchangeBuyerService.pretargetingConfig().get(accountId, configId);
+    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.PretargetingConfig.Get request = adexchangebuyerService.pretargetingConfig().get(accountId, configId);
 
     PretargetingConfig response = request.execute();
+
+    // TODO: Change code below to process the `response` object:
     System.out.println(response);
   }
 
-  public AdExchangeBuyer createService() throws IOException, GeneralSecurityException {
+  public static AdExchangeBuyer createAdExchangeBuyerService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials.
-    // See: https://foo.com/bar
+    // TODO: Change placeholder below to generate authentication credentials, see:
+    // https://foo.com/bar
     //
     // Authorize using the following scope:
     //    https://www.googleapis.com/auth/adexchange.buyer
@@ -1493,18 +1278,8 @@ public class AdExchangeBuyerExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new AdExchangeBuyerExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -1521,32 +1296,33 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.adexchangebuyer.AdExchangeBuyer;
-import com.google.api.services.adexchangebuyer.AdExchangeBuyer.PretargetingConfig.Insert;
 import com.google.api.services.adexchangebuyer.model.PretargetingConfig;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
 public class AdExchangeBuyerExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The account id to insert the pretargeting config for.
-    long accountId = 0L; // TODO: Update placeholder value.
+    long accountId = 0L;  // TODO: Update placeholder value.
 
     // TODO: Assign values to desired fields of `requestBody`.
     PretargetingConfig requestBody = new PretargetingConfig();
 
-    AdExchangeBuyer adExchangeBuyerService = createService();
-    Insert request = adExchangeBuyerService.pretargetingConfig().insert(accountId, requestBody);
+    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.PretargetingConfig.Insert request = adexchangebuyerService.pretargetingConfig().insert(accountId, requestBody);
 
     PretargetingConfig response = request.execute();
+
+    // TODO: Change code below to process the `response` object:
     System.out.println(response);
   }
 
-  public AdExchangeBuyer createService() throws IOException, GeneralSecurityException {
+  public static AdExchangeBuyer createAdExchangeBuyerService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials.
-    // See: https://foo.com/bar
+    // TODO: Change placeholder below to generate authentication credentials, see:
+    // https://foo.com/bar
     //
     // Authorize using the following scope:
     //    https://www.googleapis.com/auth/adexchange.buyer
@@ -1556,18 +1332,8 @@ public class AdExchangeBuyerExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new AdExchangeBuyerExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -1584,29 +1350,30 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.adexchangebuyer.AdExchangeBuyer;
-import com.google.api.services.adexchangebuyer.AdExchangeBuyer.PretargetingConfig.List;
 import com.google.api.services.adexchangebuyer.model.PretargetingConfigList;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
 public class AdExchangeBuyerExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The account id to get the pretargeting configs for.
-    long accountId = 0L; // TODO: Update placeholder value.
+    long accountId = 0L;  // TODO: Update placeholder value.
 
-    AdExchangeBuyer adExchangeBuyerService = createService();
-    List request = adExchangeBuyerService.pretargetingConfig().list(accountId);
+    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.PretargetingConfig.List request = adexchangebuyerService.pretargetingConfig().list(accountId);
 
     PretargetingConfigList response = request.execute();
+
+    // TODO: Change code below to process the `response` object:
     System.out.println(response);
   }
 
-  public AdExchangeBuyer createService() throws IOException, GeneralSecurityException {
+  public static AdExchangeBuyer createAdExchangeBuyerService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials.
-    // See: https://foo.com/bar
+    // TODO: Change placeholder below to generate authentication credentials, see:
+    // https://foo.com/bar
     //
     // Authorize using the following scope:
     //    https://www.googleapis.com/auth/adexchange.buyer
@@ -1616,18 +1383,8 @@ public class AdExchangeBuyerExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new AdExchangeBuyerExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -1644,36 +1401,37 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.adexchangebuyer.AdExchangeBuyer;
-import com.google.api.services.adexchangebuyer.AdExchangeBuyer.PretargetingConfig.Patch;
 import com.google.api.services.adexchangebuyer.model.PretargetingConfig;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
 public class AdExchangeBuyerExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The account id to update the pretargeting config for.
-    long accountId = 0L; // TODO: Update placeholder value.
+    long accountId = 0L;  // TODO: Update placeholder value.
 
     // The specific id of the configuration to update.
-    long configId = 0L; // TODO: Update placeholder value.
+    long configId = 0L;  // TODO: Update placeholder value.
 
     // TODO: Assign values to desired fields of `requestBody`.
     // Only assigned fields will be changed.
     PretargetingConfig requestBody = new PretargetingConfig();
 
-    AdExchangeBuyer adExchangeBuyerService = createService();
-    Patch request = adExchangeBuyerService.pretargetingConfig().patch(accountId, configId, requestBody);
+    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.PretargetingConfig.Patch request = adexchangebuyerService.pretargetingConfig().patch(accountId, configId, requestBody);
 
     PretargetingConfig response = request.execute();
+
+    // TODO: Change code below to process the `response` object:
     System.out.println(response);
   }
 
-  public AdExchangeBuyer createService() throws IOException, GeneralSecurityException {
+  public static AdExchangeBuyer createAdExchangeBuyerService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials.
-    // See: https://foo.com/bar
+    // TODO: Change placeholder below to generate authentication credentials, see:
+    // https://foo.com/bar
     //
     // Authorize using the following scope:
     //    https://www.googleapis.com/auth/adexchange.buyer
@@ -1683,18 +1441,8 @@ public class AdExchangeBuyerExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new AdExchangeBuyerExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -1711,35 +1459,36 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.adexchangebuyer.AdExchangeBuyer;
-import com.google.api.services.adexchangebuyer.AdExchangeBuyer.PretargetingConfig.Update;
 import com.google.api.services.adexchangebuyer.model.PretargetingConfig;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
 public class AdExchangeBuyerExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The account id to update the pretargeting config for.
-    long accountId = 0L; // TODO: Update placeholder value.
+    long accountId = 0L;  // TODO: Update placeholder value.
 
     // The specific id of the configuration to update.
-    long configId = 0L; // TODO: Update placeholder value.
+    long configId = 0L;  // TODO: Update placeholder value.
 
     // TODO: Assign values to desired fields of `requestBody`.
     PretargetingConfig requestBody = new PretargetingConfig();
 
-    AdExchangeBuyer adExchangeBuyerService = createService();
-    Update request = adExchangeBuyerService.pretargetingConfig().update(accountId, configId, requestBody);
+    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.PretargetingConfig.Update request = adexchangebuyerService.pretargetingConfig().update(accountId, configId, requestBody);
 
     PretargetingConfig response = request.execute();
+
+    // TODO: Change code below to process the `response` object:
     System.out.println(response);
   }
 
-  public AdExchangeBuyer createService() throws IOException, GeneralSecurityException {
+  public static AdExchangeBuyer createAdExchangeBuyerService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials.
-    // See: https://foo.com/bar
+    // TODO: Change placeholder below to generate authentication credentials, see:
+    // https://foo.com/bar
     //
     // Authorize using the following scope:
     //    https://www.googleapis.com/auth/adexchange.buyer
@@ -1749,18 +1498,8 @@ public class AdExchangeBuyerExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new AdExchangeBuyerExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -1777,29 +1516,30 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.adexchangebuyer.AdExchangeBuyer;
-import com.google.api.services.adexchangebuyer.AdExchangeBuyer.Products.Get;
 import com.google.api.services.adexchangebuyer.model.Product;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
 public class AdExchangeBuyerExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The id for the product to get the head revision for.
-    String productId = ""; // TODO: Update placeholder value.
+    String productId = "";  // TODO: Update placeholder value.
 
-    AdExchangeBuyer adExchangeBuyerService = createService();
-    Get request = adExchangeBuyerService.products().get(productId);
+    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Products.Get request = adexchangebuyerService.products().get(productId);
 
     Product response = request.execute();
+
+    // TODO: Change code below to process the `response` object:
     System.out.println(response);
   }
 
-  public AdExchangeBuyer createService() throws IOException, GeneralSecurityException {
+  public static AdExchangeBuyer createAdExchangeBuyerService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials.
-    // See: https://foo.com/bar
+    // TODO: Change placeholder below to generate authentication credentials, see:
+    // https://foo.com/bar
     //
     // Authorize using the following scope:
     //    https://www.googleapis.com/auth/adexchange.buyer
@@ -1809,18 +1549,8 @@ public class AdExchangeBuyerExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new AdExchangeBuyerExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -1837,26 +1567,27 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.adexchangebuyer.AdExchangeBuyer;
-import com.google.api.services.adexchangebuyer.AdExchangeBuyer.Products.Search;
 import com.google.api.services.adexchangebuyer.model.GetOffersResponse;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
 public class AdExchangeBuyerExample {
-  public void run() throws IOException, GeneralSecurityException {
-    AdExchangeBuyer adExchangeBuyerService = createService();
-    Search request = adExchangeBuyerService.products().search();
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
+    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Products.Search request = adexchangebuyerService.products().search();
 
     GetOffersResponse response = request.execute();
+
+    // TODO: Change code below to process the `response` object:
     System.out.println(response);
   }
 
-  public AdExchangeBuyer createService() throws IOException, GeneralSecurityException {
+  public static AdExchangeBuyer createAdExchangeBuyerService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials.
-    // See: https://foo.com/bar
+    // TODO: Change placeholder below to generate authentication credentials, see:
+    // https://foo.com/bar
     //
     // Authorize using the following scope:
     //    https://www.googleapis.com/auth/adexchange.buyer
@@ -1866,18 +1597,8 @@ public class AdExchangeBuyerExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new AdExchangeBuyerExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -1894,29 +1615,30 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.adexchangebuyer.AdExchangeBuyer;
-import com.google.api.services.adexchangebuyer.AdExchangeBuyer.Proposals.Get;
 import com.google.api.services.adexchangebuyer.model.Proposal;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
 public class AdExchangeBuyerExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // Id of the proposal to retrieve.
-    String proposalId = ""; // TODO: Update placeholder value.
+    String proposalId = "";  // TODO: Update placeholder value.
 
-    AdExchangeBuyer adExchangeBuyerService = createService();
-    Get request = adExchangeBuyerService.proposals().get(proposalId);
+    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Proposals.Get request = adexchangebuyerService.proposals().get(proposalId);
 
     Proposal response = request.execute();
+
+    // TODO: Change code below to process the `response` object:
     System.out.println(response);
   }
 
-  public AdExchangeBuyer createService() throws IOException, GeneralSecurityException {
+  public static AdExchangeBuyer createAdExchangeBuyerService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials.
-    // See: https://foo.com/bar
+    // TODO: Change placeholder below to generate authentication credentials, see:
+    // https://foo.com/bar
     //
     // Authorize using the following scope:
     //    https://www.googleapis.com/auth/adexchange.buyer
@@ -1926,18 +1648,8 @@ public class AdExchangeBuyerExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new AdExchangeBuyerExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -1954,30 +1666,31 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.adexchangebuyer.AdExchangeBuyer;
-import com.google.api.services.adexchangebuyer.AdExchangeBuyer.Proposals.Insert;
 import com.google.api.services.adexchangebuyer.model.CreateOrdersRequest;
 import com.google.api.services.adexchangebuyer.model.CreateOrdersResponse;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
 public class AdExchangeBuyerExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // TODO: Assign values to desired fields of `requestBody`.
     CreateOrdersRequest requestBody = new CreateOrdersRequest();
 
-    AdExchangeBuyer adExchangeBuyerService = createService();
-    Insert request = adExchangeBuyerService.proposals().insert(requestBody);
+    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Proposals.Insert request = adexchangebuyerService.proposals().insert(requestBody);
 
     CreateOrdersResponse response = request.execute();
+
+    // TODO: Change code below to process the `response` object:
     System.out.println(response);
   }
 
-  public AdExchangeBuyer createService() throws IOException, GeneralSecurityException {
+  public static AdExchangeBuyer createAdExchangeBuyerService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials.
-    // See: https://foo.com/bar
+    // TODO: Change placeholder below to generate authentication credentials, see:
+    // https://foo.com/bar
     //
     // Authorize using the following scope:
     //    https://www.googleapis.com/auth/adexchange.buyer
@@ -1987,18 +1700,8 @@ public class AdExchangeBuyerExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new AdExchangeBuyerExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -2015,42 +1718,43 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.adexchangebuyer.AdExchangeBuyer;
-import com.google.api.services.adexchangebuyer.AdExchangeBuyer.Proposals.Patch;
 import com.google.api.services.adexchangebuyer.model.Proposal;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
 public class AdExchangeBuyerExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The proposal id to update.
-    String proposalId = ""; // TODO: Update placeholder value.
+    String proposalId = "";  // TODO: Update placeholder value.
 
     // The last known revision number to update. If the head revision in the marketplace database has
     // since changed, an error will be thrown. The caller should then fetch the latest proposal at head
     // revision and retry the update at that revision.
-    long revisionNumber = 0L; // TODO: Update placeholder value.
+    long revisionNumber = 0L;  // TODO: Update placeholder value.
 
     // The proposed action to take on the proposal. This field is required and it must be set when
     // updating a proposal.
-    String updateAction = ""; // TODO: Update placeholder value.
+    String updateAction = "";  // TODO: Update placeholder value.
 
     // TODO: Assign values to desired fields of `requestBody`.
     // Only assigned fields will be changed.
     Proposal requestBody = new Proposal();
 
-    AdExchangeBuyer adExchangeBuyerService = createService();
-    Patch request = adExchangeBuyerService.proposals().patch(proposalId, revisionNumber, updateAction, requestBody);
+    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Proposals.Patch request = adexchangebuyerService.proposals().patch(proposalId, revisionNumber, updateAction, requestBody);
 
     Proposal response = request.execute();
+
+    // TODO: Change code below to process the `response` object:
     System.out.println(response);
   }
 
-  public AdExchangeBuyer createService() throws IOException, GeneralSecurityException {
+  public static AdExchangeBuyer createAdExchangeBuyerService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials.
-    // See: https://foo.com/bar
+    // TODO: Change placeholder below to generate authentication credentials, see:
+    // https://foo.com/bar
     //
     // Authorize using the following scope:
     //    https://www.googleapis.com/auth/adexchange.buyer
@@ -2060,18 +1764,8 @@ public class AdExchangeBuyerExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new AdExchangeBuyerExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -2088,26 +1782,27 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.adexchangebuyer.AdExchangeBuyer;
-import com.google.api.services.adexchangebuyer.AdExchangeBuyer.Proposals.Search;
 import com.google.api.services.adexchangebuyer.model.GetOrdersResponse;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
 public class AdExchangeBuyerExample {
-  public void run() throws IOException, GeneralSecurityException {
-    AdExchangeBuyer adExchangeBuyerService = createService();
-    Search request = adExchangeBuyerService.proposals().search();
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
+    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Proposals.Search request = adexchangebuyerService.proposals().search();
 
     GetOrdersResponse response = request.execute();
+
+    // TODO: Change code below to process the `response` object:
     System.out.println(response);
   }
 
-  public AdExchangeBuyer createService() throws IOException, GeneralSecurityException {
+  public static AdExchangeBuyer createAdExchangeBuyerService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials.
-    // See: https://foo.com/bar
+    // TODO: Change placeholder below to generate authentication credentials, see:
+    // https://foo.com/bar
     //
     // Authorize using the following scope:
     //    https://www.googleapis.com/auth/adexchange.buyer
@@ -2117,18 +1812,8 @@ public class AdExchangeBuyerExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new AdExchangeBuyerExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -2145,27 +1830,26 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.adexchangebuyer.AdExchangeBuyer;
-import com.google.api.services.adexchangebuyer.AdExchangeBuyer.Proposals.Setupcomplete;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
 public class AdExchangeBuyerExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The proposal id for which the setup is complete
-    String proposalId = ""; // TODO: Update placeholder value.
+    String proposalId = "";  // TODO: Update placeholder value.
 
-    AdExchangeBuyer adExchangeBuyerService = createService();
-    Setupcomplete request = adExchangeBuyerService.proposals().setupcomplete(proposalId);
+    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Proposals.Setupcomplete request = adexchangebuyerService.proposals().setupcomplete(proposalId);
 
     request.execute();
   }
 
-  public AdExchangeBuyer createService() throws IOException, GeneralSecurityException {
+  public static AdExchangeBuyer createAdExchangeBuyerService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials.
-    // See: https://foo.com/bar
+    // TODO: Change placeholder below to generate authentication credentials, see:
+    // https://foo.com/bar
     //
     // Authorize using the following scope:
     //    https://www.googleapis.com/auth/adexchange.buyer
@@ -2175,18 +1859,8 @@ public class AdExchangeBuyerExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new AdExchangeBuyerExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -2203,41 +1877,42 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.adexchangebuyer.AdExchangeBuyer;
-import com.google.api.services.adexchangebuyer.AdExchangeBuyer.Proposals.Update;
 import com.google.api.services.adexchangebuyer.model.Proposal;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
 public class AdExchangeBuyerExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The proposal id to update.
-    String proposalId = ""; // TODO: Update placeholder value.
+    String proposalId = "";  // TODO: Update placeholder value.
 
     // The last known revision number to update. If the head revision in the marketplace database has
     // since changed, an error will be thrown. The caller should then fetch the latest proposal at head
     // revision and retry the update at that revision.
-    long revisionNumber = 0L; // TODO: Update placeholder value.
+    long revisionNumber = 0L;  // TODO: Update placeholder value.
 
     // The proposed action to take on the proposal. This field is required and it must be set when
     // updating a proposal.
-    String updateAction = ""; // TODO: Update placeholder value.
+    String updateAction = "";  // TODO: Update placeholder value.
 
     // TODO: Assign values to desired fields of `requestBody`.
     Proposal requestBody = new Proposal();
 
-    AdExchangeBuyer adExchangeBuyerService = createService();
-    Update request = adExchangeBuyerService.proposals().update(proposalId, revisionNumber, updateAction, requestBody);
+    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Proposals.Update request = adexchangebuyerService.proposals().update(proposalId, revisionNumber, updateAction, requestBody);
 
     Proposal response = request.execute();
+
+    // TODO: Change code below to process the `response` object:
     System.out.println(response);
   }
 
-  public AdExchangeBuyer createService() throws IOException, GeneralSecurityException {
+  public static AdExchangeBuyer createAdExchangeBuyerService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials.
-    // See: https://foo.com/bar
+    // TODO: Change placeholder below to generate authentication credentials, see:
+    // https://foo.com/bar
     //
     // Authorize using the following scope:
     //    https://www.googleapis.com/auth/adexchange.buyer
@@ -2247,18 +1922,8 @@ public class AdExchangeBuyerExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new AdExchangeBuyerExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -2275,29 +1940,30 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.adexchangebuyer.AdExchangeBuyer;
-import com.google.api.services.adexchangebuyer.AdExchangeBuyer.Pubprofiles.List;
 import com.google.api.services.adexchangebuyer.model.GetPublisherProfilesByAccountIdResponse;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
 public class AdExchangeBuyerExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The accountId of the publisher to get profiles for.
-    int accountId = 0; // TODO: Update placeholder value.
+    int accountId = 0;  // TODO: Update placeholder value.
 
-    AdExchangeBuyer adExchangeBuyerService = createService();
-    List request = adExchangeBuyerService.pubprofiles().list(accountId);
+    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Pubprofiles.List request = adexchangebuyerService.pubprofiles().list(accountId);
 
     GetPublisherProfilesByAccountIdResponse response = request.execute();
+
+    // TODO: Change code below to process the `response` object:
     System.out.println(response);
   }
 
-  public AdExchangeBuyer createService() throws IOException, GeneralSecurityException {
+  public static AdExchangeBuyer createAdExchangeBuyerService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials.
-    // See: https://foo.com/bar
+    // TODO: Change placeholder below to generate authentication credentials, see:
+    // https://foo.com/bar
     //
     // Authorize using the following scope:
     //    https://www.googleapis.com/auth/adexchange.buyer
@@ -2306,15 +1972,5 @@ public class AdExchangeBuyerExample {
     return new AdExchangeBuyer.Builder(httpTransport, jsonFactory, credential)
         .setApplicationName("Google Cloud Platform Sample")
         .build();
-  }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new AdExchangeBuyerExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
   }
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/mvvm_java/java_adexchangebuyer.v1.4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/mvvm_java/java_adexchangebuyer.v1.4.json.baseline
@@ -25,8 +25,8 @@ public class AdExchangeBuyerExample {
     // The account id
     int id = 0;  // TODO: Update placeholder value.
 
-    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
-    AdExchangeBuyer.Accounts.Get request = adexchangebuyerService.accounts().get(id);
+    AdExchangeBuyer adExchangeBuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Accounts.Get request = adExchangeBuyerService.accounts().get(id);
 
     Account response = request.execute();
 
@@ -38,7 +38,7 @@ public class AdExchangeBuyerExample {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials, see:
+    // TODO: Change placeholder below to generate authentication credentials. See:
     // https://foo.com/bar
     //
     // Authorize using the following scope:
@@ -73,8 +73,8 @@ import java.security.GeneralSecurityException;
 
 public class AdExchangeBuyerExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
-    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
-    AdExchangeBuyer.Accounts.List request = adexchangebuyerService.accounts().list();
+    AdExchangeBuyer adExchangeBuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Accounts.List request = adExchangeBuyerService.accounts().list();
 
     AccountsList response = request.execute();
 
@@ -86,7 +86,7 @@ public class AdExchangeBuyerExample {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials, see:
+    // TODO: Change placeholder below to generate authentication credentials. See:
     // https://foo.com/bar
     //
     // Authorize using the following scope:
@@ -128,8 +128,8 @@ public class AdExchangeBuyerExample {
     // Only assigned fields will be changed.
     Account requestBody = new Account();
 
-    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
-    AdExchangeBuyer.Accounts.Patch request = adexchangebuyerService.accounts().patch(id, requestBody);
+    AdExchangeBuyer adExchangeBuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Accounts.Patch request = adExchangeBuyerService.accounts().patch(id, requestBody);
 
     Account response = request.execute();
 
@@ -141,7 +141,7 @@ public class AdExchangeBuyerExample {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials, see:
+    // TODO: Change placeholder below to generate authentication credentials. See:
     // https://foo.com/bar
     //
     // Authorize using the following scope:
@@ -182,8 +182,8 @@ public class AdExchangeBuyerExample {
     // TODO: Assign values to desired fields of `requestBody`.
     Account requestBody = new Account();
 
-    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
-    AdExchangeBuyer.Accounts.Update request = adexchangebuyerService.accounts().update(id, requestBody);
+    AdExchangeBuyer adExchangeBuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Accounts.Update request = adExchangeBuyerService.accounts().update(id, requestBody);
 
     Account response = request.execute();
 
@@ -195,7 +195,7 @@ public class AdExchangeBuyerExample {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials, see:
+    // TODO: Change placeholder below to generate authentication credentials. See:
     // https://foo.com/bar
     //
     // Authorize using the following scope:
@@ -233,8 +233,8 @@ public class AdExchangeBuyerExample {
     // The account id.
     int accountId = 0;  // TODO: Update placeholder value.
 
-    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
-    AdExchangeBuyer.BillingInfo.Get request = adexchangebuyerService.billingInfo().get(accountId);
+    AdExchangeBuyer adExchangeBuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.BillingInfo.Get request = adExchangeBuyerService.billingInfo().get(accountId);
 
     BillingInfo response = request.execute();
 
@@ -246,7 +246,7 @@ public class AdExchangeBuyerExample {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials, see:
+    // TODO: Change placeholder below to generate authentication credentials. See:
     // https://foo.com/bar
     //
     // Authorize using the following scope:
@@ -281,8 +281,8 @@ import java.security.GeneralSecurityException;
 
 public class AdExchangeBuyerExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
-    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
-    AdExchangeBuyer.BillingInfo.List request = adexchangebuyerService.billingInfo().list();
+    AdExchangeBuyer adExchangeBuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.BillingInfo.List request = adExchangeBuyerService.billingInfo().list();
 
     BillingInfoList response = request.execute();
 
@@ -294,7 +294,7 @@ public class AdExchangeBuyerExample {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials, see:
+    // TODO: Change placeholder below to generate authentication credentials. See:
     // https://foo.com/bar
     //
     // Authorize using the following scope:
@@ -335,8 +335,8 @@ public class AdExchangeBuyerExample {
     // The billing id to get the budget information for.
     long billingId = 0L;  // TODO: Update placeholder value.
 
-    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
-    AdExchangeBuyer.Budget.Get request = adexchangebuyerService.budget().get(accountId, billingId);
+    AdExchangeBuyer adExchangeBuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Budget.Get request = adExchangeBuyerService.budget().get(accountId, billingId);
 
     Budget response = request.execute();
 
@@ -348,7 +348,7 @@ public class AdExchangeBuyerExample {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials, see:
+    // TODO: Change placeholder below to generate authentication credentials. See:
     // https://foo.com/bar
     //
     // Authorize using the following scope:
@@ -393,8 +393,8 @@ public class AdExchangeBuyerExample {
     // Only assigned fields will be changed.
     Budget requestBody = new Budget();
 
-    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
-    AdExchangeBuyer.Budget.Patch request = adexchangebuyerService.budget().patch(accountId, billingId, requestBody);
+    AdExchangeBuyer adExchangeBuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Budget.Patch request = adExchangeBuyerService.budget().patch(accountId, billingId, requestBody);
 
     Budget response = request.execute();
 
@@ -406,7 +406,7 @@ public class AdExchangeBuyerExample {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials, see:
+    // TODO: Change placeholder below to generate authentication credentials. See:
     // https://foo.com/bar
     //
     // Authorize using the following scope:
@@ -450,8 +450,8 @@ public class AdExchangeBuyerExample {
     // TODO: Assign values to desired fields of `requestBody`.
     Budget requestBody = new Budget();
 
-    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
-    AdExchangeBuyer.Budget.Update request = adexchangebuyerService.budget().update(accountId, billingId, requestBody);
+    AdExchangeBuyer adExchangeBuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Budget.Update request = adExchangeBuyerService.budget().update(accountId, billingId, requestBody);
 
     Budget response = request.execute();
 
@@ -463,7 +463,7 @@ public class AdExchangeBuyerExample {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials, see:
+    // TODO: Change placeholder below to generate authentication credentials. See:
     // https://foo.com/bar
     //
     // Authorize using the following scope:
@@ -506,8 +506,8 @@ public class AdExchangeBuyerExample {
     // The id of the deal id to associate with this creative.
     long dealId = 0L;  // TODO: Update placeholder value.
 
-    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
-    AdExchangeBuyer.Creatives.AddDeal request = adexchangebuyerService.creatives().addDeal(accountId, buyerCreativeId, dealId);
+    AdExchangeBuyer adExchangeBuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Creatives.AddDeal request = adExchangeBuyerService.creatives().addDeal(accountId, buyerCreativeId, dealId);
 
     request.execute();
   }
@@ -516,7 +516,7 @@ public class AdExchangeBuyerExample {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials, see:
+    // TODO: Change placeholder below to generate authentication credentials. See:
     // https://foo.com/bar
     //
     // Authorize using the following scope:
@@ -557,8 +557,8 @@ public class AdExchangeBuyerExample {
     // The buyer-specific id for this creative.
     String buyerCreativeId = "";  // TODO: Update placeholder value.
 
-    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
-    AdExchangeBuyer.Creatives.Get request = adexchangebuyerService.creatives().get(accountId, buyerCreativeId);
+    AdExchangeBuyer adExchangeBuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Creatives.Get request = adExchangeBuyerService.creatives().get(accountId, buyerCreativeId);
 
     Creative response = request.execute();
 
@@ -570,7 +570,7 @@ public class AdExchangeBuyerExample {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials, see:
+    // TODO: Change placeholder below to generate authentication credentials. See:
     // https://foo.com/bar
     //
     // Authorize using the following scope:
@@ -608,8 +608,8 @@ public class AdExchangeBuyerExample {
     // TODO: Assign values to desired fields of `requestBody`.
     Creative requestBody = new Creative();
 
-    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
-    AdExchangeBuyer.Creatives.Insert request = adexchangebuyerService.creatives().insert(requestBody);
+    AdExchangeBuyer adExchangeBuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Creatives.Insert request = adExchangeBuyerService.creatives().insert(requestBody);
 
     Creative response = request.execute();
 
@@ -621,7 +621,7 @@ public class AdExchangeBuyerExample {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials, see:
+    // TODO: Change placeholder below to generate authentication credentials. See:
     // https://foo.com/bar
     //
     // Authorize using the following scope:
@@ -657,8 +657,8 @@ import java.security.GeneralSecurityException;
 
 public class AdExchangeBuyerExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
-    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
-    AdExchangeBuyer.Creatives.List request = adexchangebuyerService.creatives().list();
+    AdExchangeBuyer adExchangeBuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Creatives.List request = adExchangeBuyerService.creatives().list();
 
     CreativesList response;
     do {
@@ -678,7 +678,7 @@ public class AdExchangeBuyerExample {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials, see:
+    // TODO: Change placeholder below to generate authentication credentials. See:
     // https://foo.com/bar
     //
     // Authorize using the following scope:
@@ -721,8 +721,8 @@ public class AdExchangeBuyerExample {
     // The id of the deal id to disassociate with this creative.
     long dealId = 0L;  // TODO: Update placeholder value.
 
-    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
-    AdExchangeBuyer.Creatives.RemoveDeal request = adexchangebuyerService.creatives().removeDeal(accountId, buyerCreativeId, dealId);
+    AdExchangeBuyer adExchangeBuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Creatives.RemoveDeal request = adExchangeBuyerService.creatives().removeDeal(accountId, buyerCreativeId, dealId);
 
     request.execute();
   }
@@ -731,7 +731,7 @@ public class AdExchangeBuyerExample {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials, see:
+    // TODO: Change placeholder below to generate authentication credentials. See:
     // https://foo.com/bar
     //
     // Authorize using the following scope:
@@ -773,8 +773,8 @@ public class AdExchangeBuyerExample {
     // TODO: Assign values to desired fields of `requestBody`.
     DeleteOrderDealsRequest requestBody = new DeleteOrderDealsRequest();
 
-    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
-    AdExchangeBuyer.Marketplacedeals.Delete request = adexchangebuyerService.marketplacedeals().delete(proposalId, requestBody);
+    AdExchangeBuyer adExchangeBuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Marketplacedeals.Delete request = adExchangeBuyerService.marketplacedeals().delete(proposalId, requestBody);
 
     DeleteOrderDealsResponse response = request.execute();
 
@@ -786,7 +786,7 @@ public class AdExchangeBuyerExample {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials, see:
+    // TODO: Change placeholder below to generate authentication credentials. See:
     // https://foo.com/bar
     //
     // Authorize using the following scope:
@@ -828,8 +828,8 @@ public class AdExchangeBuyerExample {
     // TODO: Assign values to desired fields of `requestBody`.
     AddOrderDealsRequest requestBody = new AddOrderDealsRequest();
 
-    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
-    AdExchangeBuyer.Marketplacedeals.Insert request = adexchangebuyerService.marketplacedeals().insert(proposalId, requestBody);
+    AdExchangeBuyer adExchangeBuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Marketplacedeals.Insert request = adExchangeBuyerService.marketplacedeals().insert(proposalId, requestBody);
 
     AddOrderDealsResponse response = request.execute();
 
@@ -841,7 +841,7 @@ public class AdExchangeBuyerExample {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials, see:
+    // TODO: Change placeholder below to generate authentication credentials. See:
     // https://foo.com/bar
     //
     // Authorize using the following scope:
@@ -880,8 +880,8 @@ public class AdExchangeBuyerExample {
     // the URL.
     String proposalId = "";  // TODO: Update placeholder value.
 
-    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
-    AdExchangeBuyer.Marketplacedeals.List request = adexchangebuyerService.marketplacedeals().list(proposalId);
+    AdExchangeBuyer adExchangeBuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Marketplacedeals.List request = adExchangeBuyerService.marketplacedeals().list(proposalId);
 
     GetOrderDealsResponse response = request.execute();
 
@@ -893,7 +893,7 @@ public class AdExchangeBuyerExample {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials, see:
+    // TODO: Change placeholder below to generate authentication credentials. See:
     // https://foo.com/bar
     //
     // Authorize using the following scope:
@@ -935,8 +935,8 @@ public class AdExchangeBuyerExample {
     // TODO: Assign values to desired fields of `requestBody`.
     EditAllOrderDealsRequest requestBody = new EditAllOrderDealsRequest();
 
-    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
-    AdExchangeBuyer.Marketplacedeals.Update request = adexchangebuyerService.marketplacedeals().update(proposalId, requestBody);
+    AdExchangeBuyer adExchangeBuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Marketplacedeals.Update request = adExchangeBuyerService.marketplacedeals().update(proposalId, requestBody);
 
     EditAllOrderDealsResponse response = request.execute();
 
@@ -948,7 +948,7 @@ public class AdExchangeBuyerExample {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials, see:
+    // TODO: Change placeholder below to generate authentication credentials. See:
     // https://foo.com/bar
     //
     // Authorize using the following scope:
@@ -990,8 +990,8 @@ public class AdExchangeBuyerExample {
     // TODO: Assign values to desired fields of `requestBody`.
     AddOrderNotesRequest requestBody = new AddOrderNotesRequest();
 
-    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
-    AdExchangeBuyer.Marketplacenotes.Insert request = adexchangebuyerService.marketplacenotes().insert(proposalId, requestBody);
+    AdExchangeBuyer adExchangeBuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Marketplacenotes.Insert request = adExchangeBuyerService.marketplacenotes().insert(proposalId, requestBody);
 
     AddOrderNotesResponse response = request.execute();
 
@@ -1003,7 +1003,7 @@ public class AdExchangeBuyerExample {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials, see:
+    // TODO: Change placeholder below to generate authentication credentials. See:
     // https://foo.com/bar
     //
     // Authorize using the following scope:
@@ -1042,8 +1042,8 @@ public class AdExchangeBuyerExample {
     // the URL.
     String proposalId = "";  // TODO: Update placeholder value.
 
-    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
-    AdExchangeBuyer.Marketplacenotes.List request = adexchangebuyerService.marketplacenotes().list(proposalId);
+    AdExchangeBuyer adExchangeBuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Marketplacenotes.List request = adExchangeBuyerService.marketplacenotes().list(proposalId);
 
     GetOrderNotesResponse response = request.execute();
 
@@ -1055,7 +1055,7 @@ public class AdExchangeBuyerExample {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials, see:
+    // TODO: Change placeholder below to generate authentication credentials. See:
     // https://foo.com/bar
     //
     // Authorize using the following scope:
@@ -1096,8 +1096,8 @@ public class AdExchangeBuyerExample {
     // TODO: Assign values to desired fields of `requestBody`.
     UpdatePrivateAuctionProposalRequest requestBody = new UpdatePrivateAuctionProposalRequest();
 
-    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
-    AdExchangeBuyer.Marketplaceprivateauction.Updateproposal request = adexchangebuyerService.marketplaceprivateauction().updateproposal(privateAuctionId, requestBody);
+    AdExchangeBuyer adExchangeBuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Marketplaceprivateauction.Updateproposal request = adExchangeBuyerService.marketplaceprivateauction().updateproposal(privateAuctionId, requestBody);
 
     request.execute();
   }
@@ -1106,7 +1106,7 @@ public class AdExchangeBuyerExample {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials, see:
+    // TODO: Change placeholder below to generate authentication credentials. See:
     // https://foo.com/bar
     //
     // Authorize using the following scope:
@@ -1150,8 +1150,8 @@ public class AdExchangeBuyerExample {
     // The start time of the report in ISO 8601 timestamp format using UTC.
     String startDateTime = "";  // TODO: Update placeholder value.
 
-    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
-    AdExchangeBuyer.PerformanceReport.List request = adexchangebuyerService.performanceReport().list(accountId, endDateTime, startDateTime);
+    AdExchangeBuyer adExchangeBuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.PerformanceReport.List request = adExchangeBuyerService.performanceReport().list(accountId, endDateTime, startDateTime);
 
     PerformanceReportList response = request.execute();
 
@@ -1163,7 +1163,7 @@ public class AdExchangeBuyerExample {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials, see:
+    // TODO: Change placeholder below to generate authentication credentials. See:
     // https://foo.com/bar
     //
     // Authorize using the following scope:
@@ -1203,8 +1203,8 @@ public class AdExchangeBuyerExample {
     // The specific id of the configuration to delete.
     long configId = 0L;  // TODO: Update placeholder value.
 
-    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
-    AdExchangeBuyer.PretargetingConfig.Delete request = adexchangebuyerService.pretargetingConfig().delete(accountId, configId);
+    AdExchangeBuyer adExchangeBuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.PretargetingConfig.Delete request = adExchangeBuyerService.pretargetingConfig().delete(accountId, configId);
 
     request.execute();
   }
@@ -1213,7 +1213,7 @@ public class AdExchangeBuyerExample {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials, see:
+    // TODO: Change placeholder below to generate authentication credentials. See:
     // https://foo.com/bar
     //
     // Authorize using the following scope:
@@ -1254,8 +1254,8 @@ public class AdExchangeBuyerExample {
     // The specific id of the configuration to retrieve.
     long configId = 0L;  // TODO: Update placeholder value.
 
-    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
-    AdExchangeBuyer.PretargetingConfig.Get request = adexchangebuyerService.pretargetingConfig().get(accountId, configId);
+    AdExchangeBuyer adExchangeBuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.PretargetingConfig.Get request = adExchangeBuyerService.pretargetingConfig().get(accountId, configId);
 
     PretargetingConfig response = request.execute();
 
@@ -1267,7 +1267,7 @@ public class AdExchangeBuyerExample {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials, see:
+    // TODO: Change placeholder below to generate authentication credentials. See:
     // https://foo.com/bar
     //
     // Authorize using the following scope:
@@ -1308,8 +1308,8 @@ public class AdExchangeBuyerExample {
     // TODO: Assign values to desired fields of `requestBody`.
     PretargetingConfig requestBody = new PretargetingConfig();
 
-    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
-    AdExchangeBuyer.PretargetingConfig.Insert request = adexchangebuyerService.pretargetingConfig().insert(accountId, requestBody);
+    AdExchangeBuyer adExchangeBuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.PretargetingConfig.Insert request = adExchangeBuyerService.pretargetingConfig().insert(accountId, requestBody);
 
     PretargetingConfig response = request.execute();
 
@@ -1321,7 +1321,7 @@ public class AdExchangeBuyerExample {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials, see:
+    // TODO: Change placeholder below to generate authentication credentials. See:
     // https://foo.com/bar
     //
     // Authorize using the following scope:
@@ -1359,8 +1359,8 @@ public class AdExchangeBuyerExample {
     // The account id to get the pretargeting configs for.
     long accountId = 0L;  // TODO: Update placeholder value.
 
-    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
-    AdExchangeBuyer.PretargetingConfig.List request = adexchangebuyerService.pretargetingConfig().list(accountId);
+    AdExchangeBuyer adExchangeBuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.PretargetingConfig.List request = adExchangeBuyerService.pretargetingConfig().list(accountId);
 
     PretargetingConfigList response = request.execute();
 
@@ -1372,7 +1372,7 @@ public class AdExchangeBuyerExample {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials, see:
+    // TODO: Change placeholder below to generate authentication credentials. See:
     // https://foo.com/bar
     //
     // Authorize using the following scope:
@@ -1417,8 +1417,8 @@ public class AdExchangeBuyerExample {
     // Only assigned fields will be changed.
     PretargetingConfig requestBody = new PretargetingConfig();
 
-    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
-    AdExchangeBuyer.PretargetingConfig.Patch request = adexchangebuyerService.pretargetingConfig().patch(accountId, configId, requestBody);
+    AdExchangeBuyer adExchangeBuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.PretargetingConfig.Patch request = adExchangeBuyerService.pretargetingConfig().patch(accountId, configId, requestBody);
 
     PretargetingConfig response = request.execute();
 
@@ -1430,7 +1430,7 @@ public class AdExchangeBuyerExample {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials, see:
+    // TODO: Change placeholder below to generate authentication credentials. See:
     // https://foo.com/bar
     //
     // Authorize using the following scope:
@@ -1474,8 +1474,8 @@ public class AdExchangeBuyerExample {
     // TODO: Assign values to desired fields of `requestBody`.
     PretargetingConfig requestBody = new PretargetingConfig();
 
-    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
-    AdExchangeBuyer.PretargetingConfig.Update request = adexchangebuyerService.pretargetingConfig().update(accountId, configId, requestBody);
+    AdExchangeBuyer adExchangeBuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.PretargetingConfig.Update request = adExchangeBuyerService.pretargetingConfig().update(accountId, configId, requestBody);
 
     PretargetingConfig response = request.execute();
 
@@ -1487,7 +1487,7 @@ public class AdExchangeBuyerExample {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials, see:
+    // TODO: Change placeholder below to generate authentication credentials. See:
     // https://foo.com/bar
     //
     // Authorize using the following scope:
@@ -1525,8 +1525,8 @@ public class AdExchangeBuyerExample {
     // The id for the product to get the head revision for.
     String productId = "";  // TODO: Update placeholder value.
 
-    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
-    AdExchangeBuyer.Products.Get request = adexchangebuyerService.products().get(productId);
+    AdExchangeBuyer adExchangeBuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Products.Get request = adExchangeBuyerService.products().get(productId);
 
     Product response = request.execute();
 
@@ -1538,7 +1538,7 @@ public class AdExchangeBuyerExample {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials, see:
+    // TODO: Change placeholder below to generate authentication credentials. See:
     // https://foo.com/bar
     //
     // Authorize using the following scope:
@@ -1573,8 +1573,8 @@ import java.security.GeneralSecurityException;
 
 public class AdExchangeBuyerExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
-    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
-    AdExchangeBuyer.Products.Search request = adexchangebuyerService.products().search();
+    AdExchangeBuyer adExchangeBuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Products.Search request = adExchangeBuyerService.products().search();
 
     GetOffersResponse response = request.execute();
 
@@ -1586,7 +1586,7 @@ public class AdExchangeBuyerExample {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials, see:
+    // TODO: Change placeholder below to generate authentication credentials. See:
     // https://foo.com/bar
     //
     // Authorize using the following scope:
@@ -1624,8 +1624,8 @@ public class AdExchangeBuyerExample {
     // Id of the proposal to retrieve.
     String proposalId = "";  // TODO: Update placeholder value.
 
-    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
-    AdExchangeBuyer.Proposals.Get request = adexchangebuyerService.proposals().get(proposalId);
+    AdExchangeBuyer adExchangeBuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Proposals.Get request = adExchangeBuyerService.proposals().get(proposalId);
 
     Proposal response = request.execute();
 
@@ -1637,7 +1637,7 @@ public class AdExchangeBuyerExample {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials, see:
+    // TODO: Change placeholder below to generate authentication credentials. See:
     // https://foo.com/bar
     //
     // Authorize using the following scope:
@@ -1676,8 +1676,8 @@ public class AdExchangeBuyerExample {
     // TODO: Assign values to desired fields of `requestBody`.
     CreateOrdersRequest requestBody = new CreateOrdersRequest();
 
-    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
-    AdExchangeBuyer.Proposals.Insert request = adexchangebuyerService.proposals().insert(requestBody);
+    AdExchangeBuyer adExchangeBuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Proposals.Insert request = adExchangeBuyerService.proposals().insert(requestBody);
 
     CreateOrdersResponse response = request.execute();
 
@@ -1689,7 +1689,7 @@ public class AdExchangeBuyerExample {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials, see:
+    // TODO: Change placeholder below to generate authentication credentials. See:
     // https://foo.com/bar
     //
     // Authorize using the following scope:
@@ -1740,8 +1740,8 @@ public class AdExchangeBuyerExample {
     // Only assigned fields will be changed.
     Proposal requestBody = new Proposal();
 
-    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
-    AdExchangeBuyer.Proposals.Patch request = adexchangebuyerService.proposals().patch(proposalId, revisionNumber, updateAction, requestBody);
+    AdExchangeBuyer adExchangeBuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Proposals.Patch request = adExchangeBuyerService.proposals().patch(proposalId, revisionNumber, updateAction, requestBody);
 
     Proposal response = request.execute();
 
@@ -1753,7 +1753,7 @@ public class AdExchangeBuyerExample {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials, see:
+    // TODO: Change placeholder below to generate authentication credentials. See:
     // https://foo.com/bar
     //
     // Authorize using the following scope:
@@ -1788,8 +1788,8 @@ import java.security.GeneralSecurityException;
 
 public class AdExchangeBuyerExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
-    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
-    AdExchangeBuyer.Proposals.Search request = adexchangebuyerService.proposals().search();
+    AdExchangeBuyer adExchangeBuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Proposals.Search request = adExchangeBuyerService.proposals().search();
 
     GetOrdersResponse response = request.execute();
 
@@ -1801,7 +1801,7 @@ public class AdExchangeBuyerExample {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials, see:
+    // TODO: Change placeholder below to generate authentication credentials. See:
     // https://foo.com/bar
     //
     // Authorize using the following scope:
@@ -1838,8 +1838,8 @@ public class AdExchangeBuyerExample {
     // The proposal id for which the setup is complete
     String proposalId = "";  // TODO: Update placeholder value.
 
-    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
-    AdExchangeBuyer.Proposals.Setupcomplete request = adexchangebuyerService.proposals().setupcomplete(proposalId);
+    AdExchangeBuyer adExchangeBuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Proposals.Setupcomplete request = adExchangeBuyerService.proposals().setupcomplete(proposalId);
 
     request.execute();
   }
@@ -1848,7 +1848,7 @@ public class AdExchangeBuyerExample {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials, see:
+    // TODO: Change placeholder below to generate authentication credentials. See:
     // https://foo.com/bar
     //
     // Authorize using the following scope:
@@ -1898,8 +1898,8 @@ public class AdExchangeBuyerExample {
     // TODO: Assign values to desired fields of `requestBody`.
     Proposal requestBody = new Proposal();
 
-    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
-    AdExchangeBuyer.Proposals.Update request = adexchangebuyerService.proposals().update(proposalId, revisionNumber, updateAction, requestBody);
+    AdExchangeBuyer adExchangeBuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Proposals.Update request = adExchangeBuyerService.proposals().update(proposalId, revisionNumber, updateAction, requestBody);
 
     Proposal response = request.execute();
 
@@ -1911,7 +1911,7 @@ public class AdExchangeBuyerExample {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials, see:
+    // TODO: Change placeholder below to generate authentication credentials. See:
     // https://foo.com/bar
     //
     // Authorize using the following scope:
@@ -1949,8 +1949,8 @@ public class AdExchangeBuyerExample {
     // The accountId of the publisher to get profiles for.
     int accountId = 0;  // TODO: Update placeholder value.
 
-    AdExchangeBuyer adexchangebuyerService = createAdExchangeBuyerService();
-    AdExchangeBuyer.Pubprofiles.List request = adexchangebuyerService.pubprofiles().list(accountId);
+    AdExchangeBuyer adExchangeBuyerService = createAdExchangeBuyerService();
+    AdExchangeBuyer.Pubprofiles.List request = adExchangeBuyerService.pubprofiles().list(accountId);
 
     GetPublisherProfilesByAccountIdResponse response = request.execute();
 
@@ -1962,7 +1962,7 @@ public class AdExchangeBuyerExample {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
-    // TODO: Change placeholder below to generate authentication credentials, see:
+    // TODO: Change placeholder below to generate authentication credentials. See:
     // https://foo.com/bar
     //
     // Authorize using the following scope:

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/mvvm_java/java_logging.v2beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/mvvm_java/java_logging.v2beta1.json.baseline
@@ -209,7 +209,8 @@ import java.util.Arrays;
 public class LoggingExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
     // Required. The resource name of the log to delete. Example: `"projects/my-project/logs/syslog"`.
-    String logName = "projects/{MY-PROJECT}/logs/{MY-LOG}";  // TODO: Update placeholder values.
+    String logName = "";  // TODO: Update placeholder value.
+    // ex: "projects/my-project/logs/my-log"
 
     Logging loggingService = createLoggingService();
     Logging.Projects.Logs.Delete request = loggingService.projects().logs().delete(logName);
@@ -262,7 +263,8 @@ public class LoggingExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The resource name of the project in which to create the metric. Example:
     // `"projects/my-project-id"`. The new metric must be provided in the request.
-    String projectName = "projects/{MY-PROJECT}";  // TODO: Update placeholder value.
+    String projectName = "";  // TODO: Update placeholder value.
+    // ex: "projects/my-project"
 
     // TODO: Assign values to desired fields of `requestBody`.
     LogMetric requestBody = new LogMetric();
@@ -320,7 +322,8 @@ public class LoggingExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The resource name of the metric to delete. Example:
     // `"projects/my-project-id/metrics/my-metric-id"`.
-    String metricName = "projects/{MY-PROJECT}/metrics/{MY-METRIC}";  // TODO: Update placeholder values.
+    String metricName = "";  // TODO: Update placeholder value.
+    // ex: "projects/my-project/metrics/my-metric"
 
     Logging loggingService = createLoggingService();
     Logging.Projects.Metrics.Delete request = loggingService.projects().metrics().delete(metricName);
@@ -372,7 +375,8 @@ import java.util.Arrays;
 public class LoggingExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The resource name of the desired metric. Example: `"projects/my-project-id/metrics/my-metric-id"`.
-    String metricName = "projects/{MY-PROJECT}/metrics/{MY-METRIC}";  // TODO: Update placeholder values.
+    String metricName = "";  // TODO: Update placeholder value.
+    // ex: "projects/my-project/metrics/my-metric"
 
     Logging loggingService = createLoggingService();
     Logging.Projects.Metrics.Get request = loggingService.projects().metrics().get(metricName);
@@ -429,7 +433,8 @@ public class LoggingExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
     // Required. The resource name of the project containing the metrics. Example:
     // `"projects/my-project-id"`.
-    String projectName = "projects/{MY-PROJECT}";  // TODO: Update placeholder value.
+    String projectName = "";  // TODO: Update placeholder value.
+    // ex: "projects/my-project"
 
     Logging loggingService = createLoggingService();
     Logging.Projects.Metrics.List request = loggingService.projects().metrics().list(projectName);
@@ -495,7 +500,8 @@ public class LoggingExample {
     // `"projects/my-project-id/metrics/my-metric-id"`. The updated metric must be provided in the request
     // and have the same identifier that is specified in `metricName`. If the metric does not exist, it is
     // created.
-    String metricName = "projects/{MY-PROJECT}/metrics/{MY-METRIC}";  // TODO: Update placeholder values.
+    String metricName = "";  // TODO: Update placeholder value.
+    // ex: "projects/my-project/metrics/my-metric"
 
     // TODO: Assign values to desired fields of `requestBody`.
     LogMetric requestBody = new LogMetric();
@@ -554,7 +560,8 @@ public class LoggingExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The resource name of the project in which to create the sink. Example: `"projects/my-project-id"`.
     // The new sink must be provided in the request.
-    String projectName = "projects/{MY-PROJECT}";  // TODO: Update placeholder value.
+    String projectName = "";  // TODO: Update placeholder value.
+    // ex: "projects/my-project"
 
     // TODO: Assign values to desired fields of `requestBody`.
     LogSink requestBody = new LogSink();
@@ -611,7 +618,8 @@ import java.util.Arrays;
 public class LoggingExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The resource name of the sink to delete. Example: `"projects/my-project-id/sinks/my-sink-id"`.
-    String sinkName = "projects/{MY-PROJECT}/sinks/{MY-SINK}";  // TODO: Update placeholder values.
+    String sinkName = "";  // TODO: Update placeholder value.
+    // ex: "projects/my-project/sinks/my-sink"
 
     Logging loggingService = createLoggingService();
     Logging.Projects.Sinks.Delete request = loggingService.projects().sinks().delete(sinkName);
@@ -663,7 +671,8 @@ import java.util.Arrays;
 public class LoggingExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The resource name of the sink to return. Example: `"projects/my-project-id/sinks/my-sink-id"`.
-    String sinkName = "projects/{MY-PROJECT}/sinks/{MY-SINK}";  // TODO: Update placeholder values.
+    String sinkName = "";  // TODO: Update placeholder value.
+    // ex: "projects/my-project/sinks/my-sink"
 
     Logging loggingService = createLoggingService();
     Logging.Projects.Sinks.Get request = loggingService.projects().sinks().get(sinkName);
@@ -720,7 +729,8 @@ public class LoggingExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
     // Required. The resource name of the project containing the sinks. Example:
     // `"projects/my-logging-project"`.
-    String projectName = "projects/{MY-PROJECT}";  // TODO: Update placeholder value.
+    String projectName = "";  // TODO: Update placeholder value.
+    // ex: "projects/my-project"
 
     Logging loggingService = createLoggingService();
     Logging.Projects.Sinks.List request = loggingService.projects().sinks().list(projectName);
@@ -785,7 +795,8 @@ public class LoggingExample {
     // The resource name of the sink to update. Example: `"projects/my-project-id/sinks/my-sink-id"`. The
     // updated sink must be provided in the request and have the same name that is specified in
     // `sinkName`. If the sink does not exist, it is created.
-    String sinkName = "projects/{MY-PROJECT}/sinks/{MY-SINK}";  // TODO: Update placeholder values.
+    String sinkName = "";  // TODO: Update placeholder value.
+    // ex: "projects/my-project/sinks/my-sink"
 
     // TODO: Assign values to desired fields of `requestBody`.
     LogSink requestBody = new LogSink();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/mvvm_java/java_logging.v2beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/mvvm_java/java_logging.v2beta1.json.baseline
@@ -1,5 +1,5 @@
 
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Logging API
@@ -20,7 +20,6 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.logging.v2beta1.Logging;
-import com.google.api.services.logging.v2beta1.Logging.Entries.List;
 import com.google.api.services.logging.v2beta1.model.ListLogEntriesRequest;
 import com.google.api.services.logging.v2beta1.model.ListLogEntriesResponse;
 import com.google.api.services.logging.v2beta1.model.LogEntry;
@@ -29,12 +28,12 @@ import java.security.GeneralSecurityException;
 import java.util.Arrays;
 
 public class LoggingExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // TODO: Assign values to desired fields of `requestBody`.
     ListLogEntriesRequest requestBody = new ListLogEntriesRequest();
 
-    Logging loggingService = createService();
-    List request = loggingService.entries().list(requestBody);
+    Logging loggingService = createLoggingService();
+    Logging.Entries.List request = loggingService.entries().list(requestBody);
 
     ListLogEntriesResponse response;
     do {
@@ -46,15 +45,15 @@ public class LoggingExample {
         // TODO: Change code below to process each `logEntry` resource:
         System.out.println(logEntry);
       }
+      requestBody.setPageToken(response.getNextPageToken());
     } while (response.getNextPageToken() != null);
   }
 
-  public Logging createService() throws IOException, GeneralSecurityException {
+  public static Logging createLoggingService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
     if (credential.createScopedRequired()) {
       credential =
           credential.createScoped(Arrays.asList("https://www.googleapis.com/auth/cloud-platform"));
@@ -64,18 +63,8 @@ public class LoggingExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new LoggingExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Logging API
@@ -96,7 +85,6 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.logging.v2beta1.Logging;
-import com.google.api.services.logging.v2beta1.Logging.Entries.Write;
 import com.google.api.services.logging.v2beta1.model.WriteLogEntriesRequest;
 import com.google.api.services.logging.v2beta1.model.WriteLogEntriesResponse;
 import java.io.IOException;
@@ -104,23 +92,24 @@ import java.security.GeneralSecurityException;
 import java.util.Arrays;
 
 public class LoggingExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // TODO: Assign values to desired fields of `requestBody`.
     WriteLogEntriesRequest requestBody = new WriteLogEntriesRequest();
 
-    Logging loggingService = createService();
-    Write request = loggingService.entries().write(requestBody);
+    Logging loggingService = createLoggingService();
+    Logging.Entries.Write request = loggingService.entries().write(requestBody);
 
     WriteLogEntriesResponse response = request.execute();
+
+    // TODO: Change code below to process the `response` object:
     System.out.println(response);
   }
 
-  public Logging createService() throws IOException, GeneralSecurityException {
+  public static Logging createLoggingService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
     if (credential.createScopedRequired()) {
       credential =
           credential.createScoped(Arrays.asList("https://www.googleapis.com/auth/cloud-platform"));
@@ -130,18 +119,8 @@ public class LoggingExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new LoggingExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Logging API
@@ -162,7 +141,6 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.logging.v2beta1.Logging;
-import com.google.api.services.logging.v2beta1.Logging.MonitoredResourceDescriptors.List;
 import com.google.api.services.logging.v2beta1.model.ListMonitoredResourceDescriptorsResponse;
 import com.google.api.services.logging.v2beta1.model.MonitoredResourceDescriptor;
 import java.io.IOException;
@@ -170,9 +148,9 @@ import java.security.GeneralSecurityException;
 import java.util.Arrays;
 
 public class LoggingExample {
-  public void run() throws IOException, GeneralSecurityException {
-    Logging loggingService = createService();
-    List request = loggingService.monitoredResourceDescriptors().list();
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
+    Logging loggingService = createLoggingService();
+    Logging.MonitoredResourceDescriptors.List request = loggingService.monitoredResourceDescriptors().list();
 
     ListMonitoredResourceDescriptorsResponse response;
     do {
@@ -184,15 +162,15 @@ public class LoggingExample {
         // TODO: Change code below to process each `monitoredResourceDescriptor` resource:
         System.out.println(monitoredResourceDescriptor);
       }
+      request.setPageToken(response.getNextPageToken());
     } while (response.getNextPageToken() != null);
   }
 
-  public Logging createService() throws IOException, GeneralSecurityException {
+  public static Logging createLoggingService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
     if (credential.createScopedRequired()) {
       credential =
           credential.createScoped(Arrays.asList("https://www.googleapis.com/auth/cloud-platform"));
@@ -202,18 +180,8 @@ public class LoggingExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new LoggingExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Logging API
@@ -234,28 +202,26 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.logging.v2beta1.Logging;
-import com.google.api.services.logging.v2beta1.Logging.Projects.Logs.Delete;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Arrays;
 
 public class LoggingExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // Required. The resource name of the log to delete. Example: `"projects/my-project/logs/syslog"`.
-    String logName = "projects/{MY-PROJECT}/logs/{MY-LOG}"; // TODO: Update placeholder values.
+    String logName = "projects/{MY-PROJECT}/logs/{MY-LOG}";  // TODO: Update placeholder values.
 
-    Logging loggingService = createService();
-    Delete request = loggingService.projects().logs().delete(logName);
+    Logging loggingService = createLoggingService();
+    Logging.Projects.Logs.Delete request = loggingService.projects().logs().delete(logName);
 
     request.execute();
   }
 
-  public Logging createService() throws IOException, GeneralSecurityException {
+  public static Logging createLoggingService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
     if (credential.createScopedRequired()) {
       credential =
           credential.createScoped(Arrays.asList("https://www.googleapis.com/auth/cloud-platform"));
@@ -265,18 +231,8 @@ public class LoggingExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new LoggingExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Logging API
@@ -297,34 +253,34 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.logging.v2beta1.Logging;
-import com.google.api.services.logging.v2beta1.Logging.Projects.Metrics.Create;
 import com.google.api.services.logging.v2beta1.model.LogMetric;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Arrays;
 
 public class LoggingExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The resource name of the project in which to create the metric. Example:
     // `"projects/my-project-id"`. The new metric must be provided in the request.
-    String projectName = "projects/{MY-PROJECT}"; // TODO: Update placeholder value.
+    String projectName = "projects/{MY-PROJECT}";  // TODO: Update placeholder value.
 
     // TODO: Assign values to desired fields of `requestBody`.
     LogMetric requestBody = new LogMetric();
 
-    Logging loggingService = createService();
-    Create request = loggingService.projects().metrics().create(projectName, requestBody);
+    Logging loggingService = createLoggingService();
+    Logging.Projects.Metrics.Create request = loggingService.projects().metrics().create(projectName, requestBody);
 
     LogMetric response = request.execute();
+
+    // TODO: Change code below to process the `response` object:
     System.out.println(response);
   }
 
-  public Logging createService() throws IOException, GeneralSecurityException {
+  public static Logging createLoggingService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
     if (credential.createScopedRequired()) {
       credential =
           credential.createScoped(Arrays.asList("https://www.googleapis.com/auth/cloud-platform"));
@@ -334,18 +290,8 @@ public class LoggingExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new LoggingExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Logging API
@@ -366,29 +312,27 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.logging.v2beta1.Logging;
-import com.google.api.services.logging.v2beta1.Logging.Projects.Metrics.Delete;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Arrays;
 
 public class LoggingExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The resource name of the metric to delete. Example:
     // `"projects/my-project-id/metrics/my-metric-id"`.
-    String metricName = "projects/{MY-PROJECT}/metrics/{MY-METRIC}"; // TODO: Update placeholder values.
+    String metricName = "projects/{MY-PROJECT}/metrics/{MY-METRIC}";  // TODO: Update placeholder values.
 
-    Logging loggingService = createService();
-    Delete request = loggingService.projects().metrics().delete(metricName);
+    Logging loggingService = createLoggingService();
+    Logging.Projects.Metrics.Delete request = loggingService.projects().metrics().delete(metricName);
 
     request.execute();
   }
 
-  public Logging createService() throws IOException, GeneralSecurityException {
+  public static Logging createLoggingService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
     if (credential.createScopedRequired()) {
       credential =
           credential.createScoped(Arrays.asList("https://www.googleapis.com/auth/cloud-platform"));
@@ -398,18 +342,8 @@ public class LoggingExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new LoggingExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Logging API
@@ -430,30 +364,30 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.logging.v2beta1.Logging;
-import com.google.api.services.logging.v2beta1.Logging.Projects.Metrics.Get;
 import com.google.api.services.logging.v2beta1.model.LogMetric;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Arrays;
 
 public class LoggingExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The resource name of the desired metric. Example: `"projects/my-project-id/metrics/my-metric-id"`.
-    String metricName = "projects/{MY-PROJECT}/metrics/{MY-METRIC}"; // TODO: Update placeholder values.
+    String metricName = "projects/{MY-PROJECT}/metrics/{MY-METRIC}";  // TODO: Update placeholder values.
 
-    Logging loggingService = createService();
-    Get request = loggingService.projects().metrics().get(metricName);
+    Logging loggingService = createLoggingService();
+    Logging.Projects.Metrics.Get request = loggingService.projects().metrics().get(metricName);
 
     LogMetric response = request.execute();
+
+    // TODO: Change code below to process the `response` object:
     System.out.println(response);
   }
 
-  public Logging createService() throws IOException, GeneralSecurityException {
+  public static Logging createLoggingService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
     if (credential.createScopedRequired()) {
       credential =
           credential.createScoped(Arrays.asList("https://www.googleapis.com/auth/cloud-platform"));
@@ -463,18 +397,8 @@ public class LoggingExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new LoggingExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Logging API
@@ -495,7 +419,6 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.logging.v2beta1.Logging;
-import com.google.api.services.logging.v2beta1.Logging.Projects.Metrics.List;
 import com.google.api.services.logging.v2beta1.model.ListLogMetricsResponse;
 import com.google.api.services.logging.v2beta1.model.LogMetric;
 import java.io.IOException;
@@ -503,13 +426,13 @@ import java.security.GeneralSecurityException;
 import java.util.Arrays;
 
 public class LoggingExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // Required. The resource name of the project containing the metrics. Example:
     // `"projects/my-project-id"`.
-    String projectName = "projects/{MY-PROJECT}"; // TODO: Update placeholder value.
+    String projectName = "projects/{MY-PROJECT}";  // TODO: Update placeholder value.
 
-    Logging loggingService = createService();
-    List request = loggingService.projects().metrics().list(projectName);
+    Logging loggingService = createLoggingService();
+    Logging.Projects.Metrics.List request = loggingService.projects().metrics().list(projectName);
 
     ListLogMetricsResponse response;
     do {
@@ -521,15 +444,15 @@ public class LoggingExample {
         // TODO: Change code below to process each `logMetric` resource:
         System.out.println(logMetric);
       }
+      request.setPageToken(response.getNextPageToken());
     } while (response.getNextPageToken() != null);
   }
 
-  public Logging createService() throws IOException, GeneralSecurityException {
+  public static Logging createLoggingService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
     if (credential.createScopedRequired()) {
       credential =
           credential.createScoped(Arrays.asList("https://www.googleapis.com/auth/cloud-platform"));
@@ -539,18 +462,8 @@ public class LoggingExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new LoggingExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Logging API
@@ -571,36 +484,36 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.logging.v2beta1.Logging;
-import com.google.api.services.logging.v2beta1.Logging.Projects.Metrics.Update;
 import com.google.api.services.logging.v2beta1.model.LogMetric;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Arrays;
 
 public class LoggingExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The resource name of the metric to update. Example:
     // `"projects/my-project-id/metrics/my-metric-id"`. The updated metric must be provided in the request
     // and have the same identifier that is specified in `metricName`. If the metric does not exist, it is
     // created.
-    String metricName = "projects/{MY-PROJECT}/metrics/{MY-METRIC}"; // TODO: Update placeholder values.
+    String metricName = "projects/{MY-PROJECT}/metrics/{MY-METRIC}";  // TODO: Update placeholder values.
 
     // TODO: Assign values to desired fields of `requestBody`.
     LogMetric requestBody = new LogMetric();
 
-    Logging loggingService = createService();
-    Update request = loggingService.projects().metrics().update(metricName, requestBody);
+    Logging loggingService = createLoggingService();
+    Logging.Projects.Metrics.Update request = loggingService.projects().metrics().update(metricName, requestBody);
 
     LogMetric response = request.execute();
+
+    // TODO: Change code below to process the `response` object:
     System.out.println(response);
   }
 
-  public Logging createService() throws IOException, GeneralSecurityException {
+  public static Logging createLoggingService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
     if (credential.createScopedRequired()) {
       credential =
           credential.createScoped(Arrays.asList("https://www.googleapis.com/auth/cloud-platform"));
@@ -610,18 +523,8 @@ public class LoggingExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new LoggingExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Logging API
@@ -642,34 +545,34 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.logging.v2beta1.Logging;
-import com.google.api.services.logging.v2beta1.Logging.Projects.Sinks.Create;
 import com.google.api.services.logging.v2beta1.model.LogSink;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Arrays;
 
 public class LoggingExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The resource name of the project in which to create the sink. Example: `"projects/my-project-id"`.
     // The new sink must be provided in the request.
-    String projectName = "projects/{MY-PROJECT}"; // TODO: Update placeholder value.
+    String projectName = "projects/{MY-PROJECT}";  // TODO: Update placeholder value.
 
     // TODO: Assign values to desired fields of `requestBody`.
     LogSink requestBody = new LogSink();
 
-    Logging loggingService = createService();
-    Create request = loggingService.projects().sinks().create(projectName, requestBody);
+    Logging loggingService = createLoggingService();
+    Logging.Projects.Sinks.Create request = loggingService.projects().sinks().create(projectName, requestBody);
 
     LogSink response = request.execute();
+
+    // TODO: Change code below to process the `response` object:
     System.out.println(response);
   }
 
-  public Logging createService() throws IOException, GeneralSecurityException {
+  public static Logging createLoggingService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
     if (credential.createScopedRequired()) {
       credential =
           credential.createScoped(Arrays.asList("https://www.googleapis.com/auth/cloud-platform"));
@@ -679,18 +582,8 @@ public class LoggingExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new LoggingExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Logging API
@@ -711,28 +604,26 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.logging.v2beta1.Logging;
-import com.google.api.services.logging.v2beta1.Logging.Projects.Sinks.Delete;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Arrays;
 
 public class LoggingExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The resource name of the sink to delete. Example: `"projects/my-project-id/sinks/my-sink-id"`.
-    String sinkName = "projects/{MY-PROJECT}/sinks/{MY-SINK}"; // TODO: Update placeholder values.
+    String sinkName = "projects/{MY-PROJECT}/sinks/{MY-SINK}";  // TODO: Update placeholder values.
 
-    Logging loggingService = createService();
-    Delete request = loggingService.projects().sinks().delete(sinkName);
+    Logging loggingService = createLoggingService();
+    Logging.Projects.Sinks.Delete request = loggingService.projects().sinks().delete(sinkName);
 
     request.execute();
   }
 
-  public Logging createService() throws IOException, GeneralSecurityException {
+  public static Logging createLoggingService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
     if (credential.createScopedRequired()) {
       credential =
           credential.createScoped(Arrays.asList("https://www.googleapis.com/auth/cloud-platform"));
@@ -742,18 +633,8 @@ public class LoggingExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new LoggingExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Logging API
@@ -774,30 +655,30 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.logging.v2beta1.Logging;
-import com.google.api.services.logging.v2beta1.Logging.Projects.Sinks.Get;
 import com.google.api.services.logging.v2beta1.model.LogSink;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Arrays;
 
 public class LoggingExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The resource name of the sink to return. Example: `"projects/my-project-id/sinks/my-sink-id"`.
-    String sinkName = "projects/{MY-PROJECT}/sinks/{MY-SINK}"; // TODO: Update placeholder values.
+    String sinkName = "projects/{MY-PROJECT}/sinks/{MY-SINK}";  // TODO: Update placeholder values.
 
-    Logging loggingService = createService();
-    Get request = loggingService.projects().sinks().get(sinkName);
+    Logging loggingService = createLoggingService();
+    Logging.Projects.Sinks.Get request = loggingService.projects().sinks().get(sinkName);
 
     LogSink response = request.execute();
+
+    // TODO: Change code below to process the `response` object:
     System.out.println(response);
   }
 
-  public Logging createService() throws IOException, GeneralSecurityException {
+  public static Logging createLoggingService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
     if (credential.createScopedRequired()) {
       credential =
           credential.createScoped(Arrays.asList("https://www.googleapis.com/auth/cloud-platform"));
@@ -807,18 +688,8 @@ public class LoggingExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new LoggingExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Logging API
@@ -839,7 +710,6 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.logging.v2beta1.Logging;
-import com.google.api.services.logging.v2beta1.Logging.Projects.Sinks.List;
 import com.google.api.services.logging.v2beta1.model.ListSinksResponse;
 import com.google.api.services.logging.v2beta1.model.LogSink;
 import java.io.IOException;
@@ -847,13 +717,13 @@ import java.security.GeneralSecurityException;
 import java.util.Arrays;
 
 public class LoggingExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // Required. The resource name of the project containing the sinks. Example:
     // `"projects/my-logging-project"`.
-    String projectName = "projects/{MY-PROJECT}"; // TODO: Update placeholder value.
+    String projectName = "projects/{MY-PROJECT}";  // TODO: Update placeholder value.
 
-    Logging loggingService = createService();
-    List request = loggingService.projects().sinks().list(projectName);
+    Logging loggingService = createLoggingService();
+    Logging.Projects.Sinks.List request = loggingService.projects().sinks().list(projectName);
 
     ListSinksResponse response;
     do {
@@ -865,15 +735,15 @@ public class LoggingExample {
         // TODO: Change code below to process each `logSink` resource:
         System.out.println(logSink);
       }
+      request.setPageToken(response.getNextPageToken());
     } while (response.getNextPageToken() != null);
   }
 
-  public Logging createService() throws IOException, GeneralSecurityException {
+  public static Logging createLoggingService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
     if (credential.createScopedRequired()) {
       credential =
           credential.createScoped(Arrays.asList("https://www.googleapis.com/auth/cloud-platform"));
@@ -883,18 +753,8 @@ public class LoggingExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new LoggingExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Logging API
@@ -915,35 +775,35 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.logging.v2beta1.Logging;
-import com.google.api.services.logging.v2beta1.Logging.Projects.Sinks.Update;
 import com.google.api.services.logging.v2beta1.model.LogSink;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Arrays;
 
 public class LoggingExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The resource name of the sink to update. Example: `"projects/my-project-id/sinks/my-sink-id"`. The
     // updated sink must be provided in the request and have the same name that is specified in
     // `sinkName`. If the sink does not exist, it is created.
-    String sinkName = "projects/{MY-PROJECT}/sinks/{MY-SINK}"; // TODO: Update placeholder values.
+    String sinkName = "projects/{MY-PROJECT}/sinks/{MY-SINK}";  // TODO: Update placeholder values.
 
     // TODO: Assign values to desired fields of `requestBody`.
     LogSink requestBody = new LogSink();
 
-    Logging loggingService = createService();
-    Update request = loggingService.projects().sinks().update(sinkName, requestBody);
+    Logging loggingService = createLoggingService();
+    Logging.Projects.Sinks.Update request = loggingService.projects().sinks().update(sinkName, requestBody);
 
     LogSink response = request.execute();
+
+    // TODO: Change code below to process the `response` object:
     System.out.println(response);
   }
 
-  public Logging createService() throws IOException, GeneralSecurityException {
+  public static Logging createLoggingService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
     GoogleCredential credential = GoogleCredential.getApplicationDefault();
-
     if (credential.createScopedRequired()) {
       credential =
           credential.createScoped(Arrays.asList("https://www.googleapis.com/auth/cloud-platform"));
@@ -952,15 +812,5 @@ public class LoggingExample {
     return new Logging.Builder(httpTransport, jsonFactory, credential)
         .setApplicationName("Google Cloud Platform Sample")
         .build();
-  }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new LoggingExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
   }
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/mvvm_java/java_translate.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/mvvm_java/java_translate.v2.json.baseline
@@ -1,5 +1,5 @@
 
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Translate API
@@ -16,25 +16,27 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.translate.Translate;
-import com.google.api.services.translate.Translate.Detections.List;
 import com.google.api.services.translate.model.DetectionsListResponse;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
+import java.util.List;
 
 public class TranslateExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The text to detect
-    java.util.List<String> q = new ArrayList<>(); // TODO: Update placeholder value.
+    List<String> q = new ArrayList<>();  // TODO: Update placeholder value.
 
-    Translate translateService = createService();
-    List request = translateService.detections().list(q);
+    Translate translateService = createTranslateService();
+    Translate.Detections.List request = translateService.detections().list(q);
 
     DetectionsListResponse response = request.execute();
+
+    // TODO: Change code below to process the `response` object:
     System.out.println(response);
   }
 
-  public Translate createService() throws IOException, GeneralSecurityException {
+  public static Translate createTranslateService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
@@ -46,18 +48,8 @@ public class TranslateExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new TranslateExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Translate API
@@ -74,21 +66,22 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.translate.Translate;
-import com.google.api.services.translate.Translate.Languages.List;
 import com.google.api.services.translate.model.LanguagesListResponse;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
 public class TranslateExample {
-  public void run() throws IOException, GeneralSecurityException {
-    Translate translateService = createService();
-    List request = translateService.languages().list();
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
+    Translate translateService = createTranslateService();
+    Translate.Languages.List request = translateService.languages().list();
 
     LanguagesListResponse response = request.execute();
+
+    // TODO: Change code below to process the `response` object:
     System.out.println(response);
   }
 
-  public Translate createService() throws IOException, GeneralSecurityException {
+  public static Translate createTranslateService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
@@ -100,18 +93,8 @@ public class TranslateExample {
         .setApplicationName("Google Cloud Platform Sample")
         .build();
   }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new TranslateExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
-  }
 }
-/*
+/**
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Translate API
@@ -128,28 +111,30 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.translate.Translate;
-import com.google.api.services.translate.Translate.Translations.List;
 import com.google.api.services.translate.model.TranslationsListResponse;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
+import java.util.List;
 
 public class TranslateExample {
-  public void run() throws IOException, GeneralSecurityException {
+  public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The text to translate
-    java.util.List<String> q = new ArrayList<>(); // TODO: Update placeholder value.
+    List<String> q = new ArrayList<>();  // TODO: Update placeholder value.
 
     // The target language into which the text should be translated
-    String target = ""; // TODO: Update placeholder value.
+    String target = "";  // TODO: Update placeholder value.
 
-    Translate translateService = createService();
-    List request = translateService.translations().list(q, target);
+    Translate translateService = createTranslateService();
+    Translate.Translations.List request = translateService.translations().list(q, target);
 
     TranslationsListResponse response = request.execute();
+
+    // TODO: Change code below to process the `response` object:
     System.out.println(response);
   }
 
-  public Translate createService() throws IOException, GeneralSecurityException {
+  public static Translate createTranslateService() throws IOException, GeneralSecurityException {
     HttpTransport httpTransport = GoogleNetHttpTransport.newTrustedTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
 
@@ -160,15 +145,5 @@ public class TranslateExample {
     return new Translate.Builder(httpTransport, jsonFactory, credential)
         .setApplicationName("Google Cloud Platform Sample")
         .build();
-  }
-
-  public static void main(String[] args) throws IOException, GeneralSecurityException {
-    try {
-      new TranslateExample().run();
-    } catch (IOException e) {
-      System.out.println(e.getMessage());
-    } catch (GeneralSecurityException e) {
-      System.out.println(e.getMessage());
-    }
   }
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/sqladmin.v1beta4.json.overrides
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/sqladmin.v1beta4.json.overrides
@@ -1,7 +1,6 @@
 {
   "java": {
     "apiTypeName": "SQLAdmin",
-    "lowerCamelApiTypeName": "sqlAdmin",
     "methods": {
       "sql.instances.import": {
         "nameComponents": [

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/sqladmin.v1beta4.json.overrides
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/sqladmin.v1beta4.json.overrides
@@ -1,6 +1,7 @@
 {
   "java": {
     "apiTypeName": "SQLAdmin",
+    "lowerCamelApiTypeName": "sqlAdmin",
     "methods": {
       "sql.instances.import": {
         "nameComponents": [
@@ -12,6 +13,9 @@
             "typeName": "Instances.SQLAdminImport"
           }
         }
+      },
+      "sql.users.list": {
+        "isPageStreaming": false
       }
     }
   }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/storagetransfer.v1.json.overrides
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/storagetransfer.v1.json.overrides
@@ -13,8 +13,7 @@
               "isArray": false,
               "isMessage": false
             },
-            "placeholder": "",
-            "isPlaceholderSingular": true,
+            "example": "",
             "description": "The ID of the Google Developers Console project that the Google service account is associated with. Required."
           }
         },


### PR DESCRIPTION
- Remove the main function.
- Rename createService to create{apiTypeName}service and make it static.
- Add missing nextPageToken assignment.
- Change to two spaces before placeholder TODOs.
- Put back response TODO.
- Fully qualify request types.
- Use double asterisk in instructions doc comment.
- Be consistent in auth link TODO formatting.
- Seed symbol table with reserved identifiers.
- Add override option for where the page streaming resource setter is in the
  request body instead of the request.
- Override isPageStreaming in sql.users.list, the Java client doesn't have the
  setPageToken function on the SQLAdmin.Users.List request.