### PR TITLE
Support enum init fields in gapic config

### DIFF
--- a/src/main/java/com/google/api/codegen/metacode/InitCodeNode.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitCodeNode.java
@@ -463,53 +463,52 @@ public class InitCodeNode {
    * if the provided type is not supported or doesn't match the value.
    */
   private static void validateValue(TypeRef type, String value) {
-    if (type.isEnum()) {
-      for (EnumValue enumValue : type.getEnumType().getValues()) {
-        if (enumValue.getSimpleName().equals(value)) {
+    Type descType = type.getKind();
+    switch (descType) {
+      case TYPE_ENUM:
+        for (EnumValue enumValue : type.getEnumType().getValues()) {
+          if (enumValue.getSimpleName().equals(value)) {
+            return;
+          }
+        }
+        break;
+      case TYPE_BOOL:
+        String lowerCaseValue = value.toLowerCase();
+        if (lowerCaseValue.equals("true") || lowerCaseValue.equals("false")) {
           return;
         }
-      }
-    } else {
-      Type descType = type.getKind();
-      switch (descType) {
-        case TYPE_BOOL:
-          String lowerCaseValue = value.toLowerCase();
-          if (lowerCaseValue.equals("true") || lowerCaseValue.equals("false")) {
-            return;
-          }
-          break;
-        case TYPE_DOUBLE:
-        case TYPE_FLOAT:
-          if (Pattern.matches("[+-]?([0-9]*[.])?[0-9]+", value)) {
-            return;
-          }
-          break;
-        case TYPE_INT64:
-        case TYPE_UINT64:
-        case TYPE_SINT64:
-        case TYPE_FIXED64:
-        case TYPE_SFIXED64:
-        case TYPE_INT32:
-        case TYPE_UINT32:
-        case TYPE_SINT32:
-        case TYPE_FIXED32:
-        case TYPE_SFIXED32:
-          if (Pattern.matches("[+-]?[0-9]+", value)) {
-            return;
-          }
-          break;
-        case TYPE_STRING:
-        case TYPE_BYTES:
-          Matcher matcher = Pattern.compile("([^\\\"']*)").matcher(value);
-          if (matcher.matches()) {
-            return;
-          }
-          break;
-        default:
-          // Throw an exception if a value is unsupported for the given type.
-          throw new IllegalArgumentException(
-              "Tried to assign value for unsupported type " + type + "; value " + value);
-      }
+        break;
+      case TYPE_DOUBLE:
+      case TYPE_FLOAT:
+        if (Pattern.matches("[+-]?([0-9]*[.])?[0-9]+", value)) {
+          return;
+        }
+        break;
+      case TYPE_INT64:
+      case TYPE_UINT64:
+      case TYPE_SINT64:
+      case TYPE_FIXED64:
+      case TYPE_SFIXED64:
+      case TYPE_INT32:
+      case TYPE_UINT32:
+      case TYPE_SINT32:
+      case TYPE_FIXED32:
+      case TYPE_SFIXED32:
+        if (Pattern.matches("[+-]?[0-9]+", value)) {
+          return;
+        }
+        break;
+      case TYPE_STRING:
+      case TYPE_BYTES:
+        Matcher matcher = Pattern.compile("([^\\\"']*)").matcher(value);
+        if (matcher.matches()) {
+          return;
+        }
+        break;
+      default:
+        // Throw an exception if a value is unsupported for the given type.
+        throw new IllegalArgumentException(
+            "Tried to assign value for unsupported type " + type + "; value " + value);
     }
     throw new IllegalArgumentException("Could not assign value '" + value + "' to type " + type);
   }

--- a/src/main/java/com/google/api/codegen/metacode/InitCodeNode.java
+++ b/src/main/java/com/google/api/codegen/metacode/InitCodeNode.java
@@ -19,6 +19,7 @@ import com.google.api.codegen.metacode.InitCodeContext.InitCodeOutputType;
 import com.google.api.codegen.util.Name;
 import com.google.api.codegen.util.SymbolTable;
 import com.google.api.codegen.util.testing.TestValueGenerator;
+import com.google.api.tools.framework.model.EnumValue;
 import com.google.api.tools.framework.model.Field;
 import com.google.api.tools.framework.model.TypeRef;
 import com.google.common.collect.Lists;
@@ -462,45 +463,53 @@ public class InitCodeNode {
    * if the provided type is not supported or doesn't match the value.
    */
   private static void validateValue(TypeRef type, String value) {
-    Type descType = type.getKind();
-    switch (descType) {
-      case TYPE_BOOL:
-        String lowerCaseValue = value.toLowerCase();
-        if (lowerCaseValue.equals("true") || lowerCaseValue.equals("false")) {
+    if (type.isEnum()) {
+      for (EnumValue enumValue : type.getEnumType().getValues()) {
+        if (enumValue.getSimpleName().equals(value)) {
           return;
         }
-        break;
-      case TYPE_DOUBLE:
-      case TYPE_FLOAT:
-        if (Pattern.matches("[+-]?([0-9]*[.])?[0-9]+", value)) {
-          return;
-        }
-        break;
-      case TYPE_INT64:
-      case TYPE_UINT64:
-      case TYPE_SINT64:
-      case TYPE_FIXED64:
-      case TYPE_SFIXED64:
-      case TYPE_INT32:
-      case TYPE_UINT32:
-      case TYPE_SINT32:
-      case TYPE_FIXED32:
-      case TYPE_SFIXED32:
-        if (Pattern.matches("[+-]?[0-9]+", value)) {
-          return;
-        }
-        break;
-      case TYPE_STRING:
-      case TYPE_BYTES:
-        Matcher matcher = Pattern.compile("([^\\\"']*)").matcher(value);
-        if (matcher.matches()) {
-          return;
-        }
-        break;
-      default:
-        // Throw an exception if a value is unsupported for the given type.
-        throw new IllegalArgumentException(
-            "Tried to assign value for unsupported type " + type + "; value " + value);
+      }
+    } else {
+      Type descType = type.getKind();
+      switch (descType) {
+        case TYPE_BOOL:
+          String lowerCaseValue = value.toLowerCase();
+          if (lowerCaseValue.equals("true") || lowerCaseValue.equals("false")) {
+            return;
+          }
+          break;
+        case TYPE_DOUBLE:
+        case TYPE_FLOAT:
+          if (Pattern.matches("[+-]?([0-9]*[.])?[0-9]+", value)) {
+            return;
+          }
+          break;
+        case TYPE_INT64:
+        case TYPE_UINT64:
+        case TYPE_SINT64:
+        case TYPE_FIXED64:
+        case TYPE_SFIXED64:
+        case TYPE_INT32:
+        case TYPE_UINT32:
+        case TYPE_SINT32:
+        case TYPE_FIXED32:
+        case TYPE_SFIXED32:
+          if (Pattern.matches("[+-]?[0-9]+", value)) {
+            return;
+          }
+          break;
+        case TYPE_STRING:
+        case TYPE_BYTES:
+          Matcher matcher = Pattern.compile("([^\\\"']*)").matcher(value);
+          if (matcher.matches()) {
+            return;
+          }
+          break;
+        default:
+          // Throw an exception if a value is unsupported for the given type.
+          throw new IllegalArgumentException(
+              "Tried to assign value for unsupported type " + type + "; value " + value);
+      }
     }
     throw new IllegalArgumentException("Could not assign value '" + value + "' to type " + type);
   }

--- a/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
@@ -362,7 +362,11 @@ public class InitCodeTransformer {
         String value = initValueConfig.getInitialValue().getValue();
         switch (initValueConfig.getInitialValue().getType()) {
           case Literal:
-            value = context.getTypeTable().renderPrimitiveValue(item.getType(), value);
+            if (item.getType().isEnum()) {
+              value = context.getTypeTable().getEnumValue(item.getType(), value);
+            } else {
+              value = context.getTypeTable().renderPrimitiveValue(item.getType(), value);
+            }
             break;
           case Random:
             value = context.getNamer().injectRandomStringGeneratorCode(value);

--- a/src/main/java/com/google/api/codegen/transformer/ModelTypeNameConverter.java
+++ b/src/main/java/com/google/api/codegen/transformer/ModelTypeNameConverter.java
@@ -25,6 +25,9 @@ public interface ModelTypeNameConverter {
   /** Provides a TypeName for the given TypeRef. */
   TypeName getTypeName(TypeRef type);
 
+  /** Provides a TypedValue for the given enum TypeRef. */
+  TypedValue getEnumValue(TypeRef type, String value);
+
   /** Provides a TypeName for the element type of the given TypeRef. */
   TypeName getTypeNameForElementType(TypeRef type);
 

--- a/src/main/java/com/google/api/codegen/transformer/ModelTypeTable.java
+++ b/src/main/java/com/google/api/codegen/transformer/ModelTypeTable.java
@@ -67,6 +67,11 @@ public class ModelTypeTable implements ModelTypeFormatter {
     return typeFormatter.renderPrimitiveValue(type, value);
   }
 
+  /** Returns the enum value string */
+  public String getEnumValue(TypeRef type, String value) {
+    return typeNameConverter.getEnumValue(type, value).getValueAndSaveTypeNicknameIn(typeTable);
+  }
+
   /** Creates a new ModelTypeTable of the same concrete type, but with an empty import set. */
   public ModelTypeTable cloneEmpty() {
     return new ModelTypeTable(typeTable.cloneEmpty(), typeNameConverter);

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpModelTypeNameConverter.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpModelTypeNameConverter.java
@@ -218,4 +218,9 @@ public class CSharpModelTypeNameConverter implements ModelTypeNameConverter {
     throw new UnsupportedOperationException(
         "getTypeNameForResourceNameElementType not supported by C#");
   }
+
+  @Override
+  public TypedValue getEnumValue(TypeRef type, String value) {
+    throw new UnsupportedOperationException("getEnumValue not supported by C#");
+  }
 }

--- a/src/main/java/com/google/api/codegen/transformer/go/GoModelTypeNameConverter.java
+++ b/src/main/java/com/google/api/codegen/transformer/go/GoModelTypeNameConverter.java
@@ -241,4 +241,9 @@ public class GoModelTypeNameConverter implements ModelTypeNameConverter {
     throw new UnsupportedOperationException(
         "getTypeNameForResourceNameElementType not supported by Go");
   }
+
+  @Override
+  public TypedValue getEnumValue(TypeRef type, String value) {
+    throw new UnsupportedOperationException("getEnumValue not supported by Go");
+  }
 }

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
@@ -644,6 +644,7 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
     typeTable.saveNicknameFor("java.util.logging.Level");
     typeTable.saveNicknameFor("java.util.logging.Logger");
     typeTable.saveNicknameFor("java.util.List");
+    typeTable.saveNicknameFor("java.util.Arrays");
     typeTable.saveNicknameFor("com.google.common.collect.Lists");
     typeTable.saveNicknameFor("com.google.api.gax.core.PagedListResponse");
     typeTable.saveNicknameFor("org.apache.commons.lang.builder.ReflectionToStringBuilder");

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaModelTypeNameConverter.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaModelTypeNameConverter.java
@@ -112,6 +112,16 @@ public class JavaModelTypeNameConverter implements ModelTypeNameConverter {
   }
 
   @Override
+  public TypedValue getEnumValue(TypeRef type, String value) {
+    for (EnumValue enumValue : type.getEnumType().getValues()) {
+      if (enumValue.getSimpleName().equals(value)) {
+        return TypedValue.create(getTypeName(type), "%s." + enumValue.getSimpleName());
+      }
+    }
+    throw new IllegalArgumentException("Unrecognized enum value: " + value);
+  }
+
+  @Override
   public TypeName getTypeNameForElementType(TypeRef type) {
     return getTypeNameForElementType(type, true);
   }

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSModelTypeNameConverter.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSModelTypeNameConverter.java
@@ -177,4 +177,9 @@ public class NodeJSModelTypeNameConverter implements ModelTypeNameConverter {
     throw new UnsupportedOperationException(
         "getTypeNameForResourceNameElementType not supported by NodeJS");
   }
+
+  @Override
+  public TypedValue getEnumValue(TypeRef type, String value) {
+    throw new UnsupportedOperationException("getEnumValue not supported by NodeJS");
+  }
 }

--- a/src/main/java/com/google/api/codegen/transformer/php/PhpModelTypeNameConverter.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpModelTypeNameConverter.java
@@ -188,4 +188,9 @@ public class PhpModelTypeNameConverter implements ModelTypeNameConverter {
     throw new UnsupportedOperationException(
         "getTypeNameForResourceNameElementType not supported by PHP");
   }
+
+  @Override
+  public TypedValue getEnumValue(TypeRef type, String value) {
+    throw new UnsupportedOperationException("getEnumValue not supported by PHP");
+  }
 }

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubyModelTypeNameConverter.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubyModelTypeNameConverter.java
@@ -178,4 +178,9 @@ public class RubyModelTypeNameConverter implements ModelTypeNameConverter {
     throw new UnsupportedOperationException(
         "getTypeNameForResourceNameElementType not supported by Ruby");
   }
+
+  @Override
+  public TypedValue getEnumValue(TypeRef type, String value) {
+    throw new UnsupportedOperationException("getEnumValue not supported by Ruby");
+  }
 }

--- a/src/test/java/com/google/api/codegen/testdata/java_smoke_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_smoke_test_library.baseline
@@ -19,7 +19,9 @@ package com.google.gcloud.pubsub.spi;
 import com.google.api.gax.core.PagedListResponse;
 import com.google.common.collect.Lists;
 import com.google.example.library.v1.Book;
+import com.google.example.library.v1.Book.Rating;
 import com.google.example.library.v1.BookName;
+import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -62,8 +64,12 @@ public class LibraryServiceSmokeTest {
   public static void executeNoCatch(String projectId) throws Exception {
     try (LibraryServiceApi api = LibraryServiceApi.create()) {
       BookName name = BookName.create("testShelf-" + System.currentTimeMillis(), projectId);
+      Book.Rating rating = Book.Rating.GOOD;
+      Book book = Book.newBuilder()
+        .setRating(rating)
+        .build();
 
-      Book response = api.getBook(name);
+      Book response = api.updateBook(name, book);
       System.out.println(ReflectionToStringBuilder.toString(response, ToStringStyle.MULTI_LINE_STYLE));
     }
   }

--- a/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
@@ -67,11 +67,12 @@ interfaces:
   - name_pattern: shelves/{shelf}/books/{book}/returns/{return}
     entity_name: return
   smoke_test:
-    method: GetBook
+    method: UpdateBook
     init_fields:
       - name%shelf_id="testShelf-$RANDOM"
       - name%book_id=$PROJECT_ID
-    flattening_group_name: get_book_1
+      - book.rating=GOOD
+    flattening_group_name: update_book_1
   experimental_features:
     iam_resources:
     - type: google.example.library.v1.Book
@@ -261,7 +262,8 @@ interfaces:
   - name: UpdateBook
     flattening:
       groups:
-      - parameters:
+      - flattening_group_name: update_book_1
+        parameters:
         - name
         - book
       - parameters:


### PR DESCRIPTION
- Example config:
`book.rating=GOOD`
- Also adds missing import "java.util.Arrays" into generated smoke test.

Fixes https://github.com/googleapis/toolkit/issues/733