### PR TITLE
Update smoke test and minor fixes.

### DIFF
--- a/src/main/java/com/google/api/codegen/metacode/InitCodeNode.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitCodeNode.java
@@ -15,6 +15,7 @@
 package com.google.api.codegen.metacode;
 
 import com.google.api.codegen.config.FieldConfig;
+import com.google.api.codegen.metacode.InitCodeContext.InitCodeOutputType;
 import com.google.api.codegen.util.Name;
 import com.google.api.codegen.util.SymbolTable;
 import com.google.api.codegen.util.testing.TestValueGenerator;
@@ -238,6 +239,8 @@ public class InitCodeNode {
         }
       }
       subTrees = newSubTrees;
+    } else if (context.outputType() == InitCodeOutputType.FieldList) {
+      throw new IllegalArgumentException("Init field array is not set for flattened method.");
     }
     if (context.additionalInitCodeNodes() != null) {
       subTrees.addAll(Lists.newArrayList(context.additionalInitCodeNodes()));

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
@@ -236,14 +236,8 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
             .initFieldConfigStrings(testConfig.getInitFieldConfigStrings())
             .symbolTable(table)
             .fieldConfigMap(fieldConfigMap);
-
     if (context.getMethodConfig().isFlattening()) {
-      ArrayList<Field> initFields = new ArrayList<>();
-      for (FieldConfig fieldConfig :
-          context.getFlatteningConfig().getFlattenedFieldConfigs().values()) {
-        initFields.add(fieldConfig.getField());
-      }
-      contextBuilder.initFields(initFields);
+      contextBuilder.initFields(context.getFlatteningConfig().getFlattenedFields());
     }
     return contextBuilder.build();
   }

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
@@ -167,15 +167,19 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
     SurfaceNamer namer = context.getNamer();
 
     ApiMethodType methodType = ApiMethodType.FlattenedMethod;
+    String responseTypeName = context.getTypeTable().getAndSaveNicknameFor(method.getOutputType());
     if (context.getMethodConfig().isPageStreaming()) {
       methodType = ApiMethodType.PagedFlattenedMethod;
+      Field resourcesField = context.getMethodConfig().getPageStreaming().getResourcesField();
+      responseTypeName =
+          namer.getAndSavePagedResponseTypeName(method, context.getTypeTable(), resourcesField);
     }
     InitCodeView initCodeView =
         initCodeTransformer.generateInitCode(context, createSmokeTestInitContext(context));
 
     return TestMethodView.newBuilder()
         .name(namer.getApiMethodName(method, context.getMethodConfig().getVisibility()))
-        .responseTypeName(context.getTypeTable().getAndSaveNicknameFor(method.getOutputType()))
+        .responseTypeName(responseTypeName)
         .type(methodType)
         .initCode(initCodeView)
         .hasReturnValue(!ServiceMessages.s_isEmptyType(method.getOutputType()))
@@ -217,14 +221,31 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
       outputType = InitCodeOutputType.SingleObject;
       fieldConfigMap = null;
     }
-    return InitCodeContext.newBuilder()
-        .initObjectType(testConfig.getMethod().getInputType())
-        .suggestedName(Name.from("request"))
-        .outputType(outputType)
-        .initValueConfigMap(InitCodeTransformer.createCollectionMap(context))
-        .initFieldConfigStrings(testConfig.getInitFieldConfigStrings())
-        .fieldConfigMap(fieldConfigMap)
-        .build();
+
+    // Store project ID variable name into the symbol table since it is used by the execute method
+    // as a parameter. For more information please see smoke_test.snip.
+    SymbolTable table = new SymbolTable();
+    table.getNewSymbol(Name.from(InitFieldConfig.PROJECT_ID_VARIABLE_NAME));
+
+    InitCodeContext.Builder contextBuilder =
+        InitCodeContext.newBuilder()
+            .initObjectType(testConfig.getMethod().getInputType())
+            .suggestedName(Name.from("request"))
+            .outputType(outputType)
+            .initValueConfigMap(InitCodeTransformer.createCollectionMap(context))
+            .initFieldConfigStrings(testConfig.getInitFieldConfigStrings())
+            .symbolTable(table)
+            .fieldConfigMap(fieldConfigMap);
+
+    if (context.getMethodConfig().isFlattening()) {
+      ArrayList<Field> initFields = new ArrayList<>();
+      for (FieldConfig fieldConfig :
+          context.getFlatteningConfig().getFlattenedFieldConfigs().values()) {
+        initFields.add(fieldConfig.getField());
+      }
+      contextBuilder.initFields(initFields);
+    }
+    return contextBuilder.build();
   }
 
   private FlatteningConfig getFlatteningGroup(

--- a/src/main/resources/com/google/api/codegen/java/smoke_test.snip
+++ b/src/main/resources/com/google/api/codegen/java/smoke_test.snip
@@ -71,10 +71,10 @@
 
   @switch method.type
   @case "PagedFlattenedMethod"
-    PageAccessor<{@method.responseTypeName}> pageAccessor =
+    {@method.responseTypeName} pagedResponse =
         api.{@method.name}(\
           {@sampleMethodCallArgList(method.initCode.fieldSettings)});
-    System.out.println(ReflectionToStringBuilder.toString(pageAccessor));
+    System.out.println(ReflectionToStringBuilder.toString(pagedResponse));
   @case "FlattenedMethod"
     @if method.hasReturnValue
       {@method.responseTypeName} response = \


### PR DESCRIPTION
- Deprecate PageAccessor.
- Fixed an issue that the variable name "projectId" is already taken by
  the `executeNoCatch()` method.
- Fixed an issue of default flattened parameters were initialized correctly.

- Tests passed against api-client-staging

After this PR I will add the generated smoke tests into api-client-staging repo.