### PR TITLE
Add streaming support to Java automated tests.

### DIFF
--- a/src/main/java/com/google/api/codegen/config/MethodConfig.java
+++ b/src/main/java/com/google/api/codegen/config/MethodConfig.java
@@ -29,11 +29,14 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+
+import org.joda.time.Duration;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+
 import javax.annotation.Nullable;
-import org.joda.time.Duration;
 
 // TODO(garrettjones) consider using AutoValue in this class and related classes.
 /**
@@ -280,9 +283,9 @@ public class MethodConfig {
     }
   }
 
-  /** Returns true if this method has flattening configured. */
+  /** Returns true if this method supports parameter flattening. */
   public boolean isFlattening() {
-    return flattening != null;
+    return !isGrpcStreaming() && flattening != null;
   }
 
   /** Returns the flattening configuration of the method. */

--- a/src/main/java/com/google/api/codegen/config/MethodConfig.java
+++ b/src/main/java/com/google/api/codegen/config/MethodConfig.java
@@ -283,9 +283,9 @@ public class MethodConfig {
     }
   }
 
-  /** Returns true if this method supports parameter flattening. */
+  /** Returns true if this method has flattening configured. */
   public boolean isFlattening() {
-    return !isGrpcStreaming() && flattening != null;
+    return flattening != null;
   }
 
   /** Returns the flattening configuration of the method. */

--- a/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
@@ -42,7 +42,6 @@ import com.google.api.codegen.viewmodel.testing.GapicSurfaceTestAssertView;
 import com.google.api.tools.framework.model.Field;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -80,12 +79,11 @@ public class InitCodeTransformer {
     return buildInitCodeViewRequestObject(context, rootNode);
   }
 
-  public InitCodeView generateTestMethodInitCode(
+  public InitCodeView generateFlatteningTestInitCode(
       MethodTransformerContext context,
       Iterable<Field> fields,
       SymbolTable table,
-      TestValueGenerator valueGenerator,
-      boolean isFlattened) {
+      TestValueGenerator valueGenerator) {
     InitCodeNode rootNode =
         InitCodeNode.createTree(
             InitTreeParserContext.newBuilder()
@@ -97,11 +95,22 @@ public class InitCodeTransformer {
                 .initFields(fields)
                 .suggestedName(Name.from("request"))
                 .build());
-    if (isFlattened) {
-      return buildInitCodeViewFlattened(context, rootNode);
-    } else {
-      return buildInitCodeViewRequestObject(context, rootNode);
-    }
+    return buildInitCodeViewFlattened(context, rootNode);
+  }
+
+  public InitCodeView generateRequestObjectTestInitCode(
+      MethodTransformerContext context, SymbolTable table, TestValueGenerator valueGenerator) {
+    InitCodeNode rootNode =
+        InitCodeNode.createTree(
+            InitTreeParserContext.newBuilder()
+                .table(table)
+                .valueGenerator(valueGenerator)
+                .rootObjectType(context.getMethod().getInputType())
+                .initValueConfigMap(createCollectionMap(context))
+                .initFieldConfigStrings(context.getMethodConfig().getSampleCodeInitFields())
+                .suggestedName(Name.from("request"))
+                .build());
+    return buildInitCodeViewRequestObject(context, rootNode);
   }
 
   public InitCodeView generateMockResponseObjectInitCode(

--- a/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
@@ -42,6 +42,7 @@ import com.google.api.codegen.viewmodel.testing.GapicSurfaceTestAssertView;
 import com.google.api.tools.framework.model.Field;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -83,7 +84,8 @@ public class InitCodeTransformer {
       MethodTransformerContext context,
       Iterable<Field> fields,
       SymbolTable table,
-      TestValueGenerator valueGenerator) {
+      TestValueGenerator valueGenerator,
+      boolean isFlattened) {
     InitCodeNode rootNode =
         InitCodeNode.createTree(
             InitTreeParserContext.newBuilder()
@@ -95,7 +97,11 @@ public class InitCodeTransformer {
                 .initFields(fields)
                 .suggestedName(Name.from("request"))
                 .build());
-    return buildInitCodeViewFlattened(context, rootNode);
+    if (isFlattened) {
+      return buildInitCodeViewFlattened(context, rootNode);
+    } else {
+      return buildInitCodeViewRequestObject(context, rootNode);
+    }
   }
 
   public InitCodeView generateMockResponseObjectInitCode(

--- a/src/main/java/com/google/api/codegen/transformer/SurfaceTransformerContext.java
+++ b/src/main/java/com/google/api/codegen/transformer/SurfaceTransformerContext.java
@@ -14,6 +14,7 @@
  */
 package com.google.api.codegen.transformer;
 
+import com.google.api.codegen.InterfaceView;
 import com.google.api.codegen.config.ApiConfig;
 import com.google.api.codegen.config.CollectionConfig;
 import com.google.api.codegen.config.InterfaceConfig;
@@ -22,21 +23,48 @@ import com.google.api.tools.framework.model.Interface;
 import com.google.api.tools.framework.model.Method;
 import com.google.api.tools.framework.model.Model;
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Strings;
+
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /** The context for transforming a model into a view model for a surface. */
 @AutoValue
 public abstract class SurfaceTransformerContext {
   public static SurfaceTransformerContext create(
-      Interface interfaze,
+      Interface service,
       ApiConfig apiConfig,
       ModelTypeTable typeTable,
       SurfaceNamer namer,
       FeatureConfig featureConfig) {
     return new AutoValue_SurfaceTransformerContext(
-        interfaze, apiConfig, typeTable, namer, featureConfig);
+        service,
+        apiConfig,
+        typeTable,
+        namer,
+        featureConfig,
+        createGrpcRerouteMap(service.getModel(), apiConfig));
+  }
+
+  private static Map<Interface, Interface> createGrpcRerouteMap(Model model, ApiConfig apiConfig) {
+    HashMap<Interface, Interface> grpcRerouteMap = new HashMap<>();
+    for (Interface interfaze : new InterfaceView().getElementIterable(model)) {
+      if (!interfaze.isReachable()) {
+        continue;
+      }
+      InterfaceConfig interfaceConfig = apiConfig.getInterfaceConfig(interfaze);
+      for (MethodConfig methodConfig : interfaceConfig.getMethodConfigs()) {
+        String reroute = methodConfig.getRerouteToGrpcInterface();
+        if (!Strings.isNullOrEmpty(reroute)) {
+          Interface targetInterface = model.getSymbolTable().lookupInterface(reroute);
+          grpcRerouteMap.put(targetInterface, interfaze);
+        }
+      }
+    }
+    return grpcRerouteMap;
   }
 
   public Model getModel() {
@@ -53,6 +81,9 @@ public abstract class SurfaceTransformerContext {
 
   public abstract FeatureConfig getFeatureConfig();
 
+  /** A map which maps the reroute grpc interface to its original interface */
+  public abstract Map<Interface, Interface> getGrpcRerouteMap();
+
   public SurfaceTransformerContext withNewTypeTable() {
     return create(
         getInterface(),
@@ -66,11 +97,22 @@ public abstract class SurfaceTransformerContext {
     return getApiConfig().getInterfaceConfig(getInterface());
   }
 
+  /**
+   * Returns the MethodConfig object of the given gRPC method.
+   *
+   * If the method is a gRPC re-route method, returns the MethodConfig of the original method.
+   */
   public MethodConfig getMethodConfig(Method method) {
-    if (getInterfaceConfig() != null) {
-      return getInterfaceConfig().getMethodConfig(method);
+    Interface originalInterface = getInterface();
+    if (getGrpcRerouteMap().containsKey(originalInterface)) {
+      originalInterface = getGrpcRerouteMap().get(originalInterface);
+    }
+    InterfaceConfig originalInterfaceConfig = getApiConfig().getInterfaceConfig(originalInterface);
+    if (originalInterfaceConfig != null) {
+      return originalInterfaceConfig.getMethodConfig(method);
     } else {
-      return null;
+      throw new IllegalArgumentException(
+          "Interface config does not exist for method: " + method.getSimpleName());
     }
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
@@ -213,7 +213,11 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
     SymbolTable initSymbolTable = new SymbolTable();
     InitCodeView initCodeView =
         initCodeTransformer.generateTestMethodInitCode(
-            methodContext, paramFields, initSymbolTable, valueGenerator);
+            methodContext,
+            paramFields,
+            initSymbolTable,
+            valueGenerator,
+            methodConfig.isFlattening());
 
     String requestTypeName =
         methodContext.getTypeTable().getAndSaveNicknameFor(method.getInputType());

--- a/src/main/java/com/google/api/codegen/viewmodel/testing/GapicSurfaceTestCaseView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/testing/GapicSurfaceTestCaseView.java
@@ -14,6 +14,7 @@
  */
 package com.google.api.codegen.viewmodel.testing;
 
+import com.google.api.codegen.config.GrpcStreamingConfig.GrpcStreamingType;
 import com.google.api.codegen.viewmodel.ApiMethodType;
 import com.google.api.codegen.viewmodel.InitCodeView;
 import com.google.auto.value.AutoValue;
@@ -46,6 +47,12 @@ public abstract class GapicSurfaceTestCaseView {
 
   public abstract String mockServiceVarName();
 
+  public abstract GrpcStreamingType grpcStreamingType();
+
+  public boolean isGrpcStreaming() {
+    return grpcStreamingType() != GrpcStreamingType.NonStreaming;
+  }
+
   public static Builder newBuilder() {
     return new AutoValue_GapicSurfaceTestCaseView.Builder();
   }
@@ -75,6 +82,8 @@ public abstract class GapicSurfaceTestCaseView {
     public abstract Builder mockResponse(MockGrpcResponseView val);
 
     public abstract Builder mockServiceVarName(String val);
+
+    public abstract Builder grpcStreamingType(GrpcStreamingType val);
 
     public abstract GapicSurfaceTestCaseView build();
   }

--- a/src/main/java/com/google/api/codegen/viewmodel/testing/MockGrpcMethodView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/testing/MockGrpcMethodView.java
@@ -14,6 +14,7 @@
  */
 package com.google.api.codegen.viewmodel.testing;
 
+import com.google.api.codegen.config.GrpcStreamingConfig.GrpcStreamingType;
 import com.google.auto.value.AutoValue;
 
 @AutoValue
@@ -24,10 +25,11 @@ public abstract class MockGrpcMethodView {
 
   public abstract String responseTypeName();
 
-  public abstract boolean isStreaming();
+  public abstract GrpcStreamingType grpcStreamingType();
 
   public static Builder newBuilder() {
-    return new AutoValue_MockGrpcMethodView.Builder();
+    return new AutoValue_MockGrpcMethodView.Builder()
+        .grpcStreamingType(GrpcStreamingType.NonStreaming);
   }
 
   @AutoValue.Builder
@@ -38,7 +40,7 @@ public abstract class MockGrpcMethodView {
 
     public abstract Builder responseTypeName(String val);
 
-    public abstract Builder isStreaming(boolean val);
+    public abstract Builder grpcStreamingType(GrpcStreamingType val);
 
     public abstract MockGrpcMethodView build();
   }

--- a/src/main/resources/com/google/api/codegen/java/mock_service_impl.snip
+++ b/src/main/resources/com/google/api/codegen/java/mock_service_impl.snip
@@ -40,20 +40,53 @@
 @end
 
 @private grpcMethod(method)
-  @@Override
-  @if method.isStreaming
-    public StreamObserver<{@method.requestTypeName}> {@method.name}(
-        StreamObserver<{@method.responseTypeName}> responseObserver) {
-      System.err.println("Streaming method is not supported.");
-      return null;
-    }
-  @else
-    public void {@method.name}({@method.requestTypeName} request,
-      StreamObserver<{@method.responseTypeName}> responseObserver) {
-      {@method.responseTypeName} response = ({@method.responseTypeName}) responses.remove();
-      requests.add(request);
-      responseObserver.onNext(response);
-      responseObserver.onCompleted();
-    }
+  @switch method.grpcStreamingType
+  @case "NonStreaming"
+    {@simpleGrpcMethod(method)}
+  @case "ServerStreaming"
+    {@simpleGrpcMethod(method)}
+  @case "ClientStreaming"
+    {@streamingGrpcMethod(method)}
+  @case "BidiStreaming"
+    {@streamingGrpcMethod(method)}
+  @default
+    $unhandledCase: {@method.streamingType.toString}$
   @end
+@end
+
+@private simpleGrpcMethod(method)
+  @@Override
+  public void {@method.name}({@method.requestTypeName} request,
+    StreamObserver<{@method.responseTypeName}> responseObserver) {
+    {@method.responseTypeName} response = ({@method.responseTypeName}) responses.remove();
+    requests.add(request);
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
+  }
+@end
+
+@private streamingGrpcMethod(method)
+  @@Override
+  public StreamObserver<{@method.requestTypeName}> {@method.name}(
+      final StreamObserver<{@method.responseTypeName}> responseObserver) {
+    final {@method.responseTypeName} response = ({@method.responseTypeName}) responses.remove();
+    StreamObserver<{@method.requestTypeName}> requestObserver =
+        new StreamObserver<{@method.requestTypeName}>() {
+      @@Override
+      public void onNext({@method.requestTypeName} value) {
+        responseObserver.onNext(response);
+      }
+
+      @@Override
+      public void onError(Throwable t) {
+        responseObserver.onError(t);
+      }
+
+      @@Override
+      public void onCompleted() {
+        responseObserver.onCompleted();
+      }
+    };
+    return requestObserver;
+  }
 @end

--- a/src/main/resources/com/google/api/codegen/java/test.snip
+++ b/src/main/resources/com/google/api/codegen/java/test.snip
@@ -104,10 +104,10 @@
       $unhandled case - test.grpcStreamingType.toString$
     @end
 
-    List<{@test.responseTypeName}> actualResponses = responseObserver.future.get();
+    List<{@test.responseTypeName}> actualResponses = responseObserver.future().get();
     Assert.assertEquals(1, actualResponses.size());
     Assert.assertEquals(expectedResponse, actualResponses.get(0));
-    Assert.assertEquals(0, responseObserver.errors.size());
+    Assert.assertEquals(0, responseObserver.errors().size());
   }
 @end
 

--- a/src/main/resources/com/google/api/codegen/java/test.snip
+++ b/src/main/resources/com/google/api/codegen/java/test.snip
@@ -91,7 +91,7 @@
 @private grpcStreamingTestCase(test)
   @@Test
   @@SuppressWarnings("all")
-  public void {@test.name}() {
+  public void {@test.name}() throws Exception {
     {@setResponse(test)}
     {@initCode(test.initCode)}
 
@@ -104,14 +104,10 @@
       $unhandled case - test.grpcStreamingType.toString$
     @end
 
-    try {
-      List<{@test.responseTypeName}> actualResponses = responseObserver.future.get();
-      Assert.assertEquals(1, actualResponses.size());
-      Assert.assertEquals(expectedResponse, actualResponses.get(0));
-      Assert.assertEquals(0, responseObserver.errors.size());
-    } catch (Exception e) {
-      Assert.fail();
-    }
+    List<{@test.responseTypeName}> actualResponses = responseObserver.future.get();
+    Assert.assertEquals(1, actualResponses.size());
+    Assert.assertEquals(expectedResponse, actualResponses.get(0));
+    Assert.assertEquals(0, responseObserver.errors.size());
   }
 @end
 

--- a/src/main/resources/com/google/api/codegen/java/test.snip
+++ b/src/main/resources/com/google/api/codegen/java/test.snip
@@ -89,6 +89,8 @@
 @end
 
 @private grpcStreamingTestCase(test)
+  @@Test
+  @@SuppressWarnings("all")
   public void {@test.name}() {
     {@setResponse(test)}
     {@initCode(test.initCode)}
@@ -121,23 +123,16 @@
   StreamObserver<{@test.requestTypeName}> requestObserver =
       callable.bidiStreamingCall(responseObserver);
 
-  {@test.requestTypeName} request =
-      {@test.requestTypeName}.newBuilder().build();
   requestObserver.onNext(request);
   requestObserver.onCompleted();
 @end
 
 @private serverStreamingCall(test)
-  MockStreamObserver<StreamingRecognizeResponse> responseObserver = new MockStreamObserver<>();
+  MockStreamObserver<{@test.responseTypeName}> responseObserver = new MockStreamObserver<>();
 
   StreamingApiCallable<{@test.requestTypeName}, {@test.responseTypeName}> callable =
       api.{@test.surfaceMethodName}();
   callable.serverStreamingCall(request, responseObserver);
-
-  {@test.requestTypeName} request =
-      {@test.requestTypeName}.newBuilder().build();
-  requestObserver.onNext(request);
-  requestObserver.onCompleted();
 @end
 
 @private setResponse(test)

--- a/src/main/resources/com/google/api/codegen/java/test.snip
+++ b/src/main/resources/com/google/api/codegen/java/test.snip
@@ -60,6 +60,14 @@
 @end
 
 @private testCase(test)
+  @if test.isGrpcStreaming
+    {@grpcStreamingTestCase(test)}
+  @else
+    {@nonGrpcStreamingTestCase(test)}
+  @end
+@end
+
+@private nonGrpcStreamingTestCase(test)
   @@Test
   @@SuppressWarnings("all")
   public void {@test.name}() {
@@ -78,6 +86,58 @@
         actualRequest.{@assert.actualValueGetter}());
     @end
   }
+@end
+
+@private grpcStreamingTestCase(test)
+  public void {@test.name}() {
+    {@setResponse(test)}
+    {@initCode(test.initCode)}
+
+    @switch test.grpcStreamingType
+    @case "BidiStreaming"
+      {@bidiStreamingCall(test)}
+    @case "ServerStreaming"
+      {@serverStreamingCall(test)}
+    @default
+      $unhandled case - test.grpcStreamingType.toString$
+    @end
+
+    try {
+      List<{@test.responseTypeName}> actualResponses = responseObserver.future.get();
+      Assert.assertEquals(1, actualResponses.size());
+      Assert.assertEquals(expectedResponse, actualResponses.get(0));
+      Assert.assertEquals(0, responseObserver.errors.size());
+    } catch (Exception e) {
+      Assert.fail();
+    }
+  }
+@end
+
+@private bidiStreamingCall(test)
+  MockStreamObserver<StreamingRecognizeResponse> responseObserver = new MockStreamObserver<>();
+
+  StreamingApiCallable<{@test.requestTypeName}, {@test.responseTypeName}> callable =
+      api.{@test.surfaceMethodName}();
+  StreamObserver<{@test.requestTypeName}> requestObserver =
+      callable.bidiStreamingCall(responseObserver);
+
+  {@test.requestTypeName} request =
+      {@test.requestTypeName}.newBuilder().build();
+  requestObserver.onNext(request);
+  requestObserver.onCompleted();
+@end
+
+@private serverStreamingCall(test)
+  MockStreamObserver<StreamingRecognizeResponse> responseObserver = new MockStreamObserver<>();
+
+  StreamingApiCallable<{@test.requestTypeName}, {@test.responseTypeName}> callable =
+      api.{@test.surfaceMethodName}();
+  callable.serverStreamingCall(request, responseObserver);
+
+  {@test.requestTypeName} request =
+      {@test.requestTypeName}.newBuilder().build();
+  requestObserver.onNext(request);
+  requestObserver.onCompleted();
 @end
 
 @private setResponse(test)

--- a/src/test/java/com/google/api/codegen/testdata/java_mock_service_impl_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_mock_service_impl_library.baseline
@@ -285,24 +285,45 @@ public class MockLibraryServiceImpl extends LibraryServiceImplBase  {
   }
 
   @Override
-  public StreamObserver<StreamShelvesRequest> streamShelves(
-      StreamObserver<StreamShelvesResponse> responseObserver) {
-    System.err.println("Streaming method is not supported.");
-    return null;
+  public void streamShelves(StreamShelvesRequest request,
+    StreamObserver<StreamShelvesResponse> responseObserver) {
+    StreamShelvesResponse response = (StreamShelvesResponse) responses.remove();
+    requests.add(request);
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
   }
 
   @Override
-  public StreamObserver<StreamBooksRequest> streamBooks(
-      StreamObserver<Book> responseObserver) {
-    System.err.println("Streaming method is not supported.");
-    return null;
+  public void streamBooks(StreamBooksRequest request,
+    StreamObserver<Book> responseObserver) {
+    Book response = (Book) responses.remove();
+    requests.add(request);
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
   }
 
   @Override
   public StreamObserver<DiscussBookRequest> discussBook(
-      StreamObserver<Comment> responseObserver) {
-    System.err.println("Streaming method is not supported.");
-    return null;
+      final StreamObserver<Comment> responseObserver) {
+    final Comment response = (Comment) responses.remove();
+    StreamObserver<DiscussBookRequest> requestObserver =
+        new StreamObserver<DiscussBookRequest>() {
+      @Override
+      public void onNext(DiscussBookRequest value) {
+        responseObserver.onNext(response);
+      }
+
+      @Override
+      public void onError(Throwable t) {
+        responseObserver.onError(t);
+      }
+
+      @Override
+      public void onCompleted() {
+        responseObserver.onCompleted();
+      }
+    };
+    return requestObserver;
   }
 
   @Override

--- a/src/test/java/com/google/api/codegen/testdata/java_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_test_library.baseline
@@ -672,10 +672,10 @@ public class LibraryServiceTest {
         api.streamShelvesCallable();
     callable.serverStreamingCall(request, responseObserver);
 
-    List<StreamShelvesResponse> actualResponses = responseObserver.future.get();
+    List<StreamShelvesResponse> actualResponses = responseObserver.future().get();
     Assert.assertEquals(1, actualResponses.size());
     Assert.assertEquals(expectedResponse, actualResponses.get(0));
-    Assert.assertEquals(0, responseObserver.errors.size());
+    Assert.assertEquals(0, responseObserver.errors().size());
   }
 
   @Test
@@ -705,10 +705,10 @@ public class LibraryServiceTest {
         api.streamBooksCallable();
     callable.serverStreamingCall(request, responseObserver);
 
-    List<Book> actualResponses = responseObserver.future.get();
+    List<Book> actualResponses = responseObserver.future().get();
     Assert.assertEquals(1, actualResponses.size());
     Assert.assertEquals(expectedResponse, actualResponses.get(0));
-    Assert.assertEquals(0, responseObserver.errors.size());
+    Assert.assertEquals(0, responseObserver.errors().size());
   }
 
   @Test
@@ -735,10 +735,10 @@ public class LibraryServiceTest {
     requestObserver.onNext(request);
     requestObserver.onCompleted();
 
-    List<Comment> actualResponses = responseObserver.future.get();
+    List<Comment> actualResponses = responseObserver.future().get();
     Assert.assertEquals(1, actualResponses.size());
     Assert.assertEquals(expectedResponse, actualResponses.get(0));
-    Assert.assertEquals(0, responseObserver.errors.size());
+    Assert.assertEquals(0, responseObserver.errors().size());
   }
 
   @Test

--- a/src/test/java/com/google/api/codegen/testdata/java_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_test_library.baseline
@@ -659,7 +659,7 @@ public class LibraryServiceTest {
 
   @Test
   @SuppressWarnings("all")
-  public void streamShelvesTest() {
+  public void streamShelvesTest() throws Exception {
     StreamShelvesResponse expectedResponse = StreamShelvesResponse.newBuilder().build();
     List<GeneratedMessageV3> expectedResponses = new ArrayList<>();
     expectedResponses.add(expectedResponse);
@@ -672,19 +672,15 @@ public class LibraryServiceTest {
         api.streamShelvesCallable();
     callable.serverStreamingCall(request, responseObserver);
 
-    try {
-      List<StreamShelvesResponse> actualResponses = responseObserver.future.get();
-      Assert.assertEquals(1, actualResponses.size());
-      Assert.assertEquals(expectedResponse, actualResponses.get(0));
-      Assert.assertEquals(0, responseObserver.errors.size());
-    } catch (Exception e) {
-      Assert.fail();
-    }
+    List<StreamShelvesResponse> actualResponses = responseObserver.future.get();
+    Assert.assertEquals(1, actualResponses.size());
+    Assert.assertEquals(expectedResponse, actualResponses.get(0));
+    Assert.assertEquals(0, responseObserver.errors.size());
   }
 
   @Test
   @SuppressWarnings("all")
-  public void streamBooksTest() {
+  public void streamBooksTest() throws Exception {
     BookName name2 = BookName.create("[SHELF_ID]", "[BOOK_ID]");
     String author = "author-1406328437";
     String title = "title110371416";
@@ -709,19 +705,15 @@ public class LibraryServiceTest {
         api.streamBooksCallable();
     callable.serverStreamingCall(request, responseObserver);
 
-    try {
-      List<Book> actualResponses = responseObserver.future.get();
-      Assert.assertEquals(1, actualResponses.size());
-      Assert.assertEquals(expectedResponse, actualResponses.get(0));
-      Assert.assertEquals(0, responseObserver.errors.size());
-    } catch (Exception e) {
-      Assert.fail();
-    }
+    List<Book> actualResponses = responseObserver.future.get();
+    Assert.assertEquals(1, actualResponses.size());
+    Assert.assertEquals(expectedResponse, actualResponses.get(0));
+    Assert.assertEquals(0, responseObserver.errors.size());
   }
 
   @Test
   @SuppressWarnings("all")
-  public void discussBookTest() {
+  public void discussBookTest() throws Exception {
     String userName = "userName339340927";
     ByteString comment = ByteString.copyFromUtf8("95");
     Comment expectedResponse = Comment.newBuilder()
@@ -743,14 +735,10 @@ public class LibraryServiceTest {
     requestObserver.onNext(request);
     requestObserver.onCompleted();
 
-    try {
-      List<Comment> actualResponses = responseObserver.future.get();
-      Assert.assertEquals(1, actualResponses.size());
-      Assert.assertEquals(expectedResponse, actualResponses.get(0));
-      Assert.assertEquals(0, responseObserver.errors.size());
-    } catch (Exception e) {
-      Assert.fail();
-    }
+    List<Comment> actualResponses = responseObserver.future.get();
+    Assert.assertEquals(1, actualResponses.size());
+    Assert.assertEquals(expectedResponse, actualResponses.get(0));
+    Assert.assertEquals(0, responseObserver.errors.size());
   }
 
   @Test

--- a/src/test/java/com/google/api/codegen/testdata/java_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_test_library.baseline
@@ -657,23 +657,20 @@ public class LibraryServiceTest {
     Assert.assertEquals(indexMap, actualRequest.getIndexMap());
   }
 
+  @Test
+  @SuppressWarnings("all")
   public void streamShelvesTest() {
     StreamShelvesResponse expectedResponse = StreamShelvesResponse.newBuilder().build();
     List<GeneratedMessageV3> expectedResponses = new ArrayList<>();
     expectedResponses.add(expectedResponse);
     mockLibraryService.setResponses(expectedResponses);
+    StreamShelvesRequest request = StreamShelvesRequest.newBuilder().build();
 
-
-    MockStreamObserver<StreamingRecognizeResponse> responseObserver = new MockStreamObserver<>();
+    MockStreamObserver<StreamShelvesResponse> responseObserver = new MockStreamObserver<>();
 
     StreamingApiCallable<StreamShelvesRequest, StreamShelvesResponse> callable =
         api.streamShelvesCallable();
     callable.serverStreamingCall(request, responseObserver);
-
-    StreamShelvesRequest request =
-        StreamShelvesRequest.newBuilder().build();
-    requestObserver.onNext(request);
-    requestObserver.onCompleted();
 
     try {
       List<StreamShelvesResponse> actualResponses = responseObserver.future.get();
@@ -685,6 +682,8 @@ public class LibraryServiceTest {
     }
   }
 
+  @Test
+  @SuppressWarnings("all")
   public void streamBooksTest() {
     BookName name2 = BookName.create("[SHELF_ID]", "[BOOK_ID]");
     String author = "author-1406328437";
@@ -700,17 +699,15 @@ public class LibraryServiceTest {
     expectedResponses.add(expectedResponse);
     mockLibraryService.setResponses(expectedResponses);
     String name = "name3373707";
+    StreamBooksRequest request = StreamBooksRequest.newBuilder()
+      .setName(name)
+      .build();
 
-    MockStreamObserver<StreamingRecognizeResponse> responseObserver = new MockStreamObserver<>();
+    MockStreamObserver<Book> responseObserver = new MockStreamObserver<>();
 
     StreamingApiCallable<StreamBooksRequest, Book> callable =
         api.streamBooksCallable();
     callable.serverStreamingCall(request, responseObserver);
-
-    StreamBooksRequest request =
-        StreamBooksRequest.newBuilder().build();
-    requestObserver.onNext(request);
-    requestObserver.onCompleted();
 
     try {
       List<Book> actualResponses = responseObserver.future.get();
@@ -722,6 +719,8 @@ public class LibraryServiceTest {
     }
   }
 
+  @Test
+  @SuppressWarnings("all")
   public void discussBookTest() {
     String userName = "userName339340927";
     ByteString comment = ByteString.copyFromUtf8("95");
@@ -732,7 +731,7 @@ public class LibraryServiceTest {
     List<GeneratedMessageV3> expectedResponses = new ArrayList<>();
     expectedResponses.add(expectedResponse);
     mockLibraryService.setResponses(expectedResponses);
-
+    DiscussBookRequest request = DiscussBookRequest.newBuilder().build();
 
     MockStreamObserver<StreamingRecognizeResponse> responseObserver = new MockStreamObserver<>();
 
@@ -741,8 +740,6 @@ public class LibraryServiceTest {
     StreamObserver<DiscussBookRequest> requestObserver =
         callable.bidiStreamingCall(responseObserver);
 
-    DiscussBookRequest request =
-        DiscussBookRequest.newBuilder().build();
     requestObserver.onNext(request);
     requestObserver.onCompleted();
 

--- a/src/test/java/com/google/api/codegen/testdata/java_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_test_library.baseline
@@ -16,8 +16,10 @@
 package com.google.gcloud.pubsub.spi;
 
 import com.google.api.gax.core.PagedListResponse;
+import com.google.api.gax.grpc.StreamingApiCallable;
 import com.google.api.gax.testing.MockGrpcService;
 import com.google.api.gax.testing.MockServiceHelper;
+import com.google.api.gax.testing.MockStreamObserver;
 import com.google.common.collect.Lists;
 import com.google.example.library.v1.AddCommentsRequest;
 import com.google.example.library.v1.Book;
@@ -28,6 +30,7 @@ import com.google.example.library.v1.CreateBookRequest;
 import com.google.example.library.v1.CreateShelfRequest;
 import com.google.example.library.v1.DeleteBookRequest;
 import com.google.example.library.v1.DeleteShelfRequest;
+import com.google.example.library.v1.DiscussBookRequest;
 import com.google.example.library.v1.FindRelatedBooksRequest;
 import com.google.example.library.v1.FindRelatedBooksResponse;
 import com.google.example.library.v1.GetBookFromArchiveRequest;
@@ -47,6 +50,9 @@ import com.google.example.library.v1.Shelf;
 import com.google.example.library.v1.ShelfName;
 import com.google.example.library.v1.SomeMessage;
 import com.google.example.library.v1.SomeMessage2.SomeMessage3.Alignment;
+import com.google.example.library.v1.StreamBooksRequest;
+import com.google.example.library.v1.StreamShelvesRequest;
+import com.google.example.library.v1.StreamShelvesResponse;
 import com.google.example.library.v1.UpdateBookIndexRequest;
 import com.google.example.library.v1.UpdateBookRequest;
 import com.google.protobuf.ByteString;
@@ -57,6 +63,7 @@ import com.google.tagger.v1.AddLabelRequest;
 import com.google.tagger.v1.AddLabelResponse;
 import com.google.tagger.v1.AddTagRequest;
 import com.google.tagger.v1.AddTagResponse;
+import io.grpc.stub.StreamObserver;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -648,6 +655,105 @@ public class LibraryServiceTest {
     Assert.assertEquals(name, actualRequest.getNameAsResource());
     Assert.assertEquals(indexName, actualRequest.getIndexName());
     Assert.assertEquals(indexMap, actualRequest.getIndexMap());
+  }
+
+  public void streamShelvesTest() {
+    StreamShelvesResponse expectedResponse = StreamShelvesResponse.newBuilder().build();
+    List<GeneratedMessageV3> expectedResponses = new ArrayList<>();
+    expectedResponses.add(expectedResponse);
+    mockLibraryService.setResponses(expectedResponses);
+
+
+    MockStreamObserver<StreamingRecognizeResponse> responseObserver = new MockStreamObserver<>();
+
+    StreamingApiCallable<StreamShelvesRequest, StreamShelvesResponse> callable =
+        api.streamShelvesCallable();
+    callable.serverStreamingCall(request, responseObserver);
+
+    StreamShelvesRequest request =
+        StreamShelvesRequest.newBuilder().build();
+    requestObserver.onNext(request);
+    requestObserver.onCompleted();
+
+    try {
+      List<StreamShelvesResponse> actualResponses = responseObserver.future.get();
+      Assert.assertEquals(1, actualResponses.size());
+      Assert.assertEquals(expectedResponse, actualResponses.get(0));
+      Assert.assertEquals(0, responseObserver.errors.size());
+    } catch (Exception e) {
+      Assert.fail();
+    }
+  }
+
+  public void streamBooksTest() {
+    BookName name2 = BookName.create("[SHELF_ID]", "[BOOK_ID]");
+    String author = "author-1406328437";
+    String title = "title110371416";
+    boolean read = true;
+    Book expectedResponse = Book.newBuilder()
+      .setNameWithResource(name2)
+      .setAuthor(author)
+      .setTitle(title)
+      .setRead(read)
+      .build();
+    List<GeneratedMessageV3> expectedResponses = new ArrayList<>();
+    expectedResponses.add(expectedResponse);
+    mockLibraryService.setResponses(expectedResponses);
+    String name = "name3373707";
+
+    MockStreamObserver<StreamingRecognizeResponse> responseObserver = new MockStreamObserver<>();
+
+    StreamingApiCallable<StreamBooksRequest, Book> callable =
+        api.streamBooksCallable();
+    callable.serverStreamingCall(request, responseObserver);
+
+    StreamBooksRequest request =
+        StreamBooksRequest.newBuilder().build();
+    requestObserver.onNext(request);
+    requestObserver.onCompleted();
+
+    try {
+      List<Book> actualResponses = responseObserver.future.get();
+      Assert.assertEquals(1, actualResponses.size());
+      Assert.assertEquals(expectedResponse, actualResponses.get(0));
+      Assert.assertEquals(0, responseObserver.errors.size());
+    } catch (Exception e) {
+      Assert.fail();
+    }
+  }
+
+  public void discussBookTest() {
+    String userName = "userName339340927";
+    ByteString comment = ByteString.copyFromUtf8("95");
+    Comment expectedResponse = Comment.newBuilder()
+      .setUserName(userName)
+      .setComment(comment)
+      .build();
+    List<GeneratedMessageV3> expectedResponses = new ArrayList<>();
+    expectedResponses.add(expectedResponse);
+    mockLibraryService.setResponses(expectedResponses);
+
+
+    MockStreamObserver<StreamingRecognizeResponse> responseObserver = new MockStreamObserver<>();
+
+    StreamingApiCallable<DiscussBookRequest, Comment> callable =
+        api.discussBookCallable();
+    StreamObserver<DiscussBookRequest> requestObserver =
+        callable.bidiStreamingCall(responseObserver);
+
+    DiscussBookRequest request =
+        DiscussBookRequest.newBuilder().build();
+    requestObserver.onNext(request);
+    requestObserver.onCompleted();
+
+    try {
+      List<Comment> actualResponses = responseObserver.future.get();
+      Assert.assertEquals(1, actualResponses.size());
+      Assert.assertEquals(expectedResponse, actualResponses.get(0));
+      Assert.assertEquals(0, responseObserver.errors.size());
+    } catch (Exception e) {
+      Assert.fail();
+    }
   }
 
   @Test


### PR DESCRIPTION
- Add grpc streaming support to unit tests and grpc mock classes
  - Add MockStreamObserver to GAX (https://github.com/googleapis/gax-java/pull/119/)
  - Support generate callable method tests for grpc streaming
- Add grpc reroute to SurfaceTransformerContext

Tests:
- Baseline tests