### PR TITLE
Updates to dummy class doc generation

### DIFF
--- a/src/main/java/com/google/api/codegen/ProtoFileView.java
+++ b/src/main/java/com/google/api/codegen/ProtoFileView.java
@@ -45,6 +45,9 @@ public class ProtoFileView implements InputElementView<ProtoFile> {
         for (Field field : method.getInputType().getMessageType().getFields()) {
           files.addAll(protoFiles(field));
         }
+        for (Field field : method.getOutputType().getMessageType().getFields()) {
+          files.addAll(protoFiles(field));
+        }
       }
     }
     return files;

--- a/src/main/java/com/google/api/codegen/py/PythonImportHandler.java
+++ b/src/main/java/com/google/api/codegen/py/PythonImportHandler.java
@@ -33,6 +33,7 @@ import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 public class PythonImportHandler {
 
@@ -104,14 +105,15 @@ public class PythonImportHandler {
   }
 
   /** This constructor is used for doc messages. */
-  public PythonImportHandler(ProtoFile file) {
+  public PythonImportHandler(ProtoFile file, Set<ProtoFile> importableProtoFiles) {
     for (MessageType message : file.getMessages()) {
       for (Field field : message.getMessageFields()) {
         MessageType messageType = field.getType().getMessageType();
         // Don't include imports to messages in the same file.
-        if (!messageType.getFile().equals(file)) {
+        ProtoFile importFile = messageType.getFile();
+        if (!importFile.equals(file) && importableProtoFiles.contains(importFile)) {
           addImport(
-              messageType.getFile(),
+              importFile,
               PythonImport.create(
                   ImportType.APP,
                   protoPackageToPythonPackage(messageType.getFile().getProto().getPackage()),

--- a/src/main/java/com/google/api/codegen/py/PythonProtoFileInitializer.java
+++ b/src/main/java/com/google/api/codegen/py/PythonProtoFileInitializer.java
@@ -14,14 +14,23 @@
  */
 package com.google.api.codegen.py;
 
+import com.google.api.codegen.ProtoFileView;
 import com.google.api.tools.framework.model.ProtoFile;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
+import java.util.Set;
 
 public class PythonProtoFileInitializer implements PythonSnippetSetInputInitializer<ProtoFile> {
 
+  private Set<ProtoFile> importableProtoFiles = null;
+
   @Override
   public PythonImportHandler getImportHandler(ProtoFile file) {
-    return new PythonImportHandler(file);
+    if (importableProtoFiles == null) {
+      importableProtoFiles =
+          Sets.newHashSet((new ProtoFileView()).getElementIterable(file.getModel()));
+    }
+    return new PythonImportHandler(file, importableProtoFiles);
   }
 
   @Override

--- a/src/test/java/com/google/api/codegen/testdata/library.proto
+++ b/src/test/java/com/google/api/codegen/testdata/library.proto
@@ -6,6 +6,7 @@ package google.example.library.v1;
 
 import "field_mask.proto";
 import "google/api/annotations.proto";
+import "google/api/monitored_resource.proto";
 import "google/longrunning/operations.proto";
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
@@ -202,6 +203,10 @@ message Book {
 
   map<int32, string> map_string_value = 25;
   map<string, SomeMessage> map_message_value = 26;
+
+  // Tests Python doc generation: should generate a dummy file for monitored
+  // resource, but *not* its import, label.
+  google.api.MonitoredResource resource = 29;
 }
 
 // A single book in the archives.

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_doc_message_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_doc_message_library.baseline
@@ -45,6 +45,98 @@ var FieldMask = {
     CARDBOARD: 4
   }
 }
+============== file: src/doc_google_api_monitored_resource.js ==============
+/*
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Note: this file is purely for documentation. Any contents are not expected
+ * to be loaded as the JS file.
+ */
+
+/**
+ * An object that describes the schema of a {@link MonitoredResource} object using a
+ * type name and a set of labels.  For example, the monitored resource
+ * descriptor for Google Compute Engine VM instances has a type of
+ * `"gce_instance"` and specifies the use of the labels `"instance_id"` and
+ * `"zone"` to identify particular VM instances.
+ *
+ * Different APIs can support different monitored resource types. APIs generally
+ * provide a `list` method that returns the monitored resource descriptors used
+ * by the API.
+ *
+ * @external "google.api.MonitoredResourceDescriptor"
+ * @property {string} name
+ *   Optional. The resource name of the monitored resource descriptor:
+ *   `"projects/{project_id}/monitoredResourceDescriptors/{type}"` where
+ *   {type} is the value of the `type` field in this object and
+ *   {project_id} is a project ID that provides API-specific context for
+ *   accessing the type.  APIs that do not use project information can use the
+ *   resource name format `"monitoredResourceDescriptors/{type}"`.
+ *
+ * @property {string} type
+ *   Required. The monitored resource type. For example, the type
+ *   `"cloudsql_database"` represents databases in Google Cloud SQL.
+ *
+ * @property {string} displayName
+ *   Optional. A concise name for the monitored resource type that might be
+ *   displayed in user interfaces. For example, `"Google Cloud SQL Database"`.
+ *
+ * @property {string} description
+ *   Optional. A detailed description of the monitored resource type that might
+ *   be used in documentation.
+ *
+ * @property {Object[]} labels
+ *   Required. A set of labels used to describe instances of this monitored
+ *   resource type. For example, an individual Google Cloud SQL database is
+ *   identified by values for the labels `"database_id"` and `"zone"`.
+ *
+ *   This object should have the same structure as [google.api.LabelDescriptor]{@link external:"google.api.LabelDescriptor"}
+ *
+ * @see [google.api.MonitoredResourceDescriptor definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/api/monitored_resource.proto}
+ */;
+
+/**
+ * An object representing a resource that can be used for monitoring, logging,
+ * billing, or other purposes. Examples include virtual machine instances,
+ * databases, and storage devices such as disks. The `type` field identifies a
+ * {@link MonitoredResourceDescriptor} object that describes the resource's
+ * schema. Information in the `labels` field identifies the actual resource and
+ * its attributes according to the schema. For example, a particular Compute
+ * Engine VM instance could be represented by the following object, because the
+ * {@link MonitoredResourceDescriptor} for `"gce_instance"` has labels
+ * `"instance_id"` and `"zone"`:
+ *
+ *     { "type": "gce_instance",
+ *       "labels": { "instance_id": "my-instance",
+ *                   "zone": "us-central1-a" }}
+ *
+ * @external "google.api.MonitoredResource"
+ * @property {string} type
+ *   Required. The monitored resource type. This field must match
+ *   the `type` field of a {@link MonitoredResourceDescriptor} object. For
+ *   example, the type of a Cloud SQL database is `"cloudsql_database"`.
+ *
+ * @property {Object.<string, string>} labels
+ *   Required. Values for all of the labels listed in the associated monitored
+ *   resource descriptor. For example, Cloud SQL databases use the labels
+ *   `"database_id"` and `"zone"`.
+ *
+ * @see [google.api.MonitoredResource definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/api/monitored_resource.proto}
+ */
 ============== file: src/doc_google_protobuf_any.js ==============
 /*
  * Copyright 2016 Google Inc. All rights reserved.
@@ -415,6 +507,94 @@ var FieldMask = {
  *
  * @see [google.protobuf.FieldMask definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/field_mask.proto}
  */
+============== file: src/doc_google_protobuf_struct.js ==============
+/*
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Note: this file is purely for documentation. Any contents are not expected
+ * to be loaded as the JS file.
+ */
+
+/**
+ * `Struct` represents a structured data value, consisting of fields
+ * which map to dynamically typed values. In some languages, `Struct`
+ * might be supported by a native representation. For example, in
+ * scripting languages like JS a struct is represented as an
+ * object. The details of that representation are described together
+ * with the proto support for the language.
+ *
+ * The JSON representation for `Struct` is JSON object.
+ *
+ * @external "google.protobuf.Struct"
+ * @property {Object.<string, Object>} fields
+ *   Unordered map of dynamically typed values.
+ *
+ * @see [google.protobuf.Struct definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/struct.proto}
+ */;
+
+/**
+ * `Value` represents a dynamically typed value which can be either
+ * null, a number, a string, a boolean, a recursive struct value, or a
+ * list of values. A producer of value is expected to set one of that
+ * variants, absence of any variant indicates an error.
+ *
+ * The JSON representation for `Value` is JSON value.
+ *
+ * @external "google.protobuf.Value"
+ * @property {number} nullValue
+ *   Represents a null value.
+ *
+ *   The number should be among the values of [google.protobuf.NullValue]{@link external:"google.protobuf.NullValue"}
+ *
+ * @property {number} numberValue
+ *   Represents a double value.
+ *
+ * @property {string} stringValue
+ *   Represents a string value.
+ *
+ * @property {boolean} boolValue
+ *   Represents a boolean value.
+ *
+ * @property {Object} structValue
+ *   Represents a structured value.
+ *
+ *   This object should have the same structure as [google.protobuf.Struct]{@link external:"google.protobuf.Struct"}
+ *
+ * @property {Object} listValue
+ *   Represents a repeated `Value`.
+ *
+ *   This object should have the same structure as [google.protobuf.ListValue]{@link external:"google.protobuf.ListValue"}
+ *
+ * @see [google.protobuf.Value definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/struct.proto}
+ */;
+
+/**
+ * `ListValue` is a wrapper around a repeated field of values.
+ *
+ * The JSON representation for `ListValue` is JSON array.
+ *
+ * @external "google.protobuf.ListValue"
+ * @property {Object[]} values
+ *   Repeated field of dynamically typed values.
+ *
+ *   This object should have the same structure as [google.protobuf.Value]{@link external:"google.protobuf.Value"}
+ *
+ * @see [google.protobuf.ListValue definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/struct.proto}
+ */
 ============== file: src/doc_google_protobuf_timestamp.js ==============
 /*
  * Copyright 2016 Google Inc. All rights reserved.
@@ -635,6 +815,99 @@ var FieldMask = {
  *
  * @see [google.protobuf.BytesValue definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/wrappers.proto}
  */
+============== file: src/doc_google_rpc_status.js ==============
+/*
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Note: this file is purely for documentation. Any contents are not expected
+ * to be loaded as the JS file.
+ */
+
+/**
+ * The `Status` type defines a logical error model that is suitable for different
+ * programming environments, including REST APIs and RPC APIs. It is used by
+ * [gRPC](https://github.com/grpc). The error model is designed to be:
+ *
+ * - Simple to use and understand for most users
+ * - Flexible enough to meet unexpected needs
+ *
+ * # Overview
+ *
+ * The `Status` message contains three pieces of data: error code, error message,
+ * and error details. The error code should be an enum value of
+ * {@link google.rpc.Code}, but it may accept additional error codes if needed.  The
+ * error message should be a developer-facing English message that helps
+ * developers *understand* and *resolve* the error. If a localized user-facing
+ * error message is needed, put the localized message in the error details or
+ * localize it in the client. The optional error details may contain arbitrary
+ * information about the error. There is a predefined set of error detail types
+ * in the package `google.rpc` which can be used for common error conditions.
+ *
+ * # Language mapping
+ *
+ * The `Status` message is the logical representation of the error model, but it
+ * is not necessarily the actual wire format. When the `Status` message is
+ * exposed in different client libraries and different wire protocols, it can be
+ * mapped differently. For example, it will likely be mapped to some exceptions
+ * in Java, but more likely mapped to some error codes in C.
+ *
+ * # Other uses
+ *
+ * The error model and the `Status` message can be used in a variety of
+ * environments, either with or without APIs, to provide a
+ * consistent developer experience across different environments.
+ *
+ * Example uses of this error model include:
+ *
+ * - Partial errors. If a service needs to return partial errors to the client,
+ *     it may embed the `Status` in the normal response to indicate the partial
+ *     errors.
+ *
+ * - Workflow errors. A typical workflow has multiple steps. Each step may
+ *     have a `Status` message for error reporting purpose.
+ *
+ * - Batch operations. If a client uses batch request and batch response, the
+ *     `Status` message should be used directly inside batch response, one for
+ *     each error sub-response.
+ *
+ * - Asynchronous operations. If an API call embeds asynchronous operation
+ *     results in its response, the status of those operations should be
+ *     represented directly using the `Status` message.
+ *
+ * - Logging. If some API errors are stored in logs, the message `Status` could
+ *     be used directly after any stripping needed for security/privacy reasons.
+ *
+ * @external "google.rpc.Status"
+ * @property {number} code
+ *   The status code, which should be an enum value of {@link google.rpc.Code}.
+ *
+ * @property {string} message
+ *   A developer-facing error message, which should be in English. Any
+ *   user-facing error message should be localized and sent in the
+ *   {@link google.rpc.Status.details} field, or localized by the client.
+ *
+ * @property {Object[]} details
+ *   A list of messages that carry the error details.  There will be a
+ *   common set of message types for APIs to use.
+ *
+ *   This object should have the same structure as [google.protobuf.Any]{@link external:"google.protobuf.Any"}
+ *
+ * @see [google.rpc.Status definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto}
+ */
 ============== file: src/doc_library.js ==============
 /*
  * Copyright 2016 Google Inc. All rights reserved.
@@ -733,6 +1006,12 @@ var FieldMask = {
  * @property {Object.<number, string>} mapStringValue
  *
  * @property {Object.<string, Object>} mapMessageValue
+ *
+ * @property {Object} resource
+ *   Tests Python doc generation: should generate a dummy file for monitored
+ *   resource, but *not* its import, label.
+ *
+ *   This object should have the same structure as [google.api.MonitoredResource]{@link external:"google.api.MonitoredResource"}
  *
  * @class
  * @see [google.example.library.v1.Book definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_message_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_message_library.baseline
@@ -22,6 +22,82 @@ class FieldMask(object):
     """
     pass
 
+============== file: google/api/monitored_resource_pb2.py ==============
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class MonitoredResourceDescriptor(object):
+    """
+    An object that describes the schema of a ``MonitoredResource`` object using a
+    type name and a set of labels.  For example, the monitored resource
+    descriptor for Google Compute Engine VM instances has a type of
+    ``\"gce_instance\"`` and specifies the use of the labels ``\"instance_id\"`` and
+    ``\"zone\"`` to identify particular VM instances.
+
+    Different APIs can support different monitored resource types. APIs generally
+    provide a ``list`` method that returns the monitored resource descriptors used
+    by the API.
+
+    Attributes:
+      name (string): Optional. The resource name of the monitored resource descriptor:
+        ``\"projects/{project_id}/monitoredResourceDescriptors/{type}\"`` where
+        {type} is the value of the ``type`` field in this object and
+        {project_id} is a project ID that provides API-specific context for
+        accessing the type.  APIs that do not use project information can use the
+        resource name format ``\"monitoredResourceDescriptors/{type}\"``.
+      type (string): Required. The monitored resource type. For example, the type
+        ``\"cloudsql_database\"`` represents databases in Google Cloud SQL.
+      display_name (string): Optional. A concise name for the monitored resource type that might be
+        displayed in user interfaces. For example, ``\"Google Cloud SQL Database\"``.
+      description (string): Optional. A detailed description of the monitored resource type that might
+        be used in documentation.
+      labels (list[:class:`google.api.label_pb2.LabelDescriptor`]): Required. A set of labels used to describe instances of this monitored
+        resource type. For example, an individual Google Cloud SQL database is
+        identified by values for the labels ``\"database_id\"`` and ``\"zone\"``.
+
+    """
+    pass
+
+
+class MonitoredResource(object):
+    """
+    An object representing a resource that can be used for monitoring, logging,
+    billing, or other purposes. Examples include virtual machine instances,
+    databases, and storage devices such as disks. The ``type`` field identifies a
+    ``MonitoredResourceDescriptor`` object that describes the resource's
+    schema. Information in the ``labels`` field identifies the actual resource and
+    its attributes according to the schema. For example, a particular Compute
+    Engine VM instance could be represented by the following object, because the
+    ``MonitoredResourceDescriptor`` for ``\"gce_instance\"`` has labels
+    ``\"instance_id\"`` and ``\"zone\"``:
+
+        { \"type\": \"gce_instance\",
+          \"labels\": { \"instance_id\": \"my-instance\",
+                      \"zone\": \"us-central1-a\" }}
+
+    Attributes:
+      type (string): Required. The monitored resource type. This field must match
+        the ``type`` field of a ``MonitoredResourceDescriptor`` object. For
+        example, the type of a Cloud SQL database is ``\"cloudsql_database\"``.
+      labels (dict[string -> :class:`google.api.monitored_resource_pb2.MonitoredResource.LabelsEntry`]): Required. Values for all of the labels listed in the associated monitored
+        resource descriptor. For example, Cloud SQL databases use the labels
+        ``\"database_id\"`` and ``\"zone\"``.
+
+    """
+    pass
+
 ============== file: google/protobuf/any_pb2.py ==============
 # Copyright 2016 Google Inc. All rights reserved.
 #
@@ -373,6 +449,73 @@ class FieldMask(object):
     """
     pass
 
+============== file: google/protobuf/struct_pb2.py ==============
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class Struct(object):
+    """
+    ``Struct`` represents a structured data value, consisting of fields
+    which map to dynamically typed values. In some languages, ``Struct``
+    might be supported by a native representation. For example, in
+    scripting languages like JS a struct is represented as an
+    object. The details of that representation are described together
+    with the proto support for the language.
+
+    The JSON representation for ``Struct`` is JSON object.
+
+    Attributes:
+      fields (dict[string -> :class:`google.protobuf.struct_pb2.Struct.FieldsEntry`]): Unordered map of dynamically typed values.
+
+    """
+    pass
+
+
+class Value(object):
+    """
+    ``Value`` represents a dynamically typed value which can be either
+    null, a number, a string, a boolean, a recursive struct value, or a
+    list of values. A producer of value is expected to set one of that
+    variants, absence of any variant indicates an error.
+
+    The JSON representation for ``Value`` is JSON value.
+
+    Attributes:
+      null_value (enum :class:`google.cloud.gapic.example.library.v1.enums.NullValue`): Represents a null value.
+      number_value (float): Represents a double value.
+      string_value (string): Represents a string value.
+      bool_value (bool): Represents a boolean value.
+      struct_value (:class:`google.protobuf.struct_pb2.Struct`): Represents a structured value.
+      list_value (:class:`google.protobuf.struct_pb2.ListValue`): Represents a repeated ``Value``.
+
+    """
+    pass
+
+
+class ListValue(object):
+    """
+    ``ListValue`` is a wrapper around a repeated field of values.
+
+    The JSON representation for ``ListValue`` is JSON array.
+
+    Attributes:
+      values (list[:class:`google.protobuf.struct_pb2.Value`]): Repeated field of dynamically typed values.
+
+    """
+    pass
+
 ============== file: google/protobuf/timestamp_pb2.py ==============
 # Copyright 2016 Google Inc. All rights reserved.
 #
@@ -589,6 +732,90 @@ class BytesValue(object):
     """
     pass
 
+============== file: google/rpc/status_pb2.py ==============
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from google.protobuf import any_pb2
+
+
+class Status(object):
+    """
+    The ``Status`` type defines a logical error model that is suitable for different
+    programming environments, including REST APIs and RPC APIs. It is used by
+    `gRPC <https://github.com/grpc>`_. The error model is designed to be:
+
+    - Simple to use and understand for most users
+    - Flexible enough to meet unexpected needs
+
+    # Overview
+
+    The ``Status`` message contains three pieces of data: error code, error message,
+    and error details. The error code should be an enum value of
+    ``google.rpc.Code``, but it may accept additional error codes if needed.  The
+    error message should be a developer-facing English message that helps
+    developers *understand* and *resolve* the error. If a localized user-facing
+    error message is needed, put the localized message in the error details or
+    localize it in the client. The optional error details may contain arbitrary
+    information about the error. There is a predefined set of error detail types
+    in the package ``google.rpc`` which can be used for common error conditions.
+
+    # Language mapping
+
+    The ``Status`` message is the logical representation of the error model, but it
+    is not necessarily the actual wire format. When the ``Status`` message is
+    exposed in different client libraries and different wire protocols, it can be
+    mapped differently. For example, it will likely be mapped to some exceptions
+    in Java, but more likely mapped to some error codes in C.
+
+    # Other uses
+
+    The error model and the ``Status`` message can be used in a variety of
+    environments, either with or without APIs, to provide a
+    consistent developer experience across different environments.
+
+    Example uses of this error model include:
+
+    - Partial errors. If a service needs to return partial errors to the client,
+        it may embed the ``Status`` in the normal response to indicate the partial
+        errors.
+
+    - Workflow errors. A typical workflow has multiple steps. Each step may
+        have a ``Status`` message for error reporting purpose.
+
+    - Batch operations. If a client uses batch request and batch response, the
+        ``Status`` message should be used directly inside batch response, one for
+        each error sub-response.
+
+    - Asynchronous operations. If an API call embeds asynchronous operation
+        results in its response, the status of those operations should be
+        represented directly using the ``Status`` message.
+
+    - Logging. If some API errors are stored in logs, the message ``Status`` could
+        be used directly after any stripping needed for security/privacy reasons.
+
+    Attributes:
+      code (int): The status code, which should be an enum value of ``google.rpc.Code``.
+      message (string): A developer-facing error message, which should be in English. Any
+        user-facing error message should be localized and sent in the
+        ``google.rpc.Status.details`` field, or localized by the client.
+      details (list[:class:`google.protobuf.any_pb2.Any`]): A list of messages that carry the error details.  There will be a
+        common set of message types for APIs to use.
+
+    """
+    pass
+
 ============== file: library_pb2.py ==============
 # Copyright 2016 Google Inc. All rights reserved.
 #
@@ -604,6 +831,7 @@ class BytesValue(object):
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from google.api import monitored_resource_pb2
 from google.cloud.grpc.example.library.v1 import field_mask_pb2 as v1_field_mask_pb2
 from google.protobuf import any_pb2
 from google.protobuf import duration_pb2
@@ -643,6 +871,8 @@ class Book(object):
       bytes_value (:class:`google.protobuf.wrappers_pb2.BytesValue`)
       map_string_value (dict[int -> :class:`google.cloud.grpc.example.library.v1.library_pb2.Book.MapStringValueEntry`])
       map_message_value (dict[string -> :class:`google.cloud.grpc.example.library.v1.library_pb2.Book.MapMessageValueEntry`])
+      resource (:class:`google.api.monitored_resource_pb2.MonitoredResource`): Tests Python doc generation: should generate a dummy file for monitored
+        resource, but *not* its import, label.
 
     """
     pass

--- a/src/test/java/com/google/api/codegen/testdata/ruby_doc_message_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_doc_message_library.baseline
@@ -36,6 +36,85 @@ module Google
     end
   end
 end
+============== file: lib/library/v1/doc/google/api/monitored_resource.rb ==============
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Google
+  module Api
+    # An object that describes the schema of a MonitoredResource object using a
+    # type name and a set of labels.  For example, the monitored resource
+    # descriptor for Google Compute Engine VM instances has a type of
+    # +"gce_instance"+ and specifies the use of the labels +"instance_id"+ and
+    # +"zone"+ to identify particular VM instances.
+    #
+    # Different APIs can support different monitored resource types. APIs generally
+    # provide a +list+ method that returns the monitored resource descriptors used
+    # by the API.
+    # @!attribute [rw] name
+    #   @return [String]
+    #     Optional. The resource name of the monitored resource descriptor:
+    #     +"projects/{project_id}/monitoredResourceDescriptors/{type}"+ where
+    #     {type} is the value of the +type+ field in this object and
+    #     {project_id} is a project ID that provides API-specific context for
+    #     accessing the type.  APIs that do not use project information can use the
+    #     resource name format +"monitoredResourceDescriptors/{type}"+.
+    # @!attribute [rw] type
+    #   @return [String]
+    #     Required. The monitored resource type. For example, the type
+    #     +"cloudsql_database"+ represents databases in Google Cloud SQL.
+    # @!attribute [rw] display_name
+    #   @return [String]
+    #     Optional. A concise name for the monitored resource type that might be
+    #     displayed in user interfaces. For example, +"Google Cloud SQL Database"+.
+    # @!attribute [rw] description
+    #   @return [String]
+    #     Optional. A detailed description of the monitored resource type that might
+    #     be used in documentation.
+    # @!attribute [rw] labels
+    #   @return [Array<Google::Api::LabelDescriptor>]
+    #     Required. A set of labels used to describe instances of this monitored
+    #     resource type. For example, an individual Google Cloud SQL database is
+    #     identified by values for the labels +"database_id"+ and +"zone"+.
+    class MonitoredResourceDescriptor; end
+
+    # An object representing a resource that can be used for monitoring, logging,
+    # billing, or other purposes. Examples include virtual machine instances,
+    # databases, and storage devices such as disks. The +type+ field identifies a
+    # MonitoredResourceDescriptor object that describes the resource's
+    # schema. Information in the +labels+ field identifies the actual resource and
+    # its attributes according to the schema. For example, a particular Compute
+    # Engine VM instance could be represented by the following object, because the
+    # MonitoredResourceDescriptor for +"gce_instance"+ has labels
+    # +"instance_id"+ and +"zone"+:
+    #
+    #     { "type": "gce_instance",
+    #       "labels": { "instance_id": "my-instance",
+    #                   "zone": "us-central1-a" }}
+    # @!attribute [rw] type
+    #   @return [String]
+    #     Required. The monitored resource type. This field must match
+    #     the +type+ field of a MonitoredResourceDescriptor object. For
+    #     example, the type of a Cloud SQL database is +"cloudsql_database"+.
+    # @!attribute [rw] labels
+    #   @return [Hash{String => String}]
+    #     Required. Values for all of the labels listed in the associated monitored
+    #     resource descriptor. For example, Cloud SQL databases use the labels
+    #     +"database_id"+ and +"zone"+.
+    class MonitoredResource; end
+  end
+end
 ============== file: lib/library/v1/doc/google/protobuf/any.rb ==============
 # Copyright 2016 Google Inc. All rights reserved.
 #
@@ -385,6 +464,80 @@ module Google
     class FieldMask; end
   end
 end
+============== file: lib/library/v1/doc/google/protobuf/struct.rb ==============
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Google
+  module Protobuf
+    # +Struct+ represents a structured data value, consisting of fields
+    # which map to dynamically typed values. In some languages, +Struct+
+    # might be supported by a native representation. For example, in
+    # scripting languages like JS a struct is represented as an
+    # object. The details of that representation are described together
+    # with the proto support for the language.
+    #
+    # The JSON representation for +Struct+ is JSON object.
+    # @!attribute [rw] fields
+    #   @return [Hash{String => Google::Protobuf::Value}]
+    #     Unordered map of dynamically typed values.
+    class Struct; end
+
+    # +Value+ represents a dynamically typed value which can be either
+    # null, a number, a string, a boolean, a recursive struct value, or a
+    # list of values. A producer of value is expected to set one of that
+    # variants, absence of any variant indicates an error.
+    #
+    # The JSON representation for +Value+ is JSON value.
+    # @!attribute [rw] null_value
+    #   @return [Google::Protobuf::NullValue]
+    #     Represents a null value.
+    # @!attribute [rw] number_value
+    #   @return [Float]
+    #     Represents a double value.
+    # @!attribute [rw] string_value
+    #   @return [String]
+    #     Represents a string value.
+    # @!attribute [rw] bool_value
+    #   @return [true, false]
+    #     Represents a boolean value.
+    # @!attribute [rw] struct_value
+    #   @return [Google::Protobuf::Struct]
+    #     Represents a structured value.
+    # @!attribute [rw] list_value
+    #   @return [Google::Protobuf::ListValue]
+    #     Represents a repeated +Value+.
+    class Value; end
+
+    # +ListValue+ is a wrapper around a repeated field of values.
+    #
+    # The JSON representation for +ListValue+ is JSON array.
+    # @!attribute [rw] values
+    #   @return [Array<Google::Protobuf::Value>]
+    #     Repeated field of dynamically typed values.
+    class ListValue; end
+
+    # +NullValue+ is a singleton enumeration to represent the null value for the
+    # +Value+ type union.
+    #
+    #  The JSON representation for +NullValue+ is JSON +null+.
+    module NullValue
+      # Null value.
+      NULL_VALUE = 0
+    end
+  end
+end
 ============== file: lib/library/v1/doc/google/protobuf/timestamp.rb ==============
 # Copyright 2016 Google Inc. All rights reserved.
 #
@@ -559,6 +712,90 @@ module Google
     class BytesValue; end
   end
 end
+============== file: lib/library/v1/doc/google/rpc/status.rb ==============
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Google
+  module Rpc
+    # The +Status+ type defines a logical error model that is suitable for different
+    # programming environments, including REST APIs and RPC APIs. It is used by
+    # {gRPC}[https://github.com/grpc]. The error model is designed to be:
+    #
+    # - Simple to use and understand for most users
+    # - Flexible enough to meet unexpected needs
+    #
+    # = Overview
+    #
+    # The +Status+ message contains three pieces of data: error code, error message,
+    # and error details. The error code should be an enum value of
+    # Google::Rpc::Code, but it may accept additional error codes if needed.  The
+    # error message should be a developer-facing English message that helps
+    # developers *understand* and *resolve* the error. If a localized user-facing
+    # error message is needed, put the localized message in the error details or
+    # localize it in the client. The optional error details may contain arbitrary
+    # information about the error. There is a predefined set of error detail types
+    # in the package +google.rpc+ which can be used for common error conditions.
+    #
+    # = Language mapping
+    #
+    # The +Status+ message is the logical representation of the error model, but it
+    # is not necessarily the actual wire format. When the +Status+ message is
+    # exposed in different client libraries and different wire protocols, it can be
+    # mapped differently. For example, it will likely be mapped to some exceptions
+    # in Java, but more likely mapped to some error codes in C.
+    #
+    # = Other uses
+    #
+    # The error model and the +Status+ message can be used in a variety of
+    # environments, either with or without APIs, to provide a
+    # consistent developer experience across different environments.
+    #
+    # Example uses of this error model include:
+    #
+    # - Partial errors. If a service needs to return partial errors to the client,
+    #     it may embed the +Status+ in the normal response to indicate the partial
+    #     errors.
+    #
+    # - Workflow errors. A typical workflow has multiple steps. Each step may
+    #     have a +Status+ message for error reporting purpose.
+    #
+    # - Batch operations. If a client uses batch request and batch response, the
+    #     +Status+ message should be used directly inside batch response, one for
+    #     each error sub-response.
+    #
+    # - Asynchronous operations. If an API call embeds asynchronous operation
+    #     results in its response, the status of those operations should be
+    #     represented directly using the +Status+ message.
+    #
+    # - Logging. If some API errors are stored in logs, the message +Status+ could
+    #     be used directly after any stripping needed for security/privacy reasons.
+    # @!attribute [rw] code
+    #   @return [Integer]
+    #     The status code, which should be an enum value of Google::Rpc::Code.
+    # @!attribute [rw] message
+    #   @return [String]
+    #     A developer-facing error message, which should be in English. Any
+    #     user-facing error message should be localized and sent in the
+    #     Google::Rpc::Status#details field, or localized by the client.
+    # @!attribute [rw] details
+    #   @return [Array<Google::Protobuf::Any>]
+    #     A list of messages that carry the error details.  There will be a
+    #     common set of message types for APIs to use.
+    class Status; end
+  end
+end
 ============== file: lib/library/v1/doc/library.rb ==============
 # Copyright 2016 Google Inc. All rights reserved.
 #
@@ -634,6 +871,10 @@ module Google
         #   @return [Hash{Integer => String}]
         # @!attribute [rw] map_message_value
         #   @return [Hash{String => Google::Example::Library::V1::SomeMessage}]
+        # @!attribute [rw] resource
+        #   @return [Google::Api::MonitoredResource]
+        #     Tests Python doc generation: should generate a dummy file for monitored
+        #     resource, but *not* its import, label.
         class Book
           module Rating
             # GOOD enum description


### PR DESCRIPTION
- Generate dummy classes for both input and output types (previously,
  only input types were generated)
- In Python, don't generate imports for classes where there is no
  dummy class, since such imports will break during Sphinx doc
  generation.

Updates #804 

cc: @swcloud @jmuk, this PR adds additional classes to the dummy proto classes, since we previously didn't generate dummy classes for output types.