### PR TITLE
Fix Python oneof default parameter generation

### DIFF
--- a/src/main/java/com/google/api/codegen/GapicContext.java
+++ b/src/main/java/com/google/api/codegen/GapicContext.java
@@ -26,7 +26,6 @@ import com.google.api.tools.framework.model.Method;
 import com.google.api.tools.framework.model.Model;
 import com.google.api.tools.framework.model.ProtoElement;
 import com.google.common.base.Preconditions;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -42,9 +41,7 @@ public class GapicContext extends CodegenContext {
   private final ServiceMessages serviceMessages;
   private final ServiceConfig serviceConfig;
 
-  /**
-   * Constructs the abstract instance.
-   */
+  /** Constructs the abstract instance. */
   protected GapicContext(Model model, ApiConfig apiConfig) {
     this.model = Preconditions.checkNotNull(model);
     this.apiConfig = Preconditions.checkNotNull(apiConfig);
@@ -52,16 +49,12 @@ public class GapicContext extends CodegenContext {
     this.serviceConfig = new ServiceConfig();
   }
 
-  /**
-   * Returns the associated model.
-   */
+  /** Returns the associated model. */
   public Model getModel() {
     return model;
   }
 
-  /**
-   * Returns the associated config.
-   */
+  /** Returns the associated config. */
   public ApiConfig getApiConfig() {
     return apiConfig;
   }
@@ -74,23 +67,17 @@ public class GapicContext extends CodegenContext {
     return serviceConfig;
   }
 
-  /**
-   * Return the name of the class which is the GAPIC wrapper for this service interface.
-   */
+  /** Return the name of the class which is the GAPIC wrapper for this service interface. */
   public String getApiWrapperName(Interface service) {
     return service.getSimpleName() + "Api";
   }
 
-  /**
-   * Returns the description of the proto element, in markdown format.
-   */
+  /** Returns the description of the proto element, in markdown format. */
   public String getDescription(ProtoElement element) {
     return DocumentationUtil.getDescription(element);
   }
 
-  /**
-   * Get collection configuration for a method.
-   */
+  /** Get collection configuration for a method. */
   public CollectionConfig getCollectionConfig(Interface service, String entityName) {
     CollectionConfig result =
         getApiConfig().getInterfaceConfig(service).getCollectionConfig(entityName);
@@ -118,16 +105,14 @@ public class GapicContext extends CodegenContext {
 
   /**
    * Returns true when the method is supported by the current codegen context. By default, only non
-   * stremaing methods are supported unless subclass explicitly allows.
-   * TODO: remove this method when all languages support gRPC streaming.
+   * stremaing methods are supported unless subclass explicitly allows. TODO: remove this method
+   * when all languages support gRPC streaming.
    */
   protected boolean isSupported(Method method) {
     return !method.getRequestStreaming() && !method.getResponseStreaming();
   }
 
-  /**
-   * Returns a list of RPC methods supported by the context.
-   */
+  /** Returns a list of RPC methods supported by the context. */
   public List<Method> getSupportedMethods(Interface service) {
     List<Method> simples = new ArrayList<>(service.getMethods().size());
     for (Method method : service.getMethods()) {
@@ -140,8 +125,7 @@ public class GapicContext extends CodegenContext {
 
   /**
    * Returns a list of RPC methods supported by the context, taking into account GRPC interface
-   * rerouting.
-   * TODO replace getSupportedMethods with this when all languages are migrated.
+   * rerouting. TODO replace getSupportedMethods with this when all languages are migrated.
    */
   public List<Method> getSupportedMethodsV2(Interface service) {
     InterfaceConfig interfaceConfig = getApiConfig().getInterfaceConfig(service);
@@ -157,5 +141,9 @@ public class GapicContext extends CodegenContext {
       }
     }
     return methods;
+  }
+
+  public boolean isOneof(Field field) {
+    return field.getOneof() != null;
   }
 }

--- a/src/main/resources/com/google/api/codegen/py/main.snip
+++ b/src/main/resources/com/google/api/codegen/py/main.snip
@@ -498,7 +498,7 @@
 @private optionalParameterValues(params)
     @join field : params on ",".add(BREAK)
         @let paramName = {@context.python.wrapIfKeywordOrBuiltIn(field.getSimpleName())}
-            @if {@context.isDefaultValueMutable(field)}
+            @if or(context.isDefaultValueMutable(field), context.isOneof(field))
                 {@paramName}=None
             @else
                 {@paramName}={@context.defaultValue(field, importHandler)}
@@ -508,7 +508,7 @@
 @end
 
 @private defaultMutableValues(params)
-    @join field : params if {@context.isDefaultValueMutable(field)} on BREAK
+    @join field : params if and(context.isDefaultValueMutable(field), not(context.isOneof(field))) on BREAK
         @let paramName = {@context.python.wrapIfKeywordOrBuiltIn(field.getSimpleName())}
             if {@paramName} is None:
                 {@paramName} = {@context.defaultValue(field, importHandler)}

--- a/src/test/java/com/google/api/codegen/testdata/library.proto
+++ b/src/test/java/com/google/api/codegen/testdata/library.proto
@@ -347,8 +347,13 @@ message PublishSeriesRequest {
   // The books to publish in the series.
   repeated Book books = 2;
 
-  // The edition of the series
-  uint32 edition = 3;
+  oneof versioning {
+    // The edition of the series
+    uint32 edition = 3;
+
+    // If the book is in a pre-publish state
+    bool review_copy = 4;
+  }
 }
 
 // Response message for LibraryService.PublishSeries.

--- a/src/test/java/com/google/api/codegen/testdata/library_config.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/library_config.baseline
@@ -131,10 +131,12 @@ interfaces:
         - shelf
         - books
         - edition
+        - review_copy
     required_fields:
     - shelf
     - books
     - edition
+    - review_copy
     request_object_method: true
     retry_codes_name: non_idempotent
     retry_params_name: default

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_doc_main_library.baseline
@@ -573,6 +573,8 @@ LibraryServiceApi.prototype.createBook = function(request, options, callback) {
  *   This object should have the same structure as [Book]{@link Book}
  * @param {number=} request.edition
  *   The edition of the series
+ * @param {boolean=} request.reviewCopy
+ *   If the book is in a pre-publish state
  * @param {Object=} options
  *   Optional parameters. You can override the default settings for this call, e.g, timeout,
  *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_doc_message_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_doc_message_library.baseline
@@ -1048,6 +1048,9 @@ var CreateBookRequest = {
  * @property {number} edition
  *   The edition of the series
  *
+ * @property {boolean} reviewCopy
+ *   If the book is in a pre-publish state
+ *
  * @class
  * @see [google.example.library.v1.PublishSeriesRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_main_library.baseline
@@ -573,6 +573,8 @@ LibraryServiceApi.prototype.createBook = function(request, options, callback) {
  *   This object should have the same structure as [Book]{@link Book}
  * @param {number=} request.edition
  *   The edition of the series
+ * @param {boolean=} request.reviewCopy
+ *   If the book is in a pre-publish state
  * @param {Object=} options
  *   Optional parameters. You can override the default settings for this call, e.g, timeout,
  *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.

--- a/src/test/java/com/google/api/codegen/testdata/php_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php_main_library.baseline
@@ -727,6 +727,8 @@ class LibraryServiceApi
      *     Optional.
      *     @type int $edition
      *          The edition of the series
+     *     @type bool $reviewCopy
+     *          If the book is in a pre-publish state
      *     @type Google\GAX\RetrySettings $retrySettings
      *          Retry settings to use for this call. If present, then
      *          $timeoutMillis is ignored.
@@ -748,6 +750,9 @@ class LibraryServiceApi
         }
         if (isset($optionalArgs['edition'])) {
             $request->setEdition($optionalArgs['edition']);
+        }
+        if (isset($optionalArgs['reviewCopy'])) {
+            $request->setReviewCopy($optionalArgs['reviewCopy']);
         }
 
         $mergedSettings = $this->defaultCallSettings['publishSeries']->merge(

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
@@ -560,7 +560,8 @@ class LibraryServiceApi(object):
             self,
             shelf,
             books,
-            edition=0,
+            edition=None,
+            review_copy=None,
             options=None):
         """
         Creates a series of books.
@@ -577,6 +578,7 @@ class LibraryServiceApi(object):
           shelf (:class:`google.example.library.v1.library_pb2.Shelf`): The shelf in which the series is created.
           books (list[:class:`google.example.library.v1.library_pb2.Book`]): The books to publish in the series.
           edition (int): The edition of the series
+          review_copy (bool): If the book is in a pre-publish state
           options (:class:`google.gax.CallOptions`): Overrides the default
             settings for this call, e.g, timeout, retries etc.
 
@@ -590,7 +592,8 @@ class LibraryServiceApi(object):
         request = library_pb2.PublishSeriesRequest(
             shelf=shelf,
             books=books,
-            edition=edition)
+            edition=edition,
+            review_copy=review_copy)
         return self._publish_series(request, options)
 
     def get_book(

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_message_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_message_library.baseline
@@ -814,6 +814,7 @@ class PublishSeriesRequest(object):
       shelf (:class:`google.example.library.v1.library_pb2.Shelf`): The shelf in which the series is created.
       books (list[:class:`google.example.library.v1.library_pb2.Book`]): The books to publish in the series.
       edition (int): The edition of the series
+      review_copy (bool): If the book is in a pre-publish state
 
     """
     pass

--- a/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
@@ -560,7 +560,8 @@ class LibraryServiceApi(object):
             self,
             shelf,
             books,
-            edition=0,
+            edition=None,
+            review_copy=None,
             options=None):
         """
         Creates a series of books.
@@ -577,6 +578,7 @@ class LibraryServiceApi(object):
           shelf (:class:`google.example.library.v1.library_pb2.Shelf`): The shelf in which the series is created.
           books (list[:class:`google.example.library.v1.library_pb2.Book`]): The books to publish in the series.
           edition (int): The edition of the series
+          review_copy (bool): If the book is in a pre-publish state
           options (:class:`google.gax.CallOptions`): Overrides the default
             settings for this call, e.g, timeout, retries etc.
 
@@ -590,7 +592,8 @@ class LibraryServiceApi(object):
         request = library_pb2.PublishSeriesRequest(
             shelf=shelf,
             books=books,
-            edition=edition)
+            edition=edition,
+            review_copy=review_copy)
         return self._publish_series(request, options)
 
     def get_book(

--- a/src/test/java/com/google/api/codegen/testdata/ruby_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_doc_main_library.baseline
@@ -541,6 +541,8 @@ module Library
       #   The books to publish in the series.
       # @param edition [Integer]
       #   The edition of the series
+      # @param review_copy [true, false]
+      #   If the book is in a pre-publish state
       # @param options [Google::Gax::CallOptions]
       #   Overrides the default settings for this call, e.g, timeout,
       #   retries, etc.
@@ -561,12 +563,14 @@ module Library
           shelf,
           books,
           edition: nil,
+          review_copy: nil,
           options: nil
         req = Google::Example::Library::V1::PublishSeriesRequest.new(
           shelf: shelf,
           books: books
         )
         req.edition = edition unless edition.nil?
+        req.review_copy = review_copy unless review_copy.nil?
         @publish_series.call(req, options)
       end
 

--- a/src/test/java/com/google/api/codegen/testdata/ruby_doc_message_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_doc_message_library.baseline
@@ -795,6 +795,9 @@ module Google
         # @!attribute [rw] edition
         #   @return [Integer]
         #     The edition of the series
+        # @!attribute [rw] review_copy
+        #   @return [true, false]
+        #     If the book is in a pre-publish state
         class PublishSeriesRequest; end
 
         # Response message for LibraryService.PublishSeries.

--- a/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
@@ -541,6 +541,8 @@ module Library
       #   The books to publish in the series.
       # @param edition [Integer]
       #   The edition of the series
+      # @param review_copy [true, false]
+      #   If the book is in a pre-publish state
       # @param options [Google::Gax::CallOptions]
       #   Overrides the default settings for this call, e.g, timeout,
       #   retries, etc.
@@ -561,12 +563,14 @@ module Library
           shelf,
           books,
           edition: nil,
+          review_copy: nil,
           options: nil
         req = Google::Example::Library::V1::PublishSeriesRequest.new(
           shelf: shelf,
           books: books
         )
         req.edition = edition unless edition.nil?
+        req.review_copy = review_copy unless review_copy.nil?
         @publish_series.call(req, options)
       end
 


### PR DESCRIPTION
Previously multiple oneof fields were being set.

Fixes #591 