### PR TITLE
Fix the missing comma between required and optional parameters

### DIFF
--- a/src/main/resources/com/google/api/codegen/ruby/main.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/main.snip
@@ -398,12 +398,16 @@
           @end
           options: nil
         req = {@inputTypeName}.new({
-            @if requiredParams
+          @if requiredParams
+            @if optionalParams
+              {@namedParameters(requiredParams)},
+              {@namedParameters(optionalParams)}
+            @else
               {@namedParameters(requiredParams)}
             @end
-            @if optionalParams
-              {@namedParameters(optionalParams)}
-            @end
+          @else
+            {@namedParameters(optionalParams)}
+          @end
         }.delete_if { |_, v| v.nil? })
         @@{@methodName}.call(req, options)
       end

--- a/src/test/java/com/google/api/codegen/testdata/ruby_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_doc_main_library.baseline
@@ -366,7 +366,7 @@ module Library
           shelf,
           options: nil
         req = Google::Example::Library::V1::CreateShelfRequest.new({
-            shelf: shelf
+          shelf: shelf
         }.delete_if { |_, v| v.nil? })
         @create_shelf.call(req, options)
       end
@@ -402,10 +402,10 @@ module Library
           string_builder: nil,
           options: nil
         req = Google::Example::Library::V1::GetShelfRequest.new({
-            name: name,
-            options: options_
-            message: message,
-            string_builder: string_builder
+          name: name,
+          options: options_,
+          message: message,
+          string_builder: string_builder
         }.delete_if { |_, v| v.nil? })
         @get_shelf.call(req, options)
       end
@@ -467,7 +467,7 @@ module Library
           name,
           options: nil
         req = Google::Example::Library::V1::DeleteShelfRequest.new({
-            name: name
+          name: name
         }.delete_if { |_, v| v.nil? })
         @delete_shelf.call(req, options)
       end
@@ -500,8 +500,8 @@ module Library
           other_shelf_name,
           options: nil
         req = Google::Example::Library::V1::MergeShelvesRequest.new({
-            name: name,
-            other_shelf_name: other_shelf_name
+          name: name,
+          other_shelf_name: other_shelf_name
         }.delete_if { |_, v| v.nil? })
         @merge_shelves.call(req, options)
       end
@@ -533,8 +533,8 @@ module Library
           book,
           options: nil
         req = Google::Example::Library::V1::CreateBookRequest.new({
-            name: name,
-            book: book
+          name: name,
+          book: book
         }.delete_if { |_, v| v.nil? })
         @create_book.call(req, options)
       end
@@ -572,10 +572,10 @@ module Library
           review_copy: nil,
           options: nil
         req = Google::Example::Library::V1::PublishSeriesRequest.new({
-            shelf: shelf,
-            books: books
-            edition: edition,
-            review_copy: review_copy
+          shelf: shelf,
+          books: books,
+          edition: edition,
+          review_copy: review_copy
         }.delete_if { |_, v| v.nil? })
         @publish_series.call(req, options)
       end
@@ -602,7 +602,7 @@ module Library
           name,
           options: nil
         req = Google::Example::Library::V1::GetBookRequest.new({
-            name: name
+          name: name
         }.delete_if { |_, v| v.nil? })
         @get_book.call(req, options)
       end
@@ -655,9 +655,9 @@ module Library
           filter: nil,
           options: nil
         req = Google::Example::Library::V1::ListBooksRequest.new({
-            name: name
-            page_size: page_size,
-            filter: filter
+          name: name,
+          page_size: page_size,
+          filter: filter
         }.delete_if { |_, v| v.nil? })
         @list_books.call(req, options)
       end
@@ -683,7 +683,7 @@ module Library
           name,
           options: nil
         req = Google::Example::Library::V1::DeleteBookRequest.new({
-            name: name
+          name: name
         }.delete_if { |_, v| v.nil? })
         @delete_book.call(req, options)
       end
@@ -721,10 +721,10 @@ module Library
           physical_mask: nil,
           options: nil
         req = Google::Example::Library::V1::UpdateBookRequest.new({
-            name: name,
-            book: book
-            update_mask: update_mask,
-            physical_mask: physical_mask
+          name: name,
+          book: book,
+          update_mask: update_mask,
+          physical_mask: physical_mask
         }.delete_if { |_, v| v.nil? })
         @update_book.call(req, options)
       end
@@ -755,8 +755,8 @@ module Library
           other_shelf_name,
           options: nil
         req = Google::Example::Library::V1::MoveBookRequest.new({
-            name: name,
-            other_shelf_name: other_shelf_name
+          name: name,
+          other_shelf_name: other_shelf_name
         }.delete_if { |_, v| v.nil? })
         @move_book.call(req, options)
       end
@@ -804,8 +804,8 @@ module Library
           page_size: nil,
           options: nil
         req = Google::Example::Library::V1::ListStringsRequest.new({
-            name: name,
-            page_size: page_size
+          name: name,
+          page_size: page_size
         }.delete_if { |_, v| v.nil? })
         @list_strings.call(req, options)
       end
@@ -843,8 +843,8 @@ module Library
           comments,
           options: nil
         req = Google::Example::Library::V1::AddCommentsRequest.new({
-            name: name,
-            comments: comments
+          name: name,
+          comments: comments
         }.delete_if { |_, v| v.nil? })
         @add_comments.call(req, options)
       end
@@ -871,7 +871,7 @@ module Library
           name,
           options: nil
         req = Google::Example::Library::V1::GetBookFromArchiveRequest.new({
-            name: name
+          name: name
         }.delete_if { |_, v| v.nil? })
         @get_book_from_archive.call(req, options)
       end
@@ -906,9 +906,9 @@ module Library
           index_map,
           options: nil
         req = Google::Example::Library::V1::UpdateBookIndexRequest.new({
-            name: name,
-            index_name: index_name,
-            index_map: index_map
+          name: name,
+          index_name: index_name,
+          index_map: index_map
         }.delete_if { |_, v| v.nil? })
         @update_book_index.call(req, options)
       end
@@ -959,9 +959,9 @@ module Library
           page_size: nil,
           options: nil
         req = Google::Example::Library::V1::FindRelatedBooksRequest.new({
-            names: names,
-            shelves: shelves
-            page_size: page_size
+          names: names,
+          shelves: shelves,
+          page_size: page_size
         }.delete_if { |_, v| v.nil? })
         @find_related_books.call(req, options)
       end
@@ -994,8 +994,8 @@ module Library
           tag,
           options: nil
         req = Google::Tagger::V1::AddTagRequest.new({
-            resource: resource,
-            tag: tag
+          resource: resource,
+          tag: tag
         }.delete_if { |_, v| v.nil? })
         @add_tag.call(req, options)
       end
@@ -1028,8 +1028,8 @@ module Library
           label,
           options: nil
         req = Google::Tagger::V1::AddLabelRequest.new({
-            resource: resource,
-            label: label
+          resource: resource,
+          label: label
         }.delete_if { |_, v| v.nil? })
         @add_label.call(req, options)
       end
@@ -1054,7 +1054,7 @@ module Library
           name,
           options: nil
         req = Google::Example::Library::V1::GetBookRequest.new({
-            name: name
+          name: name
         }.delete_if { |_, v| v.nil? })
         @get_big_book.call(req, options)
       end

--- a/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
@@ -366,7 +366,7 @@ module Library
           shelf,
           options: nil
         req = Google::Example::Library::V1::CreateShelfRequest.new({
-            shelf: shelf
+          shelf: shelf
         }.delete_if { |_, v| v.nil? })
         @create_shelf.call(req, options)
       end
@@ -402,10 +402,10 @@ module Library
           string_builder: nil,
           options: nil
         req = Google::Example::Library::V1::GetShelfRequest.new({
-            name: name,
-            options: options_
-            message: message,
-            string_builder: string_builder
+          name: name,
+          options: options_,
+          message: message,
+          string_builder: string_builder
         }.delete_if { |_, v| v.nil? })
         @get_shelf.call(req, options)
       end
@@ -467,7 +467,7 @@ module Library
           name,
           options: nil
         req = Google::Example::Library::V1::DeleteShelfRequest.new({
-            name: name
+          name: name
         }.delete_if { |_, v| v.nil? })
         @delete_shelf.call(req, options)
       end
@@ -500,8 +500,8 @@ module Library
           other_shelf_name,
           options: nil
         req = Google::Example::Library::V1::MergeShelvesRequest.new({
-            name: name,
-            other_shelf_name: other_shelf_name
+          name: name,
+          other_shelf_name: other_shelf_name
         }.delete_if { |_, v| v.nil? })
         @merge_shelves.call(req, options)
       end
@@ -533,8 +533,8 @@ module Library
           book,
           options: nil
         req = Google::Example::Library::V1::CreateBookRequest.new({
-            name: name,
-            book: book
+          name: name,
+          book: book
         }.delete_if { |_, v| v.nil? })
         @create_book.call(req, options)
       end
@@ -572,10 +572,10 @@ module Library
           review_copy: nil,
           options: nil
         req = Google::Example::Library::V1::PublishSeriesRequest.new({
-            shelf: shelf,
-            books: books
-            edition: edition,
-            review_copy: review_copy
+          shelf: shelf,
+          books: books,
+          edition: edition,
+          review_copy: review_copy
         }.delete_if { |_, v| v.nil? })
         @publish_series.call(req, options)
       end
@@ -602,7 +602,7 @@ module Library
           name,
           options: nil
         req = Google::Example::Library::V1::GetBookRequest.new({
-            name: name
+          name: name
         }.delete_if { |_, v| v.nil? })
         @get_book.call(req, options)
       end
@@ -655,9 +655,9 @@ module Library
           filter: nil,
           options: nil
         req = Google::Example::Library::V1::ListBooksRequest.new({
-            name: name
-            page_size: page_size,
-            filter: filter
+          name: name,
+          page_size: page_size,
+          filter: filter
         }.delete_if { |_, v| v.nil? })
         @list_books.call(req, options)
       end
@@ -683,7 +683,7 @@ module Library
           name,
           options: nil
         req = Google::Example::Library::V1::DeleteBookRequest.new({
-            name: name
+          name: name
         }.delete_if { |_, v| v.nil? })
         @delete_book.call(req, options)
       end
@@ -721,10 +721,10 @@ module Library
           physical_mask: nil,
           options: nil
         req = Google::Example::Library::V1::UpdateBookRequest.new({
-            name: name,
-            book: book
-            update_mask: update_mask,
-            physical_mask: physical_mask
+          name: name,
+          book: book,
+          update_mask: update_mask,
+          physical_mask: physical_mask
         }.delete_if { |_, v| v.nil? })
         @update_book.call(req, options)
       end
@@ -755,8 +755,8 @@ module Library
           other_shelf_name,
           options: nil
         req = Google::Example::Library::V1::MoveBookRequest.new({
-            name: name,
-            other_shelf_name: other_shelf_name
+          name: name,
+          other_shelf_name: other_shelf_name
         }.delete_if { |_, v| v.nil? })
         @move_book.call(req, options)
       end
@@ -804,8 +804,8 @@ module Library
           page_size: nil,
           options: nil
         req = Google::Example::Library::V1::ListStringsRequest.new({
-            name: name,
-            page_size: page_size
+          name: name,
+          page_size: page_size
         }.delete_if { |_, v| v.nil? })
         @list_strings.call(req, options)
       end
@@ -843,8 +843,8 @@ module Library
           comments,
           options: nil
         req = Google::Example::Library::V1::AddCommentsRequest.new({
-            name: name,
-            comments: comments
+          name: name,
+          comments: comments
         }.delete_if { |_, v| v.nil? })
         @add_comments.call(req, options)
       end
@@ -871,7 +871,7 @@ module Library
           name,
           options: nil
         req = Google::Example::Library::V1::GetBookFromArchiveRequest.new({
-            name: name
+          name: name
         }.delete_if { |_, v| v.nil? })
         @get_book_from_archive.call(req, options)
       end
@@ -906,9 +906,9 @@ module Library
           index_map,
           options: nil
         req = Google::Example::Library::V1::UpdateBookIndexRequest.new({
-            name: name,
-            index_name: index_name,
-            index_map: index_map
+          name: name,
+          index_name: index_name,
+          index_map: index_map
         }.delete_if { |_, v| v.nil? })
         @update_book_index.call(req, options)
       end
@@ -959,9 +959,9 @@ module Library
           page_size: nil,
           options: nil
         req = Google::Example::Library::V1::FindRelatedBooksRequest.new({
-            names: names,
-            shelves: shelves
-            page_size: page_size
+          names: names,
+          shelves: shelves,
+          page_size: page_size
         }.delete_if { |_, v| v.nil? })
         @find_related_books.call(req, options)
       end
@@ -994,8 +994,8 @@ module Library
           tag,
           options: nil
         req = Google::Tagger::V1::AddTagRequest.new({
-            resource: resource,
-            tag: tag
+          resource: resource,
+          tag: tag
         }.delete_if { |_, v| v.nil? })
         @add_tag.call(req, options)
       end
@@ -1028,8 +1028,8 @@ module Library
           label,
           options: nil
         req = Google::Tagger::V1::AddLabelRequest.new({
-            resource: resource,
-            label: label
+          resource: resource,
+          label: label
         }.delete_if { |_, v| v.nil? })
         @add_label.call(req, options)
       end
@@ -1054,7 +1054,7 @@ module Library
           name,
           options: nil
         req = Google::Example::Library::V1::GetBookRequest.new({
-            name: name
+          name: name
         }.delete_if { |_, v| v.nil? })
         @get_big_book.call(req, options)
       end


### PR DESCRIPTION
When using hash with the grpc message object constructor, there was a missing ',' between required and optional parameters.