### PR TITLE
Format parse methods

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/PathTemplateTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/PathTemplateTransformer.java
@@ -14,6 +14,7 @@
  */
 package com.google.api.codegen.transformer;
 
+import com.google.api.codegen.config.InterfaceConfig;
 import com.google.api.codegen.config.SingleResourceNameConfig;
 import com.google.api.codegen.util.Name;
 import com.google.api.codegen.viewmodel.FormatResourceFunctionView;
@@ -32,7 +33,9 @@ public class PathTemplateTransformer {
   public List<PathTemplateView> generatePathTemplates(SurfaceTransformerContext context) {
     List<PathTemplateView> pathTemplates = new ArrayList<>();
 
-    for (SingleResourceNameConfig resourceNameConfig : context.getSimpleResourceNameConfigs()) {
+    InterfaceConfig interfaceConfig = context.getInterfaceConfig();
+    for (SingleResourceNameConfig resourceNameConfig :
+        interfaceConfig.getSingleResourceNameConfigs()) {
       PathTemplateView.Builder pathTemplate = PathTemplateView.newBuilder();
       pathTemplate.name(
           context.getNamer().getPathTemplateName(context.getInterface(), resourceNameConfig));
@@ -49,7 +52,9 @@ public class PathTemplateTransformer {
 
     SurfaceNamer namer = context.getNamer();
     Interface service = context.getInterface();
-    for (SingleResourceNameConfig resourceNameConfig : context.getSimpleResourceNameConfigs()) {
+    InterfaceConfig interfaceConfig = context.getInterfaceConfig();
+    for (SingleResourceNameConfig resourceNameConfig :
+        interfaceConfig.getSingleResourceNameConfigs()) {
       FormatResourceFunctionView.Builder function = FormatResourceFunctionView.newBuilder();
       function.entityName(resourceNameConfig.getEntityName());
       function.name(namer.getFormatFunctionName(resourceNameConfig));
@@ -80,7 +85,9 @@ public class PathTemplateTransformer {
 
     SurfaceNamer namer = context.getNamer();
     Interface service = context.getInterface();
-    for (SingleResourceNameConfig resourceNameConfig : context.getSimpleResourceNameConfigs()) {
+    InterfaceConfig interfaceConfig = context.getInterfaceConfig();
+    for (SingleResourceNameConfig resourceNameConfig :
+        interfaceConfig.getSingleResourceNameConfigs()) {
       for (String var : resourceNameConfig.getNameTemplate().vars()) {
         ParseResourceFunctionView.Builder function = ParseResourceFunctionView.newBuilder();
         function.entityName(resourceNameConfig.getEntityName());
@@ -104,7 +111,9 @@ public class PathTemplateTransformer {
 
     SurfaceNamer namer = context.getNamer();
     Interface service = context.getInterface();
-    for (SingleResourceNameConfig resourceNameConfig : context.getSimpleResourceNameConfigs()) {
+    InterfaceConfig interfaceConfig = context.getInterfaceConfig();
+    for (SingleResourceNameConfig resourceNameConfig :
+        interfaceConfig.getSingleResourceNameConfigs()) {
       PathTemplateGetterFunctionView.Builder function = PathTemplateGetterFunctionView.newBuilder();
       function.name(namer.getPathTemplateNameGetter(service, resourceNameConfig));
       function.resourceName(namer.getPathTemplateResourcePhraseName(resourceNameConfig));

--- a/src/main/java/com/google/api/codegen/transformer/SurfaceTransformerContext.java
+++ b/src/main/java/com/google/api/codegen/transformer/SurfaceTransformerContext.java
@@ -19,7 +19,6 @@ import com.google.api.codegen.config.ApiConfig;
 import com.google.api.codegen.config.FlatteningConfig;
 import com.google.api.codegen.config.InterfaceConfig;
 import com.google.api.codegen.config.MethodConfig;
-import com.google.api.codegen.config.SingleResourceNameConfig;
 import com.google.api.codegen.config.VisibilityConfig;
 import com.google.api.tools.framework.model.Interface;
 import com.google.api.tools.framework.model.Method;
@@ -114,10 +113,6 @@ public abstract class SurfaceTransformerContext {
       throw new IllegalArgumentException(
           "Interface config does not exist for method: " + method.getSimpleName());
     }
-  }
-
-  public Iterable<SingleResourceNameConfig> getSimpleResourceNameConfigs() {
-    return getApiConfig().getSingleResourceNameConfigs();
   }
 
   public MethodTransformerContext asFlattenedMethodContext(

--- a/src/main/resources/com/google/api/codegen/nodejs/main.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/main.snip
@@ -287,14 +287,14 @@
 @end
 
 @private pathTemplateSection(service)
-  @if context.getApiConfig.getSingleResourceNameConfigs()
-    @join collectionConfig : context.getApiConfig.getSingleResourceNameConfigs()
+  @if context.getApiConfig.getInterfaceConfig(service).getSingleResourceNameConfigs()
+    @join collectionConfig : context.getApiConfig.getInterfaceConfig(service).getSingleResourceNameConfigs()
 
       var {@pathTemplateName(collectionConfig)} = new gax.PathTemplate(
           '{@collectionConfig.getNamePattern}');
     @end
 
-    @join collectionConfig : context.getApiConfig.getSingleResourceNameConfigs()
+    @join collectionConfig : context.getApiConfig.getInterfaceConfig(service).getSingleResourceNameConfigs()
 
       {@createResourceFunction(service, collectionConfig)}
 

--- a/src/main/resources/com/google/api/codegen/py/main.snip
+++ b/src/main/resources/com/google/api/codegen/py/main.snip
@@ -284,17 +284,17 @@
 @end
 
 @private pathTemplateSection(service)
-    @if context.getApiConfig.getSingleResourceNameConfigs()
-        @join collectionConfig : context.getApiConfig.getSingleResourceNameConfigs()
+    @if context.getApiConfig.getInterfaceConfig(service).getSingleResourceNameConfigs()
+        @join collectionConfig : context.getApiConfig.getInterfaceConfig(service).getSingleResourceNameConfigs()
             {@pathTemplateName(collectionConfig)} = path_template.PathTemplate(
                 '{@collectionConfig.getNamePattern}')
         @end
 
-        @join collectionConfig : context.getApiConfig.getSingleResourceNameConfigs()
+        @join collectionConfig : context.getApiConfig.getInterfaceConfig(service).getSingleResourceNameConfigs()
 
             {@createResourceFunction(collectionConfig)}
         @end
-        @join collectionConfig : context.getApiConfig.getSingleResourceNameConfigs()
+        @join collectionConfig : context.getApiConfig.getInterfaceConfig(service).getSingleResourceNameConfigs()
 
             {@createMatchFunctions(collectionConfig)}
         @end

--- a/src/main/resources/com/google/api/codegen/ruby/main.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/main.snip
@@ -291,8 +291,8 @@
 @end
 
 @private pathTemplateSection(service)
-  @if context.getApiConfig.getSingleResourceNameConfigs()
-    @join collectionConfig : context.getApiConfig.getSingleResourceNameConfigs()
+  @if context.getApiConfig.getInterfaceConfig(service).getSingleResourceNameConfigs()
+    @join collectionConfig : context.getApiConfig.getInterfaceConfig(service).getSingleResourceNameConfigs()
 
       {@pathTemplateName(collectionConfig)} = Google::Gax::PathTemplate.new(
         "{@collectionConfig.getNamePattern}"
@@ -301,11 +301,11 @@
       private_constant :{@pathTemplateName(collectionConfig)}
     @end
 
-    @join collectionConfig : context.getApiConfig.getSingleResourceNameConfigs()
+    @join collectionConfig : context.getApiConfig.getInterfaceConfig(service).getSingleResourceNameConfigs()
 
       {@createResourceFunction(collectionConfig)}
     @end
-    @join collectionConfig : context.getApiConfig.getSingleResourceNameConfigs()
+    @join collectionConfig : context.getApiConfig.getInterfaceConfig(service).getSingleResourceNameConfigs()
 
         {@createMatchFunctions(collectionConfig)}
     @end

--- a/src/test/java/com/google/api/codegen/testdata/csharp_gapic_client_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/csharp_gapic_client_library.baseline
@@ -831,25 +831,6 @@ namespace Google.Example.Library.V1
         public static string FormatBookName(string shelfIdId, string bookIdId) => BookTemplate.Expand(shelfIdId, bookIdId);
 
         /// <summary>
-        /// Path template for a archived_book resource. Parameters:
-        /// <list type="bullet">
-        /// <item><description>archivePath</description></item>
-        /// <item><description>bookId</description></item>
-        /// </list>
-        /// </summary>
-        public static PathTemplate ArchivedBookTemplate { get; } = new PathTemplate("archives/{archive_path}/books/{book_id=**}");
-
-        /// <summary>
-        /// Creates a archived_book resource name from its component IDs.
-        /// </summary>
-        /// <param name="archivePathId">The archivePath ID.</param>
-        /// <param name="bookIdId">The bookId ID.</param>
-        /// <returns>
-        /// The full archived_book resource name.
-        /// </returns>
-        public static string FormatArchivedBookName(string archivePathId, string bookIdId) => ArchivedBookTemplate.Expand(archivePathId, bookIdId);
-
-        /// <summary>
         /// Path template for a return resource. Parameters:
         /// <list type="bullet">
         /// <item><description>shelf</description></item>

--- a/src/test/java/com/google/api/codegen/testdata/go_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_main_library.baseline
@@ -41,7 +41,6 @@ import (
 var (
     libraryShelfPathTemplate = gax.MustCompilePathTemplate("shelves/{shelf_id}")
     libraryBookPathTemplate = gax.MustCompilePathTemplate("shelves/{shelf_id}/books/{book_id}")
-    libraryArchivedBookPathTemplate = gax.MustCompilePathTemplate("archives/{archive_path}/books/{book_id=**}")
     libraryReturnPathTemplate = gax.MustCompilePathTemplate("shelves/{shelf}/books/{book}/returns/{return}")
 )
 
@@ -204,18 +203,6 @@ func LibraryShelfPath(shelfId string) string {
 func LibraryBookPath(shelfId, bookId string) string {
     path, err := libraryBookPathTemplate.Render(map[string]string{
         "shelf_id": shelfId,
-        "book_id": bookId,
-    })
-    if err != nil {
-        panic(err)
-    }
-    return path
-}
-
-// LibraryArchivedBookPath returns the path for the archived book resource.
-func LibraryArchivedBookPath(archivePath, bookId string) string {
-    path, err := libraryArchivedBookPathTemplate.Render(map[string]string{
-        "archive_path": archivePath,
         "book_id": bookId,
     })
     if err != nil {

--- a/src/test/java/com/google/api/codegen/testdata/java_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_main_library.baseline
@@ -186,9 +186,6 @@ public class LibraryServiceApi implements AutoCloseable {
   private static final PathTemplate BOOK_PATH_TEMPLATE =
       PathTemplate.createWithoutUrlEncoding("shelves/{shelf_id}/books/{book_id}");
 
-  private static final PathTemplate ARCHIVED_BOOK_PATH_TEMPLATE =
-      PathTemplate.createWithoutUrlEncoding("archives/{archive_path}/books/{book_id=**}");
-
   private static final PathTemplate RETURN_PATH_TEMPLATE =
       PathTemplate.createWithoutUrlEncoding("shelves/{shelf}/books/{book}/returns/{return}");
 
@@ -208,16 +205,6 @@ public class LibraryServiceApi implements AutoCloseable {
   public static final String formatBookName(String shelfId, String bookId) {
     return BOOK_PATH_TEMPLATE.instantiate(
         "shelf_id", shelfId,
-        "book_id", bookId);
-  }
-
-  /**
-   * Formats a string containing the fully-qualified path to represent
-   * a archived_book resource.
-   */
-  public static final String formatArchivedBookName(String archivePath, String bookId) {
-    return ARCHIVED_BOOK_PATH_TEMPLATE.instantiate(
-        "archive_path", archivePath,
         "book_id", bookId);
   }
 
@@ -254,22 +241,6 @@ public class LibraryServiceApi implements AutoCloseable {
    */
   public static final String parseBookIdFromBookName(String bookName) {
     return BOOK_PATH_TEMPLATE.parse(bookName).get("book_id");
-  }
-
-  /**
-   * Parses the archive_path from the given fully-qualified path which
-   * represents a archived_book resource.
-   */
-  public static final String parseArchivePathFromArchivedBookName(String archivedBookName) {
-    return ARCHIVED_BOOK_PATH_TEMPLATE.parse(archivedBookName).get("archive_path");
-  }
-
-  /**
-   * Parses the book_id from the given fully-qualified path which
-   * represents a archived_book resource.
-   */
-  public static final String parseBookIdFromArchivedBookName(String archivedBookName) {
-    return ARCHIVED_BOOK_PATH_TEMPLATE.parse(archivedBookName).get("book_id");
   }
 
   /**

--- a/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
@@ -26,6 +26,10 @@ license_header:
 collections:
   - name_pattern: shelves/{shelf_id}
     entity_name: shelf
+  # This pattern is present here and not in the interface configuration to test
+  # the restriction of generated parse/format methods
+  - name_pattern: archives/{archive_path}/books/{book_id=**}
+    entity_name: archived_book
 fixed_resource_name_values:
   - entity_name: deleted_book
     fixed_value: _deleted-book_
@@ -58,8 +62,6 @@ interfaces:
     entity_name: shelf
   - name_pattern: shelves/{shelf_id}/books/{book_id}
     entity_name: book
-  - name_pattern: archives/{archive_path}/books/{book_id=**}
-    entity_name: archived_book
   # To test the case that entity name / variable which happens to be
   # a language keyword. See: https://github.com/googleapis/toolkit/issues/618
   - name_pattern: shelves/{shelf}/books/{book}/returns/{return}

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_doc_main_library.baseline
@@ -195,9 +195,6 @@ var SHELF_PATH_TEMPLATE = new gax.PathTemplate(
 var BOOK_PATH_TEMPLATE = new gax.PathTemplate(
     'shelves/{shelf_id}/books/{book_id}');
 
-var ARCHIVED_BOOK_PATH_TEMPLATE = new gax.PathTemplate(
-    'archives/{archive_path}/books/{book_id=**}');
-
 var RETURN_PATH_TEMPLATE = new gax.PathTemplate(
     'shelves/{shelf}/books/{book}/returns/{return}');
 
@@ -253,39 +250,6 @@ LibraryServiceApi.prototype.matchShelfIdFromBookName = function(bookName) {
  */
 LibraryServiceApi.prototype.matchBookIdFromBookName = function(bookName) {
   return BOOK_PATH_TEMPLATE.match(bookName).book_id;
-};
-
-/**
- * Returns a fully-qualified archived_book resource name string.
- * @param {String} archivePath
- * @param {String} bookId
- * @returns {String}
- */
-LibraryServiceApi.prototype.archivedBookPath = function(archivePath, bookId) {
-  return ARCHIVED_BOOK_PATH_TEMPLATE.render({
-    archive_path: archivePath,
-    book_id: bookId
-  });
-};
-
-/**
- * Parses the archivedBookName from a archived_book resource.
- * @param {String} archivedBookName
- *   A fully-qualified path representing a archived_book resources.
- * @returns {String} - A string representing the archive_path.
- */
-LibraryServiceApi.prototype.matchArchivePathFromArchivedBookName = function(archivedBookName) {
-  return ARCHIVED_BOOK_PATH_TEMPLATE.match(archivedBookName).archive_path;
-};
-
-/**
- * Parses the archivedBookName from a archived_book resource.
- * @param {String} archivedBookName
- *   A fully-qualified path representing a archived_book resources.
- * @returns {String} - A string representing the book_id.
- */
-LibraryServiceApi.prototype.matchBookIdFromArchivedBookName = function(archivedBookName) {
-  return ARCHIVED_BOOK_PATH_TEMPLATE.match(archivedBookName).book_id;
 };
 
 /**

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_main_library.baseline
@@ -195,9 +195,6 @@ var SHELF_PATH_TEMPLATE = new gax.PathTemplate(
 var BOOK_PATH_TEMPLATE = new gax.PathTemplate(
     'shelves/{shelf_id}/books/{book_id}');
 
-var ARCHIVED_BOOK_PATH_TEMPLATE = new gax.PathTemplate(
-    'archives/{archive_path}/books/{book_id=**}');
-
 var RETURN_PATH_TEMPLATE = new gax.PathTemplate(
     'shelves/{shelf}/books/{book}/returns/{return}');
 
@@ -253,39 +250,6 @@ LibraryServiceApi.prototype.matchShelfIdFromBookName = function(bookName) {
  */
 LibraryServiceApi.prototype.matchBookIdFromBookName = function(bookName) {
   return BOOK_PATH_TEMPLATE.match(bookName).book_id;
-};
-
-/**
- * Returns a fully-qualified archived_book resource name string.
- * @param {String} archivePath
- * @param {String} bookId
- * @returns {String}
- */
-LibraryServiceApi.prototype.archivedBookPath = function(archivePath, bookId) {
-  return ARCHIVED_BOOK_PATH_TEMPLATE.render({
-    archive_path: archivePath,
-    book_id: bookId
-  });
-};
-
-/**
- * Parses the archivedBookName from a archived_book resource.
- * @param {String} archivedBookName
- *   A fully-qualified path representing a archived_book resources.
- * @returns {String} - A string representing the archive_path.
- */
-LibraryServiceApi.prototype.matchArchivePathFromArchivedBookName = function(archivedBookName) {
-  return ARCHIVED_BOOK_PATH_TEMPLATE.match(archivedBookName).archive_path;
-};
-
-/**
- * Parses the archivedBookName from a archived_book resource.
- * @param {String} archivedBookName
- *   A fully-qualified path representing a archived_book resources.
- * @returns {String} - A string representing the book_id.
- */
-LibraryServiceApi.prototype.matchBookIdFromArchivedBookName = function(archivedBookName) {
-  return ARCHIVED_BOOK_PATH_TEMPLATE.match(archivedBookName).book_id;
 };
 
 /**

--- a/src/test/java/com/google/api/codegen/testdata/php_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php_main_library.baseline
@@ -117,7 +117,6 @@ class LibraryServiceApi
 
     private static $shelfNameTemplate;
     private static $bookNameTemplate;
-    private static $archivedBookNameTemplate;
     private static $returnNameTemplate;
 
     private $grpcCredentialsHelper;
@@ -146,18 +145,6 @@ class LibraryServiceApi
     {
         return self::getBookNameTemplate()->render([
             'shelf_id' => $shelfId,
-            'book_id' => $bookId,
-        ]);
-    }
-
-    /**
-     * Formats a string containing the fully-qualified path to represent
-     * a archived_book resource.
-     */
-    public static function formatArchivedBookName($archivePath, $bookId)
-    {
-        return self::getArchivedBookNameTemplate()->render([
-            'archive_path' => $archivePath,
             'book_id' => $bookId,
         ]);
     }
@@ -200,24 +187,6 @@ class LibraryServiceApi
     public static function parseBookIdFromBookName($bookName)
     {
         return self::getBookNameTemplate()->match($bookName)['book_id'];
-    }
-
-    /**
-     * Parses the archive_path from the given fully-qualified path which
-     * represents a archived_book resource.
-     */
-    public static function parseArchivePathFromArchivedBookName($archivedBookName)
-    {
-        return self::getArchivedBookNameTemplate()->match($archivedBookName)['archive_path'];
-    }
-
-    /**
-     * Parses the book_id from the given fully-qualified path which
-     * represents a archived_book resource.
-     */
-    public static function parseBookIdFromArchivedBookName($archivedBookName)
-    {
-        return self::getArchivedBookNameTemplate()->match($archivedBookName)['book_id'];
     }
 
     /**
@@ -264,15 +233,6 @@ class LibraryServiceApi
         }
 
         return self::$bookNameTemplate;
-    }
-
-    private static function getArchivedBookNameTemplate()
-    {
-        if (self::$archivedBookNameTemplate == null) {
-            self::$archivedBookNameTemplate = new PathTemplate('archives/{archive_path}/books/{book_id=**}');
-        }
-
-        return self::$archivedBookNameTemplate;
     }
 
     private static function getReturnNameTemplate()

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
@@ -118,8 +118,6 @@ class LibraryServiceApi(object):
         'shelves/{shelf_id}')
     _BOOK_PATH_TEMPLATE = path_template.PathTemplate(
         'shelves/{shelf_id}/books/{book_id}')
-    _ARCHIVED_BOOK_PATH_TEMPLATE = path_template.PathTemplate(
-        'archives/{archive_path}/books/{book_id=**}')
     _RETURN_PATH_TEMPLATE = path_template.PathTemplate(
         'shelves/{shelf}/books/{book}/returns/{return}')
 
@@ -135,14 +133,6 @@ class LibraryServiceApi(object):
         """Returns a fully-qualified book resource name string."""
         return cls._BOOK_PATH_TEMPLATE.render({
             'shelf_id': shelf_id,
-            'book_id': book_id,
-        })
-
-    @classmethod
-    def archived_book_path(cls, archive_path, book_id):
-        """Returns a fully-qualified archived_book resource name string."""
-        return cls._ARCHIVED_BOOK_PATH_TEMPLATE.render({
-            'archive_path': archive_path,
             'book_id': book_id,
         })
 
@@ -193,32 +183,6 @@ class LibraryServiceApi(object):
           A string representing the book_id.
         """
         return cls._BOOK_PATH_TEMPLATE.match(book_name).get('book_id')
-
-    @classmethod
-    def match_archive_path_from_archived_book_name(cls, archived_book_name):
-        """Parses the archive_path from a archived_book resource.
-
-        Args:
-          archived_book_name (string): A fully-qualified path representing a archived_book
-            resource.
-
-        Returns:
-          A string representing the archive_path.
-        """
-        return cls._ARCHIVED_BOOK_PATH_TEMPLATE.match(archived_book_name).get('archive_path')
-
-    @classmethod
-    def match_book_id_from_archived_book_name(cls, archived_book_name):
-        """Parses the book_id from a archived_book resource.
-
-        Args:
-          archived_book_name (string): A fully-qualified path representing a archived_book
-            resource.
-
-        Returns:
-          A string representing the book_id.
-        """
-        return cls._ARCHIVED_BOOK_PATH_TEMPLATE.match(archived_book_name).get('book_id')
 
     @classmethod
     def match_shelf_from_return_name(cls, return_name):

--- a/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
@@ -118,8 +118,6 @@ class LibraryServiceApi(object):
         'shelves/{shelf_id}')
     _BOOK_PATH_TEMPLATE = path_template.PathTemplate(
         'shelves/{shelf_id}/books/{book_id}')
-    _ARCHIVED_BOOK_PATH_TEMPLATE = path_template.PathTemplate(
-        'archives/{archive_path}/books/{book_id=**}')
     _RETURN_PATH_TEMPLATE = path_template.PathTemplate(
         'shelves/{shelf}/books/{book}/returns/{return}')
 
@@ -135,14 +133,6 @@ class LibraryServiceApi(object):
         """Returns a fully-qualified book resource name string."""
         return cls._BOOK_PATH_TEMPLATE.render({
             'shelf_id': shelf_id,
-            'book_id': book_id,
-        })
-
-    @classmethod
-    def archived_book_path(cls, archive_path, book_id):
-        """Returns a fully-qualified archived_book resource name string."""
-        return cls._ARCHIVED_BOOK_PATH_TEMPLATE.render({
-            'archive_path': archive_path,
             'book_id': book_id,
         })
 
@@ -193,32 +183,6 @@ class LibraryServiceApi(object):
           A string representing the book_id.
         """
         return cls._BOOK_PATH_TEMPLATE.match(book_name).get('book_id')
-
-    @classmethod
-    def match_archive_path_from_archived_book_name(cls, archived_book_name):
-        """Parses the archive_path from a archived_book resource.
-
-        Args:
-          archived_book_name (string): A fully-qualified path representing a archived_book
-            resource.
-
-        Returns:
-          A string representing the archive_path.
-        """
-        return cls._ARCHIVED_BOOK_PATH_TEMPLATE.match(archived_book_name).get('archive_path')
-
-    @classmethod
-    def match_book_id_from_archived_book_name(cls, archived_book_name):
-        """Parses the book_id from a archived_book resource.
-
-        Args:
-          archived_book_name (string): A fully-qualified path representing a archived_book
-            resource.
-
-        Returns:
-          A string representing the book_id.
-        """
-        return cls._ARCHIVED_BOOK_PATH_TEMPLATE.match(archived_book_name).get('book_id')
 
     @classmethod
     def match_shelf_from_return_name(cls, return_name):

--- a/src/test/java/com/google/api/codegen/testdata/ruby_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_doc_main_library.baseline
@@ -114,12 +114,6 @@ module Library
 
       private_constant :BOOK_PATH_TEMPLATE
 
-      ARCHIVED_BOOK_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
-        "archives/{archive_path}/books/{book_id=**}"
-      )
-
-      private_constant :ARCHIVED_BOOK_PATH_TEMPLATE
-
       RETURN_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
         "shelves/{shelf}/books/{book}/returns/{return}"
       )
@@ -142,17 +136,6 @@ module Library
       def self.book_path shelf_id, book_id
         BOOK_PATH_TEMPLATE.render(
           :"shelf_id" => shelf_id,
-          :"book_id" => book_id
-        )
-      end
-
-      # Returns a fully-qualified archived_book resource name string.
-      # @param archive_path [String]
-      # @param book_id [String]
-      # @return [String]
-      def self.archived_book_path archive_path, book_id
-        ARCHIVED_BOOK_PATH_TEMPLATE.render(
-          :"archive_path" => archive_path,
           :"book_id" => book_id
         )
       end
@@ -189,20 +172,6 @@ module Library
       # @return [String]
       def self.match_book_id_from_book_name book_name
         BOOK_PATH_TEMPLATE.match(book_name)["book_id"]
-      end
-
-      # Parses the archive_path from a archived_book resource.
-      # @param archived_book_name [String]
-      # @return [String]
-      def self.match_archive_path_from_archived_book_name archived_book_name
-        ARCHIVED_BOOK_PATH_TEMPLATE.match(archived_book_name)["archive_path"]
-      end
-
-      # Parses the book_id from a archived_book resource.
-      # @param archived_book_name [String]
-      # @return [String]
-      def self.match_book_id_from_archived_book_name archived_book_name
-        ARCHIVED_BOOK_PATH_TEMPLATE.match(archived_book_name)["book_id"]
       end
 
       # Parses the shelf from a return resource.

--- a/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
@@ -114,12 +114,6 @@ module Library
 
       private_constant :BOOK_PATH_TEMPLATE
 
-      ARCHIVED_BOOK_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
-        "archives/{archive_path}/books/{book_id=**}"
-      )
-
-      private_constant :ARCHIVED_BOOK_PATH_TEMPLATE
-
       RETURN_PATH_TEMPLATE = Google::Gax::PathTemplate.new(
         "shelves/{shelf}/books/{book}/returns/{return}"
       )
@@ -142,17 +136,6 @@ module Library
       def self.book_path shelf_id, book_id
         BOOK_PATH_TEMPLATE.render(
           :"shelf_id" => shelf_id,
-          :"book_id" => book_id
-        )
-      end
-
-      # Returns a fully-qualified archived_book resource name string.
-      # @param archive_path [String]
-      # @param book_id [String]
-      # @return [String]
-      def self.archived_book_path archive_path, book_id
-        ARCHIVED_BOOK_PATH_TEMPLATE.render(
-          :"archive_path" => archive_path,
           :"book_id" => book_id
         )
       end
@@ -189,20 +172,6 @@ module Library
       # @return [String]
       def self.match_book_id_from_book_name book_name
         BOOK_PATH_TEMPLATE.match(book_name)["book_id"]
-      end
-
-      # Parses the archive_path from a archived_book resource.
-      # @param archived_book_name [String]
-      # @return [String]
-      def self.match_archive_path_from_archived_book_name archived_book_name
-        ARCHIVED_BOOK_PATH_TEMPLATE.match(archived_book_name)["archive_path"]
-      end
-
-      # Parses the book_id from a archived_book resource.
-      # @param archived_book_name [String]
-      # @return [String]
-      def self.match_book_id_from_archived_book_name archived_book_name
-        ARCHIVED_BOOK_PATH_TEMPLATE.match(archived_book_name)["book_id"]
       end
 
       # Parses the shelf from a return resource.


### PR DESCRIPTION
This fixes an issue introduced by adding support for collection configs to the top level of the gapic config. Format and parse methods will now be generated in each XApi class based on the collection config for that interface only, instead of based on all collection configs in the gapic yaml.

Have moved the archive collection config to the top level to test that format and parse methods are not generated.