### PR TITLE
Extend VisibilityConfig to private methods

### DIFF
--- a/src/main/java/com/google/api/codegen/config/VisibilityConfig.java
+++ b/src/main/java/com/google/api/codegen/config/VisibilityConfig.java
@@ -14,17 +14,38 @@
  */
 package com.google.api.codegen.config;
 
+import com.google.api.codegen.transformer.SurfaceNamer;
+import com.google.api.codegen.util.Name;
 import com.google.api.codegen.VisibilityProto;
 import com.google.common.collect.ImmutableMap;
 
 public enum VisibilityConfig {
   PUBLIC,
+  PRIVATE,
   DISABLED;
 
   private static ImmutableMap<VisibilityProto, VisibilityConfig> protoMap =
-      ImmutableMap.of(VisibilityProto.PUBLIC, PUBLIC, VisibilityProto.DISABLED, DISABLED);
+      ImmutableMap.of(
+          VisibilityProto.PUBLIC,
+          PUBLIC,
+          VisibilityProto.PRIVATE,
+          PRIVATE,
+          VisibilityProto.DISABLED,
+          DISABLED);
 
   public static VisibilityConfig fromProto(VisibilityProto proto) {
     return protoMap.get(proto);
+  }
+
+  public String methodName(SurfaceNamer namer, Name name) {
+    switch (this) {
+      case PUBLIC:
+        return namer.publicMethodName(name);
+      case PRIVATE:
+        return namer.privateMethodName(name);
+      case DISABLED:
+        throw new IllegalStateException("disabled methods cannot be named");
+    }
+    throw new IllegalStateException("unhandled case " + this);
   }
 }

--- a/src/main/java/com/google/api/codegen/transformer/ApiCallableTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ApiCallableTransformer.java
@@ -16,6 +16,7 @@ package com.google.api.codegen.transformer;
 
 import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.config.PageStreamingConfig;
+import com.google.api.codegen.config.VisibilityConfig;
 import com.google.api.codegen.viewmodel.ApiCallSettingsView;
 import com.google.api.codegen.viewmodel.ApiCallableType;
 import com.google.api.codegen.viewmodel.ApiCallableView;
@@ -75,7 +76,8 @@ public class ApiCallableTransformer {
     apiCallableBuilder.requestTypeName(typeTable.getAndSaveNicknameFor(method.getInputType()));
     apiCallableBuilder.responseTypeName(typeTable.getAndSaveNicknameFor(method.getOutputType()));
     apiCallableBuilder.name(context.getNamer().getCallableName(method));
-    apiCallableBuilder.methodName(context.getNamer().getApiMethodName(method));
+    apiCallableBuilder.methodName(
+        context.getNamer().getApiMethodName(method, context.getMethodConfig().getVisibility()));
     apiCallableBuilder.asyncMethodName(context.getNamer().getAsyncApiMethodName(method));
     apiCallableBuilder.memberName(context.getNamer().getSettingsMemberName(method));
     apiCallableBuilder.settingsFunctionName(context.getNamer().getSettingsFunctionName(method));
@@ -107,7 +109,8 @@ public class ApiCallableTransformer {
           typeTable.getAndSaveNicknameFor(method.getInputType()));
       pagedApiCallableBuilder.responseTypeName(pagedResponseTypeName);
       pagedApiCallableBuilder.name(context.getNamer().getPagedCallableName(method));
-      pagedApiCallableBuilder.methodName(context.getNamer().getApiMethodName(method));
+      pagedApiCallableBuilder.methodName(
+          context.getNamer().getApiMethodName(method, context.getMethodConfig().getVisibility()));
       pagedApiCallableBuilder.asyncMethodName(context.getNamer().getAsyncApiMethodName(method));
       pagedApiCallableBuilder.memberName(context.getNamer().getSettingsMemberName(method));
       pagedApiCallableBuilder.settingsFunctionName(
@@ -139,7 +142,7 @@ public class ApiCallableTransformer {
 
     ApiCallSettingsView.Builder settings = ApiCallSettingsView.newBuilder();
 
-    settings.methodName(namer.getApiMethodName(method));
+    settings.methodName(namer.getApiMethodName(method, VisibilityConfig.PUBLIC));
     settings.asyncMethodName(namer.getAsyncApiMethodName(method));
     settings.requestTypeName(typeTable.getAndSaveNicknameFor(method.getInputType()));
     settings.responseTypeName(typeTable.getAndSaveNicknameFor(method.getOutputType()));

--- a/src/main/java/com/google/api/codegen/transformer/ApiMethodTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ApiMethodTransformer.java
@@ -69,7 +69,8 @@ public class ApiMethodTransformer {
     StaticLangApiMethodView.Builder methodViewBuilder = StaticLangApiMethodView.newBuilder();
 
     setCommonFields(context, methodViewBuilder);
-    methodViewBuilder.name(namer.getApiMethodName(context.getMethod()));
+    methodViewBuilder.name(
+        namer.getApiMethodName(context.getMethod(), context.getMethodConfig().getVisibility()));
     methodViewBuilder.exampleName(
         namer.getApiMethodExampleName(context.getInterface(), context.getMethod()));
     setListMethodFields(context, Synchronicity.Sync, methodViewBuilder);
@@ -110,7 +111,8 @@ public class ApiMethodTransformer {
     StaticLangApiMethodView.Builder methodViewBuilder = StaticLangApiMethodView.newBuilder();
 
     setCommonFields(context, methodViewBuilder);
-    methodViewBuilder.name(namer.getApiMethodName(context.getMethod()));
+    methodViewBuilder.name(
+        namer.getApiMethodName(context.getMethod(), context.getMethodConfig().getVisibility()));
     methodViewBuilder.exampleName(
         namer.getApiMethodExampleName(context.getInterface(), context.getMethod()));
     setListMethodFields(context, Synchronicity.Sync, methodViewBuilder);
@@ -207,7 +209,8 @@ public class ApiMethodTransformer {
     StaticLangApiMethodView.Builder methodViewBuilder = StaticLangApiMethodView.newBuilder();
 
     setCommonFields(context, methodViewBuilder);
-    methodViewBuilder.name(namer.getApiMethodName(context.getMethod()));
+    methodViewBuilder.name(
+        namer.getApiMethodName(context.getMethod(), context.getMethodConfig().getVisibility()));
     methodViewBuilder.exampleName(
         namer.getApiMethodExampleName(context.getInterface(), context.getMethod()));
     methodViewBuilder.isPageStreaming(false);
@@ -224,7 +227,8 @@ public class ApiMethodTransformer {
     StaticLangApiMethodView.Builder methodViewBuilder = StaticLangApiMethodView.newBuilder();
 
     setCommonFields(context, methodViewBuilder);
-    methodViewBuilder.name(namer.getApiMethodName(context.getMethod()));
+    methodViewBuilder.name(
+        namer.getApiMethodName(context.getMethod(), context.getMethodConfig().getVisibility()));
     methodViewBuilder.exampleName(
         context.getNamer().getApiMethodExampleName(context.getInterface(), context.getMethod()));
     setRequestObjectMethodFields(
@@ -341,7 +345,7 @@ public class ApiMethodTransformer {
             context.cloneWithEmptyTypeTable(), createInitCodeContext(context, fields)));
     methodViewBuilder.doc(
         ApiMethodDocView.newBuilder()
-            .mainDocLines(namer.getDocLines(context.getMethod()))
+            .mainDocLines(namer.getDocLines(context.getMethod(), context.getMethodConfig()))
             .paramDocs(getMethodParamDocs(context, fields, additionalParams))
             .throwsDocLines(namer.getThrowsDocLines())
             .returnsDocLines(
@@ -371,7 +375,7 @@ public class ApiMethodTransformer {
     SurfaceNamer namer = context.getNamer();
     methodViewBuilder.doc(
         ApiMethodDocView.newBuilder()
-            .mainDocLines(namer.getDocLines(context.getMethod()))
+            .mainDocLines(namer.getDocLines(context.getMethod(), context.getMethodConfig()))
             .paramDocs(
                 Arrays.<ParamDocView>asList(
                     getRequestObjectParamDoc(context, context.getMethod().getInputType())))
@@ -400,7 +404,8 @@ public class ApiMethodTransformer {
       MethodTransformerContext context, String callableName, Builder methodViewBuilder) {
     methodViewBuilder.doc(
         ApiMethodDocView.newBuilder()
-            .mainDocLines(context.getNamer().getDocLines(context.getMethod()))
+            .mainDocLines(
+                context.getNamer().getDocLines(context.getMethod(), context.getMethodConfig()))
             .paramDocs(new ArrayList<ParamDocView>())
             .throwsDocLines(new ArrayList<String>())
             .build());
@@ -475,7 +480,10 @@ public class ApiMethodTransformer {
             context.getNamer().getPathTemplateName(context.getInterface(), collectionConfig));
         check.paramName(context.getNamer().getVariableName(field));
         check.allowEmptyString(shouldAllowEmpty(context, field));
-        check.validationMessageContext(context.getNamer().getApiMethodName(context.getMethod()));
+        check.validationMessageContext(
+            context
+                .getNamer()
+                .getApiMethodName(context.getMethod(), context.getMethodConfig().getVisibility()));
         pathTemplateChecks.add(check.build());
       }
     }
@@ -510,7 +518,8 @@ public class ApiMethodTransformer {
 
     apiMethod.doc(generateOptionalArrayMethodDoc(context));
 
-    apiMethod.name(namer.getApiMethodName(context.getMethod()));
+    apiMethod.name(
+        namer.getApiMethodName(context.getMethod(), context.getMethodConfig().getVisibility()));
     apiMethod.requestTypeName(
         context.getTypeTable().getAndSaveNicknameFor(context.getMethod().getInputType()));
     apiMethod.hasReturnValue(!ServiceMessages.s_isEmptyType(context.getMethod().getOutputType()));
@@ -535,7 +544,8 @@ public class ApiMethodTransformer {
   private ApiMethodDocView generateOptionalArrayMethodDoc(MethodTransformerContext context) {
     ApiMethodDocView.Builder docBuilder = ApiMethodDocView.newBuilder();
 
-    docBuilder.mainDocLines(context.getNamer().getDocLines(context.getMethod()));
+    docBuilder.mainDocLines(
+        context.getNamer().getDocLines(context.getMethod(), context.getMethodConfig()));
     List<ParamDocView> paramDocs =
         getMethodParamDocs(
             context,
@@ -576,7 +586,9 @@ public class ApiMethodTransformer {
     StaticLangApiMethodView.Builder methodViewBuilder = StaticLangApiMethodView.newBuilder();
 
     setCommonFields(context, methodViewBuilder);
-    methodViewBuilder.name(namer.getGrpcStreamingApiMethodName(context.getMethod()));
+    methodViewBuilder.name(
+        namer.getGrpcStreamingApiMethodName(
+            context.getMethod(), context.getMethodConfig().getVisibility()));
     methodViewBuilder.exampleName(
         context
             .getNamer()

--- a/src/main/java/com/google/api/codegen/transformer/GrpcStubTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/GrpcStubTransformer.java
@@ -62,7 +62,8 @@ public class GrpcStubTransformer {
 
     List<String> methodNames = new ArrayList<>();
     for (Method method : methods) {
-      methodNames.add(namer.getApiMethodName(method));
+      methodNames.add(
+          namer.getApiMethodName(method, context.getMethodConfig(method).getVisibility()));
     }
     stub.methodNames(methodNames);
 

--- a/src/main/java/com/google/api/codegen/transformer/MethodTransformerContext.java
+++ b/src/main/java/com/google/api/codegen/transformer/MethodTransformerContext.java
@@ -61,7 +61,6 @@ public abstract class MethodTransformerContext {
 
   public abstract Method getMethod();
 
-  @Nullable
   public abstract MethodConfig getMethodConfig();
 
   public abstract FeatureConfig getFeatureConfig();

--- a/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
@@ -16,6 +16,7 @@ package com.google.api.codegen.transformer;
 
 import com.google.api.codegen.config.CollectionConfig;
 import com.google.api.codegen.config.MethodConfig;
+import com.google.api.codegen.config.VisibilityConfig;
 import com.google.api.codegen.util.CommonRenderingUtil;
 import com.google.api.codegen.util.Name;
 import com.google.api.codegen.util.NameFormatter;
@@ -475,8 +476,8 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** The name of the surface method which can call the given API method. */
-  public String getApiMethodName(Method method) {
-    return publicMethodName(Name.upperCamel(method.getSimpleName()));
+  public String getApiMethodName(Method method, VisibilityConfig visibility) {
+    return visibility.methodName(this, Name.upperCamel(method.getSimpleName()));
   }
 
   /** The name of the async surface method which can call the given API method. */
@@ -486,7 +487,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
 
   /** The name of the example for the method. */
   public String getApiMethodExampleName(Interface interfaze, Method method) {
-    return getApiMethodName(method);
+    return getApiMethodName(method, VisibilityConfig.PUBLIC);
   }
 
   public String getAsyncApiMethodExampleName(Method method) {
@@ -494,13 +495,13 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** The name of the GRPC streaming surface method which can call the given API method. */
-  public String getGrpcStreamingApiMethodName(Method method) {
-    return getApiMethodName(method);
+  public String getGrpcStreamingApiMethodName(Method method, VisibilityConfig visibility) {
+    return getApiMethodName(method, visibility);
   }
 
   /** The name of the example of the GRPC streaming surface method which can call the given API method. */
   public String getGrpcStreamingApiMethodExampleName(Interface interfaze, Method method) {
-    return getGrpcStreamingApiMethodName(method);
+    return getGrpcStreamingApiMethodName(method, VisibilityConfig.PUBLIC);
   }
 
   /**
@@ -540,6 +541,11 @@ public class SurfaceNamer extends NameFormatterDelegator {
   /** Provides the doc lines for the given proto element in the current language. */
   public List<String> getDocLines(ProtoElement element) {
     return getDocLines(DocumentationUtil.getDescription(element));
+  }
+
+  /** Provides the doc lines for the given method element in the current language. */
+  public List<String> getDocLines(Method method, MethodConfig methodConfig) {
+    return getDocLines(method);
   }
 
   /** The doc lines that declare what exception(s) are thrown for an API method. */

--- a/src/main/java/com/google/api/codegen/transformer/SurfaceTransformerContext.java
+++ b/src/main/java/com/google/api/codegen/transformer/SurfaceTransformerContext.java
@@ -149,10 +149,11 @@ public abstract class SurfaceTransformerContext {
     return methods;
   }
 
-  /** Returns a list of methods with samples, similar to getSupportedMethods,
-   *  but also filter out private methods.
+  /**
+   * Returns a list of methods with samples, similar to getSupportedMethods,
+   * but also filter out private methods.
    */
-  public List<Method> getMethodsWithSamples() {
+  public List<Method> getPublicMethods() {
     List<Method> methods = new ArrayList<>(getInterfaceConfig().getMethodConfigs().size());
     for (MethodConfig methodConfig : getInterfaceConfig().getMethodConfigs()) {
       Method method = methodConfig.getMethod();

--- a/src/main/java/com/google/api/codegen/transformer/SurfaceTransformerContext.java
+++ b/src/main/java/com/google/api/codegen/transformer/SurfaceTransformerContext.java
@@ -137,12 +137,27 @@ public abstract class SurfaceTransformerContext {
         getFeatureConfig());
   }
 
-  /** Returns a list of simple RPC methods. */
+  /** Returns a list of supported methods, configured by FeatureConfig. */
   public List<Method> getSupportedMethods() {
     List<Method> methods = new ArrayList<>(getInterfaceConfig().getMethodConfigs().size());
     for (MethodConfig methodConfig : getInterfaceConfig().getMethodConfigs()) {
       Method method = methodConfig.getMethod();
       if (isSupported(method)) {
+        methods.add(method);
+      }
+    }
+    return methods;
+  }
+
+  /** Returns a list of methods with samples, similar to getSupportedMethods,
+   *  but also filter out private methods.
+   */
+  public List<Method> getMethodsWithSamples() {
+    List<Method> methods = new ArrayList<>(getInterfaceConfig().getMethodConfigs().size());
+    for (MethodConfig methodConfig : getInterfaceConfig().getMethodConfigs()) {
+      Method method = methodConfig.getMethod();
+      VisibilityConfig visibility = getInterfaceConfig().getMethodConfig(method).getVisibility();
+      if (isSupported(method) && visibility == VisibilityConfig.PUBLIC) {
         methods.add(method);
       }
     }

--- a/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformer.java
@@ -194,7 +194,7 @@ public class GoGapicSurfaceTransformer implements ModelToViewTransformer {
     view.clientConstructorExampleName(namer.getApiWrapperClassConstructorExampleName(service));
     view.apiMethods(
         generateApiMethods(
-            context, context.getSupportedMethods(), Collections.<String>emptyList()));
+            context, context.getMethodsWithSamples(), Collections.<String>emptyList()));
     view.iamResources(iamResourceTransformer.generateIamResources(context));
 
     // Examples are different from the API. In particular, we use short declaration
@@ -204,7 +204,7 @@ public class GoGapicSurfaceTransformer implements ModelToViewTransformer {
     //   - The input types of the methods, to initialize the requests
     // So, we clear all imports; addXExampleImports will add back the ones we want.
     context.getTypeTable().getImports().clear();
-    addXExampleImports(context, context.getSupportedMethods());
+    addXExampleImports(context, context.getMethodsWithSamples());
     view.imports(GoTypeTable.formatImports(context.getTypeTable().getImports()));
 
     return view.build();

--- a/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformer.java
@@ -193,8 +193,7 @@ public class GoGapicSurfaceTransformer implements ModelToViewTransformer {
     view.clientConstructorName(namer.getApiWrapperClassConstructorName(service));
     view.clientConstructorExampleName(namer.getApiWrapperClassConstructorExampleName(service));
     view.apiMethods(
-        generateApiMethods(
-            context, context.getMethodsWithSamples(), Collections.<String>emptyList()));
+        generateApiMethods(context, context.getPublicMethods(), Collections.<String>emptyList()));
     view.iamResources(iamResourceTransformer.generateIamResources(context));
 
     // Examples are different from the API. In particular, we use short declaration
@@ -204,7 +203,7 @@ public class GoGapicSurfaceTransformer implements ModelToViewTransformer {
     //   - The input types of the methods, to initialize the requests
     // So, we clear all imports; addXExampleImports will add back the ones we want.
     context.getTypeTable().getImports().clear();
-    addXExampleImports(context, context.getMethodsWithSamples());
+    addXExampleImports(context, context.getPublicMethods());
     view.imports(GoTypeTable.formatImports(context.getTypeTable().getImports()));
 
     return view.build();

--- a/src/main/java/com/google/api/codegen/transformer/go/GoSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/go/GoSurfaceNamer.java
@@ -16,12 +16,13 @@ package com.google.api.codegen.transformer.go;
 
 import com.google.api.codegen.config.CollectionConfig;
 import com.google.api.codegen.config.MethodConfig;
+import com.google.api.codegen.config.VisibilityConfig;
 import com.google.api.codegen.transformer.ModelTypeFormatterImpl;
 import com.google.api.codegen.transformer.ModelTypeTable;
 import com.google.api.codegen.transformer.SurfaceNamer;
-import com.google.api.codegen.util.Name;
 import com.google.api.codegen.util.go.GoNameFormatter;
 import com.google.api.codegen.util.go.GoTypeTable;
+import com.google.api.codegen.util.Name;
 import com.google.api.tools.framework.aspects.documentation.model.DocumentationUtil;
 import com.google.api.tools.framework.model.Field;
 import com.google.api.tools.framework.model.Interface;
@@ -67,14 +68,10 @@ public class GoSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public List<String> getDocLines(ProtoElement element) {
-    if (!(element instanceof Method)) {
-      return super.getDocLines(element);
-    }
-    Method method = (Method) element;
+  public List<String> getDocLines(Method method, MethodConfig methodConfig) {
     String text = DocumentationUtil.getDescription(method);
     text = lowerFirstLetter(text);
-    return super.getDocLines(getApiMethodName(method) + " " + text);
+    return super.getDocLines(getApiMethodName(method, methodConfig.getVisibility()) + " " + text);
   }
 
   @Override
@@ -135,7 +132,7 @@ public class GoSurfaceNamer extends SurfaceNamer {
 
   @Override
   public String getApiMethodExampleName(Interface service, Method method) {
-    return exampleFunction(service, getApiMethodName(method));
+    return exampleFunction(service, getApiMethodName(method, VisibilityConfig.PUBLIC));
   }
 
   @Override
@@ -220,6 +217,11 @@ public class GoSurfaceNamer extends SurfaceNamer {
   @Override
   public String getIamResourceGetterFunctionExampleName(Interface service, Field field) {
     return exampleFunction(service, getIamResourceGetterFunctionName(field));
+  }
+
+  @Override
+  public String getSettingsMemberName(Method method) {
+    return publicFieldName(Name.upperCamel(method.getSimpleName()));
   }
 
   private String exampleFunction(Interface service, String functionName) {

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
@@ -153,7 +153,7 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
         initCodeTransformer.generateInitCode(context, createSmokeTestInitContext(context));
 
     return TestMethodView.newBuilder()
-        .name(namer.getApiMethodName(method))
+        .name(namer.getApiMethodName(method, context.getMethodConfig().getVisibility()))
         .responseTypeName(context.getTypeTable().getAndSaveNicknameFor(method.getOutputType()))
         .type(methodType)
         .initCode(initCodeView)
@@ -253,7 +253,7 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
         methodContext.getTypeTable().getAndSaveNicknameFor(method.getInputType());
     String responseTypeName =
         methodContext.getTypeTable().getAndSaveNicknameFor(method.getOutputType());
-    String surfaceMethodName = namer.getApiMethodName(method);
+    String surfaceMethodName = namer.getApiMethodName(method, methodConfig.getVisibility());
 
     ApiMethodType type = ApiMethodType.FlattenedMethod;
     if (methodConfig.isPageStreaming()) {
@@ -488,7 +488,10 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
         methodContext.getTypeTable().getAndSaveNicknameFor(method.getOutputType());
 
     return MockGrpcMethodView.newBuilder()
-        .name(methodContext.getNamer().getApiMethodName(method))
+        .name(
+            methodContext
+                .getNamer()
+                .getApiMethodName(method, methodContext.getMethodConfig().getVisibility()))
         .requestTypeName(requestTypeName)
         .responseTypeName(responseTypeName)
         .grpcStreamingType(methodContext.getMethodConfig().getGrpcStreamingType())

--- a/src/main/proto/com/google/api/codegen/config.proto
+++ b/src/main/proto/com/google/api/codegen/config.proto
@@ -355,5 +355,6 @@ message SurfaceTreatmentProto {
 enum VisibilityProto {
   UNSET = 0;
   PUBLIC = 1;
-  DISABLED = 2;
+  PRIVATE = 2;
+  DISABLED = 3;
 }

--- a/src/main/resources/com/google/api/codegen/go/main.snip
+++ b/src/main/resources/com/google/api/codegen/go/main.snip
@@ -21,8 +21,8 @@
 
     // {@view.callOptionsTypeName} contains the retry settings for each method of {@view.clientTypeName}.
     type {@view.callOptionsTypeName} struct {
-        @join apiMethod : view.apiMethods
-            {@apiMethod.name} []gax.CallOption
+        @join settings : view.callSettings
+            {@settings.methodName} []gax.CallOption
         @end
     }
 
@@ -181,7 +181,7 @@
             var err error
             resp, err = c.{@method.stubName}.{@method.name}(ctx, req)
             return err
-        }, c.CallOptions.{@method.name}...)
+        }, c.CallOptions.{@method.settingsGetterName}...)
         if err != nil {
             return nil, err
         }
@@ -199,7 +199,7 @@
             var err error
             resp, err = c.{@method.stubName}.{@method.name}(ctx)
             return err
-        }, c.CallOptions.{@method.name}...)
+        }, c.CallOptions.{@method.settingsGetterName}...)
         if err != nil {
             return nil, err
         }
@@ -214,7 +214,7 @@
             var err error
             _, err = c.{@method.stubName}.{@method.name}(ctx, req)
             return err
-        }, c.CallOptions.{@method.name}...)
+        }, c.CallOptions.{@method.settingsGetterName}...)
         return err
     }
 @end
@@ -236,7 +236,7 @@
                 var err error
                 resp, err = c.{@method.stubName}.{@method.name}(ctx, req)
                 return err
-            }, c.CallOptions.{@method.name}...)
+            }, c.CallOptions.{@method.settingsGetterName}...)
             if err != nil {
                 return "", err
             }

--- a/src/test/java/com/google/api/codegen/testdata/go_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_main_library.baseline
@@ -30,6 +30,7 @@ import (
     "google.golang.org/api/option"
     "google.golang.org/api/transport"
     librarypb "google.golang.org/genproto/googleapis/example/library/v1"
+    taggerpb "google.golang.org/genproto/googleapis/tagger/v1"
     "google.golang.org/grpc"
     "google.golang.org/grpc/codes"
     "google.golang.org/grpc/metadata"
@@ -63,6 +64,7 @@ type CallOptions struct {
     StreamBooks []gax.CallOption
     DiscussBook []gax.CallOption
     FindRelatedBooks []gax.CallOption
+    AddLabel []gax.CallOption
 }
 
 func defaultClientOptions() []option.ClientOption {
@@ -111,6 +113,7 @@ func defaultCallOptions() *CallOptions {
         StreamBooks: retry[[2]string{"default", "idempotent"}],
         DiscussBook: retry[[2]string{"default", "non_idempotent"}],
         FindRelatedBooks: retry[[2]string{"default", "idempotent"}],
+        AddLabel: retry[[2]string{"default", "non_idempotent"}],
     }
 }
 
@@ -121,6 +124,7 @@ type Client struct {
 
     // The gRPC API client.
     client librarypb.LibraryServiceClient
+    labelerClient taggerpb.LabelerClient
 
     // The call options for this service.
     CallOptions *CallOptions
@@ -153,6 +157,7 @@ func NewClient(ctx context.Context, opts ...option.ClientOption) (*Client, error
         CallOptions: defaultCallOptions(),
 
         client: librarypb.NewLibraryServiceClient(conn),
+        labelerClient: taggerpb.NewLabelerClient(conn),
     }
     c.SetGoogleClientInfo("gax", gax.Version)
     return c, nil
@@ -604,6 +609,22 @@ func (c *Client) FindRelatedBooks(ctx context.Context, req *librarypb.FindRelate
 
     it.pageInfo, it.nextFunc = iterator.NewPageInfo(fetch, bufLen, takeBuf)
     return it
+}
+
+// addLabel adds a label to the entity.
+func (c *Client) addLabel(ctx context.Context, req *taggerpb.AddLabelRequest) (*taggerpb.AddLabelResponse, error) {
+    md, _ := metadata.FromContext(ctx)
+    ctx = metadata.NewContext(ctx, metadata.Join(md, c.metadata))
+    var resp *taggerpb.AddLabelResponse
+    err := gax.Invoke(ctx, func(ctx context.Context) error {
+        var err error
+        resp, err = c.labelerClient.addLabel(ctx, req)
+        return err
+    }, c.CallOptions.AddLabel...)
+    if err != nil {
+        return nil, err
+    }
+    return resp, nil
 }
 
 

--- a/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
@@ -410,4 +410,4 @@ interfaces:
     surface_treatments:
     - include_languages:
       - go
-      visibility: DISABLED
+      visibility: PRIVATE


### PR DESCRIPTION
This commit extends VisibilityConfig to include private methods. The main motivation of these private methods is to let us create hand-written methods in their places. The private methods can be used by the hand-written ones to simplify work.