### PR TITLE
Reduce # of forked JVMs and initial heap size

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 sudo: false
 language: java
+env:
+  global:
+    - GRADLE_OPTS="-Xms128m"
 jdk:
   - oraclejdk8
   - oraclejdk7

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,18 @@
 // Build Script
 // ============
 
+if (System.env.TRAVIS == 'true') {
+  allprojects {
+    tasks.withType(GroovyCompile) {
+      groovyOptions.fork = false
+    }
+    tasks.withType(Test) {
+      maxParallelForks = 2
+      minHeapSize = '128m'
+    }
+  }
+}
+
 import groovy.io.FileType
 
 buildscript {


### PR DESCRIPTION
Should close the case of the mysterious flaky builds.