### PR TITLE
Use a non-doc multiline instructions comment

### DIFF
--- a/src/main/resources/com/google/api/codegen/java/sample.snip
+++ b/src/main/resources/com/google/api/codegen/java/sample.snip
@@ -1,5 +1,5 @@
 @snippet generate(class)
-  /**
+  /*
    * BEFORE RUNNING:
    * ---------------
    * 1. If not already done, enable the {@class.apiTitle}

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_adexchangebuyer.v1.4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_adexchangebuyer.v1.4.json.baseline
@@ -1,5 +1,5 @@
 
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -50,7 +50,7 @@ public class AdExchangeBuyerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -98,7 +98,7 @@ public class AdExchangeBuyerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -153,7 +153,7 @@ public class AdExchangeBuyerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -207,7 +207,7 @@ public class AdExchangeBuyerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -258,7 +258,7 @@ public class AdExchangeBuyerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -306,7 +306,7 @@ public class AdExchangeBuyerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -360,7 +360,7 @@ public class AdExchangeBuyerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -418,7 +418,7 @@ public class AdExchangeBuyerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -475,7 +475,7 @@ public class AdExchangeBuyerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -528,7 +528,7 @@ public class AdExchangeBuyerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -582,7 +582,7 @@ public class AdExchangeBuyerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -633,7 +633,7 @@ public class AdExchangeBuyerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -690,7 +690,7 @@ public class AdExchangeBuyerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -744,7 +744,7 @@ public class AdExchangeBuyerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -797,7 +797,7 @@ public class AdExchangeBuyerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -852,7 +852,7 @@ public class AdExchangeBuyerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -907,7 +907,7 @@ public class AdExchangeBuyerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -959,7 +959,7 @@ public class AdExchangeBuyerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -1014,7 +1014,7 @@ public class AdExchangeBuyerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -1069,7 +1069,7 @@ public class AdExchangeBuyerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -1121,7 +1121,7 @@ public class AdExchangeBuyerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -1172,7 +1172,7 @@ public class AdExchangeBuyerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -1229,7 +1229,7 @@ public class AdExchangeBuyerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -1279,7 +1279,7 @@ public class AdExchangeBuyerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -1333,7 +1333,7 @@ public class AdExchangeBuyerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -1387,7 +1387,7 @@ public class AdExchangeBuyerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -1438,7 +1438,7 @@ public class AdExchangeBuyerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -1496,7 +1496,7 @@ public class AdExchangeBuyerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -1553,7 +1553,7 @@ public class AdExchangeBuyerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -1604,7 +1604,7 @@ public class AdExchangeBuyerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -1652,7 +1652,7 @@ public class AdExchangeBuyerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -1703,7 +1703,7 @@ public class AdExchangeBuyerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -1755,7 +1755,7 @@ public class AdExchangeBuyerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -1819,7 +1819,7 @@ public class AdExchangeBuyerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -1867,7 +1867,7 @@ public class AdExchangeBuyerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -1914,7 +1914,7 @@ public class AdExchangeBuyerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API
@@ -1977,7 +1977,7 @@ public class AdExchangeBuyerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Ad Exchange Buyer API

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_appengine.v1beta5.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_appengine.v1beta5.json.baseline
@@ -1,5 +1,5 @@
 
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google App Engine Admin API
@@ -55,7 +55,7 @@ public class AppengineExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google App Engine Admin API
@@ -110,7 +110,7 @@ public class AppengineExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google App Engine Admin API
@@ -168,7 +168,7 @@ public class AppengineExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google App Engine Admin API
@@ -232,7 +232,7 @@ public class AppengineExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google App Engine Admin API
@@ -290,7 +290,7 @@ public class AppengineExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google App Engine Admin API
@@ -354,7 +354,7 @@ public class AppengineExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google App Engine Admin API
@@ -414,7 +414,7 @@ public class AppengineExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google App Engine Admin API
@@ -472,7 +472,7 @@ public class AppengineExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google App Engine Admin API
@@ -530,7 +530,7 @@ public class AppengineExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google App Engine Admin API
@@ -594,7 +594,7 @@ public class AppengineExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google App Engine Admin API
@@ -657,7 +657,7 @@ public class AppengineExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google App Engine Admin API
@@ -719,7 +719,7 @@ public class AppengineExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google App Engine Admin API
@@ -780,7 +780,7 @@ public class AppengineExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google App Engine Admin API
@@ -841,7 +841,7 @@ public class AppengineExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google App Engine Admin API
@@ -910,7 +910,7 @@ public class AppengineExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google App Engine Admin API
@@ -975,7 +975,7 @@ public class AppengineExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google App Engine Admin API
@@ -1040,7 +1040,7 @@ public class AppengineExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google App Engine Admin API
@@ -1110,7 +1110,7 @@ public class AppengineExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google App Engine Admin API
@@ -1177,7 +1177,7 @@ public class AppengineExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google App Engine Admin API

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_bigquery.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_bigquery.v2.json.baseline
@@ -1,5 +1,5 @@
 
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the BigQuery API
@@ -53,7 +53,7 @@ public class BigqueryExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the BigQuery API
@@ -111,7 +111,7 @@ public class BigqueryExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the BigQuery API
@@ -169,7 +169,7 @@ public class BigqueryExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the BigQuery API
@@ -233,7 +233,7 @@ public class BigqueryExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the BigQuery API
@@ -295,7 +295,7 @@ public class BigqueryExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the BigQuery API
@@ -356,7 +356,7 @@ public class BigqueryExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the BigQuery API
@@ -414,7 +414,7 @@ public class BigqueryExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the BigQuery API
@@ -472,7 +472,7 @@ public class BigqueryExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the BigQuery API
@@ -530,7 +530,7 @@ public class BigqueryExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the BigQuery API
@@ -591,7 +591,7 @@ public class BigqueryExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the BigQuery API
@@ -655,7 +655,7 @@ public class BigqueryExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the BigQuery API
@@ -714,7 +714,7 @@ public class BigqueryExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the BigQuery API
@@ -775,7 +775,7 @@ public class BigqueryExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the BigQuery API
@@ -840,7 +840,7 @@ public class BigqueryExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the BigQuery API
@@ -901,7 +901,7 @@ public class BigqueryExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the BigQuery API
@@ -958,7 +958,7 @@ public class BigqueryExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the BigQuery API
@@ -1019,7 +1019,7 @@ public class BigqueryExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the BigQuery API
@@ -1080,7 +1080,7 @@ public class BigqueryExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the BigQuery API
@@ -1147,7 +1147,7 @@ public class BigqueryExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the BigQuery API
@@ -1212,7 +1212,7 @@ public class BigqueryExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the BigQuery API

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_cloudbilling.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_cloudbilling.v1.json.baseline
@@ -1,5 +1,5 @@
 
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Billing API
@@ -56,7 +56,7 @@ public class CloudbillingExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Billing API
@@ -117,7 +117,7 @@ public class CloudbillingExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Billing API
@@ -183,7 +183,7 @@ public class CloudbillingExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Billing API
@@ -240,7 +240,7 @@ public class CloudbillingExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Billing API

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_clouddebugger.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_clouddebugger.v2.json.baseline
@@ -1,5 +1,5 @@
 
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Stackdriver Debugger API
@@ -54,7 +54,7 @@ public class CloudDebuggerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Stackdriver Debugger API
@@ -116,7 +116,7 @@ public class CloudDebuggerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Stackdriver Debugger API
@@ -172,7 +172,7 @@ public class CloudDebuggerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Stackdriver Debugger API
@@ -226,7 +226,7 @@ public class CloudDebuggerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Stackdriver Debugger API
@@ -284,7 +284,7 @@ public class CloudDebuggerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Stackdriver Debugger API
@@ -339,7 +339,7 @@ public class CloudDebuggerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Stackdriver Debugger API
@@ -398,7 +398,7 @@ public class CloudDebuggerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Stackdriver Debugger API

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_cloudmonitoring.v2beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_cloudmonitoring.v2beta2.json.baseline
@@ -1,5 +1,5 @@
 
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud Monitoring API
@@ -57,7 +57,7 @@ public class CloudMonitoringExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud Monitoring API
@@ -115,7 +115,7 @@ public class CloudMonitoringExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud Monitoring API
@@ -179,7 +179,7 @@ public class CloudMonitoringExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud Monitoring API
@@ -251,7 +251,7 @@ public class CloudMonitoringExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud Monitoring API
@@ -310,7 +310,7 @@ public class CloudMonitoringExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud Monitoring API

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_cloudresourcemanager.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_cloudresourcemanager.v1.json.baseline
@@ -1,5 +1,5 @@
 
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Resource Manager API
@@ -54,7 +54,7 @@ public class CloudResourceManagerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Resource Manager API
@@ -110,7 +110,7 @@ public class CloudResourceManagerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Resource Manager API
@@ -171,7 +171,7 @@ public class CloudResourceManagerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Resource Manager API
@@ -236,7 +236,7 @@ public class CloudResourceManagerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Resource Manager API
@@ -297,7 +297,7 @@ public class CloudResourceManagerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Resource Manager API
@@ -358,7 +358,7 @@ public class CloudResourceManagerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Resource Manager API
@@ -414,7 +414,7 @@ public class CloudResourceManagerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Resource Manager API
@@ -465,7 +465,7 @@ public class CloudResourceManagerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Resource Manager API
@@ -520,7 +520,7 @@ public class CloudResourceManagerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Resource Manager API
@@ -580,7 +580,7 @@ public class CloudResourceManagerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Resource Manager API
@@ -641,7 +641,7 @@ public class CloudResourceManagerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Resource Manager API
@@ -701,7 +701,7 @@ public class CloudResourceManagerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Resource Manager API
@@ -761,7 +761,7 @@ public class CloudResourceManagerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Resource Manager API
@@ -816,7 +816,7 @@ public class CloudResourceManagerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Resource Manager API

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_cloudresourcemanager.v1beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_cloudresourcemanager.v1beta1.json.baseline
@@ -1,5 +1,5 @@
 
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Resource Manager API
@@ -55,7 +55,7 @@ public class CloudResourceManagerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Resource Manager API
@@ -116,7 +116,7 @@ public class CloudResourceManagerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Resource Manager API
@@ -177,7 +177,7 @@ public class CloudResourceManagerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Resource Manager API
@@ -238,7 +238,7 @@ public class CloudResourceManagerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Resource Manager API
@@ -299,7 +299,7 @@ public class CloudResourceManagerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Resource Manager API
@@ -359,7 +359,7 @@ public class CloudResourceManagerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Resource Manager API
@@ -414,7 +414,7 @@ public class CloudResourceManagerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Resource Manager API
@@ -465,7 +465,7 @@ public class CloudResourceManagerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Resource Manager API
@@ -520,7 +520,7 @@ public class CloudResourceManagerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Resource Manager API
@@ -579,7 +579,7 @@ public class CloudResourceManagerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Resource Manager API
@@ -639,7 +639,7 @@ public class CloudResourceManagerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Resource Manager API
@@ -700,7 +700,7 @@ public class CloudResourceManagerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Resource Manager API
@@ -760,7 +760,7 @@ public class CloudResourceManagerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Resource Manager API
@@ -820,7 +820,7 @@ public class CloudResourceManagerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Resource Manager API
@@ -875,7 +875,7 @@ public class CloudResourceManagerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Resource Manager API

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_cloudtrace.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_cloudtrace.v1.json.baseline
@@ -1,5 +1,5 @@
 
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Trace API
@@ -55,7 +55,7 @@ public class CloudTraceExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Trace API
@@ -113,7 +113,7 @@ public class CloudTraceExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Trace API

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_clouduseraccounts.beta.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_clouduseraccounts.beta.json.baseline
@@ -1,5 +1,5 @@
 
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud User Accounts API
@@ -53,7 +53,7 @@ public class CloudUserAccountsExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud User Accounts API
@@ -111,7 +111,7 @@ public class CloudUserAccountsExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud User Accounts API
@@ -175,7 +175,7 @@ public class CloudUserAccountsExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud User Accounts API
@@ -237,7 +237,7 @@ public class CloudUserAccountsExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud User Accounts API
@@ -295,7 +295,7 @@ public class CloudUserAccountsExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud User Accounts API
@@ -353,7 +353,7 @@ public class CloudUserAccountsExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud User Accounts API
@@ -412,7 +412,7 @@ public class CloudUserAccountsExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud User Accounts API
@@ -476,7 +476,7 @@ public class CloudUserAccountsExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud User Accounts API
@@ -538,7 +538,7 @@ public class CloudUserAccountsExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud User Accounts API
@@ -602,7 +602,7 @@ public class CloudUserAccountsExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud User Accounts API
@@ -663,7 +663,7 @@ public class CloudUserAccountsExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud User Accounts API
@@ -725,7 +725,7 @@ public class CloudUserAccountsExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud User Accounts API
@@ -783,7 +783,7 @@ public class CloudUserAccountsExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud User Accounts API
@@ -841,7 +841,7 @@ public class CloudUserAccountsExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud User Accounts API
@@ -900,7 +900,7 @@ public class CloudUserAccountsExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud User Accounts API
@@ -964,7 +964,7 @@ public class CloudUserAccountsExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud User Accounts API

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_compute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_compute.v1.json.baseline
@@ -1,5 +1,5 @@
 
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -64,7 +64,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -125,7 +125,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -186,7 +186,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -248,7 +248,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -315,7 +315,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -380,7 +380,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -441,7 +441,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -502,7 +502,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -564,7 +564,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -631,7 +631,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -697,7 +697,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -759,7 +759,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -817,7 +817,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -875,7 +875,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -936,7 +936,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -995,7 +995,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -1059,7 +1059,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -1122,7 +1122,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -1184,7 +1184,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -1249,7 +1249,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -1310,7 +1310,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -1377,7 +1377,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -1442,7 +1442,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -1507,7 +1507,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -1568,7 +1568,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -1629,7 +1629,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -1691,7 +1691,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -1758,7 +1758,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -1823,7 +1823,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -1881,7 +1881,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -1939,7 +1939,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -1998,7 +1998,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -2062,7 +2062,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -2125,7 +2125,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -2187,7 +2187,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -2252,7 +2252,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -2313,7 +2313,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -2374,7 +2374,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -2436,7 +2436,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -2503,7 +2503,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -2568,7 +2568,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -2626,7 +2626,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -2684,7 +2684,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -2743,7 +2743,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -2807,7 +2807,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -2865,7 +2865,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -2923,7 +2923,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -2982,7 +2982,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -3046,7 +3046,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -3108,7 +3108,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -3173,7 +3173,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -3227,7 +3227,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -3285,7 +3285,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -3349,7 +3349,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -3407,7 +3407,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -3465,7 +3465,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -3524,7 +3524,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -3588,7 +3588,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -3651,7 +3651,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -3713,7 +3713,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -3771,7 +3771,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -3829,7 +3829,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -3888,7 +3888,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -3952,7 +3952,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -4015,7 +4015,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -4077,7 +4077,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -4135,7 +4135,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -4193,7 +4193,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -4252,7 +4252,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -4316,7 +4316,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -4379,7 +4379,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -4441,7 +4441,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -4499,7 +4499,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -4561,7 +4561,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -4619,7 +4619,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -4677,7 +4677,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -4736,7 +4736,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -4800,7 +4800,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -4865,7 +4865,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -4930,7 +4930,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -4991,7 +4991,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -5056,7 +5056,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -5117,7 +5117,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -5179,7 +5179,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -5246,7 +5246,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -5307,7 +5307,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -5372,7 +5372,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -5438,7 +5438,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -5503,7 +5503,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -5568,7 +5568,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -5633,7 +5633,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -5698,7 +5698,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -5759,7 +5759,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -5820,7 +5820,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -5882,7 +5882,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -5949,7 +5949,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -6023,7 +6023,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -6088,7 +6088,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -6153,7 +6153,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -6211,7 +6211,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -6269,7 +6269,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -6328,7 +6328,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -6392,7 +6392,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -6460,7 +6460,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -6525,7 +6525,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -6590,7 +6590,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -6651,7 +6651,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -6718,7 +6718,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -6782,7 +6782,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -6843,7 +6843,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -6904,7 +6904,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -6966,7 +6966,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -7033,7 +7033,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -7094,7 +7094,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -7161,7 +7161,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -7226,7 +7226,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -7291,7 +7291,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -7356,7 +7356,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -7421,7 +7421,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -7482,7 +7482,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -7547,7 +7547,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -7608,7 +7608,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -7666,7 +7666,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -7731,7 +7731,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -7792,7 +7792,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -7859,7 +7859,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -7917,7 +7917,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -7975,7 +7975,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -8034,7 +8034,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -8098,7 +8098,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -8153,7 +8153,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -8212,7 +8212,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -8271,7 +8271,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -8330,7 +8330,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -8389,7 +8389,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -8446,7 +8446,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -8507,7 +8507,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -8574,7 +8574,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -8632,7 +8632,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -8696,7 +8696,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -8761,7 +8761,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -8822,7 +8822,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -8883,7 +8883,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -8944,7 +8944,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -9006,7 +9006,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -9073,7 +9073,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -9139,7 +9139,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -9204,7 +9204,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -9269,7 +9269,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -9327,7 +9327,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -9385,7 +9385,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -9444,7 +9444,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -9508,7 +9508,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -9566,7 +9566,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -9624,7 +9624,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -9688,7 +9688,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -9746,7 +9746,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -9804,7 +9804,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -9863,7 +9863,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -9927,7 +9927,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -9992,7 +9992,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -10053,7 +10053,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -10114,7 +10114,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -10176,7 +10176,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -10243,7 +10243,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -10301,7 +10301,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -10359,7 +10359,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -10418,7 +10418,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -10482,7 +10482,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -10544,7 +10544,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -10602,7 +10602,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -10660,7 +10660,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -10719,7 +10719,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -10783,7 +10783,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -10845,7 +10845,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -10907,7 +10907,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -10972,7 +10972,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -11033,7 +11033,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -11094,7 +11094,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -11156,7 +11156,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -11223,7 +11223,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -11288,7 +11288,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -11353,7 +11353,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -11418,7 +11418,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -11479,7 +11479,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -11540,7 +11540,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -11605,7 +11605,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -11667,7 +11667,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -11734,7 +11734,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -11799,7 +11799,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -11864,7 +11864,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -11929,7 +11929,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -11987,7 +11987,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -12045,7 +12045,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -12104,7 +12104,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -12168,7 +12168,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -12230,7 +12230,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -12292,7 +12292,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -12354,7 +12354,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -12419,7 +12419,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -12480,7 +12480,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -12541,7 +12541,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -12603,7 +12603,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -12670,7 +12670,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -12728,7 +12728,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -12786,7 +12786,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -12845,7 +12845,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -12907,7 +12907,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -12971,7 +12971,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -13034,7 +13034,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -13096,7 +13096,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -13158,7 +13158,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -13223,7 +13223,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -13284,7 +13284,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -13345,7 +13345,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -13407,7 +13407,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -13474,7 +13474,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -13531,7 +13531,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -13592,7 +13592,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -13659,7 +13659,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API
@@ -13717,7 +13717,7 @@ public class ComputeExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Compute Engine API

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_container.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_container.v1.json.baseline
@@ -1,5 +1,5 @@
 
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Container Engine API
@@ -63,7 +63,7 @@ public class ContainerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Container Engine API
@@ -126,7 +126,7 @@ public class ContainerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Container Engine API
@@ -189,7 +189,7 @@ public class ContainerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Container Engine API
@@ -249,7 +249,7 @@ public class ContainerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Container Engine API
@@ -316,7 +316,7 @@ public class ContainerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Container Engine API
@@ -382,7 +382,7 @@ public class ContainerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Container Engine API
@@ -448,7 +448,7 @@ public class ContainerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Container Engine API
@@ -511,7 +511,7 @@ public class ContainerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Container Engine API
@@ -578,7 +578,7 @@ public class ContainerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Container Engine API
@@ -638,7 +638,7 @@ public class ContainerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Container Engine API
@@ -701,7 +701,7 @@ public class ContainerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Container Engine API

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_dataflow.v1b3.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_dataflow.v1b3.json.baseline
@@ -1,5 +1,5 @@
 
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Dataflow API
@@ -57,7 +57,7 @@ public class DataflowExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Dataflow API
@@ -119,7 +119,7 @@ public class DataflowExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Dataflow API
@@ -181,7 +181,7 @@ public class DataflowExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Dataflow API
@@ -239,7 +239,7 @@ public class DataflowExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Dataflow API
@@ -297,7 +297,7 @@ public class DataflowExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Dataflow API
@@ -361,7 +361,7 @@ public class DataflowExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Dataflow API
@@ -428,7 +428,7 @@ public class DataflowExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Dataflow API
@@ -489,7 +489,7 @@ public class DataflowExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Dataflow API
@@ -551,7 +551,7 @@ public class DataflowExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Dataflow API
@@ -613,7 +613,7 @@ public class DataflowExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Dataflow API
@@ -672,7 +672,7 @@ public class DataflowExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Dataflow API

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_dataproc.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_dataproc.v1.json.baseline
@@ -1,5 +1,5 @@
 
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Dataproc API
@@ -61,7 +61,7 @@ public class DataprocExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Dataproc API
@@ -122,7 +122,7 @@ public class DataprocExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Dataproc API
@@ -187,7 +187,7 @@ public class DataprocExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Dataproc API
@@ -248,7 +248,7 @@ public class DataprocExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Dataproc API
@@ -315,7 +315,7 @@ public class DataprocExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Dataproc API
@@ -381,7 +381,7 @@ public class DataprocExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Dataproc API
@@ -446,7 +446,7 @@ public class DataprocExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Dataproc API
@@ -503,7 +503,7 @@ public class DataprocExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Dataproc API
@@ -564,7 +564,7 @@ public class DataprocExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Dataproc API
@@ -631,7 +631,7 @@ public class DataprocExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Dataproc API
@@ -693,7 +693,7 @@ public class DataprocExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Dataproc API
@@ -745,7 +745,7 @@ public class DataprocExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Dataproc API
@@ -797,7 +797,7 @@ public class DataprocExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Dataproc API
@@ -853,7 +853,7 @@ public class DataprocExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Dataproc API

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_datastore.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_datastore.v1.json.baseline
@@ -1,5 +1,5 @@
 
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Datastore API
@@ -58,7 +58,7 @@ public class DatastoreExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Datastore API
@@ -117,7 +117,7 @@ public class DatastoreExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Datastore API
@@ -176,7 +176,7 @@ public class DatastoreExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Datastore API
@@ -235,7 +235,7 @@ public class DatastoreExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Datastore API
@@ -294,7 +294,7 @@ public class DatastoreExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Datastore API

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_deploymentmanager.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_deploymentmanager.v2.json.baseline
@@ -1,5 +1,5 @@
 
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Deployment Manager API
@@ -61,7 +61,7 @@ public class DeploymentManagerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Deployment Manager API
@@ -119,7 +119,7 @@ public class DeploymentManagerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Deployment Manager API
@@ -177,7 +177,7 @@ public class DeploymentManagerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Deployment Manager API
@@ -235,7 +235,7 @@ public class DeploymentManagerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Deployment Manager API
@@ -294,7 +294,7 @@ public class DeploymentManagerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Deployment Manager API
@@ -358,7 +358,7 @@ public class DeploymentManagerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Deployment Manager API
@@ -421,7 +421,7 @@ public class DeploymentManagerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Deployment Manager API
@@ -482,7 +482,7 @@ public class DeploymentManagerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Deployment Manager API
@@ -544,7 +544,7 @@ public class DeploymentManagerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Deployment Manager API
@@ -606,7 +606,7 @@ public class DeploymentManagerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Deployment Manager API
@@ -668,7 +668,7 @@ public class DeploymentManagerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Deployment Manager API
@@ -729,7 +729,7 @@ public class DeploymentManagerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Deployment Manager API
@@ -796,7 +796,7 @@ public class DeploymentManagerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Deployment Manager API
@@ -854,7 +854,7 @@ public class DeploymentManagerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Deployment Manager API
@@ -918,7 +918,7 @@ public class DeploymentManagerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Deployment Manager API
@@ -979,7 +979,7 @@ public class DeploymentManagerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Deployment Manager API
@@ -1046,7 +1046,7 @@ public class DeploymentManagerExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Deployment Manager API

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_dns.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_dns.v1.json.baseline
@@ -1,5 +1,5 @@
 
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud DNS API
@@ -60,7 +60,7 @@ public class DnsExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud DNS API
@@ -121,7 +121,7 @@ public class DnsExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud DNS API
@@ -188,7 +188,7 @@ public class DnsExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud DNS API
@@ -246,7 +246,7 @@ public class DnsExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud DNS API
@@ -300,7 +300,7 @@ public class DnsExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud DNS API
@@ -358,7 +358,7 @@ public class DnsExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud DNS API
@@ -422,7 +422,7 @@ public class DnsExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud DNS API
@@ -477,7 +477,7 @@ public class DnsExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud DNS API

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_logging.v2beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_logging.v2beta1.json.baseline
@@ -1,5 +1,5 @@
 
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Stackdriver Logging API
@@ -52,7 +52,7 @@ public class LoggingExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Stackdriver Logging API
@@ -117,7 +117,7 @@ public class LoggingExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Stackdriver Logging API
@@ -173,7 +173,7 @@ public class LoggingExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Stackdriver Logging API
@@ -234,7 +234,7 @@ public class LoggingExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Stackdriver Logging API
@@ -287,7 +287,7 @@ public class LoggingExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Stackdriver Logging API
@@ -340,7 +340,7 @@ public class LoggingExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Stackdriver Logging API
@@ -401,7 +401,7 @@ public class LoggingExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Stackdriver Logging API
@@ -454,7 +454,7 @@ public class LoggingExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Stackdriver Logging API
@@ -511,7 +511,7 @@ public class LoggingExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Stackdriver Logging API
@@ -577,7 +577,7 @@ public class LoggingExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Stackdriver Logging API
@@ -640,7 +640,7 @@ public class LoggingExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Stackdriver Logging API
@@ -701,7 +701,7 @@ public class LoggingExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Stackdriver Logging API
@@ -756,7 +756,7 @@ public class LoggingExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Stackdriver Logging API
@@ -813,7 +813,7 @@ public class LoggingExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Stackdriver Logging API
@@ -879,7 +879,7 @@ public class LoggingExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Stackdriver Logging API

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_prediction.v1.6.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_prediction.v1.6.json.baseline
@@ -1,5 +1,5 @@
 
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Prediction API
@@ -61,7 +61,7 @@ public class PredictionExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Prediction API
@@ -119,7 +119,7 @@ public class PredictionExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Prediction API
@@ -173,7 +173,7 @@ public class PredictionExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Prediction API
@@ -231,7 +231,7 @@ public class PredictionExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Prediction API
@@ -290,7 +290,7 @@ public class PredictionExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Prediction API
@@ -354,7 +354,7 @@ public class PredictionExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Prediction API
@@ -416,7 +416,7 @@ public class PredictionExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Prediction API

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_pubsub.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_pubsub.v1.json.baseline
@@ -1,5 +1,5 @@
 
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Pub/Sub API
@@ -56,7 +56,7 @@ public class PubsubExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Pub/Sub API
@@ -117,7 +117,7 @@ public class PubsubExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Pub/Sub API
@@ -178,7 +178,7 @@ public class PubsubExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Pub/Sub API
@@ -234,7 +234,7 @@ public class PubsubExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Pub/Sub API
@@ -297,7 +297,7 @@ public class PubsubExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Pub/Sub API
@@ -349,7 +349,7 @@ public class PubsubExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Pub/Sub API
@@ -405,7 +405,7 @@ public class PubsubExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Pub/Sub API
@@ -462,7 +462,7 @@ public class PubsubExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Pub/Sub API
@@ -527,7 +527,7 @@ public class PubsubExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Pub/Sub API
@@ -583,7 +583,7 @@ public class PubsubExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Pub/Sub API
@@ -639,7 +639,7 @@ public class PubsubExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Pub/Sub API
@@ -699,7 +699,7 @@ public class PubsubExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Pub/Sub API
@@ -760,7 +760,7 @@ public class PubsubExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Pub/Sub API
@@ -821,7 +821,7 @@ public class PubsubExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Pub/Sub API
@@ -883,7 +883,7 @@ public class PubsubExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Pub/Sub API
@@ -935,7 +935,7 @@ public class PubsubExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Pub/Sub API
@@ -991,7 +991,7 @@ public class PubsubExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Pub/Sub API
@@ -1048,7 +1048,7 @@ public class PubsubExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Pub/Sub API
@@ -1113,7 +1113,7 @@ public class PubsubExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Pub/Sub API
@@ -1173,7 +1173,7 @@ public class PubsubExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Pub/Sub API
@@ -1234,7 +1234,7 @@ public class PubsubExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Pub/Sub API
@@ -1298,7 +1298,7 @@ public class PubsubExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Pub/Sub API

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_replicapoolupdater.v1beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_replicapoolupdater.v1beta1.json.baseline
@@ -1,5 +1,5 @@
 
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Compute Engine Instance Group Updater API
@@ -60,7 +60,7 @@ public class ReplicapoolupdaterExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Compute Engine Instance Group Updater API
@@ -121,7 +121,7 @@ public class ReplicapoolupdaterExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Compute Engine Instance Group Updater API
@@ -183,7 +183,7 @@ public class ReplicapoolupdaterExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Compute Engine Instance Group Updater API
@@ -250,7 +250,7 @@ public class ReplicapoolupdaterExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Compute Engine Instance Group Updater API
@@ -320,7 +320,7 @@ public class ReplicapoolupdaterExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Compute Engine Instance Group Updater API
@@ -381,7 +381,7 @@ public class ReplicapoolupdaterExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Compute Engine Instance Group Updater API
@@ -442,7 +442,7 @@ public class ReplicapoolupdaterExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Compute Engine Instance Group Updater API
@@ -503,7 +503,7 @@ public class ReplicapoolupdaterExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Compute Engine Instance Group Updater API
@@ -564,7 +564,7 @@ public class ReplicapoolupdaterExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Compute Engine Instance Group Updater API

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_sqladmin.v1beta4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_sqladmin.v1beta4.json.baseline
@@ -1,5 +1,5 @@
 
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud SQL Administration API
@@ -60,7 +60,7 @@ public class SqlAdminExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud SQL Administration API
@@ -121,7 +121,7 @@ public class SqlAdminExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud SQL Administration API
@@ -183,7 +183,7 @@ public class SqlAdminExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud SQL Administration API
@@ -250,7 +250,7 @@ public class SqlAdminExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud SQL Administration API
@@ -311,7 +311,7 @@ public class SqlAdminExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud SQL Administration API
@@ -372,7 +372,7 @@ public class SqlAdminExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud SQL Administration API
@@ -434,7 +434,7 @@ public class SqlAdminExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud SQL Administration API
@@ -492,7 +492,7 @@ public class SqlAdminExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud SQL Administration API
@@ -558,7 +558,7 @@ public class SqlAdminExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud SQL Administration API
@@ -623,7 +623,7 @@ public class SqlAdminExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud SQL Administration API
@@ -675,7 +675,7 @@ public class SqlAdminExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud SQL Administration API
@@ -737,7 +737,7 @@ public class SqlAdminExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud SQL Administration API
@@ -795,7 +795,7 @@ public class SqlAdminExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud SQL Administration API
@@ -857,7 +857,7 @@ public class SqlAdminExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud SQL Administration API
@@ -919,7 +919,7 @@ public class SqlAdminExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud SQL Administration API
@@ -977,7 +977,7 @@ public class SqlAdminExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud SQL Administration API
@@ -1039,7 +1039,7 @@ public class SqlAdminExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud SQL Administration API
@@ -1098,7 +1098,7 @@ public class SqlAdminExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud SQL Administration API
@@ -1162,7 +1162,7 @@ public class SqlAdminExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud SQL Administration API
@@ -1225,7 +1225,7 @@ public class SqlAdminExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud SQL Administration API
@@ -1283,7 +1283,7 @@ public class SqlAdminExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud SQL Administration API
@@ -1341,7 +1341,7 @@ public class SqlAdminExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud SQL Administration API
@@ -1399,7 +1399,7 @@ public class SqlAdminExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud SQL Administration API
@@ -1461,7 +1461,7 @@ public class SqlAdminExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud SQL Administration API
@@ -1519,7 +1519,7 @@ public class SqlAdminExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud SQL Administration API
@@ -1577,7 +1577,7 @@ public class SqlAdminExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud SQL Administration API
@@ -1639,7 +1639,7 @@ public class SqlAdminExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud SQL Administration API
@@ -1697,7 +1697,7 @@ public class SqlAdminExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud SQL Administration API
@@ -1764,7 +1764,7 @@ public class SqlAdminExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud SQL Administration API
@@ -1826,7 +1826,7 @@ public class SqlAdminExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud SQL Administration API
@@ -1887,7 +1887,7 @@ public class SqlAdminExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud SQL Administration API
@@ -1948,7 +1948,7 @@ public class SqlAdminExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud SQL Administration API
@@ -2010,7 +2010,7 @@ public class SqlAdminExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud SQL Administration API
@@ -2068,7 +2068,7 @@ public class SqlAdminExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud SQL Administration API
@@ -2123,7 +2123,7 @@ public class SqlAdminExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud SQL Administration API
@@ -2187,7 +2187,7 @@ public class SqlAdminExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud SQL Administration API
@@ -2249,7 +2249,7 @@ public class SqlAdminExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud SQL Administration API
@@ -2307,7 +2307,7 @@ public class SqlAdminExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud SQL Administration API

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_storage.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_storage.v1.json.baseline
@@ -1,5 +1,5 @@
 
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud Storage JSON API
@@ -54,7 +54,7 @@ public class StorageExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud Storage JSON API
@@ -113,7 +113,7 @@ public class StorageExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud Storage JSON API
@@ -171,7 +171,7 @@ public class StorageExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud Storage JSON API
@@ -226,7 +226,7 @@ public class StorageExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud Storage JSON API
@@ -289,7 +289,7 @@ public class StorageExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud Storage JSON API
@@ -351,7 +351,7 @@ public class StorageExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud Storage JSON API
@@ -402,7 +402,7 @@ public class StorageExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud Storage JSON API
@@ -457,7 +457,7 @@ public class StorageExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud Storage JSON API
@@ -515,7 +515,7 @@ public class StorageExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud Storage JSON API
@@ -579,7 +579,7 @@ public class StorageExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud Storage JSON API
@@ -638,7 +638,7 @@ public class StorageExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud Storage JSON API
@@ -696,7 +696,7 @@ public class StorageExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud Storage JSON API
@@ -748,7 +748,7 @@ public class StorageExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud Storage JSON API
@@ -803,7 +803,7 @@ public class StorageExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud Storage JSON API
@@ -862,7 +862,7 @@ public class StorageExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud Storage JSON API
@@ -920,7 +920,7 @@ public class StorageExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud Storage JSON API
@@ -975,7 +975,7 @@ public class StorageExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud Storage JSON API
@@ -1038,7 +1038,7 @@ public class StorageExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud Storage JSON API
@@ -1100,7 +1100,7 @@ public class StorageExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud Storage JSON API
@@ -1159,7 +1159,7 @@ public class StorageExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud Storage JSON API
@@ -1222,7 +1222,7 @@ public class StorageExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud Storage JSON API
@@ -1284,7 +1284,7 @@ public class StorageExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud Storage JSON API
@@ -1343,7 +1343,7 @@ public class StorageExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud Storage JSON API
@@ -1410,7 +1410,7 @@ public class StorageExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud Storage JSON API
@@ -1476,7 +1476,7 @@ public class StorageExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud Storage JSON API
@@ -1542,7 +1542,7 @@ public class StorageExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud Storage JSON API
@@ -1616,7 +1616,7 @@ public class StorageExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud Storage JSON API
@@ -1671,7 +1671,7 @@ public class StorageExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud Storage JSON API
@@ -1733,7 +1733,7 @@ public class StorageExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud Storage JSON API
@@ -1795,7 +1795,7 @@ public class StorageExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud Storage JSON API
@@ -1859,7 +1859,7 @@ public class StorageExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud Storage JSON API
@@ -1922,7 +1922,7 @@ public class StorageExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud Storage JSON API
@@ -1994,7 +1994,7 @@ public class StorageExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud Storage JSON API
@@ -2059,7 +2059,7 @@ public class StorageExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Cloud Storage JSON API

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_storagetransfer.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_storagetransfer.v1.json.baseline
@@ -1,5 +1,5 @@
 
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Storage Transfer API
@@ -55,7 +55,7 @@ public class StoragetransferExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Storage Transfer API
@@ -111,7 +111,7 @@ public class StoragetransferExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Storage Transfer API
@@ -166,7 +166,7 @@ public class StoragetransferExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Storage Transfer API
@@ -221,7 +221,7 @@ public class StoragetransferExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Storage Transfer API
@@ -282,7 +282,7 @@ public class StoragetransferExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Storage Transfer API
@@ -342,7 +342,7 @@ public class StoragetransferExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Storage Transfer API
@@ -393,7 +393,7 @@ public class StoragetransferExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Storage Transfer API
@@ -444,7 +444,7 @@ public class StoragetransferExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Storage Transfer API
@@ -499,7 +499,7 @@ public class StoragetransferExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Storage Transfer API
@@ -563,7 +563,7 @@ public class StoragetransferExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Storage Transfer API
@@ -618,7 +618,7 @@ public class StoragetransferExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Storage Transfer API

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_taskqueue.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_taskqueue.v1beta2.json.baseline
@@ -1,5 +1,5 @@
 
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the TaskQueue API
@@ -54,7 +54,7 @@ public class TaskqueueExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the TaskQueue API
@@ -108,7 +108,7 @@ public class TaskqueueExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the TaskQueue API
@@ -166,7 +166,7 @@ public class TaskqueueExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the TaskQueue API
@@ -224,7 +224,7 @@ public class TaskqueueExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the TaskQueue API
@@ -285,7 +285,7 @@ public class TaskqueueExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the TaskQueue API
@@ -340,7 +340,7 @@ public class TaskqueueExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the TaskQueue API
@@ -403,7 +403,7 @@ public class TaskqueueExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the TaskQueue API

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_translate.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_translate.v2.json.baseline
@@ -1,5 +1,5 @@
 
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Translate API
@@ -49,7 +49,7 @@ public class TranslateExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Translate API
@@ -94,7 +94,7 @@ public class TranslateExample {
         .build();
   }
 }
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Translate API

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_vision.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_vision.v1.json.baseline
@@ -1,5 +1,5 @@
 
-/**
+/*
  * BEFORE RUNNING:
  * ---------------
  * 1. If not already done, enable the Google Cloud Vision API


### PR DESCRIPTION
`google-java-format` is messing up the format of the doc comment,
presumably because there's no newline separation between the first
sentence and the body. In any case, the Java sample instructions don't
really qualify as JavaDoc...