### PR TITLE
Loading license data from files in Java and C#

### DIFF
--- a/src/main/java/com/google/api/codegen/config/ApiConfig.java
+++ b/src/main/java/com/google/api/codegen/config/ApiConfig.java
@@ -17,6 +17,7 @@ package com.google.api.codegen.config;
 import com.google.api.codegen.ConfigProto;
 import com.google.api.codegen.InterfaceConfigProto;
 import com.google.api.codegen.LanguageSettingsProto;
+import com.google.api.codegen.LicenseHeaderProto;
 import com.google.api.tools.framework.model.Diag;
 import com.google.api.tools.framework.model.DiagCollector;
 import com.google.api.tools.framework.model.Interface;
@@ -25,7 +26,14 @@ import com.google.api.tools.framework.model.SimpleLocation;
 import com.google.api.tools.framework.model.SymbolTable;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Charsets;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.io.CharStreams;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import javax.annotation.Nullable;
 
 /** ApiConfig represents the code-gen config for an API library. */
@@ -38,6 +46,12 @@ public abstract class ApiConfig {
 
   /** Returns the location of the domain layer, if any. */
   public abstract String getDomainLayerLocation();
+
+  /** Returns the lines from the configured copyright file. */
+  public abstract ImmutableList<String> getCopyrightLines();
+
+  /** Returns the lines from the configured license file. */
+  public abstract ImmutableList<String> getLicenseLines();
 
   /**
    * Creates an instance of ApiConfig based on ConfigProto, linking up API interface configurations
@@ -53,18 +67,36 @@ public abstract class ApiConfig {
     if (settings == null) {
       settings = LanguageSettingsProto.getDefaultInstance();
     }
-    if (interfaceConfigMap == null) {
+
+    ImmutableList<String> copyrightLines = null;
+    ImmutableList<String> licenseLines = null;
+    try {
+      copyrightLines = loadCopyrightLines(model.getDiagCollector(), configProto.getLicenseHeader());
+      licenseLines = loadLicenseLines(model.getDiagCollector(), configProto.getLicenseHeader());
+    } catch (Exception e) {
+      model
+          .getDiagCollector()
+          .addDiag(Diag.error(SimpleLocation.TOPLEVEL, "Exception: %s", e.getMessage()));
+      e.printStackTrace(System.err);
+      throw new RuntimeException(e);
+    }
+
+    if (interfaceConfigMap == null || copyrightLines == null || licenseLines == null) {
       return null;
     } else {
       return new AutoValue_ApiConfig(
-          interfaceConfigMap, settings.getPackageName(), settings.getDomainLayerLocation());
+          interfaceConfigMap,
+          settings.getPackageName(),
+          settings.getDomainLayerLocation(),
+          copyrightLines,
+          licenseLines);
     }
   }
 
   /** Creates an ApiConfig with no content. Exposed for testing. */
   @VisibleForTesting
   public static ApiConfig createDummyApiConfig() {
-    return new AutoValue_ApiConfig(ImmutableMap.<String, InterfaceConfig>builder().build(), "", "");
+    return createDummyApiConfig(ImmutableMap.<String, InterfaceConfig>builder().build(), "", "");
   }
 
   /** Creates an ApiConfig with fixed content. Exposed for testing. */
@@ -73,7 +105,12 @@ public abstract class ApiConfig {
       ImmutableMap<String, InterfaceConfig> interfaceConfigMap,
       String packageName,
       String domainLayerLocation) {
-    return new AutoValue_ApiConfig(interfaceConfigMap, packageName, domainLayerLocation);
+    return new AutoValue_ApiConfig(
+        interfaceConfigMap,
+        packageName,
+        domainLayerLocation,
+        ImmutableList.<String>of(),
+        ImmutableList.<String>of());
   }
 
   private static ImmutableMap<String, InterfaceConfig> createInterfaceConfigMap(
@@ -104,6 +141,43 @@ public abstract class ApiConfig {
     } else {
       return interfaceConfigMap.build();
     }
+  }
+
+  private static ImmutableList<String> loadCopyrightLines(
+      DiagCollector diagCollector, LicenseHeaderProto licenseHeaderProto) throws IOException {
+    if (licenseHeaderProto == null) {
+      diagCollector.addDiag(Diag.error(SimpleLocation.TOPLEVEL, "license_header missing"));
+      return null;
+    }
+    if (Strings.isNullOrEmpty(licenseHeaderProto.getCopyrightFile())) {
+      diagCollector.addDiag(
+          Diag.error(SimpleLocation.TOPLEVEL, "license_header.copyright_file missing"));
+      return null;
+    }
+
+    return getResourceLines(licenseHeaderProto.getCopyrightFile());
+  }
+
+  private static ImmutableList<String> loadLicenseLines(
+      DiagCollector diagCollector, LicenseHeaderProto licenseHeaderProto) throws IOException {
+    if (licenseHeaderProto == null) {
+      diagCollector.addDiag(Diag.error(SimpleLocation.TOPLEVEL, "license_header missing"));
+      return null;
+    }
+    if (Strings.isNullOrEmpty(licenseHeaderProto.getLicenseFile())) {
+      diagCollector.addDiag(
+          Diag.error(SimpleLocation.TOPLEVEL, "license_header.license_file missing"));
+      return null;
+    }
+
+    return getResourceLines(licenseHeaderProto.getLicenseFile());
+  }
+
+  private static ImmutableList<String> getResourceLines(String resourceFileName)
+      throws IOException {
+    InputStream fileStream = ConfigProto.class.getResourceAsStream(resourceFileName);
+    InputStreamReader fileReader = new InputStreamReader(fileStream, Charsets.UTF_8);
+    return ImmutableList.copyOf(CharStreams.readLines(fileReader));
   }
 
   /** Returns the InterfaceConfig for the given API interface. */

--- a/src/main/java/com/google/api/codegen/transformer/FileHeaderTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/FileHeaderTransformer.java
@@ -1,0 +1,44 @@
+/* Copyright 2016 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.transformer;
+
+import com.google.api.codegen.config.ApiConfig;
+import com.google.api.codegen.util.TypeAlias;
+import com.google.api.codegen.viewmodel.FileHeaderView;
+import java.util.Map;
+
+public class FileHeaderTransformer {
+  private ImportTypeTransformer importTypeTransformer = new ImportTypeTransformer();
+
+  public FileHeaderView generateFileHeader(SurfaceTransformerContext context) {
+    return generateFileHeader(
+        context.getApiConfig(), context.getTypeTable().getImports(), context.getNamer());
+  }
+
+  public FileHeaderView generateFileHeader(
+      ApiConfig apiConfig, Map<String, TypeAlias> imports, SurfaceNamer namer) {
+    FileHeaderView.Builder fileHeader = FileHeaderView.newBuilder();
+
+    fileHeader.copyrightLines(apiConfig.getCopyrightLines());
+    fileHeader.licenseLines(apiConfig.getLicenseLines());
+    fileHeader.packageName(namer.getPackageName());
+    fileHeader.examplePackageName(namer.getExamplePackageName());
+    fileHeader.localPackageName(namer.getLocalPackageName());
+    fileHeader.localExamplePackageName(namer.getLocalExamplePackageName());
+    fileHeader.imports(importTypeTransformer.generateImports(imports));
+
+    return fileHeader.build();
+  }
+}

--- a/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
@@ -152,17 +152,14 @@ public class InitCodeTransformer {
     // Initialize the type table with the apiClassName since each sample will be using the
     // apiClass.
     typeTable.getAndSaveNicknameFor(
-        namer.getFullyQualifiedApiWrapperClassName(
-            context.getInterface(), context.getApiConfig().getPackageName()));
+        namer.getFullyQualifiedApiWrapperClassName(context.getInterface()));
 
     return InitCodeView.newBuilder()
         .lines(generateSurfaceInitCodeLines(context, orderedItems))
         .topLevelLines(generateSurfaceInitCodeLines(context, argItems))
         .fieldSettings(getFieldSettings(context, argItems))
         .imports(importTypeTransformer.generateImports(typeTable.getImports()))
-        .apiFileName(
-            namer.getServiceFileName(
-                context.getInterface(), context.getApiConfig().getPackageName()))
+        .apiFileName(namer.getServiceFileName(context.getInterface()))
         .build();
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
@@ -47,16 +47,19 @@ import java.util.List;
  * language-specific namer.
  */
 public class SurfaceNamer extends NameFormatterDelegator {
-  private ModelTypeFormatter modelTypeFormatter;
-  private TypeNameConverter typeNameConverter;
+  private final ModelTypeFormatter modelTypeFormatter;
+  private final TypeNameConverter typeNameConverter;
+  private final String packageName;
 
   public SurfaceNamer(
       NameFormatter languageNamer,
       ModelTypeFormatter modelTypeFormatter,
-      TypeNameConverter typeNameConverter) {
+      TypeNameConverter typeNameConverter,
+      String packageName) {
     super(languageNamer);
     this.modelTypeFormatter = modelTypeFormatter;
     this.typeNameConverter = typeNameConverter;
+    this.packageName = packageName;
   }
 
   public ModelTypeFormatter getModelTypeFormatter() {
@@ -65,6 +68,10 @@ public class SurfaceNamer extends NameFormatterDelegator {
 
   public TypeNameConverter getTypeNameConverter() {
     return typeNameConverter;
+  }
+
+  public String getPackageName() {
+    return packageName;
   }
 
   public String getNotImplementedString(String feature) {
@@ -290,14 +297,19 @@ public class SurfaceNamer extends NameFormatterDelegator {
     }
   }
 
-  /** The name of the package */
+  /** The name of the example package */
+  public String getExamplePackageName() {
+    return getNotImplementedString("SurfaceNamer.getExamplePackageName");
+  }
+
+  /** The local (unqualified) name of the package */
   public String getLocalPackageName() {
     return getNotImplementedString("SurfaceNamer.getLocalPackageName");
   }
 
-  /** The name of the example package */
-  public String getExamplePackageName() {
-    return getNotImplementedString("SurfaceNamer.getExamplePackageName");
+  /** The local (unqualified) name of the example package */
+  public String getLocalExamplePackageName() {
+    return getNotImplementedString("SurfaceNamer.getLocalExamplePackageName");
   }
 
   /**
@@ -766,12 +778,12 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** The file name for an API service. */
-  public String getServiceFileName(Interface service, String packageName) {
+  public String getServiceFileName(Interface service) {
     return getNotImplementedString("SurfaceNamer.getServiceFileName");
   }
 
   /** The file name for the example of an API service. */
-  public String getExampleFileName(Interface service, String packageName) {
+  public String getExampleFileName(Interface service) {
     return getNotImplementedString("SurfaceNamer.getExampleFileName");
   }
 
@@ -779,7 +791,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
    * The fully qualified class name of a an API service. TODO: Support the general pattern of
    * package + class name in NameFormatter.
    */
-  public String getFullyQualifiedApiWrapperClassName(Interface interfaze, String packageName) {
+  public String getFullyQualifiedApiWrapperClassName(Interface interfaze) {
     return getNotImplementedString("SurfaceNamer.getFullyQualifiedApiWrapperClassName");
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicClientTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicClientTransformer.java
@@ -140,16 +140,16 @@ public class CSharpGapicClientTransformer implements ModelToViewTransformer {
 
   private StaticLangApiView generateApiClass(SurfaceTransformerContext context) {
     SurfaceNamer namer = context.getNamer();
-    StaticLangApiView.Builder xapiClass = StaticLangApiView.newBuilder();
+    StaticLangApiView.Builder apiClass = StaticLangApiView.newBuilder();
     List<StaticLangApiMethodView> methods = generateApiMethods(context);
 
-    xapiClass.doc(serviceTransformer.generateServiceDoc(context, null));
+    apiClass.doc(serviceTransformer.generateServiceDoc(context, null));
 
-    xapiClass.name(namer.getApiWrapperClassName(context.getInterface()));
-    xapiClass.implName(namer.getApiWrapperClassImplName(context.getInterface()));
-    xapiClass.grpcServiceName(namer.getGrpcContainerTypeName(context.getInterface()));
-    xapiClass.grpcTypeName(namer.getGrpcServiceClassName(context.getInterface()));
-    xapiClass.settingsClassName(context.getNamer().getApiSettingsClassName(context.getInterface()));
+    apiClass.name(namer.getApiWrapperClassName(context.getInterface()));
+    apiClass.implName(namer.getApiWrapperClassImplName(context.getInterface()));
+    apiClass.grpcServiceName(namer.getGrpcContainerTypeName(context.getInterface()));
+    apiClass.grpcTypeName(namer.getGrpcServiceClassName(context.getInterface()));
+    apiClass.settingsClassName(context.getNamer().getApiSettingsClassName(context.getInterface()));
     List<ApiCallableView> callables = new ArrayList<>();
     for (ApiCallableView call : apiCallableTransformer.generateStaticLangApiCallables(context)) {
       if (call.type() == ApiCallableType.SimpleApiCallable
@@ -157,24 +157,24 @@ public class CSharpGapicClientTransformer implements ModelToViewTransformer {
         callables.add(call);
       }
     }
-    xapiClass.apiCallableMembers(callables);
-    xapiClass.pathTemplates(pathTemplateTransformer.generatePathTemplates(context));
-    xapiClass.formatResourceFunctions(
+    apiClass.apiCallableMembers(callables);
+    apiClass.pathTemplates(pathTemplateTransformer.generatePathTemplates(context));
+    apiClass.formatResourceFunctions(
         pathTemplateTransformer.generateFormatResourceFunctions(context));
-    xapiClass.parseResourceFunctions(
+    apiClass.parseResourceFunctions(
         pathTemplateTransformer.generateParseResourceFunctions(context));
-    xapiClass.apiMethods(methods);
+    apiClass.apiMethods(methods);
     List<StaticLangApiMethodView> methodsImpl = new ArrayList<>();
     for (StaticLangApiMethodView method : methods) {
       if (methodTypeHasImpl(method.type())) {
         methodsImpl.add(method);
       }
     }
-    xapiClass.apiMethodsImpl(methodsImpl);
-    xapiClass.hasDefaultInstance(context.getInterfaceConfig().hasDefaultInstance());
-    xapiClass.reroutedGrpcClients(generateReroutedGrpcView(context));
+    apiClass.apiMethodsImpl(methodsImpl);
+    apiClass.hasDefaultInstance(context.getInterfaceConfig().hasDefaultInstance());
+    apiClass.reroutedGrpcClients(generateReroutedGrpcView(context));
 
-    return xapiClass.build();
+    return apiClass.build();
   }
 
   private boolean methodTypeHasImpl(ApiMethodType type) {
@@ -182,30 +182,30 @@ public class CSharpGapicClientTransformer implements ModelToViewTransformer {
   }
 
   private StaticLangSettingsView generateSettingsClass(SurfaceTransformerContext context) {
-    StaticLangSettingsView.Builder xsettingsClass = StaticLangSettingsView.newBuilder();
-    xsettingsClass.doc(generateSettingsDoc(context));
+    StaticLangSettingsView.Builder settingsClass = StaticLangSettingsView.newBuilder();
+    settingsClass.doc(generateSettingsDoc(context));
     String name = context.getNamer().getApiSettingsClassName(context.getInterface());
-    xsettingsClass.name(name);
+    settingsClass.name(name);
     ServiceConfig serviceConfig = new ServiceConfig();
-    xsettingsClass.serviceAddress(serviceConfig.getServiceAddress(context.getInterface()));
-    xsettingsClass.servicePort(serviceConfig.getServicePort());
-    xsettingsClass.authScopes(serviceConfig.getAuthScopes(context.getInterface()));
-    xsettingsClass.callSettings(generateCallSettings(context));
-    xsettingsClass.pageStreamingDescriptors(
+    settingsClass.serviceAddress(serviceConfig.getServiceAddress(context.getInterface()));
+    settingsClass.servicePort(serviceConfig.getServicePort());
+    settingsClass.authScopes(serviceConfig.getAuthScopes(context.getInterface()));
+    settingsClass.callSettings(generateCallSettings(context));
+    settingsClass.pageStreamingDescriptors(
         pageStreamingTransformer.generateDescriptorClasses(context));
-    xsettingsClass.pagedListResponseFactories(
+    settingsClass.pagedListResponseFactories(
         pageStreamingTransformer.generateFactoryClasses(context));
-    xsettingsClass.bundlingDescriptors(bundlingTransformer.generateDescriptorClasses(context));
-    xsettingsClass.retryCodesDefinitions(
+    settingsClass.bundlingDescriptors(bundlingTransformer.generateDescriptorClasses(context));
+    settingsClass.retryCodesDefinitions(
         retryDefinitionsTransformer.generateRetryCodesDefinitions(context));
-    xsettingsClass.retryParamsDefinitions(
+    settingsClass.retryParamsDefinitions(
         retryDefinitionsTransformer.generateRetryParamsDefinitions(context));
     InterfaceConfig interfaceConfig = context.getInterfaceConfig();
-    xsettingsClass.hasDefaultServiceAddress(interfaceConfig.hasDefaultServiceAddress());
-    xsettingsClass.hasDefaultServiceScopes(interfaceConfig.hasDefaultServiceScopes());
-    xsettingsClass.hasDefaultInstance(interfaceConfig.hasDefaultInstance());
+    settingsClass.hasDefaultServiceAddress(interfaceConfig.hasDefaultServiceAddress());
+    settingsClass.hasDefaultServiceScopes(interfaceConfig.hasDefaultServiceScopes());
+    settingsClass.hasDefaultInstance(interfaceConfig.hasDefaultInstance());
 
-    return xsettingsClass.build();
+    return settingsClass.build();
   }
 
   public List<ApiCallSettingsView> generateCallSettings(SurfaceTransformerContext context) {

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicSnippetsTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicSnippetsTransformer.java
@@ -21,7 +21,7 @@ import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.config.PageStreamingConfig;
 import com.google.api.codegen.gapic.GapicCodePathMapper;
 import com.google.api.codegen.transformer.ApiMethodTransformer;
-import com.google.api.codegen.transformer.ImportTypeTransformer;
+import com.google.api.codegen.transformer.FileHeaderTransformer;
 import com.google.api.codegen.transformer.MethodTransformerContext;
 import com.google.api.codegen.transformer.ModelToViewTransformer;
 import com.google.api.codegen.transformer.ModelTypeTable;
@@ -48,13 +48,13 @@ public class CSharpGapicSnippetsTransformer implements ModelToViewTransformer {
   private static final String SNIPPETS_TEMPLATE_FILENAME = "csharp/gapic_snippets.snip";
 
   private final GapicCodePathMapper pathMapper;
-  private final ImportTypeTransformer importTypeTransformer;
+  private final FileHeaderTransformer fileHeaderTransformer;
   private final ApiMethodTransformer apiMethodTransformer;
   private final CSharpCommonTransformer csharpCommonTransformer;
 
   public CSharpGapicSnippetsTransformer(GapicCodePathMapper pathMapper) {
     this.pathMapper = pathMapper;
-    this.importTypeTransformer = new ImportTypeTransformer();
+    this.fileHeaderTransformer = new FileHeaderTransformer();
     this.apiMethodTransformer = new ApiMethodTransformer();
     this.csharpCommonTransformer = new CSharpCommonTransformer();
   }
@@ -102,13 +102,11 @@ public class CSharpGapicSnippetsTransformer implements ModelToViewTransformer {
     String outputPath = pathMapper.getOutputPath(context.getInterface(), context.getApiConfig());
     snippetsBuilder.outputPath(
         outputPath + File.separator + name.replace("Generated", "") + ".g.cs");
-    snippetsBuilder.packageName(context.getApiConfig().getPackageName() + ".Snippets");
     snippetsBuilder.name(name);
     snippetsBuilder.snippetMethods(generateMethods(context));
 
     // must be done as the last step to catch all imports
-    snippetsBuilder.imports(
-        importTypeTransformer.generateImports(context.getTypeTable().getImports()));
+    snippetsBuilder.fileHeader(fileHeaderTransformer.generateFileHeader(context));
 
     return snippetsBuilder.build();
   }

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpSurfaceNamer.java
@@ -34,16 +34,17 @@ import com.google.common.collect.ImmutableList;
 import java.util.List;
 
 public class CSharpSurfaceNamer extends SurfaceNamer {
-  public CSharpSurfaceNamer(String implicitPackageName) {
+  public CSharpSurfaceNamer(String packageName) {
     super(
         new CSharpNameFormatter(),
-        new ModelTypeFormatterImpl(new CSharpModelTypeNameConverter(implicitPackageName)),
-        new CSharpTypeTable(implicitPackageName));
+        new ModelTypeFormatterImpl(new CSharpModelTypeNameConverter(packageName)),
+        new CSharpTypeTable(packageName),
+        packageName);
   }
 
   @Override
-  public String getFullyQualifiedApiWrapperClassName(Interface service, String packageName) {
-    return packageName + "." + getApiWrapperClassName(service);
+  public String getFullyQualifiedApiWrapperClassName(Interface service) {
+    return getPackageName() + "." + getApiWrapperClassName(service);
   }
 
   @Override
@@ -93,6 +94,11 @@ public class CSharpSurfaceNamer extends SurfaceNamer {
   @Override
   public String getFieldGetFunctionName(TypeRef type, Name identifier) {
     return privateMethodName(identifier);
+  }
+
+  @Override
+  public String getExamplePackageName() {
+    return getPackageName() + ".Snippets";
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformer.java
@@ -25,6 +25,7 @@ import com.google.api.codegen.go.GoContextCommon;
 import com.google.api.codegen.transformer.ApiCallableTransformer;
 import com.google.api.codegen.transformer.ApiMethodTransformer;
 import com.google.api.codegen.transformer.FeatureConfig;
+import com.google.api.codegen.transformer.FileHeaderTransformer;
 import com.google.api.codegen.transformer.GrpcStubTransformer;
 import com.google.api.codegen.transformer.IamResourceTransformer;
 import com.google.api.codegen.transformer.MethodTransformerContext;
@@ -34,14 +35,15 @@ import com.google.api.codegen.transformer.PageStreamingTransformer;
 import com.google.api.codegen.transformer.PathTemplateTransformer;
 import com.google.api.codegen.transformer.SurfaceNamer;
 import com.google.api.codegen.transformer.SurfaceTransformerContext;
+import com.google.api.codegen.util.TypeAlias;
 import com.google.api.codegen.util.go.GoTypeTable;
 import com.google.api.codegen.viewmodel.PackageInfoView;
 import com.google.api.codegen.viewmodel.PageStreamingDescriptorClassView;
 import com.google.api.codegen.viewmodel.RetryConfigDefinitionView;
 import com.google.api.codegen.viewmodel.ServiceDocView;
 import com.google.api.codegen.viewmodel.StaticLangApiMethodView;
-import com.google.api.codegen.viewmodel.StaticLangXCombinedSurfaceView;
-import com.google.api.codegen.viewmodel.StaticLangXExampleView;
+import com.google.api.codegen.viewmodel.StaticLangClientExampleFileView;
+import com.google.api.codegen.viewmodel.StaticLangClientFileView;
 import com.google.api.codegen.viewmodel.ViewModel;
 import com.google.api.gax.core.RetrySettings;
 import com.google.api.tools.framework.aspects.documentation.model.DocumentationUtil;
@@ -61,6 +63,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -79,6 +82,7 @@ public class GoGapicSurfaceTransformer implements ModelToViewTransformer {
   private final PathTemplateTransformer pathTemplateTransformer = new PathTemplateTransformer();
   private final GrpcStubTransformer grpcStubTransformer = new GrpcStubTransformer();
   private final IamResourceTransformer iamResourceTransformer = new IamResourceTransformer();
+  private final FileHeaderTransformer fileHeaderTransformer = new FileHeaderTransformer();
   private final FeatureConfig featureConfig = new GoFeatureConfig();
   private final ServiceMessages serviceMessages = new ServiceMessages();
   private final GapicCodePathMapper pathMapper;
@@ -96,7 +100,6 @@ public class GoGapicSurfaceTransformer implements ModelToViewTransformer {
   public List<ViewModel> transform(Model model, ApiConfig apiConfig) {
     List<ViewModel> models = new ArrayList<ViewModel>();
     GoSurfaceNamer namer = new GoSurfaceNamer(apiConfig.getPackageName());
-    List<ServiceDocView> serviceDocs = new ArrayList<>();
     for (Interface service : new InterfaceView().getElementIterable(model)) {
       SurfaceTransformerContext context =
           SurfaceTransformerContext.create(
@@ -112,8 +115,8 @@ public class GoGapicSurfaceTransformer implements ModelToViewTransformer {
     return models;
   }
 
-  private StaticLangXCombinedSurfaceView generate(SurfaceTransformerContext context) {
-    StaticLangXCombinedSurfaceView.Builder view = StaticLangXCombinedSurfaceView.newBuilder();
+  private StaticLangClientFileView generate(SurfaceTransformerContext context) {
+    StaticLangClientFileView.Builder view = StaticLangClientFileView.newBuilder();
 
     SurfaceNamer namer = context.getNamer();
     Model model = context.getModel();
@@ -132,7 +135,7 @@ public class GoGapicSurfaceTransformer implements ModelToViewTransformer {
     view.servicePhraseName(namer.getServicePhraseName(service));
 
     String outputPath = pathMapper.getOutputPath(service, apiConfig);
-    String fileName = namer.getServiceFileName(service, apiConfig.getPackageName());
+    String fileName = namer.getServiceFileName(service);
     view.outputPath(outputPath + File.separator + fileName);
 
     List<RetryConfigDefinitionView> retryDef =
@@ -172,22 +175,21 @@ public class GoGapicSurfaceTransformer implements ModelToViewTransformer {
     return view.build();
   }
 
-  private StaticLangXExampleView generateExample(SurfaceTransformerContext context) {
-    StaticLangXExampleView.Builder view = StaticLangXExampleView.newBuilder();
+  private StaticLangClientExampleFileView generateExample(SurfaceTransformerContext context) {
+    StaticLangClientExampleFileView.Builder view = StaticLangClientExampleFileView.newBuilder();
 
     SurfaceNamer namer = context.getNamer();
-    Model model = context.getModel();
     Interface service = context.getInterface();
     ApiConfig apiConfig = context.getApiConfig();
 
     view.templateFileName(SAMPLE_TEMPLATE_FILENAME);
 
     String outputPath = pathMapper.getOutputPath(service, apiConfig);
-    String fileName = namer.getExampleFileName(service, apiConfig.getPackageName());
+    String fileName = namer.getExampleFileName(service);
     view.outputPath(outputPath + File.separator + fileName);
 
-    view.exampleLocalPackageName(namer.getExamplePackageName());
-    view.libLocalPackageName(namer.getLocalPackageName());
+    view.localExamplePackageName(namer.getLocalExamplePackageName());
+    view.localLibPackageName(namer.getLocalPackageName());
     view.clientTypeName(namer.getApiWrapperClassName(service));
     view.clientConstructorName(namer.getApiWrapperClassConstructorName(service));
     view.clientConstructorExampleName(namer.getApiWrapperClassConstructorExampleName(service));
@@ -212,17 +214,22 @@ public class GoGapicSurfaceTransformer implements ModelToViewTransformer {
     String outputPath = apiConfig.getPackageName();
     String fileName = "doc.go";
     String doc = model.getServiceConfig().getDocumentation().getSummary();
-    return PackageInfoView.newBuilder()
-        .templateFileName(DOC_TEMPLATE_FILENAME)
-        .outputPath(outputPath + File.separator + fileName)
-        .serviceTitle(model.getServiceConfig().getTitle())
-        .importPath(apiConfig.getPackageName())
-        .packageName(namer.getLocalPackageName())
-        .serviceDocs(Collections.<ServiceDocView>emptyList())
-        // TODO(pongad): GoContextCommon should be deleted after we convert Go discovery to MVMM.
-        .packageDoc(new GoContextCommon().getWrappedCommentLines(doc))
-        .domainLayerLocation(apiConfig.getDomainLayerLocation())
-        .build();
+    PackageInfoView.Builder packageInfo = PackageInfoView.newBuilder();
+
+    packageInfo.templateFileName(DOC_TEMPLATE_FILENAME);
+    packageInfo.outputPath(outputPath + File.separator + fileName);
+    packageInfo.serviceTitle(model.getServiceConfig().getTitle());
+    packageInfo.importPath(apiConfig.getPackageName());
+    packageInfo.serviceDocs(Collections.<ServiceDocView>emptyList());
+    // TODO(pongad): GoContextCommon should be deleted after we convert Go discovery to MVMM.
+    packageInfo.packageDoc(new GoContextCommon().getWrappedCommentLines(doc));
+    packageInfo.domainLayerLocation(apiConfig.getDomainLayerLocation());
+
+    packageInfo.fileHeader(
+        fileHeaderTransformer.generateFileHeader(
+            apiConfig, new HashMap<String, TypeAlias>(), namer));
+
+    return packageInfo.build();
   }
 
   @VisibleForTesting
@@ -298,17 +305,6 @@ public class GoGapicSurfaceTransformer implements ModelToViewTransformer {
       context.getTypeTable().saveNicknameFor("google.golang.org/grpc/codes;;;");
     }
     return new ArrayList<>(retryDef.values());
-  }
-
-  private Set<RetryConfigDefinitionView.Name> getRetryNames(SurfaceTransformerContext context) {
-    Set<RetryConfigDefinitionView.Name> retryNames = new HashSet<>();
-    for (Method method : context.getSupportedMethods()) {
-      MethodConfig conf = context.getMethodConfig(method);
-      retryNames.add(
-          RetryConfigDefinitionView.Name.create(
-              conf.getRetrySettingsConfigName(), conf.getRetryCodesConfigName()));
-    }
-    return retryNames;
   }
 
   private static final String EMPTY_PROTO_PKG = "github.com/golang/protobuf/ptypes/empty";

--- a/src/main/java/com/google/api/codegen/transformer/go/GoSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/go/GoSurfaceNamer.java
@@ -34,16 +34,18 @@ import java.util.List;
 public class GoSurfaceNamer extends SurfaceNamer {
 
   private final GoModelTypeNameConverter converter;
-  private final String packagePath;
 
-  public GoSurfaceNamer(String packagePath) {
-    this(new GoModelTypeNameConverter(), packagePath);
+  public GoSurfaceNamer(String packageName) {
+    this(new GoModelTypeNameConverter(), packageName);
   }
 
-  private GoSurfaceNamer(GoModelTypeNameConverter converter, String packagePath) {
-    super(new GoNameFormatter(), new ModelTypeFormatterImpl(converter), new GoTypeTable());
+  private GoSurfaceNamer(GoModelTypeNameConverter converter, String packageName) {
+    super(
+        new GoNameFormatter(),
+        new ModelTypeFormatterImpl(converter),
+        new GoTypeTable(),
+        packageName);
     this.converter = converter;
-    this.packagePath = packagePath;
   }
 
   @Override
@@ -143,12 +145,12 @@ public class GoSurfaceNamer extends SurfaceNamer {
   public String getLocalPackageName() {
     // packagePath is in form "cloud.google.com/go/library/apiv1";
     // we want "library".
-    String[] parts = packagePath.split("/");
+    String[] parts = getPackageName().split("/");
     return parts[parts.length - 2];
   }
 
   @Override
-  public String getExamplePackageName() {
+  public String getLocalExamplePackageName() {
     return getLocalPackageName() + "_test";
   }
 
@@ -182,12 +184,12 @@ public class GoSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getServiceFileName(Interface service, String packageName) {
+  public String getServiceFileName(Interface service) {
     return classFileNameBase(getReducedServiceName(service).join("client"));
   }
 
   @Override
-  public String getExampleFileName(Interface service, String packageName) {
+  public String getExampleFileName(Interface service) {
     return classFileNameBase(
         getReducedServiceName(service).join("client").join("example").join("test"));
   }

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
@@ -29,7 +29,7 @@ import com.google.api.codegen.metacode.InitCodeContext;
 import com.google.api.codegen.metacode.InitCodeContext.InitCodeOutputType;
 import com.google.api.codegen.metacode.InitCodeNode;
 import com.google.api.codegen.metacode.InitValueConfig;
-import com.google.api.codegen.transformer.ImportTypeTransformer;
+import com.google.api.codegen.transformer.FileHeaderTransformer;
 import com.google.api.codegen.transformer.InitCodeTransformer;
 import com.google.api.codegen.transformer.MethodTransformerContext;
 import com.google.api.codegen.transformer.ModelToViewTransformer;
@@ -42,6 +42,7 @@ import com.google.api.codegen.util.java.JavaTypeTable;
 import com.google.api.codegen.util.testing.JavaValueProducer;
 import com.google.api.codegen.util.testing.TestValueGenerator;
 import com.google.api.codegen.viewmodel.ApiMethodType;
+import com.google.api.codegen.viewmodel.FileHeaderView;
 import com.google.api.codegen.viewmodel.InitCodeView;
 import com.google.api.codegen.viewmodel.ViewModel;
 import com.google.api.codegen.viewmodel.testing.GapicSurfaceTestAssertView;
@@ -76,7 +77,7 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
 
   private final GapicCodePathMapper pathMapper;
   private final InitCodeTransformer initCodeTransformer;
-  private ImportTypeTransformer importTypeTransformer = new ImportTypeTransformer();
+  private final FileHeaderTransformer fileHeaderTransformer = new FileHeaderTransformer();
   private final TestValueGenerator valueGenerator = new TestValueGenerator(new JavaValueProducer());
 
   public JavaGapicSurfaceTestTransformer(GapicCodePathMapper javaPathMapper) {
@@ -132,19 +133,19 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
     MethodTransformerContext methodContext =
         context.asFlattenedMethodContext(method, flatteningGroup);
 
-    SmokeTestClassView testClass =
-        SmokeTestClassView.newBuilder()
-            .packageName(context.getApiConfig().getPackageName())
-            .apiSettingsClassName(namer.getApiSettingsClassName(service))
-            .apiClassName(namer.getApiWrapperClassName(service))
-            .name(name)
-            .outputPath(namer.getSourceFilePath(outputPath, name))
-            .templateFileName(SMOKE_TEST_TEMPLATE_FILE)
-            .method(createSmokeTestMethodView(methodContext))
-            // Imports must be done as the last step to catch all imports.
-            .imports(importTypeTransformer.generateImports(context.getTypeTable().getImports()))
-            .build();
-    return testClass;
+    SmokeTestClassView.Builder testClass = SmokeTestClassView.newBuilder();
+    testClass.apiSettingsClassName(namer.getApiSettingsClassName(service));
+    testClass.apiClassName(namer.getApiWrapperClassName(service));
+    testClass.name(name);
+    testClass.outputPath(namer.getSourceFilePath(outputPath, name));
+    testClass.templateFileName(SMOKE_TEST_TEMPLATE_FILE);
+    testClass.method(createSmokeTestMethodView(methodContext));
+
+    // Imports must be done as the last step to catch all imports.
+    FileHeaderView fileHeader = fileHeaderTransformer.generateFileHeader(context);
+    testClass.fileHeader(fileHeader);
+
+    return testClass.build();
   }
 
   private TestMethodView createSmokeTestMethodView(MethodTransformerContext context) {
@@ -212,20 +213,20 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
     SurfaceNamer namer = context.getNamer();
     String name = namer.getUnitTestClassName(service);
 
-    GapicSurfaceTestClassView testClass =
-        GapicSurfaceTestClassView.newBuilder()
-            .packageName(context.getApiConfig().getPackageName())
-            .apiSettingsClassName(namer.getApiSettingsClassName(service))
-            .apiClassName(namer.getApiWrapperClassName(service))
-            .name(name)
-            .testCases(createTestCaseViews(context))
-            .mockServices(createMockServices(context))
-            .outputPath(namer.getSourceFilePath(outputPath, name))
-            .templateFileName(UNIT_TEST_TEMPLATE_FILE)
-            // Imports must be done as the last step to catch all imports.
-            .imports(importTypeTransformer.generateImports(context.getTypeTable().getImports()))
-            .build();
-    return testClass;
+    GapicSurfaceTestClassView.Builder testClass = GapicSurfaceTestClassView.newBuilder();
+    testClass.apiSettingsClassName(namer.getApiSettingsClassName(service));
+    testClass.apiClassName(namer.getApiWrapperClassName(service));
+    testClass.name(name);
+    testClass.testCases(createTestCaseViews(context));
+    testClass.mockServices(createMockServices(context));
+    testClass.outputPath(namer.getSourceFilePath(outputPath, name));
+    testClass.templateFileName(UNIT_TEST_TEMPLATE_FILE);
+
+    // Imports must be done as the last step to catch all imports.
+    FileHeaderView fileHeader = fileHeaderTransformer.generateFileHeader(context);
+    testClass.fileHeader(fileHeader);
+
+    return testClass.build();
   }
 
   private List<GapicSurfaceTestCaseView> createTestCaseViews(SurfaceTransformerContext context) {
@@ -482,15 +483,19 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
     SurfaceNamer namer = context.getNamer();
     String outputPath = pathMapper.getOutputPath(service, context.getApiConfig());
     String name = namer.getMockServiceClassName(context.getInterface());
-    return MockServiceView.newBuilder()
-        .name(name)
-        .serviceImplClassName(namer.getMockGrpcServiceImplName(context.getInterface()))
-        .packageName(context.getApiConfig().getPackageName())
-        .outputPath(namer.getSourceFilePath(outputPath, name))
-        .templateFileName(MOCK_SERVICE_FILE)
-        // Imports must be done as the last step to catch all imports.
-        .imports(importTypeTransformer.generateImports(context.getTypeTable().getImports()))
-        .build();
+
+    MockServiceView.Builder mockService = MockServiceView.newBuilder();
+
+    mockService.name(name);
+    mockService.serviceImplClassName(namer.getMockGrpcServiceImplName(context.getInterface()));
+    mockService.outputPath(namer.getSourceFilePath(outputPath, name));
+    mockService.templateFileName(MOCK_SERVICE_FILE);
+
+    // Imports must be done as the last step to catch all imports.
+    FileHeaderView fileHeader = fileHeaderTransformer.generateFileHeader(context);
+    mockService.fileHeader(fileHeader);
+
+    return mockService.build();
   }
 
   private MockServiceImplView createMockServiceImplView(SurfaceTransformerContext context) {
@@ -502,16 +507,20 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
     String name = namer.getMockGrpcServiceImplName(context.getInterface());
     String grpcClassName =
         context.getTypeTable().getAndSaveNicknameFor(namer.getGrpcServiceClassName(service));
-    return MockServiceImplView.newBuilder()
-        .name(name)
-        .packageName(context.getApiConfig().getPackageName())
-        .grpcMethods(createGrpcMethodViews(context))
-        .grpcClassName(grpcClassName)
-        .outputPath(namer.getSourceFilePath(outputPath, name))
-        .templateFileName(MOCK_SERVICE_IMPL_FILE)
-        // Imports must be done as the last step to catch all imports.
-        .imports(importTypeTransformer.generateImports(context.getTypeTable().getImports()))
-        .build();
+
+    MockServiceImplView.Builder mockServiceImpl = MockServiceImplView.newBuilder();
+
+    mockServiceImpl.name(name);
+    mockServiceImpl.grpcMethods(createGrpcMethodViews(context));
+    mockServiceImpl.grpcClassName(grpcClassName);
+    mockServiceImpl.outputPath(namer.getSourceFilePath(outputPath, name));
+    mockServiceImpl.templateFileName(MOCK_SERVICE_IMPL_FILE);
+
+    // Imports must be done as the last step to catch all imports.
+    FileHeaderView fileHeader = fileHeaderTransformer.generateFileHeader(context);
+    mockServiceImpl.fileHeader(fileHeader);
+
+    return mockServiceImpl.build();
   }
 
   private List<MockGrpcMethodView> createGrpcMethodViews(SurfaceTransformerContext context) {

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceNamer.java
@@ -34,11 +34,12 @@ import java.util.List;
 /** The SurfaceNamer for Java. */
 public class JavaSurfaceNamer extends SurfaceNamer {
 
-  public JavaSurfaceNamer(String implicitPackageName) {
+  public JavaSurfaceNamer(String packageName) {
     super(
         new JavaNameFormatter(),
-        new ModelTypeFormatterImpl(new JavaModelTypeNameConverter(implicitPackageName)),
-        new JavaTypeTable(implicitPackageName));
+        new ModelTypeFormatterImpl(new JavaModelTypeNameConverter(packageName)),
+        new JavaTypeTable(packageName),
+        packageName);
   }
 
   @Override
@@ -138,7 +139,7 @@ public class JavaSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getFullyQualifiedApiWrapperClassName(Interface service, String packageName) {
-    return packageName + "." + getApiWrapperClassName(service);
+  public String getFullyQualifiedApiWrapperClassName(Interface service) {
+    return getPackageName() + "." + getApiWrapperClassName(service);
   }
 }

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSSurfaceNamer.java
@@ -32,11 +32,12 @@ import java.util.List;
 
 /** The SurfaceNamer for NodeJS. */
 public class NodeJSSurfaceNamer extends SurfaceNamer {
-  public NodeJSSurfaceNamer(String implicitPackageName) {
+  public NodeJSSurfaceNamer(String packageName) {
     super(
         new NodeJSNameFormatter(),
-        new ModelTypeFormatterImpl(new NodeJSModelTypeNameConverter(implicitPackageName)),
-        new NodeJSTypeTable(implicitPackageName));
+        new ModelTypeFormatterImpl(new NodeJSModelTypeNameConverter(packageName)),
+        new NodeJSTypeTable(packageName),
+        packageName);
   }
 
   /**

--- a/src/main/java/com/google/api/codegen/transformer/php/PhpSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpSurfaceNamer.java
@@ -30,11 +30,12 @@ import com.google.api.tools.framework.model.TypeRef;
 
 /** The SurfaceNamer for PHP. */
 public class PhpSurfaceNamer extends SurfaceNamer {
-  public PhpSurfaceNamer(String implicitPackageName) {
+  public PhpSurfaceNamer(String packageName) {
     super(
         new PhpNameFormatter(),
-        new ModelTypeFormatterImpl(new PhpModelTypeNameConverter(implicitPackageName)),
-        new PhpTypeTable(implicitPackageName));
+        new ModelTypeFormatterImpl(new PhpModelTypeNameConverter(packageName)),
+        new PhpTypeTable(packageName),
+        packageName);
   }
 
   @Override
@@ -90,7 +91,7 @@ public class PhpSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getFullyQualifiedApiWrapperClassName(Interface service, String packageName) {
-    return packageName + "\\" + getApiWrapperClassName(service);
+  public String getFullyQualifiedApiWrapperClassName(Interface service) {
+    return getPackageName() + "\\" + getApiWrapperClassName(service);
   }
 }

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubySurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubySurfaceNamer.java
@@ -29,11 +29,12 @@ import java.util.List;
 
 /** The SurfaceNamer for Ruby. */
 public class RubySurfaceNamer extends SurfaceNamer {
-  public RubySurfaceNamer(String implicitPackageName) {
+  public RubySurfaceNamer(String packageName) {
     super(
         new RubyNameFormatter(),
-        new ModelTypeFormatterImpl(new RubyModelTypeNameConverter(implicitPackageName)),
-        new RubyTypeTable(implicitPackageName));
+        new ModelTypeFormatterImpl(new RubyModelTypeNameConverter(packageName)),
+        new RubyTypeTable(packageName),
+        packageName);
   }
 
   /** The function name to set a field having the given type and name. */
@@ -66,8 +67,8 @@ public class RubySurfaceNamer extends SurfaceNamer {
 
   /** The file name for an API service. */
   @Override
-  public String getServiceFileName(Interface service, String packageName) {
-    String[] names = packageName.split("::");
+  public String getServiceFileName(Interface service) {
+    String[] names = getPackageName().split("::");
     List<String> newNames = new ArrayList<>();
     for (String name : names) {
       newNames.add(packageFilePathPiece(Name.upperCamel(name)));
@@ -77,8 +78,8 @@ public class RubySurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getFullyQualifiedApiWrapperClassName(Interface service, String packageName) {
-    return packageName + "::" + getApiWrapperClassName(service);
+  public String getFullyQualifiedApiWrapperClassName(Interface service) {
+    return getPackageName() + "::" + getApiWrapperClassName(service);
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/viewmodel/FileHeaderView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/FileHeaderView.java
@@ -1,0 +1,60 @@
+/* Copyright 2016 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.viewmodel;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+
+@AutoValue
+public abstract class FileHeaderView {
+
+  public abstract ImmutableList<String> copyrightLines();
+
+  public abstract ImmutableList<String> licenseLines();
+
+  public abstract String packageName();
+
+  public abstract String examplePackageName();
+
+  public abstract String localPackageName();
+
+  public abstract String localExamplePackageName();
+
+  public abstract List<ImportTypeView> imports();
+
+  public static Builder newBuilder() {
+    return new AutoValue_FileHeaderView.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder copyrightLines(ImmutableList<String> val);
+
+    public abstract Builder licenseLines(ImmutableList<String> val);
+
+    public abstract Builder packageName(String val);
+
+    public abstract Builder examplePackageName(String val);
+
+    public abstract Builder localPackageName(String val);
+
+    public abstract Builder localExamplePackageName(String val);
+
+    public abstract Builder imports(List<ImportTypeView> val);
+
+    public abstract FileHeaderView build();
+  }
+}

--- a/src/main/java/com/google/api/codegen/viewmodel/PackageInfoView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/PackageInfoView.java
@@ -27,11 +27,11 @@ public abstract class PackageInfoView implements ViewModel {
   @Override
   public abstract String outputPath();
 
+  public abstract FileHeaderView fileHeader();
+
   public abstract String serviceTitle();
 
   public abstract List<ServiceDocView> serviceDocs();
-
-  public abstract String packageName();
 
   public abstract String domainLayerLocation();
 
@@ -56,11 +56,11 @@ public abstract class PackageInfoView implements ViewModel {
 
     public abstract Builder outputPath(String val);
 
+    public abstract Builder fileHeader(FileHeaderView val);
+
     public abstract Builder serviceTitle(String val);
 
     public abstract Builder serviceDocs(List<ServiceDocView> val);
-
-    public abstract Builder packageName(String val);
 
     public abstract Builder domainLayerLocation(String val);
 

--- a/src/main/java/com/google/api/codegen/viewmodel/SnippetsFileView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/SnippetsFileView.java
@@ -29,12 +29,10 @@ public abstract class SnippetsFileView implements ViewModel {
   @Override
   public abstract String templateFileName();
 
+  public abstract FileHeaderView fileHeader();
+
   @Override
   public abstract String outputPath();
-
-  public abstract List<ImportTypeView> imports();
-
-  public abstract String packageName();
 
   public abstract String name();
 
@@ -48,11 +46,9 @@ public abstract class SnippetsFileView implements ViewModel {
   public abstract static class Builder {
     public abstract Builder templateFileName(String val);
 
+    public abstract Builder fileHeader(FileHeaderView val);
+
     public abstract Builder outputPath(String val);
-
-    public abstract Builder imports(List<ImportTypeView> val);
-
-    public abstract Builder packageName(String val);
 
     public abstract Builder name(String val);
 

--- a/src/main/java/com/google/api/codegen/viewmodel/StaticLangApiAndSettingsFileView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/StaticLangApiAndSettingsFileView.java
@@ -12,50 +12,49 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.api.codegen.viewmodel.testing;
+package com.google.api.codegen.viewmodel;
 
 import com.google.api.codegen.SnippetSetRunner;
-import com.google.api.codegen.viewmodel.FileHeaderView;
-import com.google.api.codegen.viewmodel.ViewModel;
+import com.google.api.codegen.viewmodel.StaticLangSettingsFileView.Builder;
 import com.google.auto.value.AutoValue;
 
+// View of both api and settings for static language.
+// ViewModel members delegate to api.
 @AutoValue
-public abstract class MockServiceView implements ViewModel {
+public abstract class StaticLangApiAndSettingsFileView implements ViewModel {
+  @Override
+  public abstract String templateFileName();
 
   public abstract FileHeaderView fileHeader();
 
-  public abstract String name();
+  public abstract StaticLangApiView api();
 
-  public abstract String serviceImplClassName();
+  public abstract StaticLangSettingsView settings();
+
+  @Override
+  public abstract String outputPath();
 
   @Override
   public String resourceRoot() {
     return SnippetSetRunner.SNIPPET_RESOURCE_ROOT;
   }
 
-  @Override
-  public abstract String templateFileName();
-
-  @Override
-  public abstract String outputPath();
-
   public static Builder newBuilder() {
-    return new AutoValue_MockServiceView.Builder();
+    return new AutoValue_StaticLangApiAndSettingsFileView.Builder();
   }
 
   @AutoValue.Builder
   public abstract static class Builder {
+    public abstract Builder templateFileName(String val);
 
     public abstract Builder fileHeader(FileHeaderView val);
 
-    public abstract Builder name(String val);
-
-    public abstract Builder serviceImplClassName(String val);
-
     public abstract Builder outputPath(String val);
 
-    public abstract Builder templateFileName(String val);
+    public abstract Builder api(StaticLangApiView val);
 
-    public abstract MockServiceView build();
+    public abstract Builder settings(StaticLangSettingsView val);
+
+    public abstract StaticLangApiAndSettingsFileView build();
   }
 }

--- a/src/main/java/com/google/api/codegen/viewmodel/StaticLangApiFileView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/StaticLangApiFileView.java
@@ -14,41 +14,40 @@
  */
 package com.google.api.codegen.viewmodel;
 
+import com.google.api.codegen.SnippetSetRunner;
 import com.google.auto.value.AutoValue;
 
-// View of both api and settings for static language.
-// ViewModel members delegate to api.
 @AutoValue
-public abstract class StaticLangXCommonView implements ViewModel {
-  public abstract StaticLangXApiView api();
+public abstract class StaticLangApiFileView implements ViewModel {
+  @Override
+  public abstract String templateFileName();
 
-  public abstract StaticLangXSettingsView settings();
+  public abstract FileHeaderView fileHeader();
 
-  public static Builder newBuilder() {
-    return new AutoValue_StaticLangXCommonView.Builder();
-  }
+  public abstract StaticLangApiView api();
+
+  @Override
+  public abstract String outputPath();
 
   @Override
   public String resourceRoot() {
-    return api().resourceRoot();
+    return SnippetSetRunner.SNIPPET_RESOURCE_ROOT;
   }
 
-  @Override
-  public String templateFileName() {
-    return api().templateFileName();
-  }
-
-  @Override
-  public String outputPath() {
-    return api().outputPath();
+  public static Builder newBuilder() {
+    return new AutoValue_StaticLangApiFileView.Builder();
   }
 
   @AutoValue.Builder
   public abstract static class Builder {
-    public abstract Builder api(StaticLangXApiView val);
+    public abstract Builder templateFileName(String val);
 
-    public abstract Builder settings(StaticLangXSettingsView val);
+    public abstract Builder fileHeader(FileHeaderView val);
 
-    public abstract StaticLangXCommonView build();
+    public abstract Builder outputPath(String val);
+
+    public abstract Builder api(StaticLangApiView val);
+
+    public abstract StaticLangApiFileView build();
   }
 }

--- a/src/main/java/com/google/api/codegen/viewmodel/StaticLangApiView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/StaticLangApiView.java
@@ -14,18 +14,12 @@
  */
 package com.google.api.codegen.viewmodel;
 
-import com.google.api.codegen.SnippetSetRunner;
 import com.google.auto.value.AutoValue;
 import java.util.List;
 import javax.annotation.Nullable;
 
 @AutoValue
-public abstract class StaticLangXApiView implements ViewModel {
-  @Override
-  public abstract String templateFileName();
-
-  public abstract String packageName();
-
+public abstract class StaticLangApiView {
   public abstract ServiceDocView doc();
 
   public abstract String name();
@@ -59,25 +53,12 @@ public abstract class StaticLangXApiView implements ViewModel {
 
   public abstract boolean hasDefaultInstance();
 
-  public abstract List<ImportTypeView> imports();
-
-  @Override
-  public abstract String outputPath();
-
-  @Override
-  public String resourceRoot() {
-    return SnippetSetRunner.SNIPPET_RESOURCE_ROOT;
-  }
-
   public static Builder newBuilder() {
-    return new AutoValue_StaticLangXApiView.Builder();
+    return new AutoValue_StaticLangApiView.Builder();
   }
 
   @AutoValue.Builder
   public abstract static class Builder {
-    public abstract Builder templateFileName(String val);
-
-    public abstract Builder packageName(String val);
 
     public abstract Builder doc(ServiceDocView val);
 
@@ -107,10 +88,6 @@ public abstract class StaticLangXApiView implements ViewModel {
 
     public abstract Builder hasDefaultInstance(boolean val);
 
-    public abstract Builder imports(List<ImportTypeView> val);
-
-    public abstract Builder outputPath(String val);
-
-    public abstract StaticLangXApiView build();
+    public abstract StaticLangApiView build();
   }
 }

--- a/src/main/java/com/google/api/codegen/viewmodel/StaticLangClientExampleFileView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/StaticLangClientExampleFileView.java
@@ -20,7 +20,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 
 @AutoValue
-public abstract class StaticLangXExampleView implements ViewModel {
+public abstract class StaticLangClientExampleFileView implements ViewModel {
   @Override
   public abstract String templateFileName();
 
@@ -33,10 +33,10 @@ public abstract class StaticLangXExampleView implements ViewModel {
   }
 
   /** The package name of the example */
-  public abstract String exampleLocalPackageName();
+  public abstract String localExamplePackageName();
 
   /** The package name of the library */
-  public abstract String libLocalPackageName();
+  public abstract String localLibPackageName();
 
   /** The name of the constructor of the client */
   public abstract String clientConstructorName();
@@ -58,7 +58,7 @@ public abstract class StaticLangXExampleView implements ViewModel {
   public abstract List<IamResourceView> iamResources();
 
   public static Builder newBuilder() {
-    return new AutoValue_StaticLangXExampleView.Builder();
+    return new AutoValue_StaticLangClientExampleFileView.Builder();
   }
 
   @AutoValue.Builder
@@ -67,9 +67,9 @@ public abstract class StaticLangXExampleView implements ViewModel {
 
     public abstract Builder outputPath(String val);
 
-    public abstract Builder exampleLocalPackageName(String val);
+    public abstract Builder localExamplePackageName(String val);
 
-    public abstract Builder libLocalPackageName(String val);
+    public abstract Builder localLibPackageName(String val);
 
     public abstract Builder clientConstructorName(String val);
 
@@ -83,6 +83,6 @@ public abstract class StaticLangXExampleView implements ViewModel {
 
     public abstract Builder iamResources(List<IamResourceView> val);
 
-    public abstract StaticLangXExampleView build();
+    public abstract StaticLangClientExampleFileView build();
   }
 }

--- a/src/main/java/com/google/api/codegen/viewmodel/StaticLangClientFileView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/StaticLangClientFileView.java
@@ -19,7 +19,7 @@ import com.google.auto.value.AutoValue;
 import java.util.List;
 
 @AutoValue
-public abstract class StaticLangXCombinedSurfaceView implements ViewModel {
+public abstract class StaticLangClientFileView implements ViewModel {
   @Override
   public abstract String templateFileName();
 
@@ -74,7 +74,7 @@ public abstract class StaticLangXCombinedSurfaceView implements ViewModel {
   public abstract List<PageStreamingDescriptorClassView> pageStreamingDescriptorClasses();
 
   public static Builder newBuilder() {
-    return new AutoValue_StaticLangXCombinedSurfaceView.Builder();
+    return new AutoValue_StaticLangClientFileView.Builder();
   }
 
   @AutoValue.Builder
@@ -127,6 +127,6 @@ public abstract class StaticLangXCombinedSurfaceView implements ViewModel {
     public abstract Builder pageStreamingDescriptorClasses(
         List<PageStreamingDescriptorClassView> val);
 
-    public abstract StaticLangXCombinedSurfaceView build();
+    public abstract StaticLangClientFileView build();
   }
 }

--- a/src/main/java/com/google/api/codegen/viewmodel/StaticLangPagedResponseWrappersView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/StaticLangPagedResponseWrappersView.java
@@ -15,6 +15,7 @@
 package com.google.api.codegen.viewmodel;
 
 import com.google.api.codegen.SnippetSetRunner;
+import com.google.api.codegen.viewmodel.StaticLangApiView.Builder;
 import com.google.auto.value.AutoValue;
 import java.util.List;
 
@@ -23,11 +24,9 @@ public abstract class StaticLangPagedResponseWrappersView implements ViewModel {
   @Override
   public abstract String templateFileName();
 
-  public abstract String packageName();
+  public abstract FileHeaderView fileHeader();
 
   public abstract String name();
-
-  public abstract List<ImportTypeView> imports();
 
   public abstract List<StaticLangPagedResponseView> pagedResponseWrapperList();
 
@@ -47,11 +46,9 @@ public abstract class StaticLangPagedResponseWrappersView implements ViewModel {
   public abstract static class Builder {
     public abstract Builder templateFileName(String val);
 
-    public abstract Builder packageName(String val);
+    public abstract Builder fileHeader(FileHeaderView val);
 
     public abstract Builder name(String val);
-
-    public abstract Builder imports(List<ImportTypeView> val);
 
     public abstract Builder pagedResponseWrapperList(List<StaticLangPagedResponseView> val);
 

--- a/src/main/java/com/google/api/codegen/viewmodel/StaticLangSettingsFileView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/StaticLangSettingsFileView.java
@@ -12,50 +12,43 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.api.codegen.viewmodel.testing;
+package com.google.api.codegen.viewmodel;
 
 import com.google.api.codegen.SnippetSetRunner;
-import com.google.api.codegen.viewmodel.FileHeaderView;
-import com.google.api.codegen.viewmodel.ViewModel;
+import com.google.api.codegen.viewmodel.StaticLangSettingsView.Builder;
 import com.google.auto.value.AutoValue;
 
 @AutoValue
-public abstract class MockServiceView implements ViewModel {
+public abstract class StaticLangSettingsFileView implements ViewModel {
+  @Override
+  public abstract String templateFileName();
 
   public abstract FileHeaderView fileHeader();
 
-  public abstract String name();
+  public abstract StaticLangSettingsView settings();
 
-  public abstract String serviceImplClassName();
+  @Override
+  public abstract String outputPath();
 
   @Override
   public String resourceRoot() {
     return SnippetSetRunner.SNIPPET_RESOURCE_ROOT;
   }
 
-  @Override
-  public abstract String templateFileName();
-
-  @Override
-  public abstract String outputPath();
-
   public static Builder newBuilder() {
-    return new AutoValue_MockServiceView.Builder();
+    return new AutoValue_StaticLangSettingsFileView.Builder();
   }
 
   @AutoValue.Builder
   public abstract static class Builder {
+    public abstract Builder templateFileName(String val);
 
     public abstract Builder fileHeader(FileHeaderView val);
 
-    public abstract Builder name(String val);
-
-    public abstract Builder serviceImplClassName(String val);
-
     public abstract Builder outputPath(String val);
 
-    public abstract Builder templateFileName(String val);
+    public abstract Builder settings(StaticLangSettingsView val);
 
-    public abstract MockServiceView build();
+    public abstract StaticLangSettingsFileView build();
   }
 }

--- a/src/main/java/com/google/api/codegen/viewmodel/StaticLangSettingsView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/StaticLangSettingsView.java
@@ -14,17 +14,12 @@
  */
 package com.google.api.codegen.viewmodel;
 
-import com.google.api.codegen.SnippetSetRunner;
 import com.google.auto.value.AutoValue;
 import java.util.List;
 import javax.annotation.Nullable;
 
 @AutoValue
-public abstract class StaticLangXSettingsView implements ViewModel {
-  @Override
-  public abstract String templateFileName();
-
-  public abstract String packageName();
+public abstract class StaticLangSettingsView {
 
   public abstract SettingsDocView doc();
 
@@ -57,25 +52,12 @@ public abstract class StaticLangXSettingsView implements ViewModel {
 
   public abstract boolean hasDefaultInstance();
 
-  public abstract List<ImportTypeView> imports();
-
-  @Override
-  public abstract String outputPath();
-
-  @Override
-  public String resourceRoot() {
-    return SnippetSetRunner.SNIPPET_RESOURCE_ROOT;
-  }
-
   public static Builder newBuilder() {
-    return new AutoValue_StaticLangXSettingsView.Builder();
+    return new AutoValue_StaticLangSettingsView.Builder();
   }
 
   @AutoValue.Builder
   public abstract static class Builder {
-    public abstract Builder templateFileName(String val);
-
-    public abstract Builder packageName(String val);
 
     public abstract Builder doc(SettingsDocView generateSettingsDoc);
 
@@ -102,16 +84,12 @@ public abstract class StaticLangXSettingsView implements ViewModel {
 
     public abstract Builder retryParamsDefinitions(List<RetryParamsDefinitionView> val);
 
-    public abstract Builder imports(List<ImportTypeView> val);
-
-    public abstract Builder outputPath(String val);
-
     public abstract Builder hasDefaultServiceAddress(boolean hasDefaultServiceAddress);
 
     public abstract Builder hasDefaultServiceScopes(boolean hasDefaultServiceScopes);
 
     public abstract Builder hasDefaultInstance(boolean hasDefaultInstance);
 
-    public abstract StaticLangXSettingsView build();
+    public abstract StaticLangSettingsView build();
   }
 }

--- a/src/main/java/com/google/api/codegen/viewmodel/testing/GapicSurfaceTestClassView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/testing/GapicSurfaceTestClassView.java
@@ -15,14 +15,16 @@
 package com.google.api.codegen.viewmodel.testing;
 
 import com.google.api.codegen.SnippetSetRunner;
-import com.google.api.codegen.viewmodel.ImportTypeView;
+import com.google.api.codegen.viewmodel.FileHeaderView;
 import com.google.api.codegen.viewmodel.ViewModel;
+import com.google.api.codegen.viewmodel.testing.MockServiceImplView.Builder;
 import com.google.auto.value.AutoValue;
 import java.util.List;
 
 @AutoValue
 public abstract class GapicSurfaceTestClassView implements ViewModel {
-  public abstract String packageName();
+
+  public abstract FileHeaderView fileHeader();
 
   public abstract String name();
 
@@ -31,8 +33,6 @@ public abstract class GapicSurfaceTestClassView implements ViewModel {
   public abstract String apiSettingsClassName();
 
   public abstract List<MockServiceUsageView> mockServices();
-
-  public abstract List<ImportTypeView> imports();
 
   public abstract List<GapicSurfaceTestCaseView> testCases();
 
@@ -53,11 +53,10 @@ public abstract class GapicSurfaceTestClassView implements ViewModel {
 
   @AutoValue.Builder
   public abstract static class Builder {
-    public abstract Builder packageName(String val);
+
+    public abstract Builder fileHeader(FileHeaderView val);
 
     public abstract Builder name(String val);
-
-    public abstract Builder imports(List<ImportTypeView> val);
 
     public abstract Builder apiClassName(String val);
 

--- a/src/main/java/com/google/api/codegen/viewmodel/testing/MockServiceImplView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/testing/MockServiceImplView.java
@@ -15,7 +15,7 @@
 package com.google.api.codegen.viewmodel.testing;
 
 import com.google.api.codegen.SnippetSetRunner;
-import com.google.api.codegen.viewmodel.ImportTypeView;
+import com.google.api.codegen.viewmodel.FileHeaderView;
 import com.google.api.codegen.viewmodel.ViewModel;
 import com.google.auto.value.AutoValue;
 import java.util.List;
@@ -23,13 +23,11 @@ import java.util.List;
 @AutoValue
 public abstract class MockServiceImplView implements ViewModel {
 
-  public abstract String packageName();
+  public abstract FileHeaderView fileHeader();
 
   public abstract String name();
 
   public abstract String grpcClassName();
-
-  public abstract List<ImportTypeView> imports();
 
   public abstract List<MockGrpcMethodView> grpcMethods();
 
@@ -50,13 +48,12 @@ public abstract class MockServiceImplView implements ViewModel {
 
   @AutoValue.Builder
   public abstract static class Builder {
-    public abstract Builder packageName(String val);
+
+    public abstract Builder fileHeader(FileHeaderView val);
 
     public abstract Builder name(String val);
 
     public abstract Builder grpcClassName(String val);
-
-    public abstract Builder imports(List<ImportTypeView> val);
 
     public abstract Builder outputPath(String val);
 

--- a/src/main/java/com/google/api/codegen/viewmodel/testing/SmokeTestClassView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/testing/SmokeTestClassView.java
@@ -15,22 +15,21 @@
 package com.google.api.codegen.viewmodel.testing;
 
 import com.google.api.codegen.SnippetSetRunner;
-import com.google.api.codegen.viewmodel.ImportTypeView;
+import com.google.api.codegen.viewmodel.FileHeaderView;
 import com.google.api.codegen.viewmodel.ViewModel;
+import com.google.api.codegen.viewmodel.testing.MockServiceView.Builder;
 import com.google.auto.value.AutoValue;
-import java.util.List;
 
 @AutoValue
 public abstract class SmokeTestClassView implements ViewModel {
-  public abstract String packageName();
+
+  public abstract FileHeaderView fileHeader();
 
   public abstract String name();
 
   public abstract String apiClassName();
 
   public abstract String apiSettingsClassName();
-
-  public abstract List<ImportTypeView> imports();
 
   public abstract TestMethodView method();
 
@@ -51,11 +50,10 @@ public abstract class SmokeTestClassView implements ViewModel {
 
   @AutoValue.Builder
   public abstract static class Builder {
-    public abstract Builder packageName(String val);
+
+    public abstract Builder fileHeader(FileHeaderView val);
 
     public abstract Builder name(String val);
-
-    public abstract Builder imports(List<ImportTypeView> val);
 
     public abstract Builder apiClassName(String val);
 

--- a/src/main/proto/com/google/api/codegen/config.proto
+++ b/src/main/proto/com/google/api/codegen/config.proto
@@ -77,6 +77,9 @@ message ConfigProto {
   // The configuration to create the providers.
   GeneratorProto generator = 6;
 
+  // The configuration for the license header to put on generated files.
+  LicenseHeaderProto license_header = 7;
+
   // A list of API interface configurations.
   repeated InterfaceConfigProto interfaces = 10;
 }
@@ -88,6 +91,14 @@ message LanguageSettingsProto {
   // Location of the domain layer, if any, that the user should use
   // instead of the generated client.
   string domain_layer_location = 2;
+}
+
+message LicenseHeaderProto {
+  // The file containing the copyright line(s).
+  string copyright_file = 1;
+
+  // The file containing the raw license header without any copyright line(s).
+  string license_file = 2;
 }
 
 message GeneratorProto {

--- a/src/main/resources/com/google/api/codegen/copyright-google.txt
+++ b/src/main/resources/com/google/api/codegen/copyright-google.txt
@@ -1,0 +1,1 @@
+Copyright 2016, Google Inc. All rights reserved.

--- a/src/main/resources/com/google/api/codegen/csharp/common.snip
+++ b/src/main/resources/com/google/api/codegen/csharp/common.snip
@@ -1,3 +1,20 @@
+@snippet renderFileHeader(fileHeader)
+    @join line : fileHeader.copyrightLines
+      // {@line}
+    @end
+
+    //
+    @join line : fileHeader.licenseLines
+      // {@line}
+    @end
+
+    // Generated code. DO NOT EDIT!
+
+    @join import : fileHeader.imports
+        using {@import.fullName};
+    @end
+@end
+
 @snippet xmlDoc(doc)
     /// <summary>
     @join line : doc.mainDocLines

--- a/src/main/resources/com/google/api/codegen/csharp/gapic_client.snip
+++ b/src/main/resources/com/google/api/codegen/csharp/gapic_client.snip
@@ -1,27 +1,9 @@
 @extends "csharp/common.snip"
 
 @snippet generate(common)
-    // Copyright 2016 Google Inc. All Rights Reserved.
-    //
-    // Licensed under the Apache License, Version 2.0 (the "License");
-    // you may not use this file except in compliance with the License.
-    // You may obtain a copy of the License at
-    //
-    //     http://www.apache.org/licenses/LICENSE-2.0
-    //
-    // Unless required by applicable law or agreed to in writing, software
-    // distributed under the License is distributed on an "AS IS" BASIS,
-    // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    // See the License for the specific language governing permissions and
-    // limitations under the License.
+    {@renderFileHeader(common.fileHeader)}
 
-    // Generated code. DO NOT EDIT!
-
-    @join import : common.api.imports
-        using {@import.fullName};
-    @end
-
-    namespace {@common.api.packageName}
+    namespace {@common.fileHeader.packageName}
     {
         {@settings(common.api, common.settings)}
 

--- a/src/main/resources/com/google/api/codegen/csharp/gapic_snippets.snip
+++ b/src/main/resources/com/google/api/codegen/csharp/gapic_snippets.snip
@@ -1,27 +1,9 @@
 @extends "csharp/common.snip"
 
 @snippet generate(snippets)
-    // Copyright 2016 Google Inc. All Rights Reserved.
-    //
-    // Licensed under the Apache License, Version 2.0 (the "License");
-    // you may not use this file except in compliance with the License.
-    // You may obtain a copy of the License at
-    //
-    //     http://www.apache.org/licenses/LICENSE-2.0
-    //
-    // Unless required by applicable law or agreed to in writing, software
-    // distributed under the License is distributed on an "AS IS" BASIS,
-    // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    // See the License for the specific language governing permissions and
-    // limitations under the License.
+    {@renderFileHeader(snippets.fileHeader)}
 
-    // Generated code. DO NOT EDIT!
-
-    @join import : snippets.imports
-        using {@import.fullName};
-    @end
-
-    namespace {@snippets.packageName}
+    namespace {@snippets.fileHeader.examplePackageName}
     {
         {@renderSnippets(snippets)}
     }

--- a/src/main/resources/com/google/api/codegen/go/doc.snip
+++ b/src/main/resources/com/google/api/codegen/go/doc.snip
@@ -3,8 +3,8 @@
 @snippet generate(view)
     {@headerComment()}
 
-    // Package {@view.packageName} is an experimental, auto-generated package for the
-    // {@view.packageName} API.
+    // Package {@view.fileHeader.localPackageName} is an experimental, auto-generated package for the
+    // {@view.fileHeader.localPackageName} API.
     //
     @join line : view.packageDoc
         {@line}
@@ -13,7 +13,7 @@
         //
         // Use the client at {@view.domainLayerLocation} in preference to this.
     @end
-    package {@view.packageName} // import "{@view.importPath}"
+    package {@view.fileHeader.localPackageName} // import "{@view.importPath}"
 
     const gapicNameVersion = "gapic/0.1.0"
 @end

--- a/src/main/resources/com/google/api/codegen/go/example.snip
+++ b/src/main/resources/com/google/api/codegen/go/example.snip
@@ -3,7 +3,7 @@
 @snippet generate(view)
     {@headerComment()}
 
-    package {@view.exampleLocalPackageName}
+    package {@view.localExamplePackageName}
 
     import (
         @join imp : view.imports
@@ -13,7 +13,7 @@
 
     func {@view.clientConstructorExampleName}() {
         ctx := context.Background()
-        c, err := {@view.libLocalPackageName}.{@view.clientConstructorName}(ctx)
+        c, err := {@view.localLibPackageName}.{@view.clientConstructorName}(ctx)
         if err != nil {
             // TODO: Handle error.
         }
@@ -24,7 +24,7 @@
     @join resource : view.iamResources
         func {@resource.exampleName}() {
             ctx := context.Background()
-            c, err := {@view.libLocalPackageName}.{@view.clientConstructorName}(ctx)
+            c, err := {@view.localLibPackageName}.{@view.clientConstructorName}(ctx)
             if err != nil {
                 // TODO: Handle error.
             }
@@ -214,7 +214,7 @@
 
 @private methodInit(view, method)
     ctx := context.Background()
-    c, err := {@view.libLocalPackageName}.{@view.clientConstructorName}(ctx)
+    c, err := {@view.localLibPackageName}.{@view.clientConstructorName}(ctx)
     if err != nil {
         // TODO: Handle error.
     }

--- a/src/main/resources/com/google/api/codegen/java/common.snip
+++ b/src/main/resources/com/google/api/codegen/java/common.snip
@@ -1,29 +1,14 @@
-@snippet license()
+
+@snippet license(fileHeader)
   /*
-   * Copyright 2016 Google Inc. All Rights Reserved.
+  @join line : fileHeader.copyrightLines
+    {@""} * {@line}
+  @end
    *
-   * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
-   * in compliance with the License. You may obtain a copy of the License at
-   *
-   * http://www.apache.org/licenses/LICENSE-2.0
-   *
-   * Unless required by applicable law or agreed to in writing, software distributed under the License
-   * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
-   * or implied. See the License for the specific language governing permissions and limitations under
-   * the License.
+  @join line : fileHeader.licenseLines
+    {@""} * {@line}
+  @end
    */
-@end
-
-@snippet paramList(params)
-  @join param : params on ", "
-    {@param.typeName} {@param.name}
-  @end
-@end
-
-@snippet argList(args)
-  @join arg : args on ", "
-    {@arg}
-  @end
 @end
 
 @snippet importList(imports)
@@ -36,5 +21,24 @@
     @default
       $unhandledCase: {@import.type.toString}$
     @end
+  @end
+@end
+
+@snippet renderFileHeader(fileHeader)
+  {@license(fileHeader)}
+  package {@fileHeader.packageName};
+
+  {@importList(fileHeader.imports)}
+@end
+
+@snippet paramList(params)
+  @join param : params on ", "
+    {@param.typeName} {@param.name}
+  @end
+@end
+
+@snippet argList(args)
+  @join arg : args on ", "
+    {@arg}
   @end
 @end

--- a/src/main/resources/com/google/api/codegen/java/main.snip
+++ b/src/main/resources/com/google/api/codegen/java/main.snip
@@ -1,21 +1,18 @@
 @extends "java/common.snip"
 @extends "java/method_sample.snip"
 
-@snippet generate(xapiClass)
-  {@license()}
-  package {@xapiClass.packageName};
+@snippet generate(apiFile)
+  {@renderFileHeader(apiFile.fileHeader)}
 
-  {@importList(xapiClass.imports)}
-
-  {@serviceDoc(xapiClass)}
+  {@serviceDoc(apiFile.api)}
   @@javax.annotation.Generated("by GAPIC")
-  public class {@xapiClass.name} implements AutoCloseable {
-    {@members(xapiClass)}
-    {@statics(xapiClass)}
-    {@staticFunctions(xapiClass)}
-    {@constructors(xapiClass)}
-    {@memberMethods(xapiClass)}
-    {@apiMethods(xapiClass)}
+  public class {@apiFile.api.name} implements AutoCloseable {
+    {@members(apiFile.api)}
+    {@statics(apiFile.api)}
+    {@staticFunctions(apiFile.api)}
+    {@constructors(apiFile.api)}
+    {@memberMethods(apiFile.api)}
+    {@apiMethods(apiFile.api)}
     {@cleanupSection()}
   }
 @end

--- a/src/main/resources/com/google/api/codegen/java/mock_service.snip
+++ b/src/main/resources/com/google/api/codegen/java/mock_service.snip
@@ -1,11 +1,7 @@
 @extends "java/common.snip"
 
 @snippet generate(mockService)
-  {@license()}
-
-  package {@mockService.packageName};
-
-  {@importList(mockService.imports)}
+  {@renderFileHeader(mockService.fileHeader)}
 
   @@javax.annotation.Generated("by GAPIC")
   public class {@mockService.name} implements MockGrpcService  {

--- a/src/main/resources/com/google/api/codegen/java/mock_service_impl.snip
+++ b/src/main/resources/com/google/api/codegen/java/mock_service_impl.snip
@@ -1,11 +1,7 @@
 @extends "java/common.snip"
 
 @snippet generate(mockServiceImpl)
-  {@license()}
-
-  package {@mockServiceImpl.packageName};
-
-  {@importList(mockServiceImpl.imports)}
+  {@renderFileHeader(mockServiceImpl.fileHeader)}
 
   @@javax.annotation.Generated("by GAPIC")
   public class {@mockServiceImpl.name} extends {@mockServiceImpl.grpcClassName}  {

--- a/src/main/resources/com/google/api/codegen/java/package-info.snip
+++ b/src/main/resources/com/google/api/codegen/java/package-info.snip
@@ -2,7 +2,7 @@
 @extends "java/method_sample.snip"
 
 @snippet generate(packageInfo)
-  {@license()}
+  {@license(packageInfo.fileHeader)}
 
   /**
    * A client to {@packageInfo.serviceTitle}.
@@ -14,7 +14,7 @@
   @end
    */
 
-  package {@packageInfo.packageName};
+  package {@packageInfo.fileHeader.packageName};
 @end
 
 @private serviceShortDoc(xapiClassDoc)

--- a/src/main/resources/com/google/api/codegen/java/page_streaming_response.snip
+++ b/src/main/resources/com/google/api/codegen/java/page_streaming_response.snip
@@ -1,10 +1,7 @@
 @extends "java/common.snip"
 
 @snippet generate(pagedResponseClasses)
-  {@license()}
-  package {@pagedResponseClasses.packageName};
-  
-  {@importList(pagedResponseClasses.imports)}
+  {@renderFileHeader(pagedResponseClasses.fileHeader)}
   
   // AUTO-GENERATED DOCUMENTATION AND CLASS
   /**

--- a/src/main/resources/com/google/api/codegen/java/settings.snip
+++ b/src/main/resources/com/google/api/codegen/java/settings.snip
@@ -1,19 +1,16 @@
 @extends "java/common.snip"
 
-@snippet generate(xsettingsClass)
-  {@license()}
-  package {@xsettingsClass.packageName};
+@snippet generate(settingsFile)
+  {@renderFileHeader(settingsFile.fileHeader)}
 
-  {@importList(xsettingsClass.imports)}
-
-  {@settingsDoc(xsettingsClass.doc)}
+  {@settingsDoc(settingsFile.settings.doc)}
   @@javax.annotation.Generated("by GAPIC")
-  public class {@xsettingsClass.name} extends ServiceApiSettings {
-    {@constants(xsettingsClass)}
-    {@members(xsettingsClass)}
-    {@constructors(xsettingsClass)}
-    {@descriptors(xsettingsClass)}
-    {@innerBuilderClass(xsettingsClass)}
+  public class {@settingsFile.settings.name} extends ServiceApiSettings {
+    {@constants(settingsFile.settings)}
+    {@members(settingsFile.settings)}
+    {@constructors(settingsFile.settings)}
+    {@descriptors(settingsFile.settings)}
+    {@innerBuilderClass(settingsFile.settings)}
   }
 @end
 

--- a/src/main/resources/com/google/api/codegen/java/smoke_test.snip
+++ b/src/main/resources/com/google/api/codegen/java/smoke_test.snip
@@ -3,11 +3,7 @@
 
 
 @snippet generate(smokeTest)
-  {@license()}
-
-  package {@smokeTest.packageName};
-
-  {@importList(smokeTest.imports)}
+  {@renderFileHeader(smokeTest.fileHeader)}
 
   @@javax.annotation.Generated("by GAPIC")
   public class {@smokeTest.name} {

--- a/src/main/resources/com/google/api/codegen/java/test.snip
+++ b/src/main/resources/com/google/api/codegen/java/test.snip
@@ -2,11 +2,7 @@
 @extends "java/initcode.snip"
 
 @snippet generate(xapiTest)
-  {@license()}
-
-  package {@xapiTest.packageName};
-
-  {@importList(xapiTest.imports)}
+  {@renderFileHeader(xapiTest.fileHeader)}
 
   @@javax.annotation.Generated("by GAPIC")
   public class {@xapiTest.name} {

--- a/src/main/resources/com/google/api/codegen/license-header-apache-2.0.txt
+++ b/src/main/resources/com/google/api/codegen/license-header-apache-2.0.txt
@@ -1,0 +1,11 @@
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/src/main/resources/com/google/api/codegen/license-header-bsd-3-clause.txt
+++ b/src/main/resources/com/google/api/codegen/license-header-bsd-3-clause.txt
@@ -1,0 +1,25 @@
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+    * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/test/java/com/google/api/codegen/testdata/csharp_gapic_client_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/csharp_gapic_client_library.baseline
@@ -1,5 +1,5 @@
 ============== file: Google/Example/Library/V1/LibraryServiceClient.cs ==============
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/api/codegen/testdata/csharp_gapic_snippets_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/csharp_gapic_snippets_library.baseline
@@ -1,5 +1,5 @@
 ============== file: Google/Example/Library/V1/LibraryServiceClientSnippets.g.cs ==============
-// Copyright 2016 Google Inc. All Rights Reserved.
+// Copyright 2016, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/api/codegen/testdata/java_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_main_library.baseline
@@ -1,16 +1,18 @@
 ============== file: src/main/java/com/google/gcloud/pubsub/spi/LibraryServiceApi.java ==============
 /*
- * Copyright 2016 Google Inc. All Rights Reserved.
+ * Copyright 2016, Google Inc. All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.google.gcloud.pubsub.spi;
 

--- a/src/test/java/com/google/api/codegen/testdata/java_main_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_main_no_path_templates.baseline
@@ -1,16 +1,18 @@
 ============== file: src/main/java/com/google/gcloud/example/NoTemplatesApiServiceApi.java ==============
 /*
- * Copyright 2016 Google Inc. All Rights Reserved.
+ * Copyright 2016, Google Inc. All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.google.gcloud.example;
 

--- a/src/test/java/com/google/api/codegen/testdata/java_mock_service_impl_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_mock_service_impl_library.baseline
@@ -1,18 +1,19 @@
 ============== file: src/test/java/com/google/gcloud/pubsub/spi/MockLabelerImpl.java ==============
 /*
- * Copyright 2016 Google Inc. All Rights Reserved.
+ * Copyright 2016, Google Inc. All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package com.google.gcloud.pubsub.spi;
 
 import com.google.common.collect.Lists;
@@ -61,19 +62,20 @@ public class MockLabelerImpl extends LabelerImplBase  {
 }
 ============== file: src/test/java/com/google/gcloud/pubsub/spi/MockLibraryServiceImpl.java ==============
 /*
- * Copyright 2016 Google Inc. All Rights Reserved.
+ * Copyright 2016, Google Inc. All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package com.google.gcloud.pubsub.spi;
 
 import com.google.common.collect.Lists;

--- a/src/test/java/com/google/api/codegen/testdata/java_mock_service_impl_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_mock_service_impl_no_path_templates.baseline
@@ -1,18 +1,19 @@
 ============== file: src/test/java/com/google/gcloud/example/MockNoTemplatesAPIServiceImpl.java ==============
 /*
- * Copyright 2016 Google Inc. All Rights Reserved.
+ * Copyright 2016, Google Inc. All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package com.google.gcloud.example;
 
 import com.google.common.collect.Lists;

--- a/src/test/java/com/google/api/codegen/testdata/java_mock_service_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_mock_service_library.baseline
@@ -1,18 +1,19 @@
 ============== file: src/test/java/com/google/gcloud/pubsub/spi/MockLabeler.java ==============
 /*
- * Copyright 2016 Google Inc. All Rights Reserved.
+ * Copyright 2016, Google Inc. All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package com.google.gcloud.pubsub.spi;
 
 import com.google.api.gax.testing.MockGrpcService;
@@ -50,19 +51,20 @@ public class MockLabeler implements MockGrpcService  {
 }
 ============== file: src/test/java/com/google/gcloud/pubsub/spi/MockLibraryService.java ==============
 /*
- * Copyright 2016 Google Inc. All Rights Reserved.
+ * Copyright 2016, Google Inc. All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package com.google.gcloud.pubsub.spi;
 
 import com.google.api.gax.testing.MockGrpcService;

--- a/src/test/java/com/google/api/codegen/testdata/java_mock_service_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_mock_service_no_path_templates.baseline
@@ -1,18 +1,19 @@
 ============== file: src/test/java/com/google/gcloud/example/MockNoTemplatesAPIService.java ==============
 /*
- * Copyright 2016 Google Inc. All Rights Reserved.
+ * Copyright 2016, Google Inc. All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package com.google.gcloud.example;
 
 import com.google.api.gax.testing.MockGrpcService;

--- a/src/test/java/com/google/api/codegen/testdata/java_package-info_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_package-info_library.baseline
@@ -1,16 +1,18 @@
 ============== file: src/main/java/com/google/gcloud/pubsub/spi/package-info.java ==============
 /*
- * Copyright 2016 Google Inc. All Rights Reserved.
+ * Copyright 2016, Google Inc. All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 /**

--- a/src/test/java/com/google/api/codegen/testdata/java_package-info_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_package-info_no_path_templates.baseline
@@ -1,16 +1,18 @@
 ============== file: src/main/java/com/google/gcloud/example/package-info.java ==============
 /*
- * Copyright 2016 Google Inc. All Rights Reserved.
+ * Copyright 2016, Google Inc. All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 /**

--- a/src/test/java/com/google/api/codegen/testdata/java_page_streaming_response_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_page_streaming_response_library.baseline
@@ -1,16 +1,18 @@
 ============== file: src/main/java/com/google/gcloud/pubsub/spi/PagedResponseWrappers.java ==============
 /*
- * Copyright 2016 Google Inc. All Rights Reserved.
+ * Copyright 2016, Google Inc. All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.google.gcloud.pubsub.spi;
 

--- a/src/test/java/com/google/api/codegen/testdata/java_page_streaming_response_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_page_streaming_response_no_path_templates.baseline
@@ -1,16 +1,18 @@
 ============== file: src/main/java/com/google/gcloud/example/PagedResponseWrappers.java ==============
 /*
- * Copyright 2016 Google Inc. All Rights Reserved.
+ * Copyright 2016, Google Inc. All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.google.gcloud.example;
 

--- a/src/test/java/com/google/api/codegen/testdata/java_settings_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_settings_library.baseline
@@ -1,16 +1,18 @@
 ============== file: src/main/java/com/google/gcloud/pubsub/spi/LibraryServiceSettings.java ==============
 /*
- * Copyright 2016 Google Inc. All Rights Reserved.
+ * Copyright 2016, Google Inc. All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.google.gcloud.pubsub.spi;
 

--- a/src/test/java/com/google/api/codegen/testdata/java_settings_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_settings_no_path_templates.baseline
@@ -1,16 +1,18 @@
 ============== file: src/main/java/com/google/gcloud/example/NoTemplatesApiServiceSettings.java ==============
 /*
- * Copyright 2016 Google Inc. All Rights Reserved.
+ * Copyright 2016, Google Inc. All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package com.google.gcloud.example;
 

--- a/src/test/java/com/google/api/codegen/testdata/java_smoke_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_smoke_test_library.baseline
@@ -1,18 +1,19 @@
 ============== file: src/test/java/com/google/gcloud/pubsub/spi/LibraryServiceSmokeTest.java ==============
 /*
- * Copyright 2016 Google Inc. All Rights Reserved.
+ * Copyright 2016, Google Inc. All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package com.google.gcloud.pubsub.spi;
 
 import com.google.api.gax.core.PagedListResponse;

--- a/src/test/java/com/google/api/codegen/testdata/java_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_test_library.baseline
@@ -1,18 +1,19 @@
 ============== file: src/test/java/com/google/gcloud/pubsub/spi/LibraryServiceTest.java ==============
 /*
- * Copyright 2016 Google Inc. All Rights Reserved.
+ * Copyright 2016, Google Inc. All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package com.google.gcloud.pubsub.spi;
 
 import com.google.api.gax.core.PagedListResponse;

--- a/src/test/java/com/google/api/codegen/testdata/java_test_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_test_no_path_templates.baseline
@@ -1,18 +1,19 @@
 ============== file: src/test/java/com/google/gcloud/example/NoTemplatesApiServiceTest.java ==============
 /*
- * Copyright 2016 Google Inc. All Rights Reserved.
+ * Copyright 2016, Google Inc. All rights reserved.
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License. You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software distributed under the License
- * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
- * or implied. See the License for the specific language governing permissions and limitations under
- * the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package com.google.gcloud.example;
 
 import com.google.api.gax.core.PagedListResponse;

--- a/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
@@ -20,6 +20,9 @@ language_settings:
     package_name: "@google-cloud/library"
   csharp:
     package_name: Google.Example.Library.V1
+license_header:
+  copyright_file: copyright-google.txt
+  license_file: license-header-apache-2.0.txt
 interfaces:
 - name: google.example.library.v1.LibraryService
   retry_codes_def:

--- a/src/test/java/com/google/api/codegen/testdata/no_path_templates_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testdata/no_path_templates_gapic.yaml
@@ -10,6 +10,9 @@ language_settings:
     package_name: Google\Example\V1
   nodejs:
     package_name: google-example-no-path-template
+license_header:
+  copyright_file: copyright-google.txt
+  license_file: license-header-apache-2.0.txt
 interfaces:
 - name: google.cloud.example.v1.NoTemplatesAPIService
   required_constructor_params:

--- a/src/test/java/com/google/api/codegen/transformer/go/testdata/myproto_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/transformer/go/testdata/myproto_gapic.yaml
@@ -3,6 +3,9 @@ language: go
 language_settings:
   go:
     package_name: cloud.google.com/go/gopher/apiv1
+license_header:
+  copyright_file: copyright-google.txt
+  license_file: license-header-apache-2.0.txt
 interfaces:
 - name: google.example.myproto.v1.Gopher
   retry_codes_def:

--- a/src/test/java/com/google/api/codegen/transformer/go/testdata/singleservice_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/transformer/go/testdata/singleservice_gapic.yaml
@@ -3,6 +3,9 @@ language: go
 language_settings:
   go:
     package_name: cloud.google.com/go/singleservice/apiv1
+license_header:
+  copyright_file: copyright-google.txt
+  license_file: license-header-apache-2.0.txt
 interfaces:
 - name: google.example.odd.v1.OddlyNamed
   retry_codes_def:


### PR DESCRIPTION
Also:

* Having SurfaceNamer store packageName
* Restructuring top-level views for Java and C# so that they are better
  normalized (file-level information is separate from class information)