### PR TITLE
Work around keyword name collisions in Go discovery sample gen

### DIFF
--- a/src/main/resources/com/google/api/codegen/go/discovery_fragment.snip
+++ b/src/main/resources/com/google/api/codegen/go/discovery_fragment.snip
@@ -281,6 +281,7 @@
   @end
 @end
 
+# TODO(tcoffee): improve suffix generator in port to MVVM
 @private unclashVar(var)
   @if or(context.getApi.getName.equals(var), context.isReserved(var))
     {@var}2

--- a/src/main/resources/com/google/api/codegen/go/discovery_fragment.snip
+++ b/src/main/resources/com/google/api/codegen/go/discovery_fragment.snip
@@ -147,15 +147,15 @@
     {@requestName()} := {@methodCall(method)}
     if err := {@requestName()}.Pages(ctx, func(page *{@context.getApi.getName}.{@responseType}) error {
       @if context.isMapField(responseTypeRef, resourceField.getName)
-        @let keyName = context.keyTypeName(resourceField), \
-             valueName = context.valueTypeName(resourceField)
+        @let keyName = unclashVar(context.keyTypeName(resourceField)), \
+             valueName = unclashVar(context.valueTypeName(resourceField))
           for {@keyName}, {@valueName} := range page.{@resources} {
             // {@TODO()} Change code below to process each ({@keyName}: {@valueName}) element:
             fmt.Printf("%v: %#v\n", {@keyName}, {@valueName})
           }
         @end
       @else
-        @let resourceName = context.elementTypeName(resourceField)
+        @let resourceName = unclashVar(context.elementTypeName(resourceField))
           for _, {@resourceName} := range page.{@resources} {
             // {@TODO()} Change code below to process each `{@resourceName}` resource:
             fmt.Printf("%#v\n", {@resourceName})

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_deploymentmanager.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_deploymentmanager.v2.json.baseline
@@ -1033,9 +1033,9 @@ func main() {
 
   req := deploymentmanagerService.Types.List(project)
   if err := req.Pages(ctx, func(page *deploymentmanager.TypesListResponse) error {
-    for _, type := range page.Types {
-      // TODO: Change code below to process each `type` resource:
-      fmt.Printf("%#v\n", type)
+    for _, type2 := range page.Types {
+      // TODO: Change code below to process each `type2` resource:
+      fmt.Printf("%#v\n", type2)
     }
     return nil
   }); err != nil {


### PR DESCRIPTION
Extends https://github.com/googleapis/toolkit/pull/567 with additional
cases.

Addresses https://github.com/googleapis/toolkit/issues/550.