### PR TITLE
Go: Properly capitalize GRPC client's method names

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/go/GoSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/go/GoSurfaceNamer.java
@@ -115,6 +115,11 @@ public class GoSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
+  public String getCallableName(Method method) {
+    return publicMethodName(Name.upperCamel(method.getSimpleName()));
+  }
+
+  @Override
   public String getApiWrapperClassName(Interface service) {
     return className(clientNamePrefix(service).join("client"));
   }

--- a/src/main/java/com/google/api/codegen/viewmodel/StaticLangApiMethodView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/StaticLangApiMethodView.java
@@ -46,7 +46,6 @@ public abstract class StaticLangApiMethodView implements ApiMethodView {
 
   public abstract String exampleName();
 
-  @Nullable // Used in C#
   public abstract String callableName();
 
   public abstract String settingsGetterName();

--- a/src/main/resources/com/google/api/codegen/go/main.snip
+++ b/src/main/resources/com/google/api/codegen/go/main.snip
@@ -185,7 +185,7 @@
         var resp {@method.responseTypeName}
         err := gax.Invoke(ctx, func(ctx context.Context) error {
             var err error
-            resp, err = c.{@method.stubName}.{@method.name}(ctx, req)
+            resp, err = c.{@method.stubName}.{@method.callableName}(ctx, req)
             return err
         }, c.CallOptions.{@method.settingsGetterName}...)
         if err != nil {
@@ -201,7 +201,7 @@
         var resp {@method.responseTypeName}
         err := gax.Invoke(ctx, func(ctx context.Context) error {
             var err error
-            resp, err = c.{@method.stubName}.{@method.name}(ctx, req)
+            resp, err = c.{@method.stubName}.{@method.callableName}(ctx, req)
             return err
         }, c.CallOptions.{@method.name}...)
         if err != nil {
@@ -234,7 +234,7 @@
         {@mergeMetadata()}
         err := gax.Invoke(ctx, func(ctx context.Context) error {
             var err error
-            _, err = c.{@method.stubName}.{@method.name}(ctx, req)
+            _, err = c.{@method.stubName}.{@method.callableName}(ctx, req)
             return err
         }, c.CallOptions.{@method.settingsGetterName}...)
         return err
@@ -256,7 +256,7 @@
             }
             err := gax.Invoke(ctx, func(ctx context.Context) error {
                 var err error
-                resp, err = c.{@method.stubName}.{@method.name}(ctx, req)
+                resp, err = c.{@method.stubName}.{@method.callableName}(ctx, req)
                 return err
             }, c.CallOptions.{@method.settingsGetterName}...)
             if err != nil {

--- a/src/test/java/com/google/api/codegen/testdata/go_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_main_library.baseline
@@ -623,7 +623,7 @@ func (c *Client) addLabel(ctx context.Context, req *taggerpb.AddLabelRequest) (*
     var resp *taggerpb.AddLabelResponse
     err := gax.Invoke(ctx, func(ctx context.Context) error {
         var err error
-        resp, err = c.labelerClient.addLabel(ctx, req)
+        resp, err = c.labelerClient.AddLabel(ctx, req)
         return err
     }, c.CallOptions.AddLabel...)
     if err != nil {


### PR DESCRIPTION
When generating private methods, the generated client's method names
are lower-cased.
However, we mistakenly also lower-case the GRPC client's method names.
This commit fixes this problem.