### PR TITLE
Fix some C# code-gen bugs

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpCommonTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpCommonTransformer.java
@@ -26,6 +26,7 @@ public class CSharpCommonTransformer {
   public void addCommonImports(SurfaceTransformerContext context) {
     ModelTypeTable typeTable = context.getTypeTable();
     // Common imports, only one class per required namespace is needed.
+    typeTable.saveNicknameFor("Google.Api.Gax.GaxPreconditions");
     typeTable.saveNicknameFor("Google.Api.Gax.Grpc.ServiceSettingsBase");
     typeTable.saveNicknameFor("Google.Protobuf.WellKnownTypes.SomeSortOfWellKnownType");
     typeTable.saveNicknameFor("Grpc.Core.StatusCode");

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpSurfaceNamer.java
@@ -31,15 +31,107 @@ import com.google.api.tools.framework.model.Method;
 import com.google.api.tools.framework.model.TypeRef;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import java.util.List;
 
 public class CSharpSurfaceNamer extends SurfaceNamer {
+
+  private static ImmutableSet<String> keywords =
+      ImmutableSet.<String>builder()
+          .add("abstract")
+          .add("as")
+          .add("base")
+          .add("bool")
+          .add("break")
+          .add("byte")
+          .add("case")
+          .add("catch")
+          .add("char")
+          .add("checked")
+          .add("class")
+          .add("const")
+          .add("continue")
+          .add("decimal")
+          .add("default")
+          .add("delegate")
+          .add("do")
+          .add("double")
+          .add("else")
+          .add("enum")
+          .add("event")
+          .add("explicit")
+          .add("extern")
+          .add("false")
+          .add("finally")
+          .add("fixed")
+          .add("float")
+          .add("for")
+          .add("foreach")
+          .add("goto")
+          .add("if")
+          .add("implicit")
+          .add("in")
+          .add("int")
+          .add("interface")
+          .add("internal")
+          .add("is")
+          .add("lock")
+          .add("long")
+          .add("namespace")
+          .add("new")
+          .add("null")
+          .add("object")
+          .add("operator")
+          .add("out")
+          .add("override")
+          .add("params")
+          .add("private")
+          .add("protected")
+          .add("public")
+          .add("readonly")
+          .add("ref")
+          .add("return")
+          .add("sbyte")
+          .add("sealed")
+          .add("short")
+          .add("sizeof")
+          .add("stackalloc")
+          .add("static")
+          .add("string")
+          .add("struct")
+          .add("switch")
+          .add("this")
+          .add("throw")
+          .add("true")
+          .add("try")
+          .add("typeof")
+          .add("uint")
+          .add("ulong")
+          .add("unchecked")
+          .add("unsafe")
+          .add("ushort")
+          .add("using")
+          .add("virtual")
+          .add("void")
+          .add("volatile")
+          .add("while")
+          .build();
+
+  private static String prefixKeyword(String name) {
+    return keywords.contains(name) ? "@" + name : name;
+  }
+
   public CSharpSurfaceNamer(String packageName) {
     super(
         new CSharpNameFormatter(),
         new ModelTypeFormatterImpl(new CSharpModelTypeNameConverter(packageName)),
         new CSharpTypeTable(packageName),
         packageName);
+  }
+
+  @Override
+  public String localVarName(Name name) {
+    return prefixKeyword(super.localVarName(name));
   }
 
   @Override
@@ -190,6 +282,11 @@ public class CSharpSurfaceNamer extends SurfaceNamer {
   @Override
   public String getParamName(String var) {
     return localVarName(Name.from(var).join("id"));
+  }
+
+  @Override
+  public String getParamDocName(String var) {
+    return super.localVarName(Name.from(var));
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/viewmodel/RequestObjectParamView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/RequestObjectParamView.java
@@ -34,6 +34,10 @@ public abstract class RequestObjectParamView {
 
   public abstract boolean isArray();
 
+  public boolean isCollection() {
+    return isMap() || isArray();
+  }
+
   @Nullable // Used in C#
   public abstract String defaultValue();
 

--- a/src/main/resources/com/google/api/codegen/csharp/gapic_client.snip
+++ b/src/main/resources/com/google/api/codegen/csharp/gapic_client.snip
@@ -430,7 +430,7 @@
 
 @private requestProperties(params)
     @join param : params
-        @if param.isArray
+        @if param.isCollection
             {@param.nameAsMethodName} = { {@param.name} },
         @else
             {@param.nameAsMethodName} = {@param.name},

--- a/src/test/java/com/google/api/codegen/testdata/csharp_gapic_client_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/csharp_gapic_client_library.baseline
@@ -3519,7 +3519,7 @@ namespace Google.Example.Library.V1
                 {
                     Name = name,
                     IndexName = indexName,
-                    IndexMap = indexMap,
+                    IndexMap = { indexMap },
                 },
                 callSettings);
 
@@ -3550,7 +3550,7 @@ namespace Google.Example.Library.V1
                 {
                     Name = name,
                     IndexName = indexName,
-                    IndexMap = indexMap,
+                    IndexMap = { indexMap },
                 },
                 callSettings);
 


### PR DESCRIPTION
Updates #697
"using Google.Api.Gax" added.
@ prefix on identifiers which are C# keywords.
Dictionary parameters now use collection initializer.