### PR TITLE
Fix issues in smoke test generator

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
@@ -22,6 +22,7 @@ import com.google.api.codegen.metacode.InitCodeContext.InitCodeOutputType;
 import com.google.api.codegen.metacode.InitCodeLineType;
 import com.google.api.codegen.metacode.InitCodeNode;
 import com.google.api.codegen.metacode.InitValue;
+import com.google.api.codegen.metacode.InitValue.InitValueType;
 import com.google.api.codegen.metacode.InitValueConfig;
 import com.google.api.codegen.util.Name;
 import com.google.api.codegen.viewmodel.FieldSettingView;
@@ -359,11 +360,13 @@ public class InitCodeTransformer {
       SimpleInitValueView.Builder initValue = SimpleInitValueView.newBuilder();
 
       if (initValueConfig.hasSimpleInitialValue()) {
-        initValue.initialValue(
-            context
-                .getTypeTable()
-                .renderPrimitiveValue(
-                    item.getType(), initValueConfig.getInitialValue().getValue()));
+        String value = initValueConfig.getInitialValue().getValue();
+        if (initValueConfig.getInitialValue().getType() == InitValueType.Literal) {
+          value = context.getTypeTable().renderPrimitiveValue(item.getType(), value);
+        } else {
+          value = context.getNamer().localVarName(Name.from(value));
+        }
+        initValue.initialValue(value);
       } else {
         initValue.initialValue(
             context.getTypeTable().getZeroValueAndSaveNicknameFor(item.getType()));

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
@@ -51,10 +51,12 @@ import com.google.api.codegen.util.testing.TestValueGenerator;
 import com.google.api.codegen.viewmodel.ApiMethodType;
 import com.google.api.codegen.viewmodel.FieldSettingView;
 import com.google.api.codegen.viewmodel.FileHeaderView;
+import com.google.api.codegen.viewmodel.FormattedInitValueView;
 import com.google.api.codegen.viewmodel.InitCodeLineView;
 import com.google.api.codegen.viewmodel.InitCodeView;
 import com.google.api.codegen.viewmodel.ResourceNameInitValueView;
 import com.google.api.codegen.viewmodel.SimpleInitCodeLineView;
+import com.google.api.codegen.viewmodel.SimpleInitValueView;
 import com.google.api.codegen.viewmodel.ViewModel;
 import com.google.api.codegen.viewmodel.testing.GapicSurfaceTestAssertView;
 import com.google.api.codegen.viewmodel.testing.GapicSurfaceTestCaseView;
@@ -185,11 +187,17 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
       InitCodeLineView line = settingsView.initCodeLine();
       if (line.lineType() == InitCodeLineType.SimpleInitLine) {
         SimpleInitCodeLineView simpleLine = (SimpleInitCodeLineView) line;
+        String projectVarName =
+            namer.localVarName(Name.from(InitFieldConfig.PROJECT_ID_VARIABLE_NAME));
         if (simpleLine.initValue() instanceof ResourceNameInitValueView) {
           ResourceNameInitValueView initValue = (ResourceNameInitValueView) simpleLine.initValue();
-          return initValue
-              .formatArgs()
-              .contains(namer.localVarName(Name.from(InitFieldConfig.PROJECT_ID_VARIABLE_NAME)));
+          return initValue.formatArgs().contains(projectVarName);
+        } else if (simpleLine.initValue() instanceof SimpleInitValueView) {
+          SimpleInitValueView initValue = (SimpleInitValueView) simpleLine.initValue();
+          return initValue.initialValue().equals(projectVarName);
+        } else if (simpleLine.initValue() instanceof FormattedInitValueView) {
+          FormattedInitValueView initValue = (FormattedInitValueView) simpleLine.initValue();
+          return initValue.formatArgs().contains(projectVarName);
         }
       }
     }

--- a/src/main/resources/com/google/api/codegen/java/method_sample.snip
+++ b/src/main/resources/com/google/api/codegen/java/method_sample.snip
@@ -135,7 +135,7 @@
       {@sampleMethodCallArgList(apiMethod.initCode.fieldSettings)})
 @end
 
-@private sampleMethodCallArgList(fieldSettings)
+@snippet sampleMethodCallArgList(fieldSettings)
   @join fieldSetting : fieldSettings on ", "
     {@fieldSetting.identifier}
   @end

--- a/src/main/resources/com/google/api/codegen/java/smoke_test.snip
+++ b/src/main/resources/com/google/api/codegen/java/smoke_test.snip
@@ -1,5 +1,6 @@
 @extends "java/common.snip"
 @extends "java/initcode.snip"
+@extends "java/method_sample.snip"
 
 
 @snippet generate(smokeTest)


### PR DESCRIPTION
- Fixed the snippet where `sampleMethodCallArgList` was private
- Fixed an issue that `InitCodeTransformer` treated variable values as quoted string
- Fixed the `requireProjectId` method which did not return correct values in some cases.