### PR TITLE
Supporting required constructor params

### DIFF
--- a/src/main/java/com/google/api/codegen/config/InterfaceConfig.java
+++ b/src/main/java/com/google/api/codegen/config/InterfaceConfig.java
@@ -58,7 +58,7 @@ public abstract class InterfaceConfig {
   private static final String SERVICE_ADDRESS_PARAM = "service_address";
   private static final String SCOPES_PARAM = "scopes";
   private static final ImmutableSet<String> CONSTRUCTOR_PARAMS =
-      ImmutableSet.<String>builder().add(SERVICE_ADDRESS_PARAM).add(SCOPES_PARAM).build();
+      ImmutableSet.<String>of(SERVICE_ADDRESS_PARAM, SCOPES_PARAM);
 
   public abstract List<MethodConfig> getMethodConfigs();
 

--- a/src/main/java/com/google/api/codegen/transformer/ServiceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ServiceTransformer.java
@@ -33,6 +33,7 @@ public class ServiceTransformer {
     serviceDoc.apiClassName(namer.getApiWrapperClassName(context.getInterface()));
     serviceDoc.settingsVarName(namer.getApiSettingsVariableName(context.getInterface()));
     serviceDoc.settingsClassName(namer.getApiSettingsClassName(context.getInterface()));
+    serviceDoc.hasDefaultInstance(context.getInterfaceConfig().hasDefaultInstance());
     return serviceDoc.build();
   }
 }

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicClientTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicClientTransformer.java
@@ -16,6 +16,7 @@ package com.google.api.codegen.transformer.csharp;
 
 import com.google.api.codegen.InterfaceView;
 import com.google.api.codegen.config.ApiConfig;
+import com.google.api.codegen.config.InterfaceConfig;
 import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.config.ServiceConfig;
 import com.google.api.codegen.gapic.GapicCodePathMapper;
@@ -152,6 +153,7 @@ public class CSharpGapicClientTransformer implements ModelToViewTransformer {
       }
     }
     xapiClass.apiMethodsImpl(methodsImpl);
+    xapiClass.hasDefaultInstance(context.getInterfaceConfig().hasDefaultInstance());
 
     // must be done as the last step to catch all imports
     xapiClass.imports(importTypeTransformer.generateImports(context.getTypeTable().getImports()));
@@ -187,6 +189,10 @@ public class CSharpGapicClientTransformer implements ModelToViewTransformer {
         retryDefinitionsTransformer.generateRetryCodesDefinitions(context));
     xsettingsClass.retryParamsDefinitions(
         retryDefinitionsTransformer.generateRetryParamsDefinitions(context));
+    InterfaceConfig interfaceConfig = context.getInterfaceConfig();
+    xsettingsClass.hasDefaultServiceAddress(interfaceConfig.hasDefaultServiceAddress());
+    xsettingsClass.hasDefaultServiceScopes(interfaceConfig.hasDefaultServiceScopes());
+    xsettingsClass.hasDefaultInstance(interfaceConfig.hasDefaultInstance());
 
     // must be done as the last step to catch all imports
     xsettingsClass.imports(
@@ -276,6 +282,7 @@ public class CSharpGapicClientTransformer implements ModelToViewTransformer {
     settingsDoc.settingsVarName(namer.getApiSettingsVariableName(context.getInterface()));
     settingsDoc.settingsClassName(namer.getApiSettingsClassName(context.getInterface()));
     settingsDoc.settingsBuilderVarName(namer.getApiSettingsBuilderVarName(context.getInterface()));
+    settingsDoc.hasDefaultInstance(context.getInterfaceConfig().hasDefaultInstance());
     return settingsDoc.build();
   }
 }

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTransformer.java
@@ -275,6 +275,9 @@ public class JavaGapicSurfaceTransformer implements ModelToViewTransformer {
       exampleApiMethod = searchExampleMethod(methods, ApiMethodType.PagedFlattenedMethod);
     }
     if (exampleApiMethod == null) {
+      exampleApiMethod = searchExampleMethod(methods, ApiMethodType.RequestObjectMethod);
+    }
+    if (exampleApiMethod == null) {
       throw new RuntimeException("Could not find method to use as an example method");
     }
     return exampleApiMethod;

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTransformer.java
@@ -16,6 +16,7 @@ package com.google.api.codegen.transformer.java;
 
 import com.google.api.codegen.InterfaceView;
 import com.google.api.codegen.config.ApiConfig;
+import com.google.api.codegen.config.InterfaceConfig;
 import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.config.ServiceConfig;
 import com.google.api.codegen.gapic.GapicCodePathMapper;
@@ -164,6 +165,7 @@ public class JavaGapicSurfaceTransformer implements ModelToViewTransformer {
     xapiClass.parseResourceFunctions(
         pathTemplateTransformer.generateParseResourceFunctions(context));
     xapiClass.apiMethods(methods);
+    xapiClass.hasDefaultInstance(context.getInterfaceConfig().hasDefaultInstance());
 
     // must be done as the last step to catch all imports
     xapiClass.imports(importTypeTransformer.generateImports(context.getTypeTable().getImports()));
@@ -316,6 +318,10 @@ public class JavaGapicSurfaceTransformer implements ModelToViewTransformer {
         retryDefinitionsTransformer.generateRetryCodesDefinitions(context));
     xsettingsClass.retryParamsDefinitions(
         retryDefinitionsTransformer.generateRetryParamsDefinitions(context));
+    InterfaceConfig interfaceConfig = context.getInterfaceConfig();
+    xsettingsClass.hasDefaultServiceAddress(interfaceConfig.hasDefaultServiceAddress());
+    xsettingsClass.hasDefaultServiceScopes(interfaceConfig.hasDefaultServiceScopes());
+    xsettingsClass.hasDefaultInstance(interfaceConfig.hasDefaultInstance());
 
     // must be done as the last step to catch all imports
     xsettingsClass.imports(
@@ -411,6 +417,7 @@ public class JavaGapicSurfaceTransformer implements ModelToViewTransformer {
     settingsDoc.settingsVarName(namer.getApiSettingsVariableName(context.getInterface()));
     settingsDoc.settingsClassName(namer.getApiSettingsClassName(context.getInterface()));
     settingsDoc.settingsBuilderVarName(namer.getApiSettingsBuilderVarName(context.getInterface()));
+    settingsDoc.hasDefaultInstance(context.getInterfaceConfig().hasDefaultInstance());
     return settingsDoc.build();
   }
 

--- a/src/main/java/com/google/api/codegen/viewmodel/ServiceDocView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/ServiceDocView.java
@@ -17,6 +17,7 @@ package com.google.api.codegen.viewmodel;
 import com.google.auto.value.AutoValue;
 
 import java.util.List;
+
 import javax.annotation.Nullable;
 
 @AutoValue
@@ -37,6 +38,8 @@ public abstract class ServiceDocView {
 
   public abstract String settingsClassName();
 
+  public abstract boolean hasDefaultInstance();
+
   public static Builder newBuilder() {
     return new AutoValue_ServiceDocView.Builder();
   }
@@ -56,6 +59,8 @@ public abstract class ServiceDocView {
     public abstract Builder settingsVarName(String val);
 
     public abstract Builder settingsClassName(String val);
+
+    public abstract Builder hasDefaultInstance(boolean hasDefaultInstance);
 
     public abstract ServiceDocView build();
   }

--- a/src/main/java/com/google/api/codegen/viewmodel/SettingsDocView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/SettingsDocView.java
@@ -34,6 +34,8 @@ public abstract class SettingsDocView {
 
   public abstract String settingsBuilderVarName();
 
+  public abstract boolean hasDefaultInstance();
+
   public static Builder newBuilder() {
     return new AutoValue_SettingsDocView.Builder();
   }
@@ -55,6 +57,8 @@ public abstract class SettingsDocView {
     public abstract Builder settingsClassName(String val);
 
     public abstract Builder settingsBuilderVarName(String val);
+
+    public abstract Builder hasDefaultInstance(boolean hasDefaultInstance);
 
     public abstract SettingsDocView build();
   }

--- a/src/main/java/com/google/api/codegen/viewmodel/StaticLangXApiView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/StaticLangXApiView.java
@@ -55,6 +55,8 @@ public abstract class StaticLangXApiView implements ViewModel {
   @Nullable // Used in C#
   public abstract List<StaticLangApiMethodView> apiMethodsImpl();
 
+  public abstract boolean hasDefaultInstance();
+
   public abstract List<ImportTypeView> imports();
 
   @Override
@@ -98,6 +100,8 @@ public abstract class StaticLangXApiView implements ViewModel {
     public abstract Builder apiMethods(List<StaticLangApiMethodView> val);
 
     public abstract Builder apiMethodsImpl(List<StaticLangApiMethodView> val);
+
+    public abstract Builder hasDefaultInstance(boolean val);
 
     public abstract Builder imports(List<ImportTypeView> val);
 

--- a/src/main/java/com/google/api/codegen/viewmodel/StaticLangXSettingsView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/StaticLangXSettingsView.java
@@ -51,6 +51,12 @@ public abstract class StaticLangXSettingsView implements ViewModel {
 
   public abstract List<RetryParamsDefinitionView> retryParamsDefinitions();
 
+  public abstract boolean hasDefaultServiceAddress();
+
+  public abstract boolean hasDefaultServiceScopes();
+
+  public abstract boolean hasDefaultInstance();
+
   public abstract List<ImportTypeView> imports();
 
   @Override
@@ -99,6 +105,12 @@ public abstract class StaticLangXSettingsView implements ViewModel {
     public abstract Builder imports(List<ImportTypeView> val);
 
     public abstract Builder outputPath(String val);
+
+    public abstract Builder hasDefaultServiceAddress(boolean hasDefaultServiceAddress);
+
+    public abstract Builder hasDefaultServiceScopes(boolean hasDefaultServiceScopes);
+
+    public abstract Builder hasDefaultInstance(boolean hasDefaultInstance);
 
     public abstract StaticLangXSettingsView build();
   }

--- a/src/main/proto/com/google/api/codegen/config.proto
+++ b/src/main/proto/com/google/api/codegen/config.proto
@@ -120,6 +120,10 @@ message InterfaceConfigProto {
   repeated RetryParamsDefinitionProto retry_params_def = 31;
 
   ExperimentalFeatures experimental_features = 40;
+
+  // Params that are always required to construct an instance of the
+  // API wrapper class.
+  repeated string required_constructor_params = 50;
 }
 
 message SmokeTestConfigProto {

--- a/src/main/resources/com/google/api/codegen/java/main.snip
+++ b/src/main/resources/com/google/api/codegen/java/main.snip
@@ -32,6 +32,11 @@
          decoratedSampleCode = decorateSampleCode(xapiClass.doc.exampleApiMethod, coreSampleCode)
       {@renderServiceDoc(xapiClass.doc, decoratedSampleCode)}
     @end
+  @case "RequestObjectMethod"
+    @let coreSampleCode = syncMethodSampleCode(xapiClass.doc.exampleApiMethod), \
+         decoratedSampleCode = decorateSampleCode(xapiClass.doc.exampleApiMethod, coreSampleCode)
+      {@renderServiceDoc(xapiClass.doc, decoratedSampleCode)}
+    @end
   @default
     $unhandledCase: {@xapiClass.doc.exampleApiMethod.type}$
   @end

--- a/src/main/resources/com/google/api/codegen/java/main.snip
+++ b/src/main/resources/com/google/api/codegen/java/main.snip
@@ -175,12 +175,15 @@
 @end
 
 @private constructors(xapiClass)
-  /**
-   * Constructs an instance of {@xapiClass.name} with default settings.
-   */
-  public static final {@xapiClass.name} create() throws IOException {
-    return create({@xapiClass.settingsClassName}.defaultBuilder().build());
-  }
+  @if xapiClass.hasDefaultInstance
+    /**
+     * Constructs an instance of {@xapiClass.name} with default settings.
+     */
+    public static final {@xapiClass.name} create() throws IOException {
+      return create({@xapiClass.settingsClassName}.defaultBuilder().build());
+    }
+    {@""}
+  @end
 
   /**
    * Constructs an instance of {@xapiClass.name}, using the given settings.

--- a/src/main/resources/com/google/api/codegen/java/package-info.snip
+++ b/src/main/resources/com/google/api/codegen/java/package-info.snip
@@ -7,7 +7,7 @@
   /**
    * A client to {@packageInfo.serviceTitle}.
    *
-   * The interfaces provided are listed below, along with a usage sample
+   * The interfaces provided are listed below, along with usage samples.
    *
   @join xapiClassDoc : packageInfo.serviceDocs
     {@serviceShortDoc(xapiClassDoc)}
@@ -30,21 +30,23 @@
   @end
   # The join above doesn't properly add a newline on the end, so we need to force it
   {@""}
-  {@""} *
+   *
    * Service Description: {@xapiClassDoc.firstLine}
   @if xapiClassDoc.remainingLines
     @join commentLine : xapiClassDoc.remainingLines
       {@""} * {@commentLine}
     @end
   @end
-   *
-   * Sample for {@xapiClassDoc.apiClassName}:
-   * <pre>
-   * <code>
-  @join sampleLine : util.getDocLines(exampleMethodSampleCode)
-    {@""} * {@sampleLine}
+  @if xapiClassDoc.hasDefaultInstance
+    {@""} *
+     * Sample for {@xapiClassDoc.apiClassName}:
+     * <pre>
+     * <code>
+    @join sampleLine : util.getDocLines(exampleMethodSampleCode)
+      {@""} * {@sampleLine}
+    @end
+     * </code>
+     * </pre>
+     *
   @end
-   * </code>
-   * </pre>
-   *
 @end

--- a/src/main/resources/com/google/api/codegen/java/settings.snip
+++ b/src/main/resources/com/google/api/codegen/java/settings.snip
@@ -21,74 +21,74 @@
   // AUTO-GENERATED DOCUMENTATION AND CLASS
   /**
    * Settings class to configure an instance of {@@link {@doc.apiClassName}}.
-   *
-   * <p>The default instance has everything set to sensible defaults:
-   *
-   * <ul>
-   * <li>The default service address ({@doc.serviceAddress}) and default port ({@doc.servicePort})
-   * are used.
-   * <li>Credentials are acquired automatically through Application Default Credentials.
-   * <li>Retries are configured for idempotent methods but not for non-idempotent methods.
-   * </ul>
-   *
-   * <p>The builder of this class is recursive, so contained classes are themselves builders.
-   * When build() is called, the tree of builders is called to create the complete settings
-   * object. For example, to set the total timeout of {@doc.exampleApiMethodName} to 30 seconds:
-   *
-   * <pre>
-   * <code>
-   * {@doc.settingsClassName}.Builder {@doc.settingsBuilderVarName} =
-   *     {@doc.settingsClassName}.defaultBuilder();
-   * {@doc.settingsBuilderVarName}.{@doc.exampleApiMethodSettingsGetter}().getRetrySettingsBuilder()
-   *     .setTotalTimeout(Duration.standardSeconds(30));
-   * {@doc.settingsClassName} {@doc.settingsVarName} = {@doc.settingsBuilderVarName}.build();
-   * </code>
-   * </pre>
+  @if doc.hasDefaultInstance
+    {@""} *
+     * <p>The default instance has everything set to sensible defaults:
+     *
+     * <ul>
+     * <li>The default service address ({@doc.serviceAddress}) and default port ({@doc.servicePort})
+     * are used.
+     * <li>Credentials are acquired automatically through Application Default Credentials.
+     * <li>Retries are configured for idempotent methods but not for non-idempotent methods.
+     * </ul>
+     *
+     * <p>The builder of this class is recursive, so contained classes are themselves builders.
+     * When build() is called, the tree of builders is called to create the complete settings
+     * object. For example, to set the total timeout of {@doc.exampleApiMethodName} to 30 seconds:
+     *
+     * <pre>
+     * <code>
+     * {@doc.settingsClassName}.Builder {@doc.settingsBuilderVarName} =
+     *     {@doc.settingsClassName}.defaultBuilder();
+     * {@doc.settingsBuilderVarName}.{@doc.exampleApiMethodSettingsGetter}().getRetrySettingsBuilder()
+     *     .setTotalTimeout(Duration.standardSeconds(30));
+     * {@doc.settingsClassName} {@doc.settingsVarName} = {@doc.settingsBuilderVarName}.build();
+     * </code>
+     * </pre>
+  @end
    */
 @end
 
 @private constants(xsettingsClass)
-  /**
-   * The default address of the service.
-   */
-  private static final String DEFAULT_SERVICE_ADDRESS = "{@xsettingsClass.serviceAddress}";
+  @if xsettingsClass.hasDefaultServiceAddress
+    /**
+     * The default address of the service.
+     */
+    private static final String DEFAULT_SERVICE_ADDRESS = "{@xsettingsClass.serviceAddress}";
+    {@""}
+  @end
 
   /**
    * The default port of the service.
    */
   private static final int DEFAULT_SERVICE_PORT = {@xsettingsClass.servicePort};
 
-  /**
-   * The default scopes of the service.
-   */
-  private static final ImmutableList<String> DEFAULT_SERVICE_SCOPES = ImmutableList.<String>builder()
-      @join scope : {@xsettingsClass.authScopes}
-        .add("{@scope}")
-      @end
-      .build();
-
-  /**
-   * The default connection settings of the service.
-   */
-  public static final ConnectionSettings DEFAULT_CONNECTION_SETTINGS =
-      ConnectionSettings.newBuilder()
-          .setServiceAddress(DEFAULT_SERVICE_ADDRESS)
-          .setPort(DEFAULT_SERVICE_PORT)
-          .provideCredentialsWith(DEFAULT_SERVICE_SCOPES)
-          .build();
+  @if xsettingsClass.hasDefaultServiceScopes
+    /**
+     * The default scopes of the service.
+     */
+    private static final ImmutableList<String> DEFAULT_SERVICE_SCOPES = ImmutableList.<String>builder()
+        @join scope : {@xsettingsClass.authScopes}
+          .add("{@scope}")
+        @end
+        .build();
+    {@""}
+  @end
   {@""}
 @end
 
 @private members(xsettingsClass)
   {@methodMembers(xsettingsClass)}
   {@methodGetters(xsettingsClass)}
-  /**
-   * Returns the default service address.
-   */
-  public static String getDefaultServiceAddress() {
-    return DEFAULT_SERVICE_ADDRESS;
-  }
+  @if xsettingsClass.hasDefaultServiceAddress
+    /**
+     * Returns the default service address.
+     */
+    public static String getDefaultServiceAddress() {
+      return DEFAULT_SERVICE_ADDRESS;
+    }
 
+  @end
   /**
    * Returns the default service port.
    */
@@ -96,13 +96,15 @@
     return DEFAULT_SERVICE_PORT;
   }
 
-  /**
-   * Returns the default service scopes.
-   */
-  public static ImmutableList<String> getDefaultServiceScopes() {
-    return DEFAULT_SERVICE_SCOPES;
-  }
+  @if xsettingsClass.hasDefaultServiceScopes
+    /**
+     * Returns the default service scopes.
+     */
+    public static ImmutableList<String> getDefaultServiceScopes() {
+      return DEFAULT_SERVICE_SCOPES;
+    }
 
+  @end
   /**
    * Returns a builder for this class with recommended defaults.
    */
@@ -428,7 +430,9 @@
 
 @private builderConstructors(xsettingsClass)
   private Builder() {
-    super(DEFAULT_CONNECTION_SETTINGS);
+    @if xsettingsClass.hasDefaultInstance
+      super(s_getDefaultConnectionSettingsBuilder().build());
+    @end
 
     @join settings : xsettingsClass.callSettings
       @switch settings.type.toString
@@ -499,9 +503,20 @@
 @end
 
 @private builderMethods(xsettingsClass)
+  private static ConnectionSettings.Builder s_getDefaultConnectionSettingsBuilder() {
+    return ConnectionSettings.newBuilder()
+      @if xsettingsClass.hasDefaultServiceAddress
+        .setServiceAddress(DEFAULT_SERVICE_ADDRESS)
+      @end
+      .setPort(DEFAULT_SERVICE_PORT)
+      @if xsettingsClass.hasDefaultServiceScopes
+        .provideCredentialsWith(DEFAULT_SERVICE_SCOPES)
+      @end
+      ;
+    }
   @@Override
-  protected ConnectionSettings getDefaultConnectionSettings() {
-    return DEFAULT_CONNECTION_SETTINGS;
+  protected ConnectionSettings.Builder getDefaultConnectionSettingsBuilder() {
+    return s_getDefaultConnectionSettingsBuilder();
   }
   @@Override
   public Builder provideExecutorWith(ScheduledExecutorService executor, boolean shouldAutoClose) {

--- a/src/main/resources/com/google/api/codegen/java/settings.snip
+++ b/src/main/resources/com/google/api/codegen/java/settings.snip
@@ -513,7 +513,7 @@
         .provideCredentialsWith(DEFAULT_SERVICE_SCOPES)
       @end
       ;
-    }
+  }
   @@Override
   protected ConnectionSettings.Builder getDefaultConnectionSettingsBuilder() {
     return s_getDefaultConnectionSettingsBuilder();

--- a/src/test/java/com/google/api/codegen/JavaNoPathTemplatesCodeGeneratorTest.java
+++ b/src/test/java/com/google/api/codegen/JavaNoPathTemplatesCodeGeneratorTest.java
@@ -1,0 +1,53 @@
+/* Copyright 2016 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen;
+
+import com.google.api.codegen.gapic.MainGapicProviderFactory;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class JavaNoPathTemplatesCodeGeneratorTest extends GapicTestBase {
+
+  public JavaNoPathTemplatesCodeGeneratorTest(
+      String name, String idForFactory, String[] gapicConfigFileNames, String snippetName) {
+    super(name, idForFactory, gapicConfigFileNames, snippetName);
+    getTestDataLocator().addTestDataSource(com.google.api.codegen.java.JavaContextCommon.class, "");
+  }
+
+  /**
+   * Declares test parameters, each one an array of values passed to the constructor, with the
+   * first element a name, the second a config of this name.
+   */
+  @Parameters(name = "{0}")
+  public static List<Object[]> testedConfigs() {
+    return GapicTestBase.createTestedConfigs(
+        MainGapicProviderFactory.JAVA,
+        new String[] {"java_gapic.yaml", "no_path_templates_gapic.yaml"});
+  }
+
+  // Tests
+  // =====
+
+  @Test
+  public void no_path_templates() throws Exception {
+    test("no_path_templates");
+  }
+}

--- a/src/test/java/com/google/api/codegen/testdata/java_main_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_main_no_path_templates.baseline
@@ -1,0 +1,195 @@
+============== file: src/main/java/com/google/gcloud/example/NoTemplatesApiServiceApi.java ==============
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.gcloud.example;
+
+import com.google.api.gax.grpc.UnaryApiCallable;
+import com.google.api.gax.protobuf.PathTemplate;
+import com.google.example.noPathTemplates.v1.IncrementRequest;
+import com.google.protobuf.Empty;
+import io.grpc.ManagedChannel;
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+
+// AUTO-GENERATED DOCUMENTATION AND SERVICE
+/**
+ * Service Description:
+ *
+ * <p>This class provides the ability to make remote calls to the backing service through method
+ * calls that map to API methods. Sample code to get started:
+ *
+ * <pre>
+ * <code>
+ * try (NoTemplatesApiServiceApi noTemplatesApiServiceApi = NoTemplatesApiServiceApi.create()) {
+ *   IncrementRequest request = IncrementRequest.newBuilder().build();
+ *   noTemplatesApiServiceApi.increment(request);
+ * }
+ * </code>
+ * </pre>
+ *
+ * <p>Note: close() needs to be called on the noTemplatesApiServiceApi object to clean up resources such
+ * as threads. In the example above, try-with-resources is used, which automatically calls
+ * close().
+ *
+ * <p>The surface of this class includes several types of Java methods for each of the API's methods:
+ *
+ * <ol>
+ * <li> A "flattened" method. With this type of method, the fields of the request type have been
+ * converted into function parameters. It may be the case that not all fields are available
+ * as parameters, and not every API method will have a flattened method entry point.
+ * <li> A "request object" method. This type of method only takes one parameter, a request
+ * object, which must be constructed before the call. Not every API method will have a request
+ * object method.
+ * <li> A "callable" method. This type of method takes no parameters and returns an immutable
+ * API callable object, which can be used to initiate calls to the service.
+ * </ol>
+ *
+ * <p>See the individual methods for example code.
+ *
+ * <p>Many parameters require resource names to be formatted in a particular way. To assist
+ * with these names, this class includes a format method for each type of name, and additionally
+ * a parse method to extract the individual identifiers contained within names that are
+ * returned.
+ *
+ * <p>This class can be customized by passing in a custom instance of NoTemplatesApiServiceSettings to
+ * create(). For example:
+ *
+ * <pre>
+ * <code>
+ * NoTemplatesApiServiceSettings noTemplatesApiServiceSettings = NoTemplatesApiServiceSettings.defaultBuilder()
+ *     .provideChannelWith(myCredentials)
+ *     .build();
+ * NoTemplatesApiServiceApi noTemplatesApiServiceApi = NoTemplatesApiServiceApi.create(noTemplatesApiServiceSettings);
+ * </code>
+ * </pre>
+ */
+@javax.annotation.Generated("by GAPIC")
+public class NoTemplatesApiServiceApi implements AutoCloseable {
+  private final NoTemplatesApiServiceSettings settings;
+  private final ManagedChannel channel;
+  private final ScheduledExecutorService executor;
+  private final List<AutoCloseable> closeables = new ArrayList<>();
+
+  private final UnaryApiCallable<IncrementRequest, Empty> incrementCallable;
+
+
+
+
+  /**
+   * Constructs an instance of NoTemplatesApiServiceApi, using the given settings.
+   * The channels are created based on the settings passed in, or defaults for any
+   * settings that are not set.
+   */
+  public static final NoTemplatesApiServiceApi create(NoTemplatesApiServiceSettings settings) throws IOException {
+    return new NoTemplatesApiServiceApi(settings);
+  }
+
+  /**
+   * Constructs an instance of NoTemplatesApiServiceApi, using the given settings.
+   * This is protected so that it easy to make a subclass, but otherwise, the static
+   * factory methods should be preferred.
+   */
+  protected NoTemplatesApiServiceApi(NoTemplatesApiServiceSettings settings) throws IOException {
+    this.settings = settings;
+    this.executor = settings.getExecutorProvider().getOrBuildExecutor();
+    this.channel = settings.getChannelProvider().getOrBuildChannel(this.executor);
+
+    this.incrementCallable = UnaryApiCallable.create(settings.incrementSettings(), this.channel, this.executor);
+
+    if (settings.getChannelProvider().shouldAutoClose()) {
+      closeables.add(
+        new Closeable() {
+          @Override
+          public void close() throws IOException {
+            channel.shutdown();
+          }
+        });
+    }
+    if (settings.getExecutorProvider().shouldAutoClose()) {
+      closeables.add(
+        new Closeable() {
+          @Override
+          public void close() throws IOException {
+            executor.shutdown();
+          }
+        });
+    }
+  }
+
+  public final NoTemplatesApiServiceSettings getSettings() {
+    return settings;
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Increments something.
+   *   Sometimes the comments are indented, but Sphinx doesn't like that. So
+   *  in Python we trim all
+   *      leading
+   *         and trailing
+   *    whitespace.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (NoTemplatesApiServiceApi noTemplatesApiServiceApi = NoTemplatesApiServiceApi.create()) {
+   *   IncrementRequest request = IncrementRequest.newBuilder().build();
+   *   noTemplatesApiServiceApi.increment(request);
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.grpc.ApiException if the remote call fails
+   */
+  private final void increment(IncrementRequest request) {
+    incrementCallable().call(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Increments something.
+   *   Sometimes the comments are indented, but Sphinx doesn't like that. So
+   *  in Python we trim all
+   *      leading
+   *         and trailing
+   *    whitespace.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (NoTemplatesApiServiceApi noTemplatesApiServiceApi = NoTemplatesApiServiceApi.create()) {
+   *   IncrementRequest request = IncrementRequest.newBuilder().build();
+   *   ListenableFuture&lt;Void&gt; future = noTemplatesApiServiceApi.incrementCallable().futureCall(request);
+   *   // Do something
+   *   future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryApiCallable<IncrementRequest, Empty> incrementCallable() {
+    return incrementCallable;
+  }
+
+  /**
+   * Initiates an orderly shutdown in which preexisting calls continue but new calls are immediately
+   * cancelled.
+   */
+  @Override
+  public final void close() throws Exception {
+    for (AutoCloseable closeable : closeables) {
+      closeable.close();
+    }
+  }
+
+}

--- a/src/test/java/com/google/api/codegen/testdata/java_mock_service_impl_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_mock_service_impl_no_path_templates.baseline
@@ -1,0 +1,61 @@
+============== file: src/test/java/com/google/gcloud/example/MockNoTemplatesAPIServiceImpl.java ==============
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.gcloud.example;
+
+import com.google.common.collect.Lists;
+import com.google.example.noPathTemplates.v1.IncrementRequest;
+import com.google.example.noPathTemplates.v1.NoTemplatesAPIServiceGrpc.NoTemplatesAPIServiceImplBase;
+import com.google.protobuf.Empty;
+import com.google.protobuf.GeneratedMessageV3;
+import io.grpc.stub.StreamObserver;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+
+@javax.annotation.Generated("by GAPIC")
+public class MockNoTemplatesAPIServiceImpl extends NoTemplatesAPIServiceImplBase  {
+  private ArrayList<GeneratedMessageV3> requests;
+  private Queue<GeneratedMessageV3> responses;
+
+  public MockNoTemplatesAPIServiceImpl() {
+    requests = new ArrayList<>();
+    responses = new LinkedList<>();
+  }
+
+  public List<GeneratedMessageV3> getRequests() {
+    return requests;
+  }
+
+  public void setResponses(List<GeneratedMessageV3> responses) {
+    this.responses = Lists.newLinkedList(responses);
+  }
+
+  public void reset() {
+    requests = new ArrayList<>();
+    responses = new LinkedList<>();
+  }
+
+  @Override
+  public void increment(IncrementRequest request,
+    StreamObserver<Empty> responseObserver) {
+    Empty response = (Empty) responses.remove();
+    requests.add(request);
+    responseObserver.onNext(response);
+    responseObserver.onCompleted();
+  }
+
+}

--- a/src/test/java/com/google/api/codegen/testdata/java_mock_service_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_mock_service_no_path_templates.baseline
@@ -1,0 +1,50 @@
+============== file: src/test/java/com/google/gcloud/example/MockNoTemplatesAPIService.java ==============
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.gcloud.example;
+
+import com.google.api.gax.testing.MockGrpcService;
+import com.google.protobuf.GeneratedMessageV3;
+import io.grpc.ServerServiceDefinition;
+import java.util.List;
+
+@javax.annotation.Generated("by GAPIC")
+public class MockNoTemplatesAPIService implements MockGrpcService  {
+  private final MockNoTemplatesAPIServiceImpl serviceImpl;
+
+  public MockNoTemplatesAPIService() {
+    serviceImpl = new MockNoTemplatesAPIServiceImpl();
+  }
+
+  @Override
+  public List<GeneratedMessageV3> getRequests() {
+    return serviceImpl.getRequests();
+  }
+
+  @Override
+  public void setResponses(List<GeneratedMessageV3> responses) {
+    serviceImpl.setResponses(responses);
+  }
+
+  @Override
+  public ServerServiceDefinition getServiceDefinition() {
+    return serviceImpl.bindService();
+  }
+
+  @Override
+  public void reset() {
+    serviceImpl.reset();
+  }
+}

--- a/src/test/java/com/google/api/codegen/testdata/java_package-info_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_package-info_library.baseline
@@ -16,7 +16,7 @@
 /**
  * A client to Google Example Library API.
  *
- * The interfaces provided are listed below, along with a usage sample
+ * The interfaces provided are listed below, along with usage samples.
  *
  * =================
  * LibraryServiceApi

--- a/src/test/java/com/google/api/codegen/testdata/java_package-info_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_package-info_no_path_templates.baseline
@@ -16,24 +16,13 @@
 /**
  * A client to Google Fake API.
  *
- * The interfaces provided are listed below, along with a usage sample
+ * The interfaces provided are listed below, along with usage samples.
  *
  * ========================
  * NoTemplatesApiServiceApi
  * ========================
  *
  * Service Description:
- *
- * Sample for NoTemplatesApiServiceApi:
- * <pre>
- * <code>
- * try (NoTemplatesApiServiceApi noTemplatesApiServiceApi = NoTemplatesApiServiceApi.create()) {
- *   IncrementRequest request = IncrementRequest.newBuilder().build();
- *   noTemplatesApiServiceApi.increment(request);
- * }
- * </code>
- * </pre>
- *
  */
 
 package com.google.gcloud.example;

--- a/src/test/java/com/google/api/codegen/testdata/java_package-info_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_package-info_no_path_templates.baseline
@@ -1,0 +1,39 @@
+============== file: src/main/java/com/google/gcloud/example/package-info.java ==============
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+/**
+ * A client to Google Fake API.
+ *
+ * The interfaces provided are listed below, along with a usage sample
+ *
+ * ========================
+ * NoTemplatesApiServiceApi
+ * ========================
+ *
+ * Service Description:
+ *
+ * Sample for NoTemplatesApiServiceApi:
+ * <pre>
+ * <code>
+ * try (NoTemplatesApiServiceApi noTemplatesApiServiceApi = NoTemplatesApiServiceApi.create()) {
+ *   IncrementRequest request = IncrementRequest.newBuilder().build();
+ *   noTemplatesApiServiceApi.increment(request);
+ * }
+ * </code>
+ * </pre>
+ *
+ */
+
+package com.google.gcloud.example;

--- a/src/test/java/com/google/api/codegen/testdata/java_page_streaming_response_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_page_streaming_response_no_path_templates.baseline
@@ -1,0 +1,31 @@
+============== file: src/main/java/com/google/gcloud/example/PagedResponseWrappers.java ==============
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.gcloud.example;
+
+import com.google.api.gax.grpc.CallContext;
+import com.google.api.gax.grpc.PageStreamingDescriptor;
+import com.google.api.gax.grpc.PagedListResponseImpl;
+import com.google.api.gax.grpc.UnaryApiCallable;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS
+/**
+ * Wrapper class to contain paged response types for page streaming methods.
+ * Each static class inside this wrapper class is used as the return type of
+ * one of an API method that implements the page streaming pattern.
+ */
+@javax.annotation.Generated("by GAPIC")
+public class PagedResponseWrappers {
+
+}

--- a/src/test/java/com/google/api/codegen/testdata/java_settings_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_settings_library.baseline
@@ -132,15 +132,6 @@ public class LibraryServiceSettings extends ServiceApiSettings {
       .add("https://www.googleapis.com/auth/library")
       .build();
 
-  /**
-   * The default connection settings of the service.
-   */
-  public static final ConnectionSettings DEFAULT_CONNECTION_SETTINGS =
-      ConnectionSettings.newBuilder()
-          .setServiceAddress(DEFAULT_SERVICE_ADDRESS)
-          .setPort(DEFAULT_SERVICE_PORT)
-          .provideCredentialsWith(DEFAULT_SERVICE_SCOPES)
-          .build();
 
   private final SimpleCallSettings<CreateShelfRequest, Shelf> createShelfSettings;
   private final SimpleCallSettings<GetShelfRequest, Shelf> getShelfSettings;
@@ -703,7 +694,7 @@ public class LibraryServiceSettings extends ServiceApiSettings {
     }
 
     private Builder() {
-      super(DEFAULT_CONNECTION_SETTINGS);
+      super(s_getDefaultConnectionSettingsBuilder().build());
 
       createShelfSettings = SimpleCallSettings.newBuilder(LibraryServiceGrpc.METHOD_CREATE_SHELF);
 
@@ -930,9 +921,16 @@ public class LibraryServiceSettings extends ServiceApiSettings {
       );
     }
 
+    private static ConnectionSettings.Builder s_getDefaultConnectionSettingsBuilder() {
+      return ConnectionSettings.newBuilder()
+        .setServiceAddress(DEFAULT_SERVICE_ADDRESS)
+        .setPort(DEFAULT_SERVICE_PORT)
+        .provideCredentialsWith(DEFAULT_SERVICE_SCOPES)
+        ;
+      }
     @Override
-    protected ConnectionSettings getDefaultConnectionSettings() {
-      return DEFAULT_CONNECTION_SETTINGS;
+    protected ConnectionSettings.Builder getDefaultConnectionSettingsBuilder() {
+      return s_getDefaultConnectionSettingsBuilder();
     }
     @Override
     public Builder provideExecutorWith(ScheduledExecutorService executor, boolean shouldAutoClose) {

--- a/src/test/java/com/google/api/codegen/testdata/java_settings_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_settings_library.baseline
@@ -927,7 +927,7 @@ public class LibraryServiceSettings extends ServiceApiSettings {
         .setPort(DEFAULT_SERVICE_PORT)
         .provideCredentialsWith(DEFAULT_SERVICE_SCOPES)
         ;
-      }
+    }
     @Override
     protected ConnectionSettings.Builder getDefaultConnectionSettingsBuilder() {
       return s_getDefaultConnectionSettingsBuilder();

--- a/src/test/java/com/google/api/codegen/testdata/java_settings_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_settings_no_path_templates.baseline
@@ -159,7 +159,7 @@ public class NoTemplatesApiServiceSettings extends ServiceApiSettings {
       return ConnectionSettings.newBuilder()
         .setPort(DEFAULT_SERVICE_PORT)
         ;
-      }
+    }
     @Override
     protected ConnectionSettings.Builder getDefaultConnectionSettingsBuilder() {
       return s_getDefaultConnectionSettingsBuilder();

--- a/src/test/java/com/google/api/codegen/testdata/java_settings_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_settings_no_path_templates.baseline
@@ -1,0 +1,227 @@
+============== file: src/main/java/com/google/gcloud/example/NoTemplatesApiServiceSettings.java ==============
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.gcloud.example;
+
+import com.google.api.gax.core.ConnectionSettings;
+import com.google.api.gax.core.RetrySettings;
+import com.google.api.gax.grpc.CallContext;
+import com.google.api.gax.grpc.PageStreamingDescriptor;
+import com.google.api.gax.grpc.PagedListResponseFactory;
+import com.google.api.gax.grpc.ServiceApiSettings;
+import com.google.api.gax.grpc.SimpleCallSettings;
+import com.google.api.gax.grpc.UnaryApiCallSettings;
+import com.google.api.gax.grpc.UnaryApiCallable;
+import com.google.auth.Credentials;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import com.google.example.noPathTemplates.v1.IncrementRequest;
+import com.google.example.noPathTemplates.v1.NoTemplatesAPIServiceGrpc;
+import com.google.protobuf.Empty;
+import io.grpc.ManagedChannel;
+import io.grpc.Status;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import org.joda.time.Duration;
+
+// AUTO-GENERATED DOCUMENTATION AND CLASS
+/**
+ * Settings class to configure an instance of {@link NoTemplatesApiServiceApi}.
+ */
+@javax.annotation.Generated("by GAPIC")
+public class NoTemplatesApiServiceSettings extends ServiceApiSettings {
+
+  /**
+   * The default port of the service.
+   */
+  private static final int DEFAULT_SERVICE_PORT = 443;
+
+
+  private final SimpleCallSettings<IncrementRequest, Empty> incrementSettings;
+
+  /**
+   * Returns the object with the settings used for calls to increment.
+   */
+  public SimpleCallSettings<IncrementRequest, Empty> incrementSettings() {
+    return incrementSettings;
+  }
+
+  /**
+   * Returns the default service port.
+   */
+  public static int getDefaultServicePort() {
+    return DEFAULT_SERVICE_PORT;
+  }
+
+  /**
+   * Returns a builder for this class with recommended defaults.
+   */
+  public static Builder defaultBuilder() {
+    return Builder.createDefault();
+  }
+
+  /**
+   * Returns a new builder for this class.
+   */
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  /**
+   * Returns a builder containing all the values of this settings class.
+   */
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  private NoTemplatesApiServiceSettings(Builder settingsBuilder) throws IOException {
+    super(settingsBuilder.getChannelProvider(),
+          settingsBuilder.getExecutorProvider(),
+          settingsBuilder.getGeneratorName(),
+          settingsBuilder.getGeneratorVersion(),
+          settingsBuilder.getClientLibName(),
+          settingsBuilder.getClientLibVersion());
+
+    incrementSettings = settingsBuilder.incrementSettings().build();
+  }
+
+
+
+
+  /**
+   * Builder for NoTemplatesApiServiceSettings.
+   */
+  public static class Builder extends ServiceApiSettings.Builder {
+    private final ImmutableList<UnaryApiCallSettings.Builder> unaryMethodSettingsBuilders;
+
+    private final SimpleCallSettings.Builder<IncrementRequest, Empty> incrementSettings;
+
+    private static final ImmutableMap<String, ImmutableSet<Status.Code>> RETRYABLE_CODE_DEFINITIONS;
+
+    static {
+      ImmutableMap.Builder<String, ImmutableSet<Status.Code>> definitions = ImmutableMap.builder();
+      RETRYABLE_CODE_DEFINITIONS = definitions.build();
+    }
+
+    private static final ImmutableMap<String, RetrySettings.Builder> RETRY_PARAM_DEFINITIONS;
+
+    static {
+      ImmutableMap.Builder<String, RetrySettings.Builder> definitions = ImmutableMap.builder();
+      RetrySettings.Builder settingsBuilder = null;
+      RETRY_PARAM_DEFINITIONS = definitions.build();
+    }
+
+    private Builder() {
+
+      incrementSettings = SimpleCallSettings.newBuilder(NoTemplatesAPIServiceGrpc.METHOD_INCREMENT);
+
+      unaryMethodSettingsBuilders = ImmutableList.<UnaryApiCallSettings.Builder>of(
+          incrementSettings
+      );
+    }
+
+    private static Builder createDefault() {
+      Builder builder = new Builder();
+
+      builder.incrementSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get(""))
+          .setRetrySettingsBuilder(RETRY_PARAM_DEFINITIONS.get("default"));
+
+      return builder;
+    }
+
+    private Builder(NoTemplatesApiServiceSettings settings) {
+      super(settings);
+
+      incrementSettings = settings.incrementSettings.toBuilder();
+
+      unaryMethodSettingsBuilders = ImmutableList.<UnaryApiCallSettings.Builder>of(
+          incrementSettings
+      );
+    }
+
+    private static ConnectionSettings.Builder s_getDefaultConnectionSettingsBuilder() {
+      return ConnectionSettings.newBuilder()
+        .setPort(DEFAULT_SERVICE_PORT)
+        ;
+      }
+    @Override
+    protected ConnectionSettings.Builder getDefaultConnectionSettingsBuilder() {
+      return s_getDefaultConnectionSettingsBuilder();
+    }
+    @Override
+    public Builder provideExecutorWith(ScheduledExecutorService executor, boolean shouldAutoClose) {
+      super.provideExecutorWith(executor, shouldAutoClose);
+      return this;
+    }
+    @Override
+    public Builder provideChannelWith(ManagedChannel channel, boolean shouldAutoClose) {
+      super.provideChannelWith(channel, shouldAutoClose);
+      return this;
+    }
+    @Override
+    public Builder provideChannelWith(ConnectionSettings settings) {
+      super.provideChannelWith(settings);
+      return this;
+    }
+    @Override
+    public Builder provideChannelWith(Credentials credentials) {
+      super.provideChannelWith(credentials);
+      return this;
+    }
+    @Override
+    public Builder provideChannelWith(List<String> scopes) {
+      super.provideChannelWith(scopes);
+      return this;
+    }
+    @Override
+    public Builder setGeneratorHeader(String name, String version) {
+      super.setGeneratorHeader(name, version);
+      return this;
+    }
+    @Override
+    public Builder setClientLibHeader(String name, String version) {
+      super.setClientLibHeader(name, version);
+      return this;
+    }
+
+    /**
+     * Applies the given settings to all of the unary API methods in this service. Only
+     * values that are non-null will be applied, so this method is not capable
+     * of un-setting any values.
+     *
+     * Note: This method does not support applying settings to streaming methods.
+     */
+    public Builder applyToAllApiMethods(UnaryApiCallSettings.Builder apiCallSettings) throws Exception {
+      super.applyToAllApiMethods(unaryMethodSettingsBuilders, apiCallSettings);
+      return this;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to increment.
+     */
+    public SimpleCallSettings.Builder<IncrementRequest, Empty> incrementSettings() {
+      return incrementSettings;
+    }
+
+    @Override
+    public NoTemplatesApiServiceSettings build() throws IOException {
+      return new NoTemplatesApiServiceSettings(this);
+    }
+  }
+}

--- a/src/test/java/com/google/api/codegen/testdata/java_test_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_test_no_path_templates.baseline
@@ -1,0 +1,66 @@
+============== file: src/test/java/com/google/gcloud/example/NoTemplatesApiServiceTest.java ==============
+/*
+ * Copyright 2016 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.gcloud.example;
+
+import com.google.api.gax.core.PagedListResponse;
+import com.google.api.gax.testing.MockGrpcService;
+import com.google.api.gax.testing.MockServiceHelper;
+import com.google.common.collect.Lists;
+import com.google.protobuf.GeneratedMessageV3;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+@javax.annotation.Generated("by GAPIC")
+public class NoTemplatesApiServiceTest {
+  private static MockNoTemplatesAPIService mockNoTemplatesAPIService;
+  private static MockServiceHelper serviceHelper;
+  private NoTemplatesApiServiceApi api;
+
+  @BeforeClass
+  public static void startStaticServer() {
+    mockNoTemplatesAPIService = new MockNoTemplatesAPIService();
+    serviceHelper = new MockServiceHelper("in-process-1", Arrays.<MockGrpcService>asList(mockNoTemplatesAPIService));
+    serviceHelper.start();
+  }
+
+  @AfterClass
+  public static void stopServer() {
+    serviceHelper.stop();
+  }
+
+  @Before
+  public void setUp() throws IOException {
+    serviceHelper.reset();
+    NoTemplatesApiServiceSettings settings = NoTemplatesApiServiceSettings.defaultBuilder()
+        .provideChannelWith(serviceHelper.createChannel(), true)
+        .build();
+    api = NoTemplatesApiServiceApi.create(settings);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    api.close();
+  }
+
+}

--- a/src/test/java/com/google/api/codegen/testdata/no_path_templates_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testdata/no_path_templates_gapic.yaml
@@ -12,6 +12,9 @@ language_settings:
     package_name: google-example-no-path-template
 interfaces:
 - name: google.cloud.example.v1.NoTemplatesAPIService
+  required_constructor_params:
+  - service_address
+  - scopes
   methods:
   - name: Increment
     retry_params_name: default


### PR DESCRIPTION
This is to support cases like OperationsApi, which does not have an
inherent service address.

Coordinates with https://github.com/googleapis/gax-java/pull/125 .