### PR TITLE
Go LRO Typo Fix

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformer.java
@@ -317,7 +317,6 @@ public class GoGapicSurfaceTransformer implements ModelToViewTransformer {
   }
 
   private static final String EMPTY_PROTO_PKG = "github.com/golang/protobuf/ptypes/empty";
-  private static final String LRO_PROTO_PKG = "google.golang.org/genproto/googleapis/longrunning";
 
   @VisibleForTesting
   void addXApiImports(SurfaceTransformerContext context, Collection<Method> methods) {
@@ -331,7 +330,6 @@ public class GoGapicSurfaceTransformer implements ModelToViewTransformer {
     typeTable.saveNicknameFor("google.golang.org/api/option;;;");
     typeTable.saveNicknameFor("google.golang.org/api/transport;;;");
     typeTable.getImports().remove(EMPTY_PROTO_PKG);
-    typeTable.getImports().remove(LRO_PROTO_PKG);
     addContextImports(context, ImportContext.CLIENT, methods);
   }
 

--- a/src/main/resources/com/google/api/codegen/go/example.snip
+++ b/src/main/resources/com/google/api/codegen/go/example.snip
@@ -38,6 +38,7 @@
             //TODO: Use the IAM policy
             _ = policy
         }
+
     @end
 
     @join method : view.apiMethods

--- a/src/main/resources/com/google/api/codegen/go/example.snip
+++ b/src/main/resources/com/google/api/codegen/go/example.snip
@@ -174,7 +174,7 @@
         }
 
         var resp ptypes.DynamicAny // resp can also be concrete protobuf-generated types.
-        if err := op.Wait(&resp); err != nil {
+        if err := op.Wait(ctx, &resp); err != nil {
             // TODO: Handle error.
         }
         // TODO: Use resp.

--- a/src/main/resources/com/google/api/codegen/go/main.snip
+++ b/src/main/resources/com/google/api/codegen/go/main.snip
@@ -140,6 +140,7 @@
         func (c *{@view.clientTypeName}) {@resource.resourceGetterFunctionName}({@resource.paramName} {@resource.resourceTypeName}) *iam.Handle {
             return iam.InternalNewHandle(c.Connection(), {@resource.paramName}.{@resource.fieldName})
         }
+
     @end
 
     @join method : view.apiMethods

--- a/src/test/java/com/google/api/codegen/testdata/go_example_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_example_library.baseline
@@ -53,6 +53,7 @@ func ExampleClient_BookIAM() {
     _ = policy
 }
 
+
 func ExampleClient_CreateShelf() {
     ctx := context.Background()
     c, err := library.NewClient(ctx)

--- a/src/test/java/com/google/api/codegen/testdata/go_example_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_example_library.baseline
@@ -471,7 +471,7 @@ func ExampleClient_GetBigBook() {
     }
 
     var resp ptypes.DynamicAny // resp can also be concrete protobuf-generated types.
-    if err := op.Wait(&resp); err != nil {
+    if err := op.Wait(ctx, &resp); err != nil {
         // TODO: Handle error.
     }
     // TODO: Use resp.

--- a/src/test/java/com/google/api/codegen/testdata/go_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_main_library.baseline
@@ -226,6 +226,7 @@ func (c *Client) BookIAM(book *librarypb.Book) *iam.Handle {
     return iam.InternalNewHandle(c.Connection(), book.Name)
 }
 
+
 // CreateShelf creates a shelf, and returns the new Shelf.
 func (c *Client) CreateShelf(ctx context.Context, req *librarypb.CreateShelfRequest) (*librarypb.Shelf, error) {
     md, _ := metadata.FromContext(ctx)

--- a/src/test/java/com/google/api/codegen/testdata/go_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_main_library.baseline
@@ -31,6 +31,7 @@ import (
     "google.golang.org/api/option"
     "google.golang.org/api/transport"
     librarypb "google.golang.org/genproto/googleapis/example/library/v1"
+    longrunningpb "google.golang.org/genproto/googleapis/longrunning"
     taggerpb "google.golang.org/genproto/googleapis/tagger/v1"
     "google.golang.org/grpc"
     "google.golang.org/grpc/codes"


### PR DESCRIPTION
There were two mistakes in Go LRO previously:
- longrunningpb was not imported.
- op.Wait was missing the context argument.

I seem to have tested this against my old development branch.
The code should compile against master now.