### PR TITLE
Fix handling of Any resource name

### DIFF
--- a/src/main/java/com/google/api/codegen/config/PageStreamingConfig.java
+++ b/src/main/java/com/google/api/codegen/config/PageStreamingConfig.java
@@ -16,7 +16,6 @@ package com.google.api.codegen.config;
 
 import com.google.api.codegen.MethodConfigProto;
 import com.google.api.codegen.PageStreamingConfigProto;
-import com.google.api.codegen.ResourceNameTreatment;
 import com.google.api.tools.framework.model.Diag;
 import com.google.api.tools.framework.model.DiagCollector;
 import com.google.api.tools.framework.model.Field;
@@ -107,17 +106,12 @@ public abstract class PageStreamingConfig {
               resourcesFieldName));
       resourcesFieldConfig = null;
     } else {
-      if (methodConfigProto.getResourceNameTreatment() == ResourceNameTreatment.STATIC_TYPES
-          && messageConfigs != null
-          && messageConfigs.fieldHasResourceName(resourcesField)) {
-        ResourceNameConfig resourceNameConfig =
-            resourceNameConfigs.get(messageConfigs.getFieldResourceName(resourcesField));
-        resourcesFieldConfig =
-            FieldConfig.createFieldConfig(
-                resourcesField, ResourceNameTreatment.STATIC_TYPES, resourceNameConfig);
-      } else {
-        resourcesFieldConfig = FieldConfig.createDefaultFieldConfig(resourcesField);
-      }
+      resourcesFieldConfig =
+          FieldConfig.createMessageFieldConfig(
+              messageConfigs,
+              resourceNameConfigs,
+              resourcesField,
+              methodConfigProto.getResourceNameTreatment());
     }
 
     if (requestTokenField == null || responseTokenField == null || resourcesFieldConfig == null) {

--- a/src/main/java/com/google/api/codegen/transformer/ApiMethodTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ApiMethodTransformer.java
@@ -583,7 +583,13 @@ public class ApiMethodTransformer {
         SingleResourceNameConfig resourceNameConfig =
             context.getSimpleResourceNameConfig(entityName);
         if (resourceNameConfig == null) {
-          throw new IllegalStateException("No collection config with id '" + entityName + "'");
+          String methodName = context.getMethod().getSimpleName();
+          throw new IllegalStateException(
+              "No collection config with id '"
+                  + entityName
+                  + "' required by configuration for method '"
+                  + methodName
+                  + "'");
         }
         PathTemplateCheckView.Builder check = PathTemplateCheckView.newBuilder();
         check.pathTemplateName(

--- a/src/main/java/com/google/api/codegen/transformer/PathTemplateTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/PathTemplateTransformer.java
@@ -184,13 +184,7 @@ public class PathTemplateTransformer {
         FieldConfig fieldConfig =
             FieldConfig.createMessageFieldConfig(
                 resourceConfigs, resourceNameConfigs, field, ResourceNameTreatment.STATIC_TYPES);
-        String fieldTypeSimpleName;
-        boolean isAny = fieldConfig.getResourceNameType() == ResourceNameType.ANY;
-        if (isAny) {
-          fieldTypeSimpleName = namer.getAnyFieldResourceTypeName();
-        } else {
-          fieldTypeSimpleName = namer.getResourceTypeName(fieldConfig.getResourceNameConfig());
-        }
+        String fieldTypeSimpleName = namer.getResourceTypeName(fieldConfig.getResourceNameConfig());
         String fieldTypeName =
             context
                 .getTypeTable()
@@ -208,7 +202,7 @@ public class PathTemplateTransformer {
                 .typeName(fieldTypeName)
                 .docTypeName(fieldDocTypeName)
                 .elementTypeName(fieldElementTypeName)
-                .isAny(isAny)
+                .isAny(fieldConfig.getResourceNameType() == ResourceNameType.ANY)
                 .isRepeated(field.getType().isRepeated())
                 .isOneof(fieldConfig.getResourceNameType() == ResourceNameType.ONEOF)
                 .propertyName(namer.getResourceNameFieldGetFunctionName(fieldConfig))

--- a/src/main/java/com/google/api/codegen/transformer/PathTemplateTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/PathTemplateTransformer.java
@@ -15,7 +15,6 @@
 package com.google.api.codegen.transformer;
 
 import com.google.api.codegen.ResourceNameTreatment;
-import com.google.api.codegen.config.AnyResourceNameConfig;
 import com.google.api.codegen.config.FieldConfig;
 import com.google.api.codegen.config.FixedResourceNameConfig;
 import com.google.api.codegen.config.InterfaceConfig;
@@ -182,21 +181,15 @@ public class PathTemplateTransformer {
       List<ResourceProtoFieldView> fieldViews = new ArrayList<>();
       for (Field field : fields) {
         String fieldName = field.getSimpleName();
-        String fieldResourceName = resourceConfigs.getFieldResourceName(field);
-        ResourceNameConfig resourceNameConfig = resourceNameConfigs.get(fieldResourceName);
         FieldConfig fieldConfig =
-            FieldConfig.createFieldConfig(
-                field,
-                resourceNameConfig == null
-                    ? ResourceNameTreatment.NONE
-                    : ResourceNameTreatment.STATIC_TYPES,
-                resourceNameConfig);
+            FieldConfig.createMessageFieldConfig(
+                resourceConfigs, resourceNameConfigs, field, ResourceNameTreatment.STATIC_TYPES);
         String fieldTypeSimpleName;
-        boolean isAny = fieldResourceName.equals(AnyResourceNameConfig.GAPIC_CONFIG_ANY_VALUE);
+        boolean isAny = fieldConfig.getResourceNameType() == ResourceNameType.ANY;
         if (isAny) {
           fieldTypeSimpleName = namer.getAnyFieldResourceTypeName();
         } else {
-          fieldTypeSimpleName = namer.getResourceTypeName(resourceNameConfig);
+          fieldTypeSimpleName = namer.getResourceTypeName(fieldConfig.getResourceNameConfig());
         }
         String fieldTypeName =
             context
@@ -217,9 +210,7 @@ public class PathTemplateTransformer {
                 .elementTypeName(fieldElementTypeName)
                 .isAny(isAny)
                 .isRepeated(field.getType().isRepeated())
-                .isOneof(
-                    resourceNameConfig != null
-                        && resourceNameConfig.getResourceNameType() == ResourceNameType.ONEOF)
+                .isOneof(fieldConfig.getResourceNameType() == ResourceNameType.ONEOF)
                 .propertyName(namer.getResourceNameFieldGetFunctionName(fieldConfig))
                 .underlyingPropertyName(namer.publicMethodName(Name.from(fieldName)))
                 .build();

--- a/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
@@ -111,7 +111,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
     ResourceNameType resourceNameType = resourceNameConfig.getResourceNameType();
     switch (resourceNameType) {
       case ANY:
-        return Name.from("resource_name");
+        return getAnyResourceTypeName();
       case FIXED:
         return Name.from(entityName).join("name_fixed");
       case ONEOF:
@@ -125,6 +125,10 @@ public class SurfaceNamer extends NameFormatterDelegator {
       default:
         throw new UnsupportedOperationException("unexpected entity name type");
     }
+  }
+
+  protected Name getAnyResourceTypeName() {
+    return Name.from("resource_name");
   }
 
   private static String removeSuffix(String original, String suffix) {
@@ -780,11 +784,6 @@ public class SurfaceNamer extends NameFormatterDelegator {
    */
   public String getGenericAwareResponseTypeName(TypeRef outputType) {
     return getNotImplementedString("SurfaceNamer.getGenericAwareResponseType");
-  }
-
-  /** The name of the resource-name type for an "Any" resource. */
-  public String getAnyFieldResourceTypeName() {
-    return getNotImplementedString("SurfaceNamer.getAnyFieldResourceTypeName");
   }
 
   /**

--- a/src/main/java/com/google/api/codegen/transformer/TestCaseTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/TestCaseTransformer.java
@@ -227,13 +227,10 @@ public class TestCaseTransformer {
     }
     ImmutableMap.Builder<String, FieldConfig> builder = ImmutableMap.builder();
     for (Field field : context.getMethod().getOutputMessage().getFields()) {
-      if (messageConfig.fieldHasResourceName(field)) {
-        ResourceNameConfig resourceNameConfig =
-            resourceNameConfigs.get(messageConfig.getFieldResourceName(field));
-        builder.put(
-            field.getFullName(),
-            FieldConfig.createFieldConfig(field, treatment, resourceNameConfig));
-      }
+      builder.put(
+          field.getFullName(),
+          FieldConfig.createMessageFieldConfig(
+              messageConfig, resourceNameConfigs, field, treatment));
     }
     return builder.build();
   }

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpSurfaceNamer.java
@@ -18,6 +18,7 @@ import com.google.api.codegen.ServiceMessages;
 import com.google.api.codegen.config.FieldConfig;
 import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.config.ResourceNameConfig;
+import com.google.api.codegen.config.ResourceNameType;
 import com.google.api.codegen.config.SingleResourceNameConfig;
 import com.google.api.codegen.transformer.ModelTypeFormatterImpl;
 import com.google.api.codegen.transformer.ModelTypeTable;
@@ -199,7 +200,8 @@ public class CSharpSurfaceNamer extends SurfaceNamer {
     String fieldName = fieldConfig.getField().getSimpleName();
     Name identifier = Name.from(fieldName);
     Name resourceName;
-    if (fieldConfig.getResourceNameConfig() == null) {
+    if (fieldConfig.getResourceNameType() == null
+        || fieldConfig.getResourceNameType() == ResourceNameType.ANY) {
       resourceName = Name.from("as_resource_name");
     } else {
       resourceName = getResourceTypeNameObject(fieldConfig.getResourceNameConfig());

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpSurfaceNamer.java
@@ -234,7 +234,7 @@ public class CSharpSurfaceNamer extends SurfaceNamer {
 
   @Override
   protected Name getAnyResourceTypeName() {
-    return Name.from("i_resource_name");
+    return Name.anyCamel("IResourceName");
   }
 
   private String getResourceTypeName(ModelTypeTable typeTable, FieldConfig resourceFieldConfig) {

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpSurfaceNamer.java
@@ -200,8 +200,7 @@ public class CSharpSurfaceNamer extends SurfaceNamer {
     String fieldName = fieldConfig.getField().getSimpleName();
     Name identifier = Name.from(fieldName);
     Name resourceName;
-    if (fieldConfig.getResourceNameType() == null
-        || fieldConfig.getResourceNameType() == ResourceNameType.ANY) {
+    if (fieldConfig.getResourceNameType() == ResourceNameType.ANY) {
       resourceName = Name.from("as_resource_name");
     } else {
       resourceName = getResourceTypeNameObject(fieldConfig.getResourceNameConfig());
@@ -234,8 +233,8 @@ public class CSharpSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getAnyFieldResourceTypeName() {
-    return "IResourceName";
+  protected Name getAnyResourceTypeName() {
+    return Name.from("i_resource_name");
   }
 
   private String getResourceTypeName(ModelTypeTable typeTable, FieldConfig resourceFieldConfig) {

--- a/src/test/java/com/google/api/codegen/testdata/csharp_gapic_client_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/csharp_gapic_client_library.baseline
@@ -3624,7 +3624,7 @@ namespace Google.Example.Library.V1
         {
             ListStringsRequest request = new ListStringsRequest
             {
-                ResourceName = name,
+                AsResourceName = name,
                 PageToken = pageToken ?? "",
                 PageSize = pageSize ?? 0,
             };
@@ -3660,7 +3660,7 @@ namespace Google.Example.Library.V1
         {
             ListStringsRequest request = new ListStringsRequest
             {
-                ResourceName = name,
+                AsResourceName = name,
                 PageToken = pageToken ?? "",
                 PageSize = pageSize ?? 0,
             };

--- a/src/test/java/com/google/api/codegen/testdata/csharp_gapic_client_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/csharp_gapic_client_library.baseline
@@ -1937,7 +1937,7 @@ namespace Google.Example.Library.V1
         /// A pageable asynchronous sequence of <see cref="string"/> resources.
         /// </returns>
         public virtual PagedAsyncEnumerable<ListStringsResponse, string> ListStringsAsync(
-            ResourceName name,
+            IResourceName name,
             string pageToken = null,
             int? pageSize = null,
             CallSettings callSettings = null)
@@ -1966,7 +1966,7 @@ namespace Google.Example.Library.V1
         /// A pageable sequence of <see cref="string"/> resources.
         /// </returns>
         public virtual PagedEnumerable<ListStringsResponse, string> ListStrings(
-            ResourceName name,
+            IResourceName name,
             string pageToken = null,
             int? pageSize = null,
             CallSettings callSettings = null)
@@ -3617,7 +3617,7 @@ namespace Google.Example.Library.V1
         /// A pageable asynchronous sequence of <see cref="string"/> resources.
         /// </returns>
         public override PagedAsyncEnumerable<ListStringsResponse, string> ListStringsAsync(
-            ResourceName name,
+            IResourceName name,
             string pageToken = null,
             int? pageSize = null,
             CallSettings callSettings = null)
@@ -3653,7 +3653,7 @@ namespace Google.Example.Library.V1
         /// A pageable sequence of <see cref="string"/> resources.
         /// </returns>
         public override PagedEnumerable<ListStringsResponse, string> ListStrings(
-            ResourceName name,
+            IResourceName name,
             string pageToken = null,
             int? pageSize = null,
             CallSettings callSettings = null)

--- a/src/test/java/com/google/api/codegen/testdata/csharp_gapic_snippets_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/csharp_gapic_snippets_library.baseline
@@ -646,11 +646,11 @@ namespace Google.Example.Library.V1.Snippets
 
         public async Task ListStringsAsync2()
         {
-            // Snippet: ListStringsAsync(ResourceName,string,int?,CallSettings)
+            // Snippet: ListStringsAsync(IResourceName,string,int?,CallSettings)
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            ResourceName name = new ShelfName("[SHELF_ID]");
+            IResourceName name = new ShelfName("[SHELF_ID]");
             // Make the request
             PagedAsyncEnumerable<ListStringsResponse,string> response =
                 libraryServiceClient.ListStringsAsync(name);
@@ -689,11 +689,11 @@ namespace Google.Example.Library.V1.Snippets
 
         public void ListStrings2()
         {
-            // Snippet: ListStrings(ResourceName,string,int?,CallSettings)
+            // Snippet: ListStrings(IResourceName,string,int?,CallSettings)
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
-            ResourceName name = new ShelfName("[SHELF_ID]");
+            IResourceName name = new ShelfName("[SHELF_ID]");
             // Make the request
             PagedEnumerable<ListStringsResponse,string> response =
                 libraryServiceClient.ListStrings(name);


### PR DESCRIPTION
- Moves logic for creating FieldConfig objects with resource names out of PageStreamingConfig and PathTemplateTransformer, and into the FieldConfig static factory methods.
- Updates C# to use IResourceName instead of ResourceName
- Fixes some error handling