### PR TITLE
Fix Python namespace package separator

### DIFF
--- a/src/main/java/com/google/api/codegen/metadatagen/py/PythonPackageCopier.java
+++ b/src/main/java/com/google/api/codegen/metadatagen/py/PythonPackageCopier.java
@@ -19,8 +19,8 @@ import com.google.api.codegen.metadatagen.PackageCopierResult;
 import com.google.api.codegen.metadatagen.PackageMetadataGenerator;
 import com.google.api.tools.framework.snippet.Doc;
 import com.google.api.tools.framework.tools.ToolOptions;
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -82,8 +82,7 @@ public class PythonPackageCopier implements PackageCopier {
       } else {
         docBuilder.put(
             outFile, Doc.text("__import__('pkg_resources').declare_namespace(__name__)\n"));
-        pythonNamespacePackages.add(
-            inputPath.relativize(dir).toString().replace(File.separator, "."));
+        pythonNamespacePackages.add(Joiner.on(".").join(inputPath.relativize(dir).iterator()));
       }
       return FileVisitResult.CONTINUE;
     }

--- a/src/main/java/com/google/api/codegen/metadatagen/py/PythonPackageCopier.java
+++ b/src/main/java/com/google/api/codegen/metadatagen/py/PythonPackageCopier.java
@@ -20,6 +20,7 @@ import com.google.api.codegen.metadatagen.PackageMetadataGenerator;
 import com.google.api.tools.framework.snippet.Doc;
 import com.google.api.tools.framework.tools.ToolOptions;
 import com.google.common.collect.ImmutableMap;
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -81,7 +82,8 @@ public class PythonPackageCopier implements PackageCopier {
       } else {
         docBuilder.put(
             outFile, Doc.text("__import__('pkg_resources').declare_namespace(__name__)\n"));
-        pythonNamespacePackages.add(inputPath.relativize(dir).toString());
+        pythonNamespacePackages.add(
+            inputPath.relativize(dir).toString().replace(File.separator, "."));
       }
       return FileVisitResult.CONTINUE;
     }

--- a/src/test/java/com/google/api/codegen/metadatagen/testdata/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/metadatagen/testdata/python_library.baseline
@@ -48,7 +48,7 @@ setuptools.setup(
   install_requires=install_requires,
   license='Apache-2.0',
   packages=find_packages(),
-  namespace_packages=['test/nested', 'test'],
+  namespace_packages=['test.nested', 'test'],
   url='https://github.com/googleapis/googleapis'
 )
 


### PR DESCRIPTION
Previously Python packages use the file separator (e.g., '/') instead
of the standard dot separator.