### PR TITLE
Go: Use LRO client

### DIFF
--- a/src/main/java/com/google/api/codegen/ServiceMessages.java
+++ b/src/main/java/com/google/api/codegen/ServiceMessages.java
@@ -28,6 +28,8 @@ import java.util.List;
  */
 public class ServiceMessages {
 
+  private static final String LRO_TYPE = "google.longrunning.Operation";
+
   /**
    * Returns true if the message is the empty message.
    */
@@ -38,6 +40,10 @@ public class ServiceMessages {
   public static boolean s_isEmptyType(TypeRef type) {
     return type.isMessage()
         && type.getMessageType().getFullName().equals(Empty.getDescriptor().getFullName());
+  }
+
+  public boolean isLongRunningOperationType(TypeRef type) {
+    return type.isMessage() && type.getMessageType().getFullName().equals(LRO_TYPE);
   }
 
   /**

--- a/src/main/java/com/google/api/codegen/transformer/ApiMethodTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ApiMethodTransformer.java
@@ -14,12 +14,12 @@
  */
 package com.google.api.codegen.transformer;
 
-import com.google.api.codegen.ServiceMessages;
 import com.google.api.codegen.config.CollectionConfig;
 import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.config.PageStreamingConfig;
 import com.google.api.codegen.metacode.InitCodeContext;
 import com.google.api.codegen.metacode.InitCodeContext.InitCodeOutputType;
+import com.google.api.codegen.ServiceMessages;
 import com.google.api.codegen.util.Name;
 import com.google.api.codegen.util.ResourceNameUtil;
 import com.google.api.codegen.viewmodel.ApiMethodDocView;
@@ -73,7 +73,6 @@ public class ApiMethodTransformer {
     methodViewBuilder.exampleName(
         namer.getApiMethodExampleName(context.getInterface(), context.getMethod()));
     setListMethodFields(context, Synchronicity.Sync, methodViewBuilder);
-    methodViewBuilder.isPageStreaming(true);
     setFlattenedMethodFields(
         context, fields, additionalParams, Synchronicity.Sync, methodViewBuilder);
 
@@ -97,7 +96,6 @@ public class ApiMethodTransformer {
     methodViewBuilder.name(namer.getAsyncApiMethodName(context.getMethod()));
     methodViewBuilder.exampleName(namer.getAsyncApiMethodExampleName(context.getMethod()));
     setListMethodFields(context, Synchronicity.Async, methodViewBuilder);
-    methodViewBuilder.isPageStreaming(true);
     setFlattenedMethodFields(
         context, fields, additionalParams, Synchronicity.Async, methodViewBuilder);
 
@@ -116,7 +114,6 @@ public class ApiMethodTransformer {
     setListMethodFields(context, Synchronicity.Sync, methodViewBuilder);
     setRequestObjectMethodFields(
         context, namer.getPagedCallableMethodName(context.getMethod()), methodViewBuilder);
-    methodViewBuilder.isPageStreaming(true);
 
     return methodViewBuilder.type(ApiMethodType.PagedRequestObjectMethod).build();
   }
@@ -132,7 +129,6 @@ public class ApiMethodTransformer {
     setListMethodFields(context, Synchronicity.Sync, methodViewBuilder);
     setCallableMethodFields(
         context, namer.getPagedCallableName(context.getMethod()), methodViewBuilder);
-    methodViewBuilder.isPageStreaming(true);
 
     return methodViewBuilder.type(ApiMethodType.PagedCallableMethod).build();
   }
@@ -162,7 +158,6 @@ public class ApiMethodTransformer {
 
     methodViewBuilder.responseTypeName(
         context.getTypeTable().getAndSaveNicknameFor(context.getMethod().getOutputType()));
-    methodViewBuilder.isPageStreaming(false);
 
     return methodViewBuilder.type(ApiMethodType.UnpagedListCallableMethod).build();
   }
@@ -189,7 +184,6 @@ public class ApiMethodTransformer {
     setFlattenedMethodFields(
         context, fields, additionalParams, Synchronicity.Async, methodViewBuilder);
     setStaticLangReturnFields(context, Synchronicity.Async, methodViewBuilder);
-    methodViewBuilder.isPageStreaming(false);
 
     return methodViewBuilder.type(type).build();
   }
@@ -210,7 +204,6 @@ public class ApiMethodTransformer {
     methodViewBuilder.name(namer.getApiMethodName(context.getMethod()));
     methodViewBuilder.exampleName(
         namer.getApiMethodExampleName(context.getInterface(), context.getMethod()));
-    methodViewBuilder.isPageStreaming(false);
     methodViewBuilder.callableName(namer.getCallableName(context.getMethod()));
     setFlattenedMethodFields(
         context, fields, additionalParams, Synchronicity.Sync, methodViewBuilder);
@@ -229,7 +222,6 @@ public class ApiMethodTransformer {
         context.getNamer().getApiMethodExampleName(context.getInterface(), context.getMethod()));
     setRequestObjectMethodFields(
         context, namer.getCallableMethodName(context.getMethod()), methodViewBuilder);
-    methodViewBuilder.isPageStreaming(false);
     setStaticLangReturnFields(context, Synchronicity.Sync, methodViewBuilder);
 
     return methodViewBuilder.type(ApiMethodType.RequestObjectMethod).build();
@@ -248,9 +240,6 @@ public class ApiMethodTransformer {
     setCallableMethodFields(context, namer.getCallableName(context.getMethod()), methodViewBuilder);
     methodViewBuilder.responseTypeName(
         context.getTypeTable().getAndSaveNicknameFor(context.getMethod().getOutputType()));
-    methodViewBuilder.hasReturnValue(
-        !ServiceMessages.s_isEmptyType(context.getMethod().getOutputType()));
-    methodViewBuilder.isPageStreaming(false);
 
     return methodViewBuilder.type(ApiMethodType.CallableMethod).build();
   }
@@ -270,6 +259,11 @@ public class ApiMethodTransformer {
     methodViewBuilder.settingsGetterName(namer.getSettingsFunctionName(context.getMethod()));
     methodViewBuilder.callableName(context.getNamer().getCallableName(context.getMethod()));
     methodViewBuilder.grpcStreamingType(context.getMethodConfig().getGrpcStreamingType());
+
+    ServiceMessages messages = new ServiceMessages();
+    methodViewBuilder.isLongRunning(
+        messages.isLongRunningOperationType(context.getMethod().getOutputType()));
+    methodViewBuilder.hasReturnValue(!messages.isEmptyType(context.getMethod().getOutputType()));
   }
 
   private void setListMethodFields(
@@ -326,7 +320,6 @@ public class ApiMethodTransformer {
                 context.getMethod(), context.getTypeTable(), resourceField));
         break;
     }
-    methodViewBuilder.hasReturnValue(true);
   }
 
   private void setFlattenedMethodFields(
@@ -450,8 +443,6 @@ public class ApiMethodTransformer {
             context.getTypeTable().getAndSaveNicknameFor(streamingReturnTypeFullName);
         methodViewBuilder.responseTypeName(streamingNickname);
     }
-    methodViewBuilder.hasReturnValue(
-        !ServiceMessages.s_isEmptyType(context.getMethod().getOutputType()));
   }
 
   private List<PathTemplateCheckView> generatePathTemplateChecks(
@@ -583,7 +574,6 @@ public class ApiMethodTransformer {
             .getGrpcStreamingApiMethodExampleName(context.getInterface(), context.getMethod()));
     setRequestObjectMethodFields(
         context, namer.getCallableMethodName(context.getMethod()), methodViewBuilder);
-    methodViewBuilder.isPageStreaming(false);
     setStaticLangReturnFields(context, Synchronicity.GrpcStreaming, methodViewBuilder);
 
     return methodViewBuilder.type(ApiMethodType.RequestObjectMethod).build();

--- a/src/main/java/com/google/api/codegen/viewmodel/StaticLangApiMethodView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/StaticLangApiMethodView.java
@@ -60,7 +60,7 @@ public abstract class StaticLangApiMethodView implements ApiMethodView {
 
   public abstract boolean hasReturnValue();
 
-  public abstract boolean isPageStreaming();
+  public abstract boolean isLongRunning();
 
   public abstract List<RequestObjectParamView> requestObjectParams();
 
@@ -124,7 +124,7 @@ public abstract class StaticLangApiMethodView implements ApiMethodView {
 
     public abstract Builder hasReturnValue(boolean hasReturnValue);
 
-    public abstract Builder isPageStreaming(boolean isPageStreaming);
+    public abstract Builder isLongRunning(boolean isLongRunning);
 
     public abstract Builder requestObjectParams(List<RequestObjectParamView> requestObjectParams);
 

--- a/src/main/resources/com/google/api/codegen/go/example.snip
+++ b/src/main/resources/com/google/api/codegen/go/example.snip
@@ -49,11 +49,16 @@
         @case "ServerStreaming"
             {@responseStreamingMethod(view, method)}
         @case "NonStreaming"
-            @if method.isPageStreaming
+            @switch method.type
+            @case "PagedRequestObjectMethod"
                 {@pageStreamingMethod(view, method)}
-            @else
+            @case "RequestObjectMethod"
                 @if method.hasReturnValue
-                    {@simpleMethod(view, method)}
+                    @if method.isLongRunning
+                        {@lroMethod(view, method)}
+                    @else
+                        {@simpleMethod(view, method)}
+                    @end
                 @else
                     {@emptyReturnMethod(view, method)}
                 @end
@@ -155,6 +160,24 @@
         }
         // TODO: Use resp.
         _ = resp
+    }
+@end
+
+@private lroMethod(view, method)
+    func {@method.exampleName}() {
+        {@methodInit(view, method)}
+
+        {@requestInit(view, method)}
+        op, err := c.{@method.name}(ctx, req)
+        if err != nil {
+            // TODO: Handle error.
+        }
+
+        var resp ptypes.DynamicAny // resp can also be concrete protobuf-generated types.
+        if err := op.Wait(&resp); err != nil {
+            // TODO: Handle error.
+        }
+        // TODO: Use resp.
     }
 @end
 

--- a/src/main/resources/com/google/api/codegen/go/main.snip
+++ b/src/main/resources/com/google/api/codegen/go/main.snip
@@ -155,11 +155,16 @@
         @case "ServerStreaming"
             {@simpleMethod(view, method)}
         @case "NonStreaming"
-            @if method.isPageStreaming
+            @switch method.type
+            @case "PagedRequestObjectMethod"
                 {@pageStreamingMethod(view, method)}
-            @else
+            @case "RequestObjectMethod"
                 @if method.hasReturnValue
-                    {@simpleMethod(view, method)}
+                    @if method.isLongRunning
+                        {@lroMethod(view, method)}
+                    @else
+                        {@simpleMethod(view, method)}
+                    @end
                 @else
                     {@emptyReturnMethod(view, method)}
                 @end
@@ -186,6 +191,22 @@
             return nil, err
         }
         return resp, nil
+    }
+@end
+
+@private lroMethod(view, method)
+    func (c *{@view.clientTypeName}) {@method.name}(ctx context.Context, req {@method.apiRequestTypeName}) (*longrunning.Operation, error) {
+        {@mergeMetadata()}
+        var resp {@method.responseTypeName}
+        err := gax.Invoke(ctx, func(ctx context.Context) error {
+            var err error
+            resp, err = c.{@method.stubName}.{@method.name}(ctx, req)
+            return err
+        }, c.CallOptions.{@method.name}...)
+        if err != nil {
+            return nil, err
+        }
+        return longrunning.InternalNewOperation(c.Connection(), resp), nil
     }
 @end
 

--- a/src/test/java/com/google/api/codegen/testdata/client_config_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/client_config_json_library.baseline
@@ -139,6 +139,11 @@
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
+        },
+        "GetBigBook": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
         }
       }
     }

--- a/src/test/java/com/google/api/codegen/testdata/csharp_gapic_client_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/csharp_gapic_client_library.baseline
@@ -67,6 +67,7 @@ namespace Google.Example.Library.V1
             UpdateBookIndexSettings = existing.UpdateBookIndexSettings?.Clone();
             FindRelatedBooksSettings = existing.FindRelatedBooksSettings?.Clone();
             AddTagSettings = existing.AddTagSettings?.Clone();
+            GetBigBookSettings = existing.GetBigBookSettings?.Clone();
         }
 
         /// <summary>
@@ -712,6 +713,38 @@ namespace Google.Example.Library.V1
         /// Default RPC expiration is 30000 milliseconds.
         /// </remarks>
         public CallSettings AddTagSettings { get; set; } = new CallSettings
+        {
+            Timing = CallTiming.FromRetry(new RetrySettings
+            {
+                RetryBackoff = GetDefaultRetryBackoff(),
+                TimeoutBackoff = GetDefaultTimeoutBackoff(),
+                RetryFilter = NonIdempotentRetryFilter,
+                TotalExpiration = Expiration.FromTimeout(TimeSpan.FromMilliseconds(30000)),
+            }),
+        };
+
+        /// <summary>
+        /// <see cref="CallSettings"/> for synchronous and asynchronous calls to
+        /// <see cref="LibraryServiceClient.GetBigBook"/> and <see cref="LibraryServiceClient.GetBigBookAsync"/>.
+        /// </summary>
+        /// <remarks>
+        /// The default <see cref="LibraryServiceClient.GetBigBook"/> and
+        /// <see cref="LibraryServiceClient.GetBigBookAsync"/> <see cref="RetrySettings"/> are:
+        /// <list type="bullet">
+        /// <item><description>Initial retry delay: 100 milliseconds</description></item>
+        /// <item><description>Retry delay multiplier: 1.2</description></item>
+        /// <item><description>Retry maximum delay: 1000 milliseconds</description></item>
+        /// <item><description>Initial timeout: 300 milliseconds</description></item>
+        /// <item><description>Timeout multiplier: 1.3</description></item>
+        /// <item><description>Timeout maximum delay: 3000 milliseconds</description></item>
+        /// </list>
+        /// Retry will be attempted on the following response status codes:
+        /// <list>
+        /// <item><description>No status codes</description></item>
+        /// </list>
+        /// Default RPC expiration is 30000 milliseconds.
+        /// </remarks>
+        public CallSettings GetBigBookSettings { get; set; } = new CallSettings
         {
             Timing = CallTiming.FromRetry(new RetrySettings
             {
@@ -2282,6 +2315,62 @@ namespace Google.Example.Library.V1
             throw new NotImplementedException();
         }
 
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to retrieve.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<Operation> GetBigBookAsync(
+            string name,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to retrieve.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<Operation> GetBigBookAsync(
+            string name,
+            CancellationToken cancellationToken) => GetBigBookAsync(
+                name,
+                new CallSettings { CancellationToken = cancellationToken });
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to retrieve.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual Operation GetBigBook(
+            string name,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
     }
 
     public sealed partial class LibraryServiceClientImpl : LibraryServiceClient
@@ -2305,6 +2394,7 @@ namespace Google.Example.Library.V1
         private readonly ApiCall<UpdateBookIndexRequest, Empty> _callUpdateBookIndex;
         private readonly ApiCall<FindRelatedBooksRequest, FindRelatedBooksResponse> _callFindRelatedBooks;
         private readonly ApiCall<AddTagRequest, AddTagResponse> _callAddTag;
+        private readonly ApiCall<GetBookRequest, Operation> _callGetBigBook;
 
         public LibraryServiceClientImpl(LibraryService.LibraryServiceClient grpcClient, LibraryServiceSettings settings)
         {
@@ -2347,6 +2437,8 @@ namespace Google.Example.Library.V1
                 GrpcClient.FindRelatedBooksAsync, GrpcClient.FindRelatedBooks, effectiveSettings.FindRelatedBooksSettings);
             _callAddTag = _clientHelper.BuildApiCall<AddTagRequest, AddTagResponse>(
                 GrpcClient.AddTagAsync, GrpcClient.AddTag, effectiveSettings.AddTagSettings);
+            _callGetBigBook = _clientHelper.BuildApiCall<GetBookRequest, Operation>(
+                GrpcClient.GetBigBookAsync, GrpcClient.GetBigBook, effectiveSettings.GetBigBookSettings);
         }
 
         /// <summary>
@@ -3509,6 +3601,48 @@ namespace Google.Example.Library.V1
                 {
                     Resource = resource,
                     Tag = tag,
+                },
+                callSettings);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to retrieve.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public override Task<Operation> GetBigBookAsync(
+            string name,
+            CallSettings callSettings = null) => _callGetBigBook.Async(
+                new GetBookRequest
+                {
+                    Name = name,
+                },
+                callSettings);
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to retrieve.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public override Operation GetBigBook(
+            string name,
+            CallSettings callSettings = null) => _callGetBigBook.Sync(
+                new GetBookRequest
+                {
+                    Name = name,
                 },
                 callSettings);
 

--- a/src/test/java/com/google/api/codegen/testdata/csharp_gapic_snippets_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/csharp_gapic_snippets_library.baseline
@@ -780,6 +780,31 @@ namespace Google.Example.Library.V1.Snippets
             // End snippet
         }
 
+        public async Task GetBigBookAsync()
+        {
+            // Snippet: GetBigBookAsync(string,CallSettings)
+            // Additional: GetBigBookAsync(string,CancellationToken)
+            // Create client
+            LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
+            // Initialize request argument(s)
+            string name = "";
+            // Make the request
+            Operation response = await libraryServiceClient.GetBigBookAsync(name);
+            // End snippet
+        }
+
+        public void GetBigBook()
+        {
+            // Snippet: GetBigBook(string,CallSettings)
+            // Create client
+            LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
+            // Initialize request argument(s)
+            string name = "";
+            // Make the request
+            Operation response = libraryServiceClient.GetBigBook(name);
+            // End snippet
+        }
+
     }
 }
 

--- a/src/test/java/com/google/api/codegen/testdata/go_example_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_example_library.baseline
@@ -21,6 +21,7 @@ import (
     "io"
 
     "cloud.google.com/go/library/apiv1"
+    "github.com/golang/protobuf/ptypes"
     "golang.org/x/net/context"
     librarypb "google.golang.org/genproto/googleapis/example/library/v1"
 )
@@ -452,6 +453,28 @@ func ExampleClient_FindRelatedBooks() {
         // TODO: Use resp.
         _ = resp
     }
+}
+
+func ExampleClient_GetBigBook() {
+    ctx := context.Background()
+    c, err := library.NewClient(ctx)
+    if err != nil {
+        // TODO: Handle error.
+    }
+
+    req := &librarypb.GetBookRequest{
+        // TODO: Fill request struct fields.
+    }
+    op, err := c.GetBigBook(ctx, req)
+    if err != nil {
+        // TODO: Handle error.
+    }
+
+    var resp ptypes.DynamicAny // resp can also be concrete protobuf-generated types.
+    if err := op.Wait(&resp); err != nil {
+        // TODO: Handle error.
+    }
+    // TODO: Use resp.
 }
 
 

--- a/src/test/java/com/google/api/codegen/testdata/go_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_main_library.baseline
@@ -24,6 +24,7 @@ import (
     "time"
 
     "cloud.google.com/go/iam"
+    "cloud.google.com/go/longrunning"
     gax "github.com/googleapis/gax-go"
     "golang.org/x/net/context"
     "google.golang.org/api/iterator"
@@ -63,6 +64,7 @@ type CallOptions struct {
     StreamBooks []gax.CallOption
     DiscussBook []gax.CallOption
     FindRelatedBooks []gax.CallOption
+    GetBigBook []gax.CallOption
 }
 
 func defaultClientOptions() []option.ClientOption {
@@ -111,6 +113,7 @@ func defaultCallOptions() *CallOptions {
         StreamBooks: retry[[2]string{"default", "idempotent"}],
         DiscussBook: retry[[2]string{"default", "non_idempotent"}],
         FindRelatedBooks: retry[[2]string{"default", "idempotent"}],
+        GetBigBook: retry[[2]string{"default", "non_idempotent"}],
     }
 }
 
@@ -604,6 +607,22 @@ func (c *Client) FindRelatedBooks(ctx context.Context, req *librarypb.FindRelate
 
     it.pageInfo, it.nextFunc = iterator.NewPageInfo(fetch, bufLen, takeBuf)
     return it
+}
+
+// GetBigBook
+func (c *Client) GetBigBook(ctx context.Context, req *librarypb.GetBookRequest) (*longrunning.Operation, error) {
+    md, _ := metadata.FromContext(ctx)
+    ctx = metadata.NewContext(ctx, metadata.Join(md, c.metadata))
+    var resp *longrunningpb.Operation
+    err := gax.Invoke(ctx, func(ctx context.Context) error {
+        var err error
+        resp, err = c.client.GetBigBook(ctx, req)
+        return err
+    }, c.CallOptions.GetBigBook...)
+    if err != nil {
+        return nil, err
+    }
+    return longrunning.InternalNewOperation(c.Connection(), resp), nil
 }
 
 

--- a/src/test/java/com/google/api/codegen/testdata/java_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_main_library.baseline
@@ -53,6 +53,7 @@ import static com.google.gcloud.pubsub.spi.PagedResponseWrappers.FindRelatedBook
 import static com.google.gcloud.pubsub.spi.PagedResponseWrappers.ListBooksPagedResponse;
 import static com.google.gcloud.pubsub.spi.PagedResponseWrappers.ListShelvesPagedResponse;
 import static com.google.gcloud.pubsub.spi.PagedResponseWrappers.ListStringsPagedResponse;
+import com.google.longrunning.Operation;
 import com.google.protobuf.Empty;
 import com.google.protobuf.FieldMask;
 import com.google.tagger.v1.AddLabelRequest;
@@ -163,6 +164,7 @@ public class LibraryServiceApi implements AutoCloseable {
   private final UnaryApiCallable<FindRelatedBooksRequest, FindRelatedBooksPagedResponse> findRelatedBooksPagedCallable;
   private final UnaryApiCallable<AddTagRequest, AddTagResponse> addTagCallable;
   private final UnaryApiCallable<AddLabelRequest, AddLabelResponse> addLabelCallable;
+  private final UnaryApiCallable<GetBookRequest, Operation> getBigBookCallable;
 
   private static final PathTemplate SHELF_PATH_TEMPLATE =
       PathTemplate.createWithoutUrlEncoding("shelves/{shelf}");
@@ -301,6 +303,7 @@ public class LibraryServiceApi implements AutoCloseable {
         UnaryApiCallable.createPagedVariant(settings.findRelatedBooksSettings(), this.channel, this.executor);
     this.addTagCallable = UnaryApiCallable.create(settings.addTagSettings(), this.channel, this.executor);
     this.addLabelCallable = UnaryApiCallable.create(settings.addLabelSettings(), this.channel, this.executor);
+    this.getBigBookCallable = UnaryApiCallable.create(settings.getBigBookSettings(), this.channel, this.executor);
 
     if (settings.getChannelProvider().shouldAutoClose()) {
       closeables.add(
@@ -2039,6 +2042,72 @@ public class LibraryServiceApi implements AutoCloseable {
    */
   public final UnaryApiCallable<AddLabelRequest, AddLabelResponse> addLabelCallable() {
     return addLabelCallable;
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryServiceApi libraryServiceApi = LibraryServiceApi.create()) {
+   *   BookName name = BookName.create("[SHELF_ID]", "[BOOK_ID]");
+   *   Operation response = libraryServiceApi.getBigBook(name);
+   * }
+   * </code></pre>
+   *
+   * @param name The name of the book to retrieve.
+   * @throws com.google.api.gax.grpc.ApiException if the remote call fails
+   */
+  public final Operation getBigBook(BookName name) {
+    GetBookRequest request =
+        GetBookRequest.newBuilder()
+        .setNameWithResource(name)
+        .build();
+    return getBigBook(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryServiceApi libraryServiceApi = LibraryServiceApi.create()) {
+   *   BookName name = BookName.create("[SHELF_ID]", "[BOOK_ID]");
+   *   GetBookRequest request = GetBookRequest.newBuilder()
+   *     .setNameWithResource(name)
+   *     .build();
+   *   Operation response = libraryServiceApi.getBigBook(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.grpc.ApiException if the remote call fails
+   */
+  public final Operation getBigBook(GetBookRequest request) {
+    return getBigBookCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   *
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryServiceApi libraryServiceApi = LibraryServiceApi.create()) {
+   *   BookName name = BookName.create("[SHELF_ID]", "[BOOK_ID]");
+   *   GetBookRequest request = GetBookRequest.newBuilder()
+   *     .setNameWithResource(name)
+   *     .build();
+   *   ListenableFuture&lt;Operation&gt; future = libraryServiceApi.getBigBookCallable().futureCall(request);
+   *   // Do something
+   *   Operation response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryApiCallable<GetBookRequest, Operation> getBigBookCallable() {
+    return getBigBookCallable;
   }
 
   /**

--- a/src/test/java/com/google/api/codegen/testdata/java_mock_service_impl_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_mock_service_impl_library.baseline
@@ -107,6 +107,7 @@ import com.google.example.library.v1.StreamShelvesRequest;
 import com.google.example.library.v1.StreamShelvesResponse;
 import com.google.example.library.v1.UpdateBookIndexRequest;
 import com.google.example.library.v1.UpdateBookRequest;
+import com.google.longrunning.Operation;
 import com.google.protobuf.Empty;
 import com.google.protobuf.GeneratedMessageV3;
 import com.google.tagger.v1.AddTagRequest;
@@ -339,6 +340,15 @@ public class MockLibraryServiceImpl extends LibraryServiceImplBase  {
   public void addTag(AddTagRequest request,
     StreamObserver<AddTagResponse> responseObserver) {
     AddTagResponse response = (AddTagResponse) responses.remove();
+    requests.add(request);
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
+  }
+
+  @Override
+  public void getBigBook(GetBookRequest request,
+    StreamObserver<Operation> responseObserver) {
+    Operation response = (Operation) responses.remove();
     requests.add(request);
     responseObserver.onNext(response);
     responseObserver.onCompleted();

--- a/src/test/java/com/google/api/codegen/testdata/java_settings_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_settings_library.baseline
@@ -69,6 +69,7 @@ import static com.google.gcloud.pubsub.spi.PagedResponseWrappers.FindRelatedBook
 import static com.google.gcloud.pubsub.spi.PagedResponseWrappers.ListBooksPagedResponse;
 import static com.google.gcloud.pubsub.spi.PagedResponseWrappers.ListShelvesPagedResponse;
 import static com.google.gcloud.pubsub.spi.PagedResponseWrappers.ListStringsPagedResponse;
+import com.google.longrunning.Operation;
 import com.google.protobuf.Empty;
 import com.google.tagger.v1.AddLabelRequest;
 import com.google.tagger.v1.AddLabelResponse;
@@ -163,6 +164,7 @@ public class LibraryServiceSettings extends ServiceApiSettings {
   private final PageStreamingCallSettings<FindRelatedBooksRequest, FindRelatedBooksResponse, FindRelatedBooksPagedResponse> findRelatedBooksSettings;
   private final SimpleCallSettings<AddTagRequest, AddTagResponse> addTagSettings;
   private final SimpleCallSettings<AddLabelRequest, AddLabelResponse> addLabelSettings;
+  private final SimpleCallSettings<GetBookRequest, Operation> getBigBookSettings;
 
   /**
    * Returns the object with the settings used for calls to createShelf.
@@ -319,6 +321,13 @@ public class LibraryServiceSettings extends ServiceApiSettings {
   }
 
   /**
+   * Returns the object with the settings used for calls to getBigBook.
+   */
+  public SimpleCallSettings<GetBookRequest, Operation> getBigBookSettings() {
+    return getBigBookSettings;
+  }
+
+  /**
    * Returns the default service address.
    */
   public static String getDefaultServiceAddress() {
@@ -390,6 +399,7 @@ public class LibraryServiceSettings extends ServiceApiSettings {
     findRelatedBooksSettings = settingsBuilder.findRelatedBooksSettings().build();
     addTagSettings = settingsBuilder.addTagSettings().build();
     addLabelSettings = settingsBuilder.addLabelSettings().build();
+    getBigBookSettings = settingsBuilder.getBigBookSettings().build();
   }
 
   private static final PageStreamingDescriptor<ListShelvesRequest, ListShelvesResponse, Shelf> LIST_SHELVES_PAGE_STR_DESC =
@@ -660,6 +670,7 @@ public class LibraryServiceSettings extends ServiceApiSettings {
     private final PageStreamingCallSettings.Builder<FindRelatedBooksRequest, FindRelatedBooksResponse, FindRelatedBooksPagedResponse> findRelatedBooksSettings;
     private final SimpleCallSettings.Builder<AddTagRequest, AddTagResponse> addTagSettings;
     private final SimpleCallSettings.Builder<AddLabelRequest, AddLabelResponse> addLabelSettings;
+    private final SimpleCallSettings.Builder<GetBookRequest, Operation> getBigBookSettings;
 
     private static final ImmutableMap<String, ImmutableSet<Status.Code>> RETRYABLE_CODE_DEFINITIONS;
 
@@ -749,6 +760,8 @@ public class LibraryServiceSettings extends ServiceApiSettings {
 
       addLabelSettings = SimpleCallSettings.newBuilder(LabelerGrpc.METHOD_ADD_LABEL);
 
+      getBigBookSettings = SimpleCallSettings.newBuilder(LibraryServiceGrpc.METHOD_GET_BIG_BOOK);
+
       unaryMethodSettingsBuilders = ImmutableList.<UnaryApiCallSettings.Builder>of(
           createShelfSettings,
           getShelfSettings,
@@ -768,7 +781,8 @@ public class LibraryServiceSettings extends ServiceApiSettings {
           updateBookIndexSettings,
           findRelatedBooksSettings,
           addTagSettings,
-          addLabelSettings
+          addLabelSettings,
+          getBigBookSettings
       );
     }
 
@@ -858,6 +872,10 @@ public class LibraryServiceSettings extends ServiceApiSettings {
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
           .setRetrySettingsBuilder(RETRY_PARAM_DEFINITIONS.get("default"));
 
+      builder.getBigBookSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetrySettingsBuilder(RETRY_PARAM_DEFINITIONS.get("default"));
+
       return builder;
     }
 
@@ -886,6 +904,7 @@ public class LibraryServiceSettings extends ServiceApiSettings {
       findRelatedBooksSettings = settings.findRelatedBooksSettings.toBuilder();
       addTagSettings = settings.addTagSettings.toBuilder();
       addLabelSettings = settings.addLabelSettings.toBuilder();
+      getBigBookSettings = settings.getBigBookSettings.toBuilder();
 
       unaryMethodSettingsBuilders = ImmutableList.<UnaryApiCallSettings.Builder>of(
           createShelfSettings,
@@ -906,7 +925,8 @@ public class LibraryServiceSettings extends ServiceApiSettings {
           updateBookIndexSettings,
           findRelatedBooksSettings,
           addTagSettings,
-          addLabelSettings
+          addLabelSettings,
+          getBigBookSettings
       );
     }
 
@@ -1114,6 +1134,13 @@ public class LibraryServiceSettings extends ServiceApiSettings {
      */
     public SimpleCallSettings.Builder<AddLabelRequest, AddLabelResponse> addLabelSettings() {
       return addLabelSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to getBigBook.
+     */
+    public SimpleCallSettings.Builder<GetBookRequest, Operation> getBigBookSettings() {
+      return getBigBookSettings;
     }
 
     @Override

--- a/src/test/java/com/google/api/codegen/testdata/java_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_test_library.baseline
@@ -59,6 +59,7 @@ import static com.google.gcloud.pubsub.spi.PagedResponseWrappers.FindRelatedBook
 import static com.google.gcloud.pubsub.spi.PagedResponseWrappers.ListBooksPagedResponse;
 import static com.google.gcloud.pubsub.spi.PagedResponseWrappers.ListShelvesPagedResponse;
 import static com.google.gcloud.pubsub.spi.PagedResponseWrappers.ListStringsPagedResponse;
+import com.google.longrunning.Operation;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Empty;
 import com.google.protobuf.FieldMask;
@@ -824,6 +825,32 @@ public class LibraryServiceTest {
 
     Assert.assertEquals(formattedResource, actualRequest.getResource());
     Assert.assertEquals(label, actualRequest.getLabel());
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void getBigBookTest() {
+    String name2 = "name2-1052831874";
+    boolean done = true;
+    Operation expectedResponse = Operation.newBuilder()
+      .setName(name2)
+      .setDone(done)
+      .build();
+    List<GeneratedMessageV3> expectedResponses = new ArrayList<>();
+    expectedResponses.add(expectedResponse);
+    mockLibraryService.setResponses(expectedResponses);
+
+    BookName name = BookName.create("[SHELF_ID]", "[BOOK_ID]");
+
+    Operation actualResponse =
+        api.getBigBook(name);
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<GeneratedMessageV3> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    GetBookRequest actualRequest = (GetBookRequest)actualRequests.get(0);
+
+    Assert.assertEquals(name, actualRequest.getNameAsResource());
   }
 
 }

--- a/src/test/java/com/google/api/codegen/testdata/library.proto
+++ b/src/test/java/com/google/api/codegen/testdata/library.proto
@@ -6,6 +6,7 @@ package google.example.library.v1;
 
 import "field_mask.proto";
 import "google/api/annotations.proto";
+import "google/longrunning/operations.proto";
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/any.proto";
@@ -152,6 +153,10 @@ service LibraryService {
   }
 
   // AddLabel intentionally left out to test the reroute_to_grpc_interface feature
+
+  rpc GetBigBook(GetBookRequest) returns (google.longrunning.Operation) {
+    option (google.api.http) = { get: "/v1/{name=bookShelves/*/books/*}:big" };
+  }
 }
 
 // A single book in the library.

--- a/src/test/java/com/google/api/codegen/testdata/library_config.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/library_config.baseline
@@ -350,4 +350,17 @@ interfaces:
     field_name_patterns:
       resource: book_2
     timeout_millis: 60000
+  - name: GetBigBook
+    flattening:
+      groups:
+      - parameters:
+        - name
+    required_fields:
+    - name
+    request_object_method: false
+    retry_codes_name: idempotent
+    retry_params_name: default
+    field_name_patterns:
+      name: book_2
+    timeout_millis: 60000
 

--- a/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
@@ -411,3 +411,16 @@ interfaces:
     - include_languages:
       - go
       visibility: DISABLED
+  - name: GetBigBook
+    flattening:
+      groups:
+      - parameters:
+        - name
+    required_fields:
+    - name
+    request_object_method: true
+    retry_codes_name: non_idempotent
+    retry_params_name: default
+    field_name_patterns:
+      resource: book
+    timeout_millis: 60000

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_doc_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_doc_json_library.baseline
@@ -139,6 +139,11 @@
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
+        },
+        "GetBigBook": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
         }
       }
     }

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_doc_main_library.baseline
@@ -150,7 +150,8 @@ function LibraryServiceApi(gaxGrpc, grpcClients, opts) {
     'getBookFromArchive',
     'updateBookIndex',
     'findRelatedBooks',
-    'addTag'
+    'addTag',
+    'getBigBook'
   ];
   libraryServiceStubMethods.forEach(function(methodName) {
     this['_' + methodName] = gax.createApiCall(
@@ -1186,6 +1187,42 @@ LibraryServiceApi.prototype.addLabel = function(request, options, callback) {
     options = {};
   }
   return this._addLabel(request, options, callback);
+};
+
+/**
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   The name of the book to retrieve.
+ * @param {Object=} options
+ *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+ *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+ * @param {function(?Error, ?Object)=} callback
+ *   The function which will be called with the result of the API call.
+ *
+ *   The second parameter to the callback is an object representing [google.longrunning.Operation]{@link external:"google.longrunning.Operation"}
+ * @returns {Promise} - The promise which resolves to the response object.
+ *   The promise has a method named "cancel" which cancels the ongoing API call.
+ *
+ * @example
+ *
+ * var api = libraryV1.libraryServiceApi();
+ * var name = '';
+ * api.getBigBook({name: name}).then(function(response) {
+ *     // doThingsWith(response)
+ * }).catch(function(err) {
+ *     console.error(err);
+ * });
+ */
+LibraryServiceApi.prototype.getBigBook = function(request, options, callback) {
+  if (options instanceof Function && callback === undefined) {
+    callback = options;
+    options = {};
+  }
+  if (options === undefined) {
+    options = {};
+  }
+  return this._getBigBook(request, options, callback);
 };
 
 function LibraryServiceApiBuilder(gaxGrpc) {

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_json_library.baseline
@@ -139,6 +139,11 @@
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
+        },
+        "GetBigBook": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
         }
       }
     }

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_main_library.baseline
@@ -150,7 +150,8 @@ function LibraryServiceApi(gaxGrpc, grpcClients, opts) {
     'getBookFromArchive',
     'updateBookIndex',
     'findRelatedBooks',
-    'addTag'
+    'addTag',
+    'getBigBook'
   ];
   libraryServiceStubMethods.forEach(function(methodName) {
     this['_' + methodName] = gax.createApiCall(
@@ -1186,6 +1187,42 @@ LibraryServiceApi.prototype.addLabel = function(request, options, callback) {
     options = {};
   }
   return this._addLabel(request, options, callback);
+};
+
+/**
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   The name of the book to retrieve.
+ * @param {Object=} options
+ *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+ *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+ * @param {function(?Error, ?Object)=} callback
+ *   The function which will be called with the result of the API call.
+ *
+ *   The second parameter to the callback is an object representing [google.longrunning.Operation]{@link external:"google.longrunning.Operation"}
+ * @returns {Promise} - The promise which resolves to the response object.
+ *   The promise has a method named "cancel" which cancels the ongoing API call.
+ *
+ * @example
+ *
+ * var api = libraryV1.libraryServiceApi();
+ * var name = '';
+ * api.getBigBook({name: name}).then(function(response) {
+ *     // doThingsWith(response)
+ * }).catch(function(err) {
+ *     console.error(err);
+ * });
+ */
+LibraryServiceApi.prototype.getBigBook = function(request, options, callback) {
+  if (options instanceof Function && callback === undefined) {
+    callback = options;
+    options = {};
+  }
+  if (options === undefined) {
+    options = {};
+  }
+  return this._getBigBook(request, options, callback);
 };
 
 function LibraryServiceApiBuilder(gaxGrpc) {

--- a/src/test/java/com/google/api/codegen/testdata/php_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php_json_library.baseline
@@ -139,6 +139,11 @@
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
+        },
+        "GetBigBook": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
         }
       }
     }

--- a/src/test/java/com/google/api/codegen/testdata/php_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php_main_library.baseline
@@ -354,6 +354,7 @@ class LibraryServiceApi
             'findRelatedBooks' => $defaultDescriptors,
             'addTag' => $defaultDescriptors,
             'addLabel' => $defaultDescriptors,
+            'getBigBook' => $defaultDescriptors,
         ];
         $pageStreamingDescriptors = self::getPageStreamingDescriptors();
         foreach ($pageStreamingDescriptors as $method => $pageStreamingDescriptor) {
@@ -1430,6 +1431,53 @@ class LibraryServiceApi
             new CallSettings($optionalArgs));
         $callable = ApiCallable::createApiCall(
             $this->labelerStub, 'AddLabel', $mergedSettings, $this->descriptors['addLabel']);
+
+        return $callable(
+            $request,
+            [],
+            ['call_credentials_callback' => $this->createCredentialsCallback()]);
+    }
+
+    /**
+     *
+     *
+     * Sample code:
+     * ```
+     * try {
+     *     $libraryServiceApi = new LibraryServiceApi();
+     *     $name = "";
+     *     $response = $libraryServiceApi->getBigBook($name);
+     * } finally {
+     *     if (isset($libraryServiceApi)) {
+     *         $libraryServiceApi->close();
+     *     }
+     * }
+     * ```
+     *
+     * @param string $name The name of the book to retrieve.
+     * @param array $optionalArgs {
+     *     Optional.
+     *     @type Google\GAX\RetrySettings $retrySettings
+     *          Retry settings to use for this call. If present, then
+     *          $timeoutMillis is ignored.
+     *     @type int $timeoutMillis
+     *          Timeout to use for this call. Only used if $retrySettings
+     *          is not set.
+     * }
+     *
+     * @return google\longrunning\Operation
+     *
+     * @throws Google\GAX\ApiException if the remote call fails
+     */
+    public function getBigBook($name, $optionalArgs = [])
+    {
+        $request = new GetBookRequest();
+        $request->setName($name);
+
+        $mergedSettings = $this->defaultCallSettings['getBigBook']->merge(
+            new CallSettings($optionalArgs));
+        $callable = ApiCallable::createApiCall(
+            $this->libraryServiceStub, 'GetBigBook', $mergedSettings, $this->descriptors['getBigBook']);
 
         return $callable(
             $request,

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_json_library.baseline
@@ -139,6 +139,11 @@
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
+        },
+        "GetBigBook": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
         }
       }
     }

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
@@ -348,6 +348,9 @@ class LibraryServiceApi(object):
         self._add_label = api_callable.create_api_call(
             self.labeler_stub.AddLabel,
             settings=defaults['add_label'])
+        self._get_big_book = api_callable.create_api_call(
+            self.library_service_stub.GetBigBook,
+            settings=defaults['get_big_book'])
 
     # Service calls
     def create_shelf(
@@ -1140,4 +1143,32 @@ class LibraryServiceApi(object):
             resource=resource,
             label=label)
         self._add_label(request, options)
+
+    def get_big_book(
+            self,
+            name,
+            options=None):
+        """
+
+        Example:
+          >>> from google.cloud.gapic.example.library.v1 import library_service_api
+          >>> api = library_service_api.LibraryServiceApi()
+          >>> name = ''
+          >>> response = api.get_big_book(name)
+
+        Args:
+          name (string): The name of the book to retrieve.
+          options (:class:`google.gax.CallOptions`): Overrides the default
+            settings for this call, e.g, timeout, retries etc.
+
+        Returns:
+          A :class:`google.longrunning.operations_pb2.Operation` instance.
+
+        Raises:
+          :exc:`google.gax.errors.GaxError` if the RPC is aborted.
+          :exc:`ValueError` if the parameters are invalid.
+        """
+        request = library_pb2.GetBookRequest(
+            name=name)
+        return self._get_big_book(request, options)
 

--- a/src/test/java/com/google/api/codegen/testdata/python_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_json_library.baseline
@@ -139,6 +139,11 @@
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
+        },
+        "GetBigBook": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
         }
       }
     }

--- a/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
@@ -348,6 +348,9 @@ class LibraryServiceApi(object):
         self._add_label = api_callable.create_api_call(
             self.labeler_stub.AddLabel,
             settings=defaults['add_label'])
+        self._get_big_book = api_callable.create_api_call(
+            self.library_service_stub.GetBigBook,
+            settings=defaults['get_big_book'])
 
     # Service calls
     def create_shelf(
@@ -1140,4 +1143,32 @@ class LibraryServiceApi(object):
             resource=resource,
             label=label)
         self._add_label(request, options)
+
+    def get_big_book(
+            self,
+            name,
+            options=None):
+        """
+
+        Example:
+          >>> from google.cloud.gapic.example.library.v1 import library_service_api
+          >>> api = library_service_api.LibraryServiceApi()
+          >>> name = ''
+          >>> response = api.get_big_book(name)
+
+        Args:
+          name (string): The name of the book to retrieve.
+          options (:class:`google.gax.CallOptions`): Overrides the default
+            settings for this call, e.g, timeout, retries etc.
+
+        Returns:
+          A :class:`google.longrunning.operations_pb2.Operation` instance.
+
+        Raises:
+          :exc:`google.gax.errors.GaxError` if the RPC is aborted.
+          :exc:`ValueError` if the parameters are invalid.
+        """
+        request = library_pb2.GetBookRequest(
+            name=name)
+        return self._get_big_book(request, options)
 

--- a/src/test/java/com/google/api/codegen/testdata/ruby_doc_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_doc_json_library.baseline
@@ -139,6 +139,11 @@
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
+        },
+        "GetBigBook": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
         }
       }
     }

--- a/src/test/java/com/google/api/codegen/testdata/ruby_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_doc_main_library.baseline
@@ -331,6 +331,10 @@ module Library
           @library_service_stub.method(:add_tag),
           defaults["add_tag"]
         )
+        @get_big_book = Google::Gax.create_api_call(
+          @library_service_stub.method(:get_big_book),
+          defaults["get_big_book"]
+        )
         @add_label = Google::Gax.create_api_call(
           @labeler_stub.method(:add_label),
           defaults["add_label"]
@@ -1027,6 +1031,31 @@ module Library
           label: label
         )
         @add_label.call(req, options)
+      end
+
+      # @param name [String]
+      #   The name of the book to retrieve.
+      # @param options [Google::Gax::CallOptions]
+      #   Overrides the default settings for this call, e.g, timeout,
+      #   retries, etc.
+      # @return [Google::Longrunning::Operation]
+      # @raise [Google::Gax::GaxError] if the RPC is aborted.
+      # @example
+      #   require "library/v1/library_service_api"
+      #
+      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #
+      #   library_service_api = LibraryServiceApi.new
+      #   name = ''
+      #   response = library_service_api.get_big_book(name)
+
+      def get_big_book \
+          name,
+          options: nil
+        req = Google::Example::Library::V1::GetBookRequest.new(
+          name: name
+        )
+        @get_big_book.call(req, options)
       end
     end
   end

--- a/src/test/java/com/google/api/codegen/testdata/ruby_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_json_library.baseline
@@ -139,6 +139,11 @@
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
+        },
+        "GetBigBook": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
         }
       }
     }

--- a/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
@@ -331,6 +331,10 @@ module Library
           @library_service_stub.method(:add_tag),
           defaults["add_tag"]
         )
+        @get_big_book = Google::Gax.create_api_call(
+          @library_service_stub.method(:get_big_book),
+          defaults["get_big_book"]
+        )
         @add_label = Google::Gax.create_api_call(
           @labeler_stub.method(:add_label),
           defaults["add_label"]
@@ -1027,6 +1031,31 @@ module Library
           label: label
         )
         @add_label.call(req, options)
+      end
+
+      # @param name [String]
+      #   The name of the book to retrieve.
+      # @param options [Google::Gax::CallOptions]
+      #   Overrides the default settings for this call, e.g, timeout,
+      #   retries, etc.
+      # @return [Google::Longrunning::Operation]
+      # @raise [Google::Gax::GaxError] if the RPC is aborted.
+      # @example
+      #   require "library/v1/library_service_api"
+      #
+      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #
+      #   library_service_api = LibraryServiceApi.new
+      #   name = ''
+      #   response = library_service_api.get_big_book(name)
+
+      def get_big_book \
+          name,
+          options: nil
+        req = Google::Example::Library::V1::GetBookRequest.new(
+          name: name
+        )
+        @get_big_book.call(req, options)
       end
     end
   end

--- a/src/test/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformerTest.java
+++ b/src/test/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformerTest.java
@@ -84,20 +84,13 @@ public class GoGapicSurfaceTransformerTest {
             apiConfig,
             GoGapicSurfaceTransformer.createTypeTable(),
             namer,
-            new FeatureConfig());
+            new GoFeatureConfig());
   }
-
-  private static final ImmutableList<String> PAGE_STREAM_IMPORTS =
-      ImmutableList.<String>of("math;;;");
-
-  private static final ImmutableList<String> LRO_IMPORTS =
-      ImmutableList.<String>of("cloud.google.com/go/longrunning;;;");
 
   @Test
   public void testGetImportsPlain() {
     Method method = getMethod(context.getInterface(), "SimpleMethod");
-    transformer.generateApiMethods(
-        context, Collections.singletonList(method), PAGE_STREAM_IMPORTS, LRO_IMPORTS);
+    transformer.addXApiImports(context, Collections.singletonList(method));
     transformer.generateRetryConfigDefinitions(context, Collections.singletonList(method));
     Truth.assertThat(context.getTypeTable().getImports()).doesNotContainKey("time");
     Truth.assertThat(context.getTypeTable().getImports()).doesNotContainKey("longrunning");
@@ -106,8 +99,7 @@ public class GoGapicSurfaceTransformerTest {
   @Test
   public void testGetImportsRetry() {
     Method method = getMethod(context.getInterface(), "RetryMethod");
-    transformer.generateApiMethods(
-        context, Collections.singletonList(method), PAGE_STREAM_IMPORTS, LRO_IMPORTS);
+    transformer.addXApiImports(context, Collections.singletonList(method));
     transformer.generateRetryConfigDefinitions(context, Collections.singletonList(method));
     Truth.assertThat(context.getTypeTable().getImports()).containsKey("time");
     Truth.assertThat(context.getTypeTable().getImports()).doesNotContainKey("longrunning");
@@ -116,8 +108,7 @@ public class GoGapicSurfaceTransformerTest {
   @Test
   public void testGetImportsPageStream() {
     Method method = getMethod(context.getInterface(), "PageStreamMethod");
-    transformer.generateApiMethods(
-        context, Collections.singletonList(method), PAGE_STREAM_IMPORTS, LRO_IMPORTS);
+    transformer.addXApiImports(context, Collections.singletonList(method));
     transformer.generateRetryConfigDefinitions(context, Collections.singletonList(method));
     Truth.assertThat(context.getTypeTable().getImports()).containsKey("math");
     Truth.assertThat(context.getTypeTable().getImports()).doesNotContainKey("longrunning");
@@ -126,8 +117,7 @@ public class GoGapicSurfaceTransformerTest {
   @Test
   public void testGetImportsLro() {
     Method method = getMethod(context.getInterface(), "LroMethod");
-    transformer.generateApiMethods(
-        context, Collections.singletonList(method), PAGE_STREAM_IMPORTS, LRO_IMPORTS);
+    transformer.addXApiImports(context, Collections.singletonList(method));
     transformer.generateRetryConfigDefinitions(context, Collections.singletonList(method));
     Truth.assertThat(context.getTypeTable().getImports()).doesNotContainKey("math");
     Truth.assertThat(context.getTypeTable().getImports())

--- a/src/test/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformerTest.java
+++ b/src/test/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformerTest.java
@@ -90,31 +90,48 @@ public class GoGapicSurfaceTransformerTest {
   private static final ImmutableList<String> PAGE_STREAM_IMPORTS =
       ImmutableList.<String>of("math;;;");
 
-  private static final ImmutableList<String> GRPC_SERVER_STREAM_IMPORTS =
-      ImmutableList.<String>of("io;;;");
+  private static final ImmutableList<String> LRO_IMPORTS =
+      ImmutableList.<String>of("cloud.google.com/go/longrunning;;;");
 
   @Test
   public void testGetImportsPlain() {
     Method method = getMethod(context.getInterface(), "SimpleMethod");
-    transformer.generateApiMethods(context, Collections.singletonList(method), PAGE_STREAM_IMPORTS);
+    transformer.generateApiMethods(
+        context, Collections.singletonList(method), PAGE_STREAM_IMPORTS, LRO_IMPORTS);
     transformer.generateRetryConfigDefinitions(context, Collections.singletonList(method));
     Truth.assertThat(context.getTypeTable().getImports()).doesNotContainKey("time");
+    Truth.assertThat(context.getTypeTable().getImports()).doesNotContainKey("longrunning");
   }
 
   @Test
   public void testGetImportsRetry() {
     Method method = getMethod(context.getInterface(), "RetryMethod");
-    transformer.generateApiMethods(context, Collections.singletonList(method), PAGE_STREAM_IMPORTS);
+    transformer.generateApiMethods(
+        context, Collections.singletonList(method), PAGE_STREAM_IMPORTS, LRO_IMPORTS);
     transformer.generateRetryConfigDefinitions(context, Collections.singletonList(method));
     Truth.assertThat(context.getTypeTable().getImports()).containsKey("time");
+    Truth.assertThat(context.getTypeTable().getImports()).doesNotContainKey("longrunning");
   }
 
   @Test
   public void testGetImportsPageStream() {
     Method method = getMethod(context.getInterface(), "PageStreamMethod");
-    transformer.generateApiMethods(context, Collections.singletonList(method), PAGE_STREAM_IMPORTS);
+    transformer.generateApiMethods(
+        context, Collections.singletonList(method), PAGE_STREAM_IMPORTS, LRO_IMPORTS);
     transformer.generateRetryConfigDefinitions(context, Collections.singletonList(method));
     Truth.assertThat(context.getTypeTable().getImports()).containsKey("math");
+    Truth.assertThat(context.getTypeTable().getImports()).doesNotContainKey("longrunning");
+  }
+
+  @Test
+  public void testGetImportsLro() {
+    Method method = getMethod(context.getInterface(), "LroMethod");
+    transformer.generateApiMethods(
+        context, Collections.singletonList(method), PAGE_STREAM_IMPORTS, LRO_IMPORTS);
+    transformer.generateRetryConfigDefinitions(context, Collections.singletonList(method));
+    Truth.assertThat(context.getTypeTable().getImports()).doesNotContainKey("math");
+    Truth.assertThat(context.getTypeTable().getImports())
+        .containsKey("cloud.google.com/go/longrunning");
   }
 
   @Test
@@ -136,6 +153,14 @@ public class GoGapicSurfaceTransformerTest {
     Method method = getMethod(context.getInterface(), "ClientStreamMethod");
     transformer.addXExampleImports(context, Collections.singletonList(method));
     Truth.assertThat(context.getTypeTable().getImports()).doesNotContainKey("io");
+  }
+
+  @Test
+  public void testGetExampleImportsLro() {
+    Method method = getMethod(context.getInterface(), "LroMethod");
+    transformer.addXExampleImports(context, Collections.singletonList(method));
+    Truth.assertThat(context.getTypeTable().getImports())
+        .containsKey("github.com/golang/protobuf/ptypes");
   }
 
   @Test

--- a/src/test/java/com/google/api/codegen/transformer/go/testdata/myproto.proto
+++ b/src/test/java/com/google/api/codegen/transformer/go/testdata/myproto.proto
@@ -2,10 +2,12 @@ syntax = "proto3";
 
 package google.example.myproto.v1;
 
+import "google/longrunning/operations.proto";
 import "singleservice.proto";
 
 service Gopher {
   rpc SimpleMethod(SimpleRequest) returns (SimpleResponse);
+  rpc LroMethod(SimpleRequest) returns (google.longrunning.Operation);
   rpc RetryMethod(SimpleRequest) returns (SimpleResponse);
   rpc PageStreamMethod(PageStreamRequest) returns (PageStreamResponse);
 

--- a/src/test/java/com/google/api/codegen/transformer/go/testdata/myproto_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/transformer/go/testdata/myproto_gapic.yaml
@@ -33,6 +33,11 @@ interfaces:
     retry_params_name: default
     timeout_millis: 1000
     request_object_method: false
+  - name: LroMethod
+    retry_codes_name: non_idempotent
+    retry_params_name: default
+    timeout_millis: 1000
+    request_object_method: false
   - name: RetryMethod
     flattening:
       groups:


### PR DESCRIPTION
This change only affects Go. There are some baseline changes in other languages due to the added `GetBigBook` method in `library.proto`.