### PR TITLE
Add oneof logic/validation for GAPIC config

### DIFF
--- a/src/main/java/com/google/api/codegen/config/MethodConfig.java
+++ b/src/main/java/com/google/api/codegen/config/MethodConfig.java
@@ -15,13 +15,12 @@
 package com.google.api.codegen.config;
 
 import com.google.api.codegen.BundlingConfigProto;
-import com.google.api.codegen.config.GrpcStreamingConfig.GrpcStreamingType;
-import com.google.api.codegen.ConfigProto;
 import com.google.api.codegen.FlatteningConfigProto;
 import com.google.api.codegen.MethodConfigProto;
 import com.google.api.codegen.PageStreamingConfigProto;
 import com.google.api.codegen.SurfaceTreatmentProto;
 import com.google.api.codegen.VisibilityProto;
+import com.google.api.codegen.config.GrpcStreamingConfig.GrpcStreamingType;
 import com.google.api.tools.framework.model.Diag;
 import com.google.api.tools.framework.model.DiagCollector;
 import com.google.api.tools.framework.model.Field;
@@ -33,14 +32,11 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
-
-import org.joda.time.Duration;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-
 import javax.annotation.Nullable;
+import org.joda.time.Duration;
 
 /**
  * MethodConfig represents the code-gen config for a method, and includes the specification of
@@ -183,6 +179,14 @@ public abstract class MethodConfig {
       Field requiredField = method.getInputMessage().lookupField(fieldName);
       if (requiredField != null) {
         builder.add(requiredField);
+        if (requiredField.getOneof() != null) {
+          Diag.error(
+              SimpleLocation.TOPLEVEL,
+              "Oneof fields cannot be required: method = %s, oneof = %s, field = %s",
+              method.getFullName(),
+              requiredField.getOneof(),
+              fieldName);
+        }
       } else {
         Diag.error(
             SimpleLocation.TOPLEVEL,

--- a/src/main/java/com/google/api/codegen/configgen/FieldConfigGenerator.java
+++ b/src/main/java/com/google/api/codegen/configgen/FieldConfigGenerator.java
@@ -17,16 +17,13 @@ package com.google.api.codegen.configgen;
 import com.google.api.tools.framework.model.Field;
 import com.google.api.tools.framework.model.MessageType;
 import com.google.api.tools.framework.model.Method;
-
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-/**
- * Config generator for method parameter flattening, required fields, and request method object.
- */
+/** Config generator for method parameter flattening, required fields, and request method object. */
 public class FieldConfigGenerator implements MethodConfigGenerator {
 
   private static final String CONFIG_KEY_GROUPS = "groups";
@@ -52,7 +49,7 @@ public class FieldConfigGenerator implements MethodConfigGenerator {
     MessageType message = method.getInputMessage();
     for (Field field : message.getFields()) {
       String fieldName = field.getSimpleName();
-      if (!ignoredFields.contains(fieldName)) {
+      if (!ignoredFields.contains(fieldName) && field.getOneof() == null) {
         parameterList.add(field.getSimpleName());
       }
     }

--- a/src/test/java/com/google/api/codegen/testdata/library_config.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/library_config.baseline
@@ -130,13 +130,9 @@ interfaces:
       - parameters:
         - shelf
         - books
-        - edition
-        - review_copy
     required_fields:
     - shelf
     - books
-    - edition
-    - review_copy
     request_object_method: true
     retry_codes_name: non_idempotent
     retry_params_name: default


### PR DESCRIPTION
This change adds a few behaviors:
- The config generator will no longer mark oneof fields as required
  or flattened
- Flattened oneof fields generate a warning in codegen
- Specifying multiple oneof fields in a single flattening generates
  an error in codegen
- Required oneof fields generate an error in codegen

Fixes #620 
