### PR TITLE
Change suffix from Api to Client for Ruby

### DIFF
--- a/src/main/java/com/google/api/codegen/ruby/RubyGapicContext.java
+++ b/src/main/java/com/google/api/codegen/ruby/RubyGapicContext.java
@@ -65,6 +65,12 @@ public class RubyGapicContext extends GapicContext implements RubyContext {
     return true;
   }
 
+  @Override
+  /** Return the name of the class which is the GAPIC wrapper for this service interface. */
+  public String getApiWrapperName(Interface service) {
+    return service.getSimpleName() + "Client";
+  }
+
   // Snippet Helpers
   // ===============
 

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubySurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubySurfaceNamer.java
@@ -37,6 +37,33 @@ public class RubySurfaceNamer extends SurfaceNamer {
         packageName);
   }
 
+  @Override
+  /** The name of the class that implements a particular proto interface. */
+  public String getApiWrapperClassName(Interface interfaze) {
+    return publicClassName(Name.upperCamel(interfaze.getSimpleName(), "Client"));
+  }
+
+  @Override
+  /** The name of the constructor for the service client. The client is VKit generated, not GRPC. */
+  public String getApiWrapperClassConstructorName(Interface interfaze) {
+    return publicClassName(Name.upperCamel(interfaze.getSimpleName(), "Client"));
+  }
+
+  @Override
+  /**
+   * The name of a variable that holds an instance of the class that implements a particular proto
+   * interface.
+   */
+  public String getApiWrapperVariableName(Interface interfaze) {
+    return localVarName(Name.upperCamel(interfaze.getSimpleName(), "Client"));
+  }
+
+  @Override
+  /** The name of the class that implements snippets for a particular proto interface. */
+  public String getApiSnippetsClassName(Interface interfaze) {
+    return publicClassName(Name.upperCamel(interfaze.getSimpleName(), "ClientSnippets"));
+  }
+
   /** The function name to set a field having the given type and name. */
   @Override
   public String getFieldSetFunctionName(TypeRef type, Name identifier) {

--- a/src/test/java/com/google/api/codegen/testdata/ruby_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_doc_main_library.baseline
@@ -1,4 +1,4 @@
-============== file: lib/library/v1/library_service_api.rb ==============
+============== file: lib/library/v1/library_service_client.rb ==============
 # Copyright 2016 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -49,7 +49,7 @@ module Library
     #   @return [Google::Example::Library::V1::LibraryService::Stub]
     # @!attribute [r] labeler_stub
     #   @return [Google::Tagger::V1::Labeler::Stub]
-    class LibraryServiceApi
+    class LibraryServiceClient
       attr_reader :library_service_stub, :labeler_stub
 
       # The default address of the service.
@@ -378,14 +378,14 @@ module Library
       # @return [Google::Example::Library::V1::Shelf]
       # @raise [Google::Gax::GaxError] if the RPC is aborted.
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #   Shelf = Google::Example::Library::V1::Shelf
       #
-      #   library_service_api = LibraryServiceApi.new
+      #   library_service_client = LibraryServiceClient.new
       #   shelf = Shelf.new
-      #   response = library_service_api.create_shelf(shelf)
+      #   response = library_service_client.create_shelf(shelf)
 
       def create_shelf \
           shelf,
@@ -411,14 +411,14 @@ module Library
       # @return [Google::Example::Library::V1::Shelf]
       # @raise [Google::Gax::GaxError] if the RPC is aborted.
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #
-      #   library_service_api = LibraryServiceApi.new
-      #   formatted_name = LibraryServiceApi.shelf_path("[SHELF_ID]")
+      #   library_service_client = LibraryServiceClient.new
+      #   formatted_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
       #   options_ = ''
-      #   response = library_service_api.get_shelf(formatted_name, options_)
+      #   response = library_service_client.get_shelf(formatted_name, options_)
 
       def get_shelf \
           name,
@@ -447,19 +447,19 @@ module Library
       #   object.
       # @raise [Google::Gax::GaxError] if the RPC is aborted.
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #
-      #   library_service_api = LibraryServiceApi.new
+      #   library_service_client = LibraryServiceClient.new
       #
       #   # Iterate over all results.
-      #   library_service_api.list_shelves.each do |element|
+      #   library_service_client.list_shelves.each do |element|
       #     # Process element.
       #   end
       #
       #   # Or iterate over results one page at a time.
-      #   library_service_api.list_shelves.each_page do |page|
+      #   library_service_client.list_shelves.each_page do |page|
       #     # Process each page at a time.
       #     page.each do |element|
       #       # Process element.
@@ -480,13 +480,13 @@ module Library
       #   retries, etc.
       # @raise [Google::Gax::GaxError] if the RPC is aborted.
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #
-      #   library_service_api = LibraryServiceApi.new
-      #   formatted_name = LibraryServiceApi.shelf_path("[SHELF_ID]")
-      #   library_service_api.delete_shelf(formatted_name)
+      #   library_service_client = LibraryServiceClient.new
+      #   formatted_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   library_service_client.delete_shelf(formatted_name)
 
       def delete_shelf \
           name,
@@ -511,14 +511,14 @@ module Library
       # @return [Google::Example::Library::V1::Shelf]
       # @raise [Google::Gax::GaxError] if the RPC is aborted.
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #
-      #   library_service_api = LibraryServiceApi.new
-      #   formatted_name = LibraryServiceApi.shelf_path("[SHELF_ID]")
-      #   formatted_other_shelf_name = LibraryServiceApi.shelf_path("[SHELF_ID]")
-      #   response = library_service_api.merge_shelves(formatted_name, formatted_other_shelf_name)
+      #   library_service_client = LibraryServiceClient.new
+      #   formatted_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   formatted_other_shelf_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   response = library_service_client.merge_shelves(formatted_name, formatted_other_shelf_name)
 
       def merge_shelves \
           name,
@@ -543,15 +543,15 @@ module Library
       # @return [Google::Example::Library::V1::Book]
       # @raise [Google::Gax::GaxError] if the RPC is aborted.
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
       #   Book = Google::Example::Library::V1::Book
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #
-      #   library_service_api = LibraryServiceApi.new
-      #   formatted_name = LibraryServiceApi.shelf_path("[SHELF_ID]")
+      #   library_service_client = LibraryServiceClient.new
+      #   formatted_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
       #   book = Book.new
-      #   response = library_service_api.create_book(formatted_name, book)
+      #   response = library_service_client.create_book(formatted_name, book)
 
       def create_book \
           name,
@@ -582,15 +582,15 @@ module Library
       # @return [Google::Example::Library::V1::PublishSeriesResponse]
       # @raise [Google::Gax::GaxError] if the RPC is aborted.
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #   Shelf = Google::Example::Library::V1::Shelf
       #
-      #   library_service_api = LibraryServiceApi.new
+      #   library_service_client = LibraryServiceClient.new
       #   shelf = Shelf.new
       #   books = []
-      #   response = library_service_api.publish_series(shelf, books)
+      #   response = library_service_client.publish_series(shelf, books)
 
       def publish_series \
           shelf,
@@ -619,13 +619,13 @@ module Library
       # @return [Google::Example::Library::V1::Book]
       # @raise [Google::Gax::GaxError] if the RPC is aborted.
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #
-      #   library_service_api = LibraryServiceApi.new
-      #   formatted_name = LibraryServiceApi.book_path("[SHELF_ID]", "[BOOK_ID]")
-      #   response = library_service_api.get_book(formatted_name)
+      #   library_service_client = LibraryServiceClient.new
+      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   response = library_service_client.get_book(formatted_name)
 
       def get_book \
           name,
@@ -658,20 +658,20 @@ module Library
       #   object.
       # @raise [Google::Gax::GaxError] if the RPC is aborted.
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #
-      #   library_service_api = LibraryServiceApi.new
-      #   formatted_name = LibraryServiceApi.shelf_path("[SHELF_ID]")
+      #   library_service_client = LibraryServiceClient.new
+      #   formatted_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
       #
       #   # Iterate over all results.
-      #   library_service_api.list_books(formatted_name).each do |element|
+      #   library_service_client.list_books(formatted_name).each do |element|
       #     # Process element.
       #   end
       #
       #   # Or iterate over results one page at a time.
-      #   library_service_api.list_books(formatted_name).each_page do |page|
+      #   library_service_client.list_books(formatted_name).each_page do |page|
       #     # Process each page at a time.
       #     page.each do |element|
       #       # Process element.
@@ -700,13 +700,13 @@ module Library
       #   retries, etc.
       # @raise [Google::Gax::GaxError] if the RPC is aborted.
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #
-      #   library_service_api = LibraryServiceApi.new
-      #   formatted_name = LibraryServiceApi.book_path("[SHELF_ID]", "[BOOK_ID]")
-      #   library_service_api.delete_book(formatted_name)
+      #   library_service_client = LibraryServiceClient.new
+      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client.delete_book(formatted_name)
 
       def delete_book \
           name,
@@ -733,15 +733,15 @@ module Library
       # @return [Google::Example::Library::V1::Book]
       # @raise [Google::Gax::GaxError] if the RPC is aborted.
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
       #   Book = Google::Example::Library::V1::Book
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #
-      #   library_service_api = LibraryServiceApi.new
-      #   formatted_name = LibraryServiceApi.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client = LibraryServiceClient.new
+      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   book = Book.new
-      #   response = library_service_api.update_book(formatted_name, book)
+      #   response = library_service_client.update_book(formatted_name, book)
 
       def update_book \
           name,
@@ -770,14 +770,14 @@ module Library
       # @return [Google::Example::Library::V1::Book]
       # @raise [Google::Gax::GaxError] if the RPC is aborted.
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #
-      #   library_service_api = LibraryServiceApi.new
-      #   formatted_name = LibraryServiceApi.book_path("[SHELF_ID]", "[BOOK_ID]")
-      #   formatted_other_shelf_name = LibraryServiceApi.shelf_path("[SHELF_ID]")
-      #   response = library_service_api.move_book(formatted_name, formatted_other_shelf_name)
+      #   library_service_client = LibraryServiceClient.new
+      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   formatted_other_shelf_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   response = library_service_client.move_book(formatted_name, formatted_other_shelf_name)
 
       def move_book \
           name,
@@ -809,19 +809,19 @@ module Library
       #   object.
       # @raise [Google::Gax::GaxError] if the RPC is aborted.
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #
-      #   library_service_api = LibraryServiceApi.new
+      #   library_service_client = LibraryServiceClient.new
       #
       #   # Iterate over all results.
-      #   library_service_api.list_strings.each do |element|
+      #   library_service_client.list_strings.each do |element|
       #     # Process element.
       #   end
       #
       #   # Or iterate over results one page at a time.
-      #   library_service_api.list_strings.each_page do |page|
+      #   library_service_client.list_strings.each_page do |page|
       #     # Process each page at a time.
       #     page.each do |element|
       #       # Process element.
@@ -848,15 +848,15 @@ module Library
       #   retries, etc.
       # @raise [Google::Gax::GaxError] if the RPC is aborted.
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
       #   Alignment = Google::Example::Library::V1::SomeMessage2::SomeMessage3::Alignment
       #   Comment = Google::Example::Library::V1::Comment
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #   Stage = Google::Example::Library::V1::Comment::Stage
       #
-      #   library_service_api = LibraryServiceApi.new
-      #   formatted_name = LibraryServiceApi.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client = LibraryServiceClient.new
+      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   comment = ''
       #   stage = Stage::UNSET
       #   alignment = Alignment::CHAR
@@ -865,7 +865,7 @@ module Library
       #   comments_element.stage = stage
       #   comments_element.alignment = alignment
       #   comments = [comments_element]
-      #   library_service_api.add_comments(formatted_name, comments)
+      #   library_service_client.add_comments(formatted_name, comments)
 
       def add_comments \
           name,
@@ -888,13 +888,13 @@ module Library
       # @return [Google::Example::Library::V1::BookFromArchive]
       # @raise [Google::Gax::GaxError] if the RPC is aborted.
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #
-      #   library_service_api = LibraryServiceApi.new
-      #   formatted_name = LibraryServiceApi.archived_book_path("[ARCHIVE_PATH]", "[BOOK_ID]")
-      #   response = library_service_api.get_book_from_archive(formatted_name)
+      #   library_service_client = LibraryServiceClient.new
+      #   formatted_name = LibraryServiceClient.archived_book_path("[ARCHIVE_PATH]", "[BOOK_ID]")
+      #   response = library_service_client.get_book_from_archive(formatted_name)
 
       def get_book_from_archive \
           name,
@@ -918,14 +918,14 @@ module Library
       # @return [Google::Example::Library::V1::BookFromAnywhere]
       # @raise [Google::Gax::GaxError] if the RPC is aborted.
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #
-      #   library_service_api = LibraryServiceApi.new
+      #   library_service_client = LibraryServiceClient.new
       #   name = ''
-      #   formatted_alt_book_name = LibraryServiceApi.book_path("[SHELF_ID]", "[BOOK_ID]")
-      #   response = library_service_api.get_book_from_anywhere(name, formatted_alt_book_name)
+      #   formatted_alt_book_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   response = library_service_client.get_book_from_anywhere(name, formatted_alt_book_name)
 
       def get_book_from_anywhere \
           name,
@@ -951,16 +951,16 @@ module Library
       #   retries, etc.
       # @raise [Google::Gax::GaxError] if the RPC is aborted.
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #
-      #   library_service_api = LibraryServiceApi.new
-      #   formatted_name = LibraryServiceApi.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client = LibraryServiceClient.new
+      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   index_name = "default index"
       #   index_map_item = ''
       #   index_map = { "default_key" => index_map_item }
-      #   library_service_api.update_book_index(formatted_name, index_name, index_map)
+      #   library_service_client.update_book_index(formatted_name, index_name, index_map)
 
       def update_book_index \
           name,
@@ -986,12 +986,12 @@ module Library
       #
       # @raise [Google::Gax::GaxError] if the RPC is aborted.
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #
-      #   library_service_api = LibraryServiceApi.new
-      #   library_service_api.stream_shelves.each do |element|
+      #   library_service_client = LibraryServiceClient.new
+      #   library_service_client.stream_shelves.each do |element|
       #     # Process element.
       #   end
 
@@ -1013,13 +1013,13 @@ module Library
       #
       # @raise [Google::Gax::GaxError] if the RPC is aborted.
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #
-      #   library_service_api = LibraryServiceApi.new
+      #   library_service_client = LibraryServiceClient.new
       #   name = ''
-      #   library_service_api.stream_books(name).each do |element|
+      #   library_service_client.stream_books(name).each do |element|
       #     # Process element.
       #   end
 
@@ -1051,17 +1051,17 @@ module Library
       #     This method interface might change in the future.
       #
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
       #   DiscussBookRequest = Google::Example::Library::V1::DiscussBookRequest
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #
-      #   library_service_api = LibraryServiceApi.new
+      #   library_service_client = LibraryServiceClient.new
       #   name = ''
       #   request = DiscussBookRequest.new
       #   request.name = name
       #   requests = [request]
-      #   library_service_api.discuss_book(requests).each do |element|
+      #   library_service_client.discuss_book(requests).each do |element|
       #     # Process element.
       #   end
 
@@ -1087,22 +1087,22 @@ module Library
       #   object.
       # @raise [Google::Gax::GaxError] if the RPC is aborted.
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #
-      #   library_service_api = LibraryServiceApi.new
+      #   library_service_client = LibraryServiceClient.new
       #   names_element = ''
       #   names = [names_element]
       #   shelves = []
       #
       #   # Iterate over all results.
-      #   library_service_api.find_related_books(names, shelves).each do |element|
+      #   library_service_client.find_related_books(names, shelves).each do |element|
       #     # Process element.
       #   end
       #
       #   # Or iterate over results one page at a time.
-      #   library_service_api.find_related_books(names, shelves).each_page do |page|
+      #   library_service_client.find_related_books(names, shelves).each_page do |page|
       #     # Process each page at a time.
       #     page.each do |element|
       #       # Process element.
@@ -1136,14 +1136,14 @@ module Library
       # @return [Google::Tagger::V1::AddTagResponse]
       # @raise [Google::Gax::GaxError] if the RPC is aborted.
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #
-      #   library_service_api = LibraryServiceApi.new
-      #   formatted_resource = LibraryServiceApi.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client = LibraryServiceClient.new
+      #   formatted_resource = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   tag = ''
-      #   response = library_service_api.add_tag(formatted_resource, tag)
+      #   response = library_service_client.add_tag(formatted_resource, tag)
 
       def add_tag \
           resource,
@@ -1170,14 +1170,14 @@ module Library
       # @return [Google::Tagger::V1::AddLabelResponse]
       # @raise [Google::Gax::GaxError] if the RPC is aborted.
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #
-      #   library_service_api = LibraryServiceApi.new
-      #   formatted_resource = LibraryServiceApi.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client = LibraryServiceClient.new
+      #   formatted_resource = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   label = ''
-      #   response = library_service_api.add_label(formatted_resource, label)
+      #   response = library_service_client.add_label(formatted_resource, label)
 
       def add_label \
           resource,
@@ -1198,13 +1198,13 @@ module Library
       # @return [Google::Longrunning::Operation]
       # @raise [Google::Gax::GaxError] if the RPC is aborted.
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #
-      #   library_service_api = LibraryServiceApi.new
-      #   formatted_name = LibraryServiceApi.book_path("[SHELF_ID]", "[BOOK_ID]")
-      #   response = library_service_api.get_big_book(formatted_name)
+      #   library_service_client = LibraryServiceClient.new
+      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   response = library_service_client.get_big_book(formatted_name)
 
       def get_big_book \
           name,

--- a/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
@@ -1,4 +1,4 @@
-============== file: lib/library/v1/library_service_api.rb ==============
+============== file: lib/library/v1/library_service_client.rb ==============
 # Copyright 2016 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -49,7 +49,7 @@ module Library
     #   @return [Google::Example::Library::V1::LibraryService::Stub]
     # @!attribute [r] labeler_stub
     #   @return [Google::Tagger::V1::Labeler::Stub]
-    class LibraryServiceApi
+    class LibraryServiceClient
       attr_reader :library_service_stub, :labeler_stub
 
       # The default address of the service.
@@ -378,14 +378,14 @@ module Library
       # @return [Google::Example::Library::V1::Shelf]
       # @raise [Google::Gax::GaxError] if the RPC is aborted.
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #   Shelf = Google::Example::Library::V1::Shelf
       #
-      #   library_service_api = LibraryServiceApi.new
+      #   library_service_client = LibraryServiceClient.new
       #   shelf = Shelf.new
-      #   response = library_service_api.create_shelf(shelf)
+      #   response = library_service_client.create_shelf(shelf)
 
       def create_shelf \
           shelf,
@@ -411,14 +411,14 @@ module Library
       # @return [Google::Example::Library::V1::Shelf]
       # @raise [Google::Gax::GaxError] if the RPC is aborted.
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #
-      #   library_service_api = LibraryServiceApi.new
-      #   formatted_name = LibraryServiceApi.shelf_path("[SHELF_ID]")
+      #   library_service_client = LibraryServiceClient.new
+      #   formatted_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
       #   options_ = ''
-      #   response = library_service_api.get_shelf(formatted_name, options_)
+      #   response = library_service_client.get_shelf(formatted_name, options_)
 
       def get_shelf \
           name,
@@ -447,19 +447,19 @@ module Library
       #   object.
       # @raise [Google::Gax::GaxError] if the RPC is aborted.
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #
-      #   library_service_api = LibraryServiceApi.new
+      #   library_service_client = LibraryServiceClient.new
       #
       #   # Iterate over all results.
-      #   library_service_api.list_shelves.each do |element|
+      #   library_service_client.list_shelves.each do |element|
       #     # Process element.
       #   end
       #
       #   # Or iterate over results one page at a time.
-      #   library_service_api.list_shelves.each_page do |page|
+      #   library_service_client.list_shelves.each_page do |page|
       #     # Process each page at a time.
       #     page.each do |element|
       #       # Process element.
@@ -480,13 +480,13 @@ module Library
       #   retries, etc.
       # @raise [Google::Gax::GaxError] if the RPC is aborted.
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #
-      #   library_service_api = LibraryServiceApi.new
-      #   formatted_name = LibraryServiceApi.shelf_path("[SHELF_ID]")
-      #   library_service_api.delete_shelf(formatted_name)
+      #   library_service_client = LibraryServiceClient.new
+      #   formatted_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   library_service_client.delete_shelf(formatted_name)
 
       def delete_shelf \
           name,
@@ -511,14 +511,14 @@ module Library
       # @return [Google::Example::Library::V1::Shelf]
       # @raise [Google::Gax::GaxError] if the RPC is aborted.
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #
-      #   library_service_api = LibraryServiceApi.new
-      #   formatted_name = LibraryServiceApi.shelf_path("[SHELF_ID]")
-      #   formatted_other_shelf_name = LibraryServiceApi.shelf_path("[SHELF_ID]")
-      #   response = library_service_api.merge_shelves(formatted_name, formatted_other_shelf_name)
+      #   library_service_client = LibraryServiceClient.new
+      #   formatted_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   formatted_other_shelf_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   response = library_service_client.merge_shelves(formatted_name, formatted_other_shelf_name)
 
       def merge_shelves \
           name,
@@ -543,15 +543,15 @@ module Library
       # @return [Google::Example::Library::V1::Book]
       # @raise [Google::Gax::GaxError] if the RPC is aborted.
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
       #   Book = Google::Example::Library::V1::Book
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #
-      #   library_service_api = LibraryServiceApi.new
-      #   formatted_name = LibraryServiceApi.shelf_path("[SHELF_ID]")
+      #   library_service_client = LibraryServiceClient.new
+      #   formatted_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
       #   book = Book.new
-      #   response = library_service_api.create_book(formatted_name, book)
+      #   response = library_service_client.create_book(formatted_name, book)
 
       def create_book \
           name,
@@ -582,15 +582,15 @@ module Library
       # @return [Google::Example::Library::V1::PublishSeriesResponse]
       # @raise [Google::Gax::GaxError] if the RPC is aborted.
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #   Shelf = Google::Example::Library::V1::Shelf
       #
-      #   library_service_api = LibraryServiceApi.new
+      #   library_service_client = LibraryServiceClient.new
       #   shelf = Shelf.new
       #   books = []
-      #   response = library_service_api.publish_series(shelf, books)
+      #   response = library_service_client.publish_series(shelf, books)
 
       def publish_series \
           shelf,
@@ -619,13 +619,13 @@ module Library
       # @return [Google::Example::Library::V1::Book]
       # @raise [Google::Gax::GaxError] if the RPC is aborted.
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #
-      #   library_service_api = LibraryServiceApi.new
-      #   formatted_name = LibraryServiceApi.book_path("[SHELF_ID]", "[BOOK_ID]")
-      #   response = library_service_api.get_book(formatted_name)
+      #   library_service_client = LibraryServiceClient.new
+      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   response = library_service_client.get_book(formatted_name)
 
       def get_book \
           name,
@@ -658,20 +658,20 @@ module Library
       #   object.
       # @raise [Google::Gax::GaxError] if the RPC is aborted.
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #
-      #   library_service_api = LibraryServiceApi.new
-      #   formatted_name = LibraryServiceApi.shelf_path("[SHELF_ID]")
+      #   library_service_client = LibraryServiceClient.new
+      #   formatted_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
       #
       #   # Iterate over all results.
-      #   library_service_api.list_books(formatted_name).each do |element|
+      #   library_service_client.list_books(formatted_name).each do |element|
       #     # Process element.
       #   end
       #
       #   # Or iterate over results one page at a time.
-      #   library_service_api.list_books(formatted_name).each_page do |page|
+      #   library_service_client.list_books(formatted_name).each_page do |page|
       #     # Process each page at a time.
       #     page.each do |element|
       #       # Process element.
@@ -700,13 +700,13 @@ module Library
       #   retries, etc.
       # @raise [Google::Gax::GaxError] if the RPC is aborted.
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #
-      #   library_service_api = LibraryServiceApi.new
-      #   formatted_name = LibraryServiceApi.book_path("[SHELF_ID]", "[BOOK_ID]")
-      #   library_service_api.delete_book(formatted_name)
+      #   library_service_client = LibraryServiceClient.new
+      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client.delete_book(formatted_name)
 
       def delete_book \
           name,
@@ -733,15 +733,15 @@ module Library
       # @return [Google::Example::Library::V1::Book]
       # @raise [Google::Gax::GaxError] if the RPC is aborted.
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
       #   Book = Google::Example::Library::V1::Book
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #
-      #   library_service_api = LibraryServiceApi.new
-      #   formatted_name = LibraryServiceApi.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client = LibraryServiceClient.new
+      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   book = Book.new
-      #   response = library_service_api.update_book(formatted_name, book)
+      #   response = library_service_client.update_book(formatted_name, book)
 
       def update_book \
           name,
@@ -770,14 +770,14 @@ module Library
       # @return [Google::Example::Library::V1::Book]
       # @raise [Google::Gax::GaxError] if the RPC is aborted.
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #
-      #   library_service_api = LibraryServiceApi.new
-      #   formatted_name = LibraryServiceApi.book_path("[SHELF_ID]", "[BOOK_ID]")
-      #   formatted_other_shelf_name = LibraryServiceApi.shelf_path("[SHELF_ID]")
-      #   response = library_service_api.move_book(formatted_name, formatted_other_shelf_name)
+      #   library_service_client = LibraryServiceClient.new
+      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   formatted_other_shelf_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   response = library_service_client.move_book(formatted_name, formatted_other_shelf_name)
 
       def move_book \
           name,
@@ -809,19 +809,19 @@ module Library
       #   object.
       # @raise [Google::Gax::GaxError] if the RPC is aborted.
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #
-      #   library_service_api = LibraryServiceApi.new
+      #   library_service_client = LibraryServiceClient.new
       #
       #   # Iterate over all results.
-      #   library_service_api.list_strings.each do |element|
+      #   library_service_client.list_strings.each do |element|
       #     # Process element.
       #   end
       #
       #   # Or iterate over results one page at a time.
-      #   library_service_api.list_strings.each_page do |page|
+      #   library_service_client.list_strings.each_page do |page|
       #     # Process each page at a time.
       #     page.each do |element|
       #       # Process element.
@@ -848,15 +848,15 @@ module Library
       #   retries, etc.
       # @raise [Google::Gax::GaxError] if the RPC is aborted.
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
       #   Alignment = Google::Example::Library::V1::SomeMessage2::SomeMessage3::Alignment
       #   Comment = Google::Example::Library::V1::Comment
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #   Stage = Google::Example::Library::V1::Comment::Stage
       #
-      #   library_service_api = LibraryServiceApi.new
-      #   formatted_name = LibraryServiceApi.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client = LibraryServiceClient.new
+      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   comment = ''
       #   stage = Stage::UNSET
       #   alignment = Alignment::CHAR
@@ -865,7 +865,7 @@ module Library
       #   comments_element.stage = stage
       #   comments_element.alignment = alignment
       #   comments = [comments_element]
-      #   library_service_api.add_comments(formatted_name, comments)
+      #   library_service_client.add_comments(formatted_name, comments)
 
       def add_comments \
           name,
@@ -888,13 +888,13 @@ module Library
       # @return [Google::Example::Library::V1::BookFromArchive]
       # @raise [Google::Gax::GaxError] if the RPC is aborted.
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #
-      #   library_service_api = LibraryServiceApi.new
-      #   formatted_name = LibraryServiceApi.archived_book_path("[ARCHIVE_PATH]", "[BOOK_ID]")
-      #   response = library_service_api.get_book_from_archive(formatted_name)
+      #   library_service_client = LibraryServiceClient.new
+      #   formatted_name = LibraryServiceClient.archived_book_path("[ARCHIVE_PATH]", "[BOOK_ID]")
+      #   response = library_service_client.get_book_from_archive(formatted_name)
 
       def get_book_from_archive \
           name,
@@ -918,14 +918,14 @@ module Library
       # @return [Google::Example::Library::V1::BookFromAnywhere]
       # @raise [Google::Gax::GaxError] if the RPC is aborted.
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #
-      #   library_service_api = LibraryServiceApi.new
+      #   library_service_client = LibraryServiceClient.new
       #   name = ''
-      #   formatted_alt_book_name = LibraryServiceApi.book_path("[SHELF_ID]", "[BOOK_ID]")
-      #   response = library_service_api.get_book_from_anywhere(name, formatted_alt_book_name)
+      #   formatted_alt_book_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   response = library_service_client.get_book_from_anywhere(name, formatted_alt_book_name)
 
       def get_book_from_anywhere \
           name,
@@ -951,16 +951,16 @@ module Library
       #   retries, etc.
       # @raise [Google::Gax::GaxError] if the RPC is aborted.
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #
-      #   library_service_api = LibraryServiceApi.new
-      #   formatted_name = LibraryServiceApi.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client = LibraryServiceClient.new
+      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   index_name = "default index"
       #   index_map_item = ''
       #   index_map = { "default_key" => index_map_item }
-      #   library_service_api.update_book_index(formatted_name, index_name, index_map)
+      #   library_service_client.update_book_index(formatted_name, index_name, index_map)
 
       def update_book_index \
           name,
@@ -986,12 +986,12 @@ module Library
       #
       # @raise [Google::Gax::GaxError] if the RPC is aborted.
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #
-      #   library_service_api = LibraryServiceApi.new
-      #   library_service_api.stream_shelves.each do |element|
+      #   library_service_client = LibraryServiceClient.new
+      #   library_service_client.stream_shelves.each do |element|
       #     # Process element.
       #   end
 
@@ -1013,13 +1013,13 @@ module Library
       #
       # @raise [Google::Gax::GaxError] if the RPC is aborted.
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #
-      #   library_service_api = LibraryServiceApi.new
+      #   library_service_client = LibraryServiceClient.new
       #   name = ''
-      #   library_service_api.stream_books(name).each do |element|
+      #   library_service_client.stream_books(name).each do |element|
       #     # Process element.
       #   end
 
@@ -1051,17 +1051,17 @@ module Library
       #     This method interface might change in the future.
       #
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
       #   DiscussBookRequest = Google::Example::Library::V1::DiscussBookRequest
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #
-      #   library_service_api = LibraryServiceApi.new
+      #   library_service_client = LibraryServiceClient.new
       #   name = ''
       #   request = DiscussBookRequest.new
       #   request.name = name
       #   requests = [request]
-      #   library_service_api.discuss_book(requests).each do |element|
+      #   library_service_client.discuss_book(requests).each do |element|
       #     # Process element.
       #   end
 
@@ -1087,22 +1087,22 @@ module Library
       #   object.
       # @raise [Google::Gax::GaxError] if the RPC is aborted.
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #
-      #   library_service_api = LibraryServiceApi.new
+      #   library_service_client = LibraryServiceClient.new
       #   names_element = ''
       #   names = [names_element]
       #   shelves = []
       #
       #   # Iterate over all results.
-      #   library_service_api.find_related_books(names, shelves).each do |element|
+      #   library_service_client.find_related_books(names, shelves).each do |element|
       #     # Process element.
       #   end
       #
       #   # Or iterate over results one page at a time.
-      #   library_service_api.find_related_books(names, shelves).each_page do |page|
+      #   library_service_client.find_related_books(names, shelves).each_page do |page|
       #     # Process each page at a time.
       #     page.each do |element|
       #       # Process element.
@@ -1136,14 +1136,14 @@ module Library
       # @return [Google::Tagger::V1::AddTagResponse]
       # @raise [Google::Gax::GaxError] if the RPC is aborted.
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #
-      #   library_service_api = LibraryServiceApi.new
-      #   formatted_resource = LibraryServiceApi.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client = LibraryServiceClient.new
+      #   formatted_resource = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   tag = ''
-      #   response = library_service_api.add_tag(formatted_resource, tag)
+      #   response = library_service_client.add_tag(formatted_resource, tag)
 
       def add_tag \
           resource,
@@ -1170,14 +1170,14 @@ module Library
       # @return [Google::Tagger::V1::AddLabelResponse]
       # @raise [Google::Gax::GaxError] if the RPC is aborted.
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #
-      #   library_service_api = LibraryServiceApi.new
-      #   formatted_resource = LibraryServiceApi.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client = LibraryServiceClient.new
+      #   formatted_resource = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   label = ''
-      #   response = library_service_api.add_label(formatted_resource, label)
+      #   response = library_service_client.add_label(formatted_resource, label)
 
       def add_label \
           resource,
@@ -1198,13 +1198,13 @@ module Library
       # @return [Google::Longrunning::Operation]
       # @raise [Google::Gax::GaxError] if the RPC is aborted.
       # @example
-      #   require "library/v1/library_service_api"
+      #   require "library/v1/library_service_client"
       #
-      #   LibraryServiceApi = Library::V1::LibraryServiceApi
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
       #
-      #   library_service_api = LibraryServiceApi.new
-      #   formatted_name = LibraryServiceApi.book_path("[SHELF_ID]", "[BOOK_ID]")
-      #   response = library_service_api.get_big_book(formatted_name)
+      #   library_service_client = LibraryServiceClient.new
+      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   response = library_service_client.get_big_book(formatted_name)
 
       def get_big_book \
           name,


### PR DESCRIPTION
This fixes #670 for Ruby.

I could make changes in super classes GapicContext.java and SurfaceNamer.java such that other languages are fixed too, but I found that triggers massive changes, which seems to be quite risky.

It's safer to wait until other language fixes this issue too, then we can do refactoring to pull up the changes to the super classes.