### PR TITLE
Fix type in Go discovery sample

### DIFF
--- a/src/main/resources/com/google/api/codegen/go/discovery_fragment.snip
+++ b/src/main/resources/com/google/api/codegen/go/discovery_fragment.snip
@@ -88,7 +88,7 @@
     }
     @if authType != "APPLICATION_DEFAULT_CREDENTIALS"
 
-      func getClient(ctx Context) (*http.Client, error) {
+      func getClient(ctx context.Context) (*http.Client, error) {
         // {@TODO()} Change placeholder below to get authentication credentials.
         @let authInstructionsUrl = apiaryConfig.getAuthInstructionsUrl
           @if authInstructionsUrl

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_adexchangebuyer.v1.4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_adexchangebuyer.v1.4.json.baseline
@@ -46,7 +46,7 @@ func main() {
   fmt.Printf("%#v\n", resp)
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   //
@@ -98,7 +98,7 @@ func main() {
   fmt.Printf("%#v\n", resp)
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   //
@@ -157,7 +157,7 @@ func main() {
   fmt.Printf("%#v\n", resp)
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   //
@@ -216,7 +216,7 @@ func main() {
   fmt.Printf("%#v\n", resp)
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   //
@@ -271,7 +271,7 @@ func main() {
   fmt.Printf("%#v\n", resp)
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   //
@@ -323,7 +323,7 @@ func main() {
   fmt.Printf("%#v\n", resp)
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   //
@@ -382,7 +382,7 @@ func main() {
   fmt.Printf("%#v\n", resp)
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   //
@@ -445,7 +445,7 @@ func main() {
   fmt.Printf("%#v\n", resp)
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   //
@@ -508,7 +508,7 @@ func main() {
   fmt.Printf("%#v\n", resp)
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   //
@@ -566,7 +566,7 @@ func main() {
   }
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   //
@@ -625,7 +625,7 @@ func main() {
   fmt.Printf("%#v\n", resp)
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   //
@@ -681,7 +681,7 @@ func main() {
   fmt.Printf("%#v\n", resp)
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   //
@@ -736,7 +736,7 @@ func main() {
   }
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   //
@@ -794,7 +794,7 @@ func main() {
   }
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   //
@@ -853,7 +853,7 @@ func main() {
   fmt.Printf("%#v\n", resp)
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   //
@@ -912,7 +912,7 @@ func main() {
   fmt.Printf("%#v\n", resp)
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   //
@@ -968,7 +968,7 @@ func main() {
   fmt.Printf("%#v\n", resp)
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   //
@@ -1027,7 +1027,7 @@ func main() {
   fmt.Printf("%#v\n", resp)
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   //
@@ -1086,7 +1086,7 @@ func main() {
   fmt.Printf("%#v\n", resp)
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   //
@@ -1142,7 +1142,7 @@ func main() {
   fmt.Printf("%#v\n", resp)
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   //
@@ -1196,7 +1196,7 @@ func main() {
   }
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   //
@@ -1259,7 +1259,7 @@ func main() {
   fmt.Printf("%#v\n", resp)
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   //
@@ -1313,7 +1313,7 @@ func main() {
   }
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   //
@@ -1372,7 +1372,7 @@ func main() {
   fmt.Printf("%#v\n", resp)
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   //
@@ -1431,7 +1431,7 @@ func main() {
   fmt.Printf("%#v\n", resp)
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   //
@@ -1486,7 +1486,7 @@ func main() {
   fmt.Printf("%#v\n", resp)
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   //
@@ -1549,7 +1549,7 @@ func main() {
   fmt.Printf("%#v\n", resp)
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   //
@@ -1612,7 +1612,7 @@ func main() {
   fmt.Printf("%#v\n", resp)
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   //
@@ -1667,7 +1667,7 @@ func main() {
   fmt.Printf("%#v\n", resp)
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   //
@@ -1719,7 +1719,7 @@ func main() {
   fmt.Printf("%#v\n", resp)
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   //
@@ -1774,7 +1774,7 @@ func main() {
   fmt.Printf("%#v\n", resp)
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   //
@@ -1830,7 +1830,7 @@ func main() {
   fmt.Printf("%#v\n", resp)
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   //
@@ -1900,7 +1900,7 @@ func main() {
   fmt.Printf("%#v\n", resp)
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   //
@@ -1952,7 +1952,7 @@ func main() {
   fmt.Printf("%#v\n", resp)
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   //
@@ -2002,7 +2002,7 @@ func main() {
   }
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   //
@@ -2072,7 +2072,7 @@ func main() {
   fmt.Printf("%#v\n", resp)
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   //
@@ -2127,7 +2127,7 @@ func main() {
   fmt.Printf("%#v\n", resp)
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   //

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_taskqueue.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_taskqueue.v1beta2.json.baseline
@@ -50,7 +50,7 @@ func main() {
   fmt.Printf("%#v\n", resp)
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   //
@@ -108,7 +108,7 @@ func main() {
   }
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   //
@@ -171,7 +171,7 @@ func main() {
   fmt.Printf("%#v\n", resp)
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   //
@@ -234,7 +234,7 @@ func main() {
   fmt.Printf("%#v\n", resp)
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   //
@@ -301,7 +301,7 @@ func main() {
   fmt.Printf("%#v\n", resp)
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   //
@@ -360,7 +360,7 @@ func main() {
   fmt.Printf("%#v\n", resp)
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   //
@@ -431,7 +431,7 @@ func main() {
   fmt.Printf("%#v\n", resp)
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   //
@@ -502,7 +502,7 @@ func main() {
   fmt.Printf("%#v\n", resp)
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   //

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_translate.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_translate.v2.json.baseline
@@ -46,7 +46,7 @@ func main() {
   fmt.Printf("%#v\n", resp)
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   return nil, errors.New("Not implemented")
@@ -95,7 +95,7 @@ func main() {
   fmt.Printf("%#v\n", resp)
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   return nil, errors.New("Not implemented")
@@ -151,7 +151,7 @@ func main() {
   fmt.Printf("%#v\n", resp)
 }
 
-func getClient(ctx Context) (*http.Client, error) {
+func getClient(ctx context.Context) (*http.Client, error) {
   // TODO: Change placeholder below to get authentication credentials.
   // See: https://foo.com/bar
   return nil, errors.New("Not implemented")


### PR DESCRIPTION
Had `Context` instead of `context.Context`

Resolves #549 