### PR TITLE
Support $PROJECT in smoke test gen.

### DIFF
--- a/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
+++ b/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
@@ -79,7 +79,7 @@ public class FieldStructureParser {
       InitValue initValue = fieldConfig.value();
       valueConfig =
           InitValueConfig.createWithValue(
-              new InitValue(stripQuotes(initValue.getValue()), initValue.getType()));
+              InitValue.create(stripQuotes(initValue.getValue()), initValue.getType()));
     } else if (initValueConfigMap.containsKey(fieldConfig.fieldPath())) {
       valueConfig = initValueConfigMap.get(fieldConfig.fieldPath());
     }

--- a/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
+++ b/src/main/java/com/google/api/codegen/metacode/FieldStructureParser.java
@@ -76,7 +76,10 @@ public class FieldStructureParser {
               .get(fieldConfig.fieldPath())
               .withInitialCollectionValue(fieldConfig.entityName(), fieldConfig.value());
     } else if (fieldConfig.hasSimpleInitValue()) {
-      valueConfig = InitValueConfig.createWithValue(stripQuotes(fieldConfig.value()));
+      InitValue initValue = fieldConfig.value();
+      valueConfig =
+          InitValueConfig.createWithValue(
+              new InitValue(stripQuotes(initValue.getValue()), initValue.getType()));
     } else if (initValueConfigMap.containsKey(fieldConfig.fieldPath())) {
       valueConfig = initValueConfigMap.get(fieldConfig.fieldPath());
     }

--- a/src/main/java/com/google/api/codegen/metacode/InitCodeNode.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitCodeNode.java
@@ -15,7 +15,6 @@
 package com.google.api.codegen.metacode;
 
 import com.google.api.codegen.config.FieldConfig;
-import com.google.api.codegen.metacode.InitValue.InitValueType;
 import com.google.api.codegen.util.Name;
 import com.google.api.codegen.util.SymbolTable;
 import com.google.api.codegen.util.testing.TestValueGenerator;
@@ -278,8 +277,7 @@ public class InitCodeNode {
           && !type.isRepeated()
           && valueGenerator != null) {
         String newValue = valueGenerator.getAndStoreValue(type, identifier);
-        initValueConfig =
-            InitValueConfig.createWithValue(new InitValue(newValue, InitValueType.Literal));
+        initValueConfig = InitValueConfig.createWithValue(InitValue.createLiteral(newValue));
       }
     }
   }

--- a/src/main/java/com/google/api/codegen/metacode/InitCodeNode.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitCodeNode.java
@@ -15,6 +15,7 @@
 package com.google.api.codegen.metacode;
 
 import com.google.api.codegen.config.FieldConfig;
+import com.google.api.codegen.metacode.InitValue.InitValueType;
 import com.google.api.codegen.util.Name;
 import com.google.api.codegen.util.SymbolTable;
 import com.google.api.codegen.util.testing.TestValueGenerator;
@@ -191,7 +192,7 @@ public class InitCodeNode {
 
   private static InitValueConfig mergeInitValueConfig(
       InitValueConfig oldConfig, InitValueConfig newConfig) {
-    HashMap<String, String> collectionValues = new HashMap<>();
+    HashMap<String, InitValue> collectionValues = new HashMap<>();
     if (oldConfig.hasSimpleInitialValue()
         && newConfig.hasSimpleInitialValue()
         && !oldConfig.getInitialValue().equals(newConfig.getInitialValue())) {
@@ -271,13 +272,14 @@ public class InitCodeNode {
 
       // Validate initValueConfig, or generate random value
       if (initValueConfig.hasSimpleInitialValue()) {
-        validateValue(type, initValueConfig.getInitialValue());
+        validateValue(type, initValueConfig.getInitialValue().getValue());
       } else if (initValueConfig.isEmpty()
           && type.isPrimitive()
           && !type.isRepeated()
           && valueGenerator != null) {
         String newValue = valueGenerator.getAndStoreValue(type, identifier);
-        initValueConfig = InitValueConfig.createWithValue(newValue);
+        initValueConfig =
+            InitValueConfig.createWithValue(new InitValue(newValue, InitValueType.Literal));
       }
     }
   }

--- a/src/main/java/com/google/api/codegen/metacode/InitFieldConfig.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitFieldConfig.java
@@ -22,10 +22,10 @@ import javax.annotation.Nullable;
  */
 @AutoValue
 public abstract class InitFieldConfig {
-  public static final String projectIdVariableName = "project_id";
+  public static final String PROJECT_ID_VARIABLE_NAME = "project_id";
 
-  private static final String randomValueToken = "$RANDOM";
-  private static final String projectIdToken = "$PROJECT_ID";
+  private static final String RANDOM_TOKEN = "$RANDOM";
+  private static final String PROJECT_ID_TOKEN = "$PROJECT_ID";
 
   public abstract String fieldPath();
 
@@ -74,15 +74,15 @@ public abstract class InitFieldConfig {
 
   private static InitValue parseValueString(String valueString, String stringToHash) {
     InitValue initValue = InitValue.createLiteral(valueString);
-    if (valueString.contains(randomValueToken)) {
+    if (valueString.contains(RANDOM_TOKEN)) {
       String randomValue = Integer.toString(Math.abs(stringToHash.hashCode()));
-      valueString = valueString.replace(randomValueToken, randomValue);
+      valueString = valueString.replace(RANDOM_TOKEN, randomValue);
       initValue = InitValue.createLiteral(valueString);
-    } else if (valueString.contains(projectIdToken)) {
-      if (!valueString.equals(projectIdToken)) {
+    } else if (valueString.contains(PROJECT_ID_TOKEN)) {
+      if (!valueString.equals(PROJECT_ID_TOKEN)) {
         throw new IllegalArgumentException("Inconsistent: found project ID as a substring ");
       }
-      valueString = projectIdVariableName;
+      valueString = PROJECT_ID_VARIABLE_NAME;
       initValue = InitValue.createVariable(valueString);
     }
     return initValue;

--- a/src/main/java/com/google/api/codegen/metacode/InitFieldConfig.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitFieldConfig.java
@@ -23,9 +23,10 @@ import javax.annotation.Nullable;
  */
 @AutoValue
 public abstract class InitFieldConfig {
+  public static final String projectIdVariableName = "project_id";
+
   private static final String randomValueToken = "$RANDOM";
   private static final String projectIdToken = "$PROJECT_ID";
-  private static final String projectIdVariableName = "project_id";
 
   public abstract String fieldPath();
 

--- a/src/main/java/com/google/api/codegen/metacode/InitFieldConfig.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitFieldConfig.java
@@ -14,7 +14,6 @@
  */
 package com.google.api.codegen.metacode;
 
-import com.google.api.codegen.metacode.InitValue.InitValueType;
 import com.google.auto.value.AutoValue;
 import javax.annotation.Nullable;
 
@@ -74,17 +73,17 @@ public abstract class InitFieldConfig {
   }
 
   private static InitValue parseValueString(String valueString, String stringToHash) {
-    InitValue initValue = new InitValue(valueString, InitValueType.Literal);
+    InitValue initValue = InitValue.createLiteral(valueString);
     if (valueString.contains(randomValueToken)) {
       String randomValue = Integer.toString(Math.abs(stringToHash.hashCode()));
       valueString = valueString.replace(randomValueToken, randomValue);
-      initValue = new InitValue(valueString, InitValueType.Literal);
+      initValue = InitValue.createLiteral(valueString);
     } else if (valueString.contains(projectIdToken)) {
       if (!valueString.equals(projectIdToken)) {
         throw new IllegalArgumentException("Inconsistent: found project ID as a substring ");
       }
       valueString = projectIdVariableName;
-      initValue = new InitValue(valueString, InitValueType.Variable);
+      initValue = InitValue.createVariable(valueString);
     }
     return initValue;
   }

--- a/src/main/java/com/google/api/codegen/metacode/InitFieldConfig.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitFieldConfig.java
@@ -79,6 +79,9 @@ public abstract class InitFieldConfig {
       valueString = valueString.replace(randomValueToken, randomValue);
       initValue = new InitValue(valueString, InitValueType.Literal);
     } else if (valueString.contains(projectIdToken)) {
+      if (!valueString.equals(projectIdToken)) {
+        throw new IllegalArgumentException("Inconsistent: found project ID as a substring ");
+      }
       valueString = projectIdVariableName;
       initValue = new InitValue(valueString, InitValueType.Variable);
     }

--- a/src/main/java/com/google/api/codegen/metacode/InitFieldConfig.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitFieldConfig.java
@@ -14,6 +14,7 @@
  */
 package com.google.api.codegen.metacode;
 
+import com.google.api.codegen.metacode.InitValue.InitValueType;
 import com.google.auto.value.AutoValue;
 import javax.annotation.Nullable;
 
@@ -23,6 +24,8 @@ import javax.annotation.Nullable;
 @AutoValue
 public abstract class InitFieldConfig {
   private static final String randomValueToken = "$RANDOM";
+  private static final String projectIdToken = "$PROJECT_ID";
+  private static final String projectIdVariableName = "project_id";
 
   public abstract String fieldPath();
 
@@ -30,7 +33,7 @@ public abstract class InitFieldConfig {
   public abstract String entityName();
 
   @Nullable
-  public abstract String value();
+  public abstract InitValue value();
 
   /*
    * Parses the given config string and returns the corresponding object.
@@ -38,7 +41,7 @@ public abstract class InitFieldConfig {
   public static InitFieldConfig from(String initFieldConfigString) {
     String fieldName = null;
     String entityName = null;
-    String value = null;
+    InitValue value = null;
 
     String[] equalsParts = initFieldConfigString.split("[=]");
     if (equalsParts.length > 2) {
@@ -69,11 +72,16 @@ public abstract class InitFieldConfig {
     return entityName() != null && value() != null;
   }
 
-  private static String parseValueString(String valueString, String stringToHash) {
+  private static InitValue parseValueString(String valueString, String stringToHash) {
+    InitValue initValue = new InitValue(valueString, InitValueType.Literal);
     if (valueString.contains(randomValueToken)) {
       String randomValue = Integer.toString(Math.abs(stringToHash.hashCode()));
       valueString = valueString.replace(randomValueToken, randomValue);
+      initValue = new InitValue(valueString, InitValueType.Literal);
+    } else if (valueString.contains(projectIdToken)) {
+      valueString = projectIdVariableName;
+      initValue = new InitValue(valueString, InitValueType.Variable);
     }
-    return valueString;
+    return initValue;
   }
 }

--- a/src/main/java/com/google/api/codegen/metacode/InitValue.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitValue.java
@@ -14,28 +14,31 @@
  */
 package com.google.api.codegen.metacode;
 
-/** A class which represents the initialized value of a field. */
-public class InitValue {
-  private final String value;
-  private final InitValueType type;
+import com.google.auto.value.AutoValue;
 
+/** A class which represents the initialized value of a field. */
+@AutoValue
+public abstract class InitValue {
   public enum InitValueType {
     Literal,
     Variable,
   }
 
-  public InitValue(String value, InitValueType type) {
-    this.value = value;
-    this.type = type;
+  public static InitValue create(String value, InitValueType type) {
+    return new AutoValue_InitValue(value, type);
   }
 
-  public String getValue() {
-    return value;
+  public static InitValue createLiteral(String value) {
+    return new AutoValue_InitValue(value, InitValueType.Literal);
   }
 
-  public InitValueType getType() {
-    return type;
+  public static InitValue createVariable(String variableName) {
+    return new AutoValue_InitValue(variableName, InitValueType.Variable);
   }
+
+  public abstract String getValue();
+
+  public abstract InitValueType getType();
 
   @Override
   public boolean equals(Object o) {
@@ -48,6 +51,6 @@ public class InitValue {
 
   @Override
   public int hashCode() {
-    return value.hashCode();
+    return getValue().hashCode();
   }
 }

--- a/src/main/java/com/google/api/codegen/metacode/InitValue.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitValue.java
@@ -1,0 +1,53 @@
+/* Copyright 2016 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.metacode;
+
+/** A class which represents the initialized value of a field. */
+public class InitValue {
+  private final String value;
+  private final InitValueType type;
+
+  public enum InitValueType {
+    Literal,
+    Variable,
+  }
+
+  public InitValue(String value, InitValueType type) {
+    this.value = value;
+    this.type = type;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public InitValueType getType() {
+    return type;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this.getClass() == o.getClass()) {
+      InitValue initValue = (InitValue) o;
+      return initValue.getValue().equals(this.getValue()) && initValue.getType() == this.getType();
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return value.hashCode();
+  }
+}

--- a/src/main/java/com/google/api/codegen/metacode/InitValue.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitValue.java
@@ -39,18 +39,4 @@ public abstract class InitValue {
   public abstract String getValue();
 
   public abstract InitValueType getType();
-
-  @Override
-  public boolean equals(Object o) {
-    if (this.getClass() == o.getClass()) {
-      InitValue initValue = (InitValue) o;
-      return initValue.getValue().equals(this.getValue()) && initValue.getType() == this.getType();
-    }
-    return false;
-  }
-
-  @Override
-  public int hashCode() {
-    return getValue().hashCode();
-  }
 }

--- a/src/main/java/com/google/api/codegen/metacode/InitValueConfig.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitValueConfig.java
@@ -28,7 +28,7 @@ public abstract class InitValueConfig {
     return new AutoValue_InitValueConfig(null, null, null, null);
   }
 
-  public static InitValueConfig createWithValue(String value) {
+  public static InitValueConfig createWithValue(InitValue value) {
     return new AutoValue_InitValueConfig(null, null, value, null);
   }
 
@@ -40,7 +40,7 @@ public abstract class InitValueConfig {
   public static InitValueConfig create(
       String apiWrapperName,
       SingleResourceNameConfig singleResourceNameConfig,
-      Map<String, String> resourceNameBindingValues) {
+      Map<String, InitValue> resourceNameBindingValues) {
     return new AutoValue_InitValueConfig(
         apiWrapperName, singleResourceNameConfig, null, resourceNameBindingValues);
   }
@@ -52,20 +52,20 @@ public abstract class InitValueConfig {
   public abstract SingleResourceNameConfig getSingleResourceNameConfig();
 
   @Nullable
-  public abstract String getInitialValue();
+  public abstract InitValue getInitialValue();
 
   @Nullable
-  public abstract Map<String, String> getResourceNameBindingValues();
+  public abstract Map<String, InitValue> getResourceNameBindingValues();
 
   /** Creates an updated InitValueConfig with the provided value. */
-  public InitValueConfig withInitialCollectionValue(String entityName, String value) {
-    HashMap<String, String> resourceNameBindingValues = new HashMap<>();
+  public InitValueConfig withInitialCollectionValue(String entityName, InitValue value) {
+    HashMap<String, InitValue> resourceNameBindingValues = new HashMap<>();
     resourceNameBindingValues.put(entityName, value);
     return withInitialCollectionValues(resourceNameBindingValues);
   }
 
   public InitValueConfig withInitialCollectionValues(
-      Map<String, String> resourceNameBindingValues) {
+      Map<String, InitValue> resourceNameBindingValues) {
     return new AutoValue_InitValueConfig(
         getApiWrapperName(), getSingleResourceNameConfig(), null, resourceNameBindingValues);
   }

--- a/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
@@ -23,7 +23,6 @@ import com.google.api.codegen.metacode.InitCodeContext.InitCodeOutputType;
 import com.google.api.codegen.metacode.InitCodeLineType;
 import com.google.api.codegen.metacode.InitCodeNode;
 import com.google.api.codegen.metacode.InitValue;
-import com.google.api.codegen.metacode.InitValue.InitValueType;
 import com.google.api.codegen.metacode.InitValueConfig;
 import com.google.api.codegen.util.Name;
 import com.google.api.codegen.viewmodel.FieldSettingView;
@@ -376,10 +375,15 @@ public class InitCodeTransformer {
       if (initValueConfig.hasFormattingConfigInitialValues()
           && initValueConfig.getResourceNameBindingValues().containsKey(entityName)) {
         InitValue initValue = initValueConfig.getResourceNameBindingValues().get(entityName);
-        if (initValue.getType() == InitValueType.Variable) {
-          entityValue = context.getNamer().localVarName(Name.from(initValue.getValue()));
-        } else {
-          entityValue = initValue.getValue();
+        switch (initValue.getType()) {
+          case Variable:
+            entityValue = context.getNamer().localVarName(Name.from(initValue.getValue()));
+            break;
+          case Literal:
+            entityValue = initValue.getValue();
+            break;
+          default:
+            throw new IllegalArgumentException("Unhandled init value type");
         }
       }
       formatFunctionArgs.add(entityValue);

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
@@ -30,7 +30,9 @@ import com.google.api.codegen.config.SmokeTestConfig;
 import com.google.api.codegen.gapic.GapicCodePathMapper;
 import com.google.api.codegen.metacode.InitCodeContext;
 import com.google.api.codegen.metacode.InitCodeContext.InitCodeOutputType;
+import com.google.api.codegen.metacode.InitCodeLineType;
 import com.google.api.codegen.metacode.InitCodeNode;
+import com.google.api.codegen.metacode.InitFieldConfig;
 import com.google.api.codegen.metacode.InitValue;
 import com.google.api.codegen.metacode.InitValue.InitValueType;
 import com.google.api.codegen.metacode.InitValueConfig;
@@ -48,8 +50,12 @@ import com.google.api.codegen.util.java.JavaTypeTable;
 import com.google.api.codegen.util.testing.JavaValueProducer;
 import com.google.api.codegen.util.testing.TestValueGenerator;
 import com.google.api.codegen.viewmodel.ApiMethodType;
+import com.google.api.codegen.viewmodel.FieldSettingView;
 import com.google.api.codegen.viewmodel.FileHeaderView;
+import com.google.api.codegen.viewmodel.InitCodeLineView;
 import com.google.api.codegen.viewmodel.InitCodeView;
+import com.google.api.codegen.viewmodel.ResourceNameInitValueView;
+import com.google.api.codegen.viewmodel.SimpleInitCodeLineView;
 import com.google.api.codegen.viewmodel.ViewModel;
 import com.google.api.codegen.viewmodel.testing.GapicSurfaceTestAssertView;
 import com.google.api.codegen.viewmodel.testing.GapicSurfaceTestCaseView;
@@ -141,12 +147,15 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
         context.asFlattenedMethodContext(method, flatteningGroup);
 
     SmokeTestClassView.Builder testClass = SmokeTestClassView.newBuilder();
+    TestMethodView testMethodView = createSmokeTestMethodView(methodContext);
+
     testClass.apiSettingsClassName(namer.getApiSettingsClassName(service));
     testClass.apiClassName(namer.getApiWrapperClassName(service));
     testClass.name(name);
     testClass.outputPath(namer.getSourceFilePath(outputPath, name));
     testClass.templateFileName(SMOKE_TEST_TEMPLATE_FILE);
-    testClass.method(createSmokeTestMethodView(methodContext));
+    testClass.method(testMethodView);
+    testClass.requireProjectID(requireProjectId(testMethodView.initCode(), context.getNamer()));
 
     // Imports must be done as the last step to catch all imports.
     FileHeaderView fileHeader = fileHeaderTransformer.generateFileHeader(context);
@@ -163,7 +172,6 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
     if (context.getMethodConfig().isPageStreaming()) {
       methodType = ApiMethodType.PagedFlattenedMethod;
     }
-
     InitCodeView initCodeView =
         initCodeTransformer.generateInitCode(context, createSmokeTestInitContext(context));
 
@@ -174,6 +182,22 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
         .initCode(initCodeView)
         .hasReturnValue(!ServiceMessages.s_isEmptyType(method.getOutputType()))
         .build();
+  }
+
+  private boolean requireProjectId(InitCodeView initCodeView, SurfaceNamer namer) {
+    for (FieldSettingView settingsView : initCodeView.fieldSettings()) {
+      InitCodeLineView line = settingsView.initCodeLine();
+      if (line.lineType() == InitCodeLineType.SimpleInitLine) {
+        SimpleInitCodeLineView simpleLine = (SimpleInitCodeLineView) line;
+        if (simpleLine.initValue() instanceof ResourceNameInitValueView) {
+          ResourceNameInitValueView initValue = (ResourceNameInitValueView) simpleLine.initValue();
+          return initValue
+              .formatArgs()
+              .contains(namer.localVarName(Name.from(InitFieldConfig.projectIdVariableName)));
+        }
+      }
+    }
+    return false;
   }
 
   private InitCodeContext createSmokeTestInitContext(MethodTransformerContext context) {

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
@@ -31,6 +31,8 @@ import com.google.api.codegen.gapic.GapicCodePathMapper;
 import com.google.api.codegen.metacode.InitCodeContext;
 import com.google.api.codegen.metacode.InitCodeContext.InitCodeOutputType;
 import com.google.api.codegen.metacode.InitCodeNode;
+import com.google.api.codegen.metacode.InitValue;
+import com.google.api.codegen.metacode.InitValue.InitValueType;
 import com.google.api.codegen.metacode.InitValueConfig;
 import com.google.api.codegen.transformer.FileHeaderTransformer;
 import com.google.api.codegen.transformer.InitCodeTransformer;
@@ -477,7 +479,9 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
       // are available
       String responseTokenName = config.getResponseTokenField().getSimpleName();
       additionalSubTrees.add(
-          InitCodeNode.createWithValue(responseTokenName, InitValueConfig.createWithValue("")));
+          InitCodeNode.createWithValue(
+              responseTokenName,
+              InitValueConfig.createWithValue(new InitValue("", InitValueType.Literal))));
     }
     if (context.getMethodConfig().isBundling()) {
       // Initialize one bundling element if it is bundling.
@@ -646,6 +650,11 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
     typeTable.saveNicknameFor("com.google.api.gax.core.PagedListResponse");
     typeTable.saveNicknameFor("org.apache.commons.lang.builder.ReflectionToStringBuilder");
     typeTable.saveNicknameFor("org.apache.commons.lang.builder.ToStringStyle");
+    typeTable.saveNicknameFor("org.apache.commons.cli.CommandLine");
+    typeTable.saveNicknameFor("org.apache.commons.cli.DefaultParser");
+    typeTable.saveNicknameFor("org.apache.commons.cli.HelpFormatter");
+    typeTable.saveNicknameFor("org.apache.commons.cli.Option");
+    typeTable.saveNicknameFor("org.apache.commons.cli.Options");
   }
 
   private void addMockServiceImplImports(SurfaceTransformerContext context) {

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
@@ -34,7 +34,6 @@ import com.google.api.codegen.metacode.InitCodeLineType;
 import com.google.api.codegen.metacode.InitCodeNode;
 import com.google.api.codegen.metacode.InitFieldConfig;
 import com.google.api.codegen.metacode.InitValue;
-import com.google.api.codegen.metacode.InitValue.InitValueType;
 import com.google.api.codegen.metacode.InitValueConfig;
 import com.google.api.codegen.transformer.FileHeaderTransformer;
 import com.google.api.codegen.transformer.InitCodeTransformer;
@@ -504,8 +503,7 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
       String responseTokenName = config.getResponseTokenField().getSimpleName();
       additionalSubTrees.add(
           InitCodeNode.createWithValue(
-              responseTokenName,
-              InitValueConfig.createWithValue(new InitValue("", InitValueType.Literal))));
+              responseTokenName, InitValueConfig.createWithValue(InitValue.createLiteral(""))));
     }
     if (context.getMethodConfig().isBundling()) {
       // Initialize one bundling element if it is bundling.

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
@@ -154,7 +154,7 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
     testClass.outputPath(namer.getSourceFilePath(outputPath, name));
     testClass.templateFileName(SMOKE_TEST_TEMPLATE_FILE);
     testClass.method(testMethodView);
-    testClass.requireProjectID(requireProjectId(testMethodView.initCode(), context.getNamer()));
+    testClass.requireProjectId(requireProjectId(testMethodView.initCode(), context.getNamer()));
 
     // Imports must be done as the last step to catch all imports.
     FileHeaderView fileHeader = fileHeaderTransformer.generateFileHeader(context);
@@ -192,7 +192,7 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
           ResourceNameInitValueView initValue = (ResourceNameInitValueView) simpleLine.initValue();
           return initValue
               .formatArgs()
-              .contains(namer.localVarName(Name.from(InitFieldConfig.projectIdVariableName)));
+              .contains(namer.localVarName(Name.from(InitFieldConfig.PROJECT_ID_VARIABLE_NAME)));
         }
       }
     }

--- a/src/main/java/com/google/api/codegen/viewmodel/testing/SmokeTestClassView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/testing/SmokeTestClassView.java
@@ -33,6 +33,8 @@ public abstract class SmokeTestClassView implements ViewModel {
 
   public abstract TestMethodView method();
 
+  public abstract boolean requireProjectID();
+
   @Override
   public String resourceRoot() {
     return SnippetSetRunner.SNIPPET_RESOURCE_ROOT;
@@ -45,7 +47,7 @@ public abstract class SmokeTestClassView implements ViewModel {
   public abstract String outputPath();
 
   public static Builder newBuilder() {
-    return new AutoValue_SmokeTestClassView.Builder();
+    return new AutoValue_SmokeTestClassView.Builder().requireProjectID(false);
   }
 
   @AutoValue.Builder
@@ -64,6 +66,8 @@ public abstract class SmokeTestClassView implements ViewModel {
     public abstract Builder templateFileName(String val);
 
     public abstract Builder method(TestMethodView val);
+
+    public abstract Builder requireProjectID(boolean val);
 
     public abstract SmokeTestClassView build();
   }

--- a/src/main/java/com/google/api/codegen/viewmodel/testing/SmokeTestClassView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/testing/SmokeTestClassView.java
@@ -17,7 +17,6 @@ package com.google.api.codegen.viewmodel.testing;
 import com.google.api.codegen.SnippetSetRunner;
 import com.google.api.codegen.viewmodel.FileHeaderView;
 import com.google.api.codegen.viewmodel.ViewModel;
-import com.google.api.codegen.viewmodel.testing.MockServiceView.Builder;
 import com.google.auto.value.AutoValue;
 
 @AutoValue
@@ -33,7 +32,7 @@ public abstract class SmokeTestClassView implements ViewModel {
 
   public abstract TestMethodView method();
 
-  public abstract boolean requireProjectID();
+  public abstract boolean requireProjectId();
 
   @Override
   public String resourceRoot() {
@@ -47,7 +46,7 @@ public abstract class SmokeTestClassView implements ViewModel {
   public abstract String outputPath();
 
   public static Builder newBuilder() {
-    return new AutoValue_SmokeTestClassView.Builder().requireProjectID(false);
+    return new AutoValue_SmokeTestClassView.Builder().requireProjectId(false);
   }
 
   @AutoValue.Builder
@@ -67,7 +66,7 @@ public abstract class SmokeTestClassView implements ViewModel {
 
     public abstract Builder method(TestMethodView val);
 
-    public abstract Builder requireProjectID(boolean val);
+    public abstract Builder requireProjectId(boolean val);
 
     public abstract SmokeTestClassView build();
   }

--- a/src/main/resources/com/google/api/codegen/java/smoke_test.snip
+++ b/src/main/resources/com/google/api/codegen/java/smoke_test.snip
@@ -18,7 +18,7 @@
                 .desc("Project id")
                 .hasArg()
                 .argName("PROJECT-ID")
-                .required(true)
+                .required(false)
                 .build());
 
         CommandLine cl = (new DefaultParser()).parse(options, args);

--- a/src/main/resources/com/google/api/codegen/java/smoke_test.snip
+++ b/src/main/resources/com/google/api/codegen/java/smoke_test.snip
@@ -18,7 +18,7 @@
         System.exit(1);
       }
     }
-    @if smokeTest.requireProjectID
+    @if smokeTest.requireProjectId
       {@executeWithProjectID(smokeTest)}
     @else
       {@executeWithNoProjectID(smokeTest)}
@@ -27,7 +27,7 @@
 @end
 
 @private testBody(smokeTest)
-  @if smokeTest.requireProjectID
+  @if smokeTest.requireProjectId
     Options options = new Options();
     options.addOption("h", "help", false, "show usage");
     options.addOption(

--- a/src/main/resources/com/google/api/codegen/java/smoke_test.snip
+++ b/src/main/resources/com/google/api/codegen/java/smoke_test.snip
@@ -10,23 +10,7 @@
     public static void main(String args[]) {
       Logger.getLogger("").setLevel(Level.WARNING);
       try {
-        Options options = new Options();
-        options.addOption("h", "help", false, "show usage");
-        options.addOption(
-            Option.builder()
-                .longOpt("project_id")
-                .desc("Project id")
-                .hasArg()
-                .argName("PROJECT-ID")
-                .required(false)
-                .build());
-
-        CommandLine cl = (new DefaultParser()).parse(options, args);
-        if (cl.hasOption("help")) {
-          HelpFormatter formater = new HelpFormatter();
-          formater.printHelp("{@smokeTest.name}", options);
-        }
-        executeNoCatch(cl.getOptionValue("project_id"));
+        {@testBody(smokeTest)}
         System.out.println("OK");
       } catch (Exception e) {
         System.err.println("Failed with exception:");
@@ -34,13 +18,47 @@
         System.exit(1);
       }
     }
-
-    {@executeNoCatch(smokeTest)}
+    @if smokeTest.requireProjectID
+      {@executeWithProjectID(smokeTest)}
+    @else
+      {@executeWithNoProjectID(smokeTest)}
+    @end
   }
 @end
 
-@private executeNoCatch(smokeTest)
+@private testBody(smokeTest)
+  @if smokeTest.requireProjectID
+    Options options = new Options();
+    options.addOption("h", "help", false, "show usage");
+    options.addOption(
+        Option.builder()
+            .longOpt("project_id")
+            .desc("Project id")
+            .hasArg()
+            .argName("PROJECT-ID")
+            .required(true)
+            .build());
+    CommandLine cl = (new DefaultParser()).parse(options, args);
+    if (cl.hasOption("help")) {
+      HelpFormatter formater = new HelpFormatter();
+      formater.printHelp("{@smokeTest.name}", options);
+    }
+    executeNoCatch(cl.getOptionValue("project_id"));
+  @else
+    executeNoCatch();
+  @end
+@end
+
+@private executeWithProjectID(smokeTest)
   public static void executeNoCatch(String projectId) throws Exception {
+    try ({@smokeTest.apiClassName} api = {@smokeTest.apiClassName}.create()) {
+      {@methodCall(smokeTest.method)}
+    }
+  }
+@end
+
+@private executeWithNoProjectID(smokeTest)
+  public static void executeNoCatch() throws Exception {
     try ({@smokeTest.apiClassName} api = {@smokeTest.apiClassName}.create()) {
       {@methodCall(smokeTest.method)}
     }

--- a/src/main/resources/com/google/api/codegen/java/smoke_test.snip
+++ b/src/main/resources/com/google/api/codegen/java/smoke_test.snip
@@ -10,8 +10,24 @@
     public static void main(String args[]) {
       Logger.getLogger("").setLevel(Level.WARNING);
       try {
-        executeNoCatch(args);
-        System.out.println("ok");
+        Options options = new Options();
+        options.addOption("h", "help", false, "show usage");
+        options.addOption(
+            Option.builder()
+                .longOpt("project_id")
+                .desc("Project id")
+                .hasArg()
+                .argName("PROJECT-ID")
+                .required(true)
+                .build());
+
+        CommandLine cl = (new DefaultParser()).parse(options, args);
+        if (cl.hasOption("help")) {
+          HelpFormatter formater = new HelpFormatter();
+          formater.printHelp("{@smokeTest.name}", options);
+        }
+        executeNoCatch(cl.getOptionValue("project_id"));
+        System.out.println("OK");
       } catch (Exception e) {
         System.err.println("Failed with exception:");
         e.printStackTrace(System.err);
@@ -24,7 +40,7 @@
 @end
 
 @private executeNoCatch(smokeTest)
-  public static void executeNoCatch(String args[]) throws Exception {
+  public static void executeNoCatch(String projectId) throws Exception {
     try ({@smokeTest.apiClassName} api = {@smokeTest.apiClassName}.create()) {
       {@methodCall(smokeTest.method)}
     }

--- a/src/test/java/com/google/api/codegen/metacode/SampleInitCodeTest.java
+++ b/src/test/java/com/google/api/codegen/metacode/SampleInitCodeTest.java
@@ -14,7 +14,6 @@
  */
 package com.google.api.codegen.metacode;
 
-import com.google.api.codegen.metacode.InitValue.InitValueType;
 import com.google.api.codegen.util.Name;
 import com.google.api.codegen.util.SymbolTable;
 import com.google.api.tools.framework.model.Interface;
@@ -182,8 +181,8 @@ public class SampleInitCodeTest {
     initValueMap.put("formatted_field", initValueConfig);
 
     HashMap<String, InitValue> expectedCollectionValues = new HashMap<>();
-    expectedCollectionValues.put("entity1", new InitValue("test1", InitValueType.Literal));
-    expectedCollectionValues.put("entity2", new InitValue("test2", InitValueType.Literal));
+    expectedCollectionValues.put("entity1", InitValue.createLiteral("test1"));
+    expectedCollectionValues.put("entity2", InitValue.createLiteral("test2"));
 
     InitCodeContext context =
         getContextBuilder()
@@ -225,8 +224,7 @@ public class SampleInitCodeTest {
 
     InitCodeNode expectedStructure =
         InitCodeNode.createWithValue(
-            "myfield",
-            InitValueConfig.createWithValue(new InitValue("default", InitValueType.Literal)));
+            "myfield", InitValueConfig.createWithValue(InitValue.createLiteral("default")));
 
     InitCodeNode actualStructure = FieldStructureParser.parse(fieldSpec);
     Truth.assertThat(checkEquals(actualStructure, expectedStructure)).isTrue();

--- a/src/test/java/com/google/api/codegen/metacode/SampleInitCodeTest.java
+++ b/src/test/java/com/google/api/codegen/metacode/SampleInitCodeTest.java
@@ -14,6 +14,7 @@
  */
 package com.google.api.codegen.metacode;
 
+import com.google.api.codegen.metacode.InitValue.InitValueType;
 import com.google.api.codegen.util.Name;
 import com.google.api.codegen.util.SymbolTable;
 import com.google.api.tools.framework.model.Interface;
@@ -180,9 +181,9 @@ public class SampleInitCodeTest {
     InitValueConfig initValueConfig = InitValueConfig.create("test-api", null);
     initValueMap.put("formatted_field", initValueConfig);
 
-    HashMap<String, String> expectedCollectionValues = new HashMap<>();
-    expectedCollectionValues.put("entity1", "test1");
-    expectedCollectionValues.put("entity2", "test2");
+    HashMap<String, InitValue> expectedCollectionValues = new HashMap<>();
+    expectedCollectionValues.put("entity1", new InitValue("test1", InitValueType.Literal));
+    expectedCollectionValues.put("entity2", new InitValue("test2", InitValueType.Literal));
 
     InitCodeContext context =
         getContextBuilder()
@@ -223,7 +224,9 @@ public class SampleInitCodeTest {
     String fieldSpec = "myfield=\"default\"";
 
     InitCodeNode expectedStructure =
-        InitCodeNode.createWithValue("myfield", InitValueConfig.createWithValue("default"));
+        InitCodeNode.createWithValue(
+            "myfield",
+            InitValueConfig.createWithValue(new InitValue("default", InitValueType.Literal)));
 
     InitCodeNode actualStructure = FieldStructureParser.parse(fieldSpec);
     Truth.assertThat(checkEquals(actualStructure, expectedStructure)).isTrue();

--- a/src/test/java/com/google/api/codegen/testdata/java_smoke_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_smoke_test_library.baseline
@@ -44,9 +44,8 @@ public class LibraryServiceSmokeTest {
               .desc("Project id")
               .hasArg()
               .argName("PROJECT-ID")
-              .required(false)
+              .required(true)
               .build());
-
       CommandLine cl = (new DefaultParser()).parse(options, args);
       if (cl.hasOption("help")) {
         HelpFormatter formater = new HelpFormatter();
@@ -60,7 +59,6 @@ public class LibraryServiceSmokeTest {
       System.exit(1);
     }
   }
-
   public static void executeNoCatch(String projectId) throws Exception {
     try (LibraryServiceApi api = LibraryServiceApi.create()) {
       BookName name = BookName.create("testShelf-1963239498", projectId);

--- a/src/test/java/com/google/api/codegen/testdata/java_smoke_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_smoke_test_library.baseline
@@ -44,7 +44,7 @@ public class LibraryServiceSmokeTest {
               .desc("Project id")
               .hasArg()
               .argName("PROJECT-ID")
-              .required(true)
+              .required(false)
               .build());
 
       CommandLine cl = (new DefaultParser()).parse(options, args);

--- a/src/test/java/com/google/api/codegen/testdata/java_smoke_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_smoke_test_library.baseline
@@ -23,6 +23,11 @@ import com.google.example.library.v1.BookName;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
 import org.apache.commons.lang.builder.ReflectionToStringBuilder;
 import org.apache.commons.lang.builder.ToStringStyle;
 
@@ -31,8 +36,24 @@ public class LibraryServiceSmokeTest {
   public static void main(String args[]) {
     Logger.getLogger("").setLevel(Level.WARNING);
     try {
-      executeNoCatch(args);
-      System.out.println("ok");
+      Options options = new Options();
+      options.addOption("h", "help", false, "show usage");
+      options.addOption(
+          Option.builder()
+              .longOpt("project_id")
+              .desc("Project id")
+              .hasArg()
+              .argName("PROJECT-ID")
+              .required(true)
+              .build());
+
+      CommandLine cl = (new DefaultParser()).parse(options, args);
+      if (cl.hasOption("help")) {
+        HelpFormatter formater = new HelpFormatter();
+        formater.printHelp("LibraryServiceSmokeTest", options);
+      }
+      executeNoCatch(cl.getOptionValue("project_id"));
+      System.out.println("OK");
     } catch (Exception e) {
       System.err.println("Failed with exception:");
       e.printStackTrace(System.err);
@@ -40,9 +61,9 @@ public class LibraryServiceSmokeTest {
     }
   }
 
-  public static void executeNoCatch(String args[]) throws Exception {
+  public static void executeNoCatch(String projectId) throws Exception {
     try (LibraryServiceApi api = LibraryServiceApi.create()) {
-      BookName name = BookName.create("testShelf-1963239498", "testBook");
+      BookName name = BookName.create("testShelf-1963239498", projectId);
 
       Book response = api.getBook(name);
       System.out.println(ReflectionToStringBuilder.toString(response, ToStringStyle.MULTI_LINE_STYLE));

--- a/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
@@ -64,7 +64,7 @@ interfaces:
     method: GetBook
     init_fields:
       - name%shelf_id="testShelf-$RANDOM"
-      - name%book_id="$PROJECT_ID"
+      - name%book_id=$PROJECT_ID
     flattening_group_name: get_book_1
   experimental_features:
     iam_resources:

--- a/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
@@ -64,7 +64,7 @@ interfaces:
     method: GetBook
     init_fields:
       - name%shelf_id="testShelf-$RANDOM"
-      - name%book_id="testBook"
+      - name%book_id="$PROJECT_ID"
     flattening_group_name: get_book_1
   experimental_features:
     iam_resources:


### PR DESCRIPTION
- Support `$PROJECT_ID` token in the smoke test config
- Add `InitValue` class which adds support of variable names in the init fields