### PR TITLE
Fix datastore grpc doc class generation for python and ruby

### DIFF
--- a/src/main/java/com/google/api/codegen/CommentPatterns.java
+++ b/src/main/java/com/google/api/codegen/CommentPatterns.java
@@ -27,6 +27,6 @@ public final class CommentPatterns {
   public static final Pattern CLOUD_LINK_PATTERN =
       Pattern.compile("\\[([^\\]]+)\\]\\(((?!\\p{Alpha}+:)[^\\)]+)\\)");
   public static final Pattern PROTO_LINK_PATTERN =
-      Pattern.compile("\\[([^\\]]+)\\]\\[([A-Za-z_][A-Za-z_.0-9]*)*\\]");
+      Pattern.compile("\\[([^\\]]+)\\]\\[([A-Za-z_][A-Za-z_.0-9]*)?\\]");
   public static final Pattern HEADLINE_PATTERN = Pattern.compile("^#+", Pattern.MULTILINE);
 }

--- a/src/main/java/com/google/api/codegen/CommentPatterns.java
+++ b/src/main/java/com/google/api/codegen/CommentPatterns.java
@@ -26,6 +26,7 @@ public final class CommentPatterns {
       Pattern.compile("\\[([^\\]]+)\\]\\((\\p{Alpha}+:[^\\)]+)\\)");
   public static final Pattern CLOUD_LINK_PATTERN =
       Pattern.compile("\\[([^\\]]+)\\]\\(((?!\\p{Alpha}+:)[^\\)]+)\\)");
-  public static final Pattern PROTO_LINK_PATTERN = Pattern.compile("\\[([^\\]]+)\\]\\[[^\\]]*\\]");
+  public static final Pattern PROTO_LINK_PATTERN =
+      Pattern.compile("\\[([^\\]]+)\\]\\[([A-Za-z_][A-Za-z_.0-9]*)*\\]");
   public static final Pattern HEADLINE_PATTERN = Pattern.compile("^#+", Pattern.MULTILINE);
 }

--- a/src/main/java/com/google/api/codegen/nodejs/JSDocCommentFixer.java
+++ b/src/main/java/com/google/api/codegen/nodejs/JSDocCommentFixer.java
@@ -50,7 +50,8 @@ public class JSDocCommentFixer {
     }
     do {
       String url = "https://cloud.google.com" + m.group(2);
-      m.appendReplacement(sb, String.format("[%s](%s)", m.group(1), url));
+      // cloud markdown links may contain '$' which needs to be escaped using Matcher.quoteReplacement
+      m.appendReplacement(sb, Matcher.quoteReplacement(String.format("[%s](%s)", m.group(1), url)));
     } while (m.find());
     m.appendTail(sb);
     return sb.toString();

--- a/src/main/java/com/google/api/codegen/nodejs/JSDocCommentFixer.java
+++ b/src/main/java/com/google/api/codegen/nodejs/JSDocCommentFixer.java
@@ -35,7 +35,8 @@ public class JSDocCommentFixer {
       return comment;
     }
     do {
-      m.appendReplacement(sb, String.format("{@link %s}", m.group(1)));
+      // proto display name may contain '$' which needs to be escaped using Matcher.quoteReplacement
+      m.appendReplacement(sb, Matcher.quoteReplacement(String.format("{@link %s}", m.group(1))));
     } while (m.find());
     m.appendTail(sb);
     return sb.toString();

--- a/src/main/java/com/google/api/codegen/py/PythonSphinxCommentFixer.java
+++ b/src/main/java/com/google/api/codegen/py/PythonSphinxCommentFixer.java
@@ -37,7 +37,8 @@ public class PythonSphinxCommentFixer {
       return comment;
     }
     do {
-      m.appendReplacement(sb, String.format("``%s``", m.group(1)));
+      // proto display name may contain '$' which needs to be escaped using Matcher.quoteReplacement
+      m.appendReplacement(sb, Matcher.quoteReplacement(String.format("``%s``", m.group(1))));
     } while (m.find());
     m.appendTail(sb);
     return sb.toString();

--- a/src/main/java/com/google/api/codegen/py/PythonSphinxCommentFixer.java
+++ b/src/main/java/com/google/api/codegen/py/PythonSphinxCommentFixer.java
@@ -22,8 +22,6 @@ public class PythonSphinxCommentFixer {
 
   /** Returns a Sphinx-formatted comment string. */
   public static String sphinxify(String comment) {
-    // escape '$' in the comment first
-    comment = comment.replaceAll("\\$", "\\\\\\$");
     comment = CommentPatterns.BACK_QUOTE_PATTERN.matcher(comment).replaceAll("``");
     comment = comment.replace("\"", "\\\"");
     comment = sphinxifyProtoMarkdownLinks(comment);
@@ -53,7 +51,9 @@ public class PythonSphinxCommentFixer {
       return comment;
     }
     do {
-      m.appendReplacement(sb, String.format("`%s <%s>`_", m.group(1), m.group(2)));
+      // absolute markdown links may contain '$' which needs to be escaped using Matcher.quoteReplacement
+      m.appendReplacement(
+          sb, Matcher.quoteReplacement(String.format("`%s <%s>`_", m.group(1), m.group(2))));
     } while (m.find());
     m.appendTail(sb);
     return sb.toString();
@@ -67,8 +67,11 @@ public class PythonSphinxCommentFixer {
       return comment;
     }
     do {
+      // cloud markdown links may contain '$' which needs to be escaped using Matcher.quoteReplacement
       m.appendReplacement(
-          sb, String.format("`%s <https://cloud.google.com%s>`_", m.group(1), m.group(2)));
+          sb,
+          Matcher.quoteReplacement(
+              String.format("`%s <https://cloud.google.com%s>`_", m.group(1), m.group(2))));
     } while (m.find());
     m.appendTail(sb);
     return sb.toString();

--- a/src/main/java/com/google/api/codegen/py/PythonSphinxCommentFixer.java
+++ b/src/main/java/com/google/api/codegen/py/PythonSphinxCommentFixer.java
@@ -22,6 +22,8 @@ public class PythonSphinxCommentFixer {
 
   /** Returns a Sphinx-formatted comment string. */
   public static String sphinxify(String comment) {
+    // escape '$' in the comment first
+    comment = comment.replaceAll("\\$", "\\\\\\$");
     comment = CommentPatterns.BACK_QUOTE_PATTERN.matcher(comment).replaceAll("``");
     comment = comment.replace("\"", "\\\"");
     comment = sphinxifyProtoMarkdownLinks(comment);

--- a/src/main/java/com/google/api/codegen/ruby/RDocCommentFixer.java
+++ b/src/main/java/com/google/api/codegen/ruby/RDocCommentFixer.java
@@ -23,8 +23,6 @@ public class RDocCommentFixer {
 
   /** Returns a RDoc-formatted comment string. */
   public static String rdocify(String comment) {
-    // escape '$' in the comment first
-    comment = comment.replaceAll("\\$", "\\\\\\$");
     comment = CommentPatterns.BACK_QUOTE_PATTERN.matcher(comment).replaceAll("+");
     comment = rdocifyProtoMarkdownLinks(comment);
     comment = rdocifyCloudMarkdownLinks(comment);
@@ -69,7 +67,7 @@ public class RDocCommentFixer {
     return sb.toString();
   }
 
-  /** Returns a string with all cloud markdown links formatted to Sphinx style. */
+  /** Returns a string with all cloud markdown links formatted to RDoc style. */
   private static String rdocifyCloudMarkdownLinks(String comment) {
     StringBuffer sb = new StringBuffer();
     Matcher m = CommentPatterns.CLOUD_LINK_PATTERN.matcher(comment);
@@ -78,13 +76,14 @@ public class RDocCommentFixer {
     }
     do {
       String url = "https://cloud.google.com" + m.group(2);
-      m.appendReplacement(sb, String.format("{%s}[%s]", m.group(1), url));
+      // cloud markdown links may contain '$' which needs to be escaped using Matcher.quoteReplacement
+      m.appendReplacement(sb, Matcher.quoteReplacement(String.format("{%s}[%s]", m.group(1), url)));
     } while (m.find());
     m.appendTail(sb);
     return sb.toString();
   }
 
-  /** Returns a string with all cloud markdown links formatted to Sphinx style. */
+  /** Returns a string with all absolute markdown links formatted to RDoc style. */
   private static String rdocifyAbsoluteMarkdownLinks(String comment) {
     StringBuffer sb = new StringBuffer();
     Matcher m = CommentPatterns.ABSOLUTE_LINK_PATTERN.matcher(comment);
@@ -92,7 +91,9 @@ public class RDocCommentFixer {
       return comment;
     }
     do {
-      m.appendReplacement(sb, String.format("{%s}[%s]", m.group(1), m.group(2)));
+      // absolute markdown links may contain '$' which needs to be escaped using Matcher.quoteReplacement
+      m.appendReplacement(
+          sb, Matcher.quoteReplacement(String.format("{%s}[%s]", m.group(1), m.group(2))));
     } while (m.find());
     m.appendTail(sb);
     return sb.toString();

--- a/src/main/java/com/google/api/codegen/ruby/RDocCommentFixer.java
+++ b/src/main/java/com/google/api/codegen/ruby/RDocCommentFixer.java
@@ -21,8 +21,10 @@ import java.util.regex.Matcher;
 /** Utility class for formatting source comments to follow RDoc style. */
 public class RDocCommentFixer {
 
-  /** Returns a Sphinx-formatted comment string. */
+  /** Returns a RDoc-formatted comment string. */
   public static String rdocify(String comment) {
+    // escape '$' in the comment first
+    comment = comment.replaceAll("\\$", "\\\\\\$");
     comment = CommentPatterns.BACK_QUOTE_PATTERN.matcher(comment).replaceAll("+");
     comment = rdocifyProtoMarkdownLinks(comment);
     comment = rdocifyCloudMarkdownLinks(comment);

--- a/src/main/java/com/google/api/codegen/ruby/RDocCommentFixer.java
+++ b/src/main/java/com/google/api/codegen/ruby/RDocCommentFixer.java
@@ -61,7 +61,9 @@ public class RDocCommentFixer {
       return comment;
     }
     do {
-      m.appendReplacement(sb, String.format("%s", protoToRubyDoc(m.group(1))));
+      // proto display name may contain '$' which needs to be escaped using Matcher.quoteReplacement
+      m.appendReplacement(
+          sb, Matcher.quoteReplacement(String.format("%s", protoToRubyDoc(m.group(1)))));
     } while (m.find());
     m.appendTail(sb);
     return sb.toString();

--- a/src/test/java/com/google/api/codegen/ProtoDocumentLinkTest.java
+++ b/src/test/java/com/google/api/codegen/ProtoDocumentLinkTest.java
@@ -41,7 +41,7 @@ public class ProtoDocumentLinkTest {
     // Fully qualified name may NOT contain special character '$'
     m = CommentPatterns.PROTO_LINK_PATTERN.matcher("[A-Za-z_$][A-Za-z_$0-9]");
     Truth.assertThat(m.find()).isFalse();
-    // Fully qualified name many NOT be numbers only
+    // Fully qualified name may NOT be numbers only
     m = CommentPatterns.PROTO_LINK_PATTERN.matcher("[Shelf][123]");
     Truth.assertThat(m.find()).isFalse();
   }

--- a/src/test/java/com/google/api/codegen/ProtoDocumentLinkTest.java
+++ b/src/test/java/com/google/api/codegen/ProtoDocumentLinkTest.java
@@ -23,19 +23,25 @@ import org.junit.Test;
 
 public class ProtoDocumentLinkTest {
 
+  /* ProtoLink in comments is defined as [display name][fully qualified name] */
   @Test
   public void testMatchProtoLink() {
     Matcher m;
     m = CommentPatterns.PROTO_LINK_PATTERN.matcher("[Shelf][google.example.library.v1.Shelf]");
     Truth.assertThat(m.find()).isTrue();
+    // Fully qualified name can be empty
     m = CommentPatterns.PROTO_LINK_PATTERN.matcher("[Shelf][]");
     Truth.assertThat(m.find()).isTrue();
+    // Display name may contain special character '$'
     m = CommentPatterns.PROTO_LINK_PATTERN.matcher("[$Shelf][]");
     Truth.assertThat(m.find()).isTrue();
+    // Display name may NOT be empty
     m = CommentPatterns.PROTO_LINK_PATTERN.matcher("[][abc]");
     Truth.assertThat(m.find()).isFalse();
+    // Fully qualified name may NOT contain special character '$'
     m = CommentPatterns.PROTO_LINK_PATTERN.matcher("[A-Za-z_$][A-Za-z_$0-9]");
     Truth.assertThat(m.find()).isFalse();
+    // Fully qualified name many NOT be numbers only
     m = CommentPatterns.PROTO_LINK_PATTERN.matcher("[Shelf][123]");
     Truth.assertThat(m.find()).isFalse();
   }
@@ -47,11 +53,13 @@ public class ProtoDocumentLinkTest {
     Truth.assertThat(RDocCommentFixer.rdocify("[$Shelf][google.example.library.v1.Shelf]"))
         .isEqualTo("$Shelf");
 
+    // Cloud link may contain special character '$'
     Truth.assertThat(RDocCommentFixer.rdocify("[cloud docs!](/library/example/link)"))
         .isEqualTo("{cloud docs!}[https://cloud.google.com/library/example/link]");
     Truth.assertThat(RDocCommentFixer.rdocify("[cloud docs!](/library/example/link$)"))
         .isEqualTo("{cloud docs!}[https://cloud.google.com/library/example/link$]");
 
+    // Absolute link may contain special character '$'
     Truth.assertThat(RDocCommentFixer.rdocify("[not a cloud link](http://www.google.com)"))
         .isEqualTo("{not a cloud link}[http://www.google.com]");
     Truth.assertThat(RDocCommentFixer.rdocify("[not a cloud link](http://www.google.com$)"))
@@ -66,11 +74,13 @@ public class ProtoDocumentLinkTest {
             PythonSphinxCommentFixer.sphinxify("[$Shelf][google.example.library.v1.Shelf]"))
         .isEqualTo("``$Shelf``");
 
+    // Cloud link may contain special character '$'
     Truth.assertThat(PythonSphinxCommentFixer.sphinxify("[cloud docs!](/library/example/link)"))
         .isEqualTo("`cloud docs! <https://cloud.google.com/library/example/link>`_");
     Truth.assertThat(PythonSphinxCommentFixer.sphinxify("[cloud docs!](/library/example/link$)"))
         .isEqualTo("`cloud docs! <https://cloud.google.com/library/example/link$>`_");
 
+    // Absolute link may contain special character '$'
     Truth.assertThat(
             PythonSphinxCommentFixer.sphinxify("[not a cloud link](http://www.google.com)"))
         .isEqualTo("`not a cloud link <http://www.google.com>`_");
@@ -86,11 +96,13 @@ public class ProtoDocumentLinkTest {
     Truth.assertThat(JSDocCommentFixer.jsdocify("[$Shelf][google.example.library.v1.Shelf]"))
         .isEqualTo("{@link $Shelf}");
 
+    // Cloud link may contain special character '$'
     Truth.assertThat(JSDocCommentFixer.jsdocify("[cloud docs!](/library/example/link)"))
         .isEqualTo("[cloud docs!](https://cloud.google.com/library/example/link)");
     Truth.assertThat(JSDocCommentFixer.jsdocify("[cloud docs!](/library/example/link$)"))
         .isEqualTo("[cloud docs!](https://cloud.google.com/library/example/link$)");
 
+    // Absolute link may contain special character '$'
     Truth.assertThat(JSDocCommentFixer.jsdocify("[not a cloud link](http://www.google.com)"))
         .isEqualTo("[not a cloud link](http://www.google.com)");
     Truth.assertThat(JSDocCommentFixer.jsdocify("[not a cloud link](http://www.google.com$)"))

--- a/src/test/java/com/google/api/codegen/ProtoDocumentLinkTest.java
+++ b/src/test/java/com/google/api/codegen/ProtoDocumentLinkTest.java
@@ -1,0 +1,99 @@
+/* Copyright 2016 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen;
+
+import com.google.api.codegen.nodejs.JSDocCommentFixer;
+import com.google.api.codegen.py.PythonSphinxCommentFixer;
+import com.google.api.codegen.ruby.RDocCommentFixer;
+import com.google.common.truth.Truth;
+import java.util.regex.Matcher;
+import org.junit.Test;
+
+public class ProtoDocumentLinkTest {
+
+  @Test
+  public void testMatchProtoLink() {
+    Matcher m;
+    m = CommentPatterns.PROTO_LINK_PATTERN.matcher("[Shelf][google.example.library.v1.Shelf]");
+    Truth.assertThat(m.find()).isTrue();
+    m = CommentPatterns.PROTO_LINK_PATTERN.matcher("[Shelf][]");
+    Truth.assertThat(m.find()).isTrue();
+    m = CommentPatterns.PROTO_LINK_PATTERN.matcher("[$Shelf][]");
+    Truth.assertThat(m.find()).isTrue();
+    m = CommentPatterns.PROTO_LINK_PATTERN.matcher("[][abc]");
+    Truth.assertThat(m.find()).isFalse();
+    m = CommentPatterns.PROTO_LINK_PATTERN.matcher("[A-Za-z_$][A-Za-z_$0-9]");
+    Truth.assertThat(m.find()).isFalse();
+    m = CommentPatterns.PROTO_LINK_PATTERN.matcher("[Shelf][123]");
+    Truth.assertThat(m.find()).isFalse();
+  }
+
+  @Test
+  public void testRDocCommentFixer() {
+    Truth.assertThat(RDocCommentFixer.rdocify("[Shelf][google.example.library.v1.Shelf]"))
+        .isEqualTo("Shelf");
+    Truth.assertThat(RDocCommentFixer.rdocify("[$Shelf][google.example.library.v1.Shelf]"))
+        .isEqualTo("$Shelf");
+
+    Truth.assertThat(RDocCommentFixer.rdocify("[cloud docs!](/library/example/link)"))
+        .isEqualTo("{cloud docs!}[https://cloud.google.com/library/example/link]");
+    Truth.assertThat(RDocCommentFixer.rdocify("[cloud docs!](/library/example/link$)"))
+        .isEqualTo("{cloud docs!}[https://cloud.google.com/library/example/link$]");
+
+    Truth.assertThat(RDocCommentFixer.rdocify("[not a cloud link](http://www.google.com)"))
+        .isEqualTo("{not a cloud link}[http://www.google.com]");
+    Truth.assertThat(RDocCommentFixer.rdocify("[not a cloud link](http://www.google.com$)"))
+        .isEqualTo("{not a cloud link}[http://www.google.com$]");
+  }
+
+  @Test
+  public void testPythonSphinxCommentFixer() {
+    Truth.assertThat(PythonSphinxCommentFixer.sphinxify("[Shelf][google.example.library.v1.Shelf]"))
+        .isEqualTo("``Shelf``");
+    Truth.assertThat(
+            PythonSphinxCommentFixer.sphinxify("[$Shelf][google.example.library.v1.Shelf]"))
+        .isEqualTo("``$Shelf``");
+
+    Truth.assertThat(PythonSphinxCommentFixer.sphinxify("[cloud docs!](/library/example/link)"))
+        .isEqualTo("`cloud docs! <https://cloud.google.com/library/example/link>`_");
+    Truth.assertThat(PythonSphinxCommentFixer.sphinxify("[cloud docs!](/library/example/link$)"))
+        .isEqualTo("`cloud docs! <https://cloud.google.com/library/example/link$>`_");
+
+    Truth.assertThat(
+            PythonSphinxCommentFixer.sphinxify("[not a cloud link](http://www.google.com)"))
+        .isEqualTo("`not a cloud link <http://www.google.com>`_");
+    Truth.assertThat(
+            PythonSphinxCommentFixer.sphinxify("[not a cloud link](http://www.google.com$)"))
+        .isEqualTo("`not a cloud link <http://www.google.com$>`_");
+  }
+
+  @Test
+  public void testJSDocCommentFixer() {
+    Truth.assertThat(JSDocCommentFixer.jsdocify("[Shelf][google.example.library.v1.Shelf]"))
+        .isEqualTo("{@link Shelf}");
+    Truth.assertThat(JSDocCommentFixer.jsdocify("[$Shelf][google.example.library.v1.Shelf]"))
+        .isEqualTo("{@link $Shelf}");
+
+    Truth.assertThat(JSDocCommentFixer.jsdocify("[cloud docs!](/library/example/link)"))
+        .isEqualTo("[cloud docs!](https://cloud.google.com/library/example/link)");
+    Truth.assertThat(JSDocCommentFixer.jsdocify("[cloud docs!](/library/example/link$)"))
+        .isEqualTo("[cloud docs!](https://cloud.google.com/library/example/link$)");
+
+    Truth.assertThat(JSDocCommentFixer.jsdocify("[not a cloud link](http://www.google.com)"))
+        .isEqualTo("[not a cloud link](http://www.google.com)");
+    Truth.assertThat(JSDocCommentFixer.jsdocify("[not a cloud link](http://www.google.com$)"))
+        .isEqualTo("[not a cloud link](http://www.google.com$)");
+  }
+}


### PR DESCRIPTION
#716 This is due to datastore API's GqlQuery message's comment contains '$' so we have to escape it, otherwise it will cause java's regex failure (throwing IAE exception)

In https://github.com/googleapis/googleapis/blob/master/google/datastore/v1/query.proto#L232,

-------------------------

Key must match regex `[A-Za-z_$][A-Za-z_$0-9]*`

-------------------------

The original CommentPatterns.PROTO_LINK_PATTERN causes the above [A-Za-z_$][A-Za-z_$0-9] to be parsed as a proto link, using Ruby as an example (similar with Python and NodeJS)

In RDocCommentFixer.java:
```
  private static String rdocifyProtoMarkdownLinks(String comment) {
    StringBuffer sb = new StringBuffer();
    Matcher m = CommentPatterns.PROTO_LINK_PATTERN.matcher(comment);
    if (!m.find()) {
      return comment;
    }
    do {
      m.appendReplacement(sb, String.format("%s", protoToRubyDoc(m.group(1))));
    } while (m.find());
    m.appendTail(sb);
    return sb.toString();
  }
```

When m.appendReplacement is called, the second argument contains a '$' in it (because m.group(1) is A-Za-z_$, so that causes appendReplacement to throw IAE.
