### PR TITLE
Work around keyword name collisions in Go discovery sample gen

### DIFF
--- a/src/main/java/com/google/api/codegen/go/GoDiscoveryContext.java
+++ b/src/main/java/com/google/api/codegen/go/GoDiscoveryContext.java
@@ -48,7 +48,7 @@ public class GoDiscoveryContext extends DiscoveryContext implements GoContext {
   }
 
   public boolean isKeyword(String name) {
-    return GoTypeTable.KEYWORD_BUILT_IN_SET.contains(name);
+    return GoTypeTable.RESERVED_IDENTIFIER_SET.contains(name);
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/go/GoDiscoveryContext.java
+++ b/src/main/java/com/google/api/codegen/go/GoDiscoveryContext.java
@@ -14,6 +14,7 @@
  */
 package com.google.api.codegen.go;
 
+import com.google.api.codegen.util.go.GoTypeTable;
 import com.google.api.codegen.ApiaryConfig;
 import com.google.api.codegen.DiscoveryContext;
 import com.google.api.codegen.DiscoveryImporter;
@@ -44,6 +45,10 @@ public class GoDiscoveryContext extends DiscoveryContext implements GoContext {
   @Override
   public String getMethodName(Method method) {
     return lowerCamelToUpperCamel(super.getMethodName(method));
+  }
+
+  public boolean isKeyword(String name) {
+    return GoTypeTable.KEYWORD_BUILT_IN_SET.contains(name);
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/go/GoDiscoveryContext.java
+++ b/src/main/java/com/google/api/codegen/go/GoDiscoveryContext.java
@@ -47,7 +47,7 @@ public class GoDiscoveryContext extends DiscoveryContext implements GoContext {
     return lowerCamelToUpperCamel(super.getMethodName(method));
   }
 
-  public boolean isKeyword(String name) {
+  public boolean isReserved(String name) {
     return GoTypeTable.RESERVED_IDENTIFIER_SET.contains(name);
   }
 

--- a/src/main/java/com/google/api/codegen/util/go/GoTypeTable.java
+++ b/src/main/java/com/google/api/codegen/util/go/GoTypeTable.java
@@ -18,6 +18,7 @@ import com.google.api.codegen.util.NamePath;
 import com.google.api.codegen.util.TypeAlias;
 import com.google.api.codegen.util.TypeName;
 import com.google.api.codegen.util.TypeTable;
+import com.google.common.collect.ImmutableSet;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -104,4 +105,38 @@ public class GoTypeTable implements TypeTable {
     // we might have to special case them.
     return !importPath.contains("/");
   }
+
+  /**
+   * A set of Go reserved words. See
+   * https://golang.org/ref/spec#Keywords
+   */
+  public static final ImmutableSet<String> KEYWORD_BUILT_IN_SET =
+      ImmutableSet.<String>builder()
+          .add(
+              "break",
+              "case",
+              "chan",
+              "const",
+              "continue",
+              "default",
+              "defer",
+              "else",
+              "fallthrough",
+              "for",
+              "func",
+              "go",
+              "goto",
+              "if",
+              "import",
+              "interface",
+              "map",
+              "package",
+              "range",
+              "return",
+              "select",
+              "struct",
+              "switch",
+              "type",
+              "var")
+          .build();
 }

--- a/src/main/java/com/google/api/codegen/util/go/GoTypeTable.java
+++ b/src/main/java/com/google/api/codegen/util/go/GoTypeTable.java
@@ -107,12 +107,14 @@ public class GoTypeTable implements TypeTable {
   }
 
   /**
-   * A set of Go reserved words. See
+   * A set of Go reserved identifiers. See
    * https://golang.org/ref/spec#Keywords
+   * https://golang.org/ref/spec#Predeclared_identifiers
    */
-  public static final ImmutableSet<String> KEYWORD_BUILT_IN_SET =
+  public static final ImmutableSet<String> RESERVED_IDENTIFIER_SET =
       ImmutableSet.<String>builder()
           .add(
+              // Keywords
               "break",
               "case",
               "chan",
@@ -137,6 +139,46 @@ public class GoTypeTable implements TypeTable {
               "struct",
               "switch",
               "type",
-              "var")
+              "var",
+              // Predeclared identifiers
+              "bool",
+              "byte",
+              "complex64",
+              "complex128",
+              "error",
+              "float32",
+              "float64",
+              "int",
+              "int8",
+              "int16",
+              "int32",
+              "int64",
+              "rune",
+              "string",
+              "uint",
+              "uint8",
+              "uint16",
+              "uint32",
+              "uint64",
+              "uintptr",
+              "true",
+              "false",
+              "iota",
+              "nil",
+              "append",
+              "cap",
+              "close",
+              "complex",
+              "copy",
+              "delete",
+              "imag",
+              "len",
+              "make",
+              "new",
+              "panic",
+              "print",
+              "println",
+              "real",
+              "recover")
           .build();
 }

--- a/src/main/resources/com/google/api/codegen/go/discovery_fragment.snip
+++ b/src/main/resources/com/google/api/codegen/go/discovery_fragment.snip
@@ -284,7 +284,7 @@
 @end
 
 @private unclashVar(var)
-  @if or(context.getApi.getName.equals(var), context.isKeyword(var))
+  @if or(context.getApi.getName.equals(var), context.isReserved(var))
     {@var}2
   @else
     {@var}

--- a/src/main/resources/com/google/api/codegen/go/discovery_fragment.snip
+++ b/src/main/resources/com/google/api/codegen/go/discovery_fragment.snip
@@ -284,7 +284,7 @@
 @end
 
 @private unclashVar(var)
-  @if context.getApi.getName.equals(var)
+  @if or(context.getApi.getName.equals(var), context.isKeyword(var))
     {@var}2
   @else
     {@var}


### PR DESCRIPTION
Temporary fix pending general collision handling in MVVM refactoring.