### PR TITLE
Make package name fully configurable; use "cloud" in default

### DIFF
--- a/src/main/java/com/google/api/codegen/metadatagen/ApiNameInfo.java
+++ b/src/main/java/com/google/api/codegen/metadatagen/ApiNameInfo.java
@@ -20,8 +20,8 @@ import com.google.auto.value.AutoValue;
 @AutoValue
 public abstract class ApiNameInfo {
   static AutoValue_ApiNameInfo create(
-      String fullName, String shortName, String majorVersion, String path) {
-    return new AutoValue_ApiNameInfo(fullName, shortName, majorVersion, path);
+      String fullName, String shortName, String packageName, String majorVersion, String path) {
+    return new AutoValue_ApiNameInfo(fullName, shortName, packageName, majorVersion, path);
   }
 
   /** The full name of the API, including branding. E.g., "Stackdriver Logging". */
@@ -29,6 +29,9 @@ public abstract class ApiNameInfo {
 
   /** A single-word short name of the API. E.g., "logging". */
   public abstract String shortName();
+
+  /** The base name of the client library package. E.g., "google-cloud-logging-v1". */
+  public abstract String packageName();
 
   /** The major version of the API, as used in the package name. E.g., "v1". */
   public abstract String majorVersion();

--- a/src/main/java/com/google/api/codegen/metadatagen/PackageMetadataContext.java
+++ b/src/main/java/com/google/api/codegen/metadatagen/PackageMetadataContext.java
@@ -87,10 +87,6 @@ public class PackageMetadataContext implements ViewModel {
     return apiNameInfo;
   }
 
-  public String getPackageName() {
-    return "grpc-google-" + apiNameInfo.shortName() + "-" + apiNameInfo.majorVersion();
-  }
-
   public PackageCopierResult.Metadata getCopierMetadata() {
     return copierResults;
   }

--- a/src/main/java/com/google/api/codegen/metadatagen/PackageMetadataGenerator.java
+++ b/src/main/java/com/google/api/codegen/metadatagen/PackageMetadataGenerator.java
@@ -75,6 +75,12 @@ public class PackageMetadataGenerator extends ToolDriverBase {
   public static final Option<String> SHORT_API_NAME =
       ToolOptions.createOption(
           String.class, "short_name", "The a single-word name for the API, e.g., 'Logging'.", "");
+  public static final Option<String> PACKAGE_NAME =
+      ToolOptions.createOption(
+          String.class,
+          "package_name",
+          "The base name of the package to create, e.g., 'google-cloud-logging-v1'",
+          "");
   public static final Option<String> API_PATH =
       ToolOptions.createOption(
           String.class,
@@ -113,6 +119,7 @@ public class PackageMetadataGenerator extends ToolDriverBase {
         ApiNameInfo.create(
             options.get(LONG_API_NAME),
             options.get(SHORT_API_NAME),
+            options.get(PACKAGE_NAME),
             options.get(API_VERSION),
             options.get(API_PATH));
 

--- a/src/main/java/com/google/api/codegen/metadatagen/PackageMetadataGeneratorTool.java
+++ b/src/main/java/com/google/api/codegen/metadatagen/PackageMetadataGeneratorTool.java
@@ -16,6 +16,7 @@ package com.google.api.codegen.metadatagen;
 
 import com.google.api.codegen.metadatagen.py.PythonPackageCopier;
 import com.google.api.tools.framework.tools.ToolOptions;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import java.util.List;
@@ -121,6 +122,14 @@ public class PackageMetadataGeneratorTool {
             .required(true)
             .build());
     options.addOption(
+        Option.builder("p")
+            .longOpt("package_name")
+            .desc(
+                "The base name of the package. Defaults to \"google-cloud-{short_name}-{version}\"")
+            .hasArg()
+            .argName("PACKAGE-NAME")
+            .build());
+    options.addOption(
         Option.builder("g")
             .longOpt("googleapis_path")
             .desc("The path to the API protos under googleapis.")
@@ -152,6 +161,7 @@ public class PackageMetadataGeneratorTool {
         cl.getOptionValue("dependencies_config"),
         cl.getOptionValue("defaults_config"),
         cl.getOptionValue("short_name"),
+        cl.getOptionValue("package_name"),
         cl.getOptionValue("name"),
         cl.getOptionValue("googleapis_path"),
         cl.getOptionValue("version"));
@@ -166,6 +176,7 @@ public class PackageMetadataGeneratorTool {
       String dependenciesConfig,
       String defaultsConfig,
       String shortName,
+      String packageName,
       String name,
       String googleapisPath,
       String version) {
@@ -180,6 +191,12 @@ public class PackageMetadataGeneratorTool {
     options.set(PackageMetadataGenerator.LONG_API_NAME, name);
     options.set(PackageMetadataGenerator.API_PATH, googleapisPath);
     options.set(PackageMetadataGenerator.API_VERSION, version);
+    if (Strings.isNullOrEmpty(packageName)) {
+      options.set(PackageMetadataGenerator.PACKAGE_NAME, packageName);
+    } else {
+      options.set(
+          PackageMetadataGenerator.PACKAGE_NAME, "google-cloud-" + shortName + "-" + version);
+    }
     PackageMetadataGenerator generator =
         new PackageMetadataGenerator(options, getSnippets(language), getCopier(language));
     generator.run();

--- a/src/main/java/com/google/api/codegen/metadatagen/PackageMetadataGeneratorTool.java
+++ b/src/main/java/com/google/api/codegen/metadatagen/PackageMetadataGeneratorTool.java
@@ -192,10 +192,10 @@ public class PackageMetadataGeneratorTool {
     options.set(PackageMetadataGenerator.API_PATH, googleapisPath);
     options.set(PackageMetadataGenerator.API_VERSION, version);
     if (Strings.isNullOrEmpty(packageName)) {
-      options.set(PackageMetadataGenerator.PACKAGE_NAME, packageName);
-    } else {
       options.set(
           PackageMetadataGenerator.PACKAGE_NAME, "google-cloud-" + shortName + "-" + version);
+    } else {
+      options.set(PackageMetadataGenerator.PACKAGE_NAME, packageName);
     }
     PackageMetadataGenerator generator =
         new PackageMetadataGenerator(options, getSnippets(language), getCopier(language));

--- a/src/main/resources/com/google/api/codegen/metadatagen/py/README.rst.snip
+++ b/src/main/resources/com/google/api/codegen/metadatagen/py/README.rst.snip
@@ -1,7 +1,7 @@
 @snippet generate(context)
     gRPC library for google-{@context.getApiNameInfo.shortName}-{@context.getApiNameInfo.majorVersion}
 
-    {@context.getPackageName} is the IDL-derived library for the {@context.getApiNameInfo.shortName} ({@context.getApiNameInfo.majorVersion}) service in the googleapis_ repository.
+    grpc-{@context.getApiNameInfo.packageName} is the IDL-derived library for the {@context.getApiNameInfo.shortName} ({@context.getApiNameInfo.majorVersion}) service in the googleapis_ repository.
 
     .. _`googleapis`: https://github.com/googleapis/googleapis/tree/master/{@context.getApiNameInfo.protoPath}/{@context.getApiNameInfo.majorVersion}
 

--- a/src/main/resources/com/google/api/codegen/metadatagen/py/setup.py.snip
+++ b/src/main/resources/com/google/api/codegen/metadatagen/py/setup.py.snip
@@ -17,7 +17,7 @@
     ]
 
     setuptools.setup(
-      name='{@context.getPackageName}',
+      name='grpc-{@context.getApiNameInfo.packageName}',
       version='{@context.getDefaultsValue("semver.python")}',
       author='{@context.getDefaultsValue("author")}',
       author_email='{@context.getDefaultsValue("email")}',

--- a/src/test/java/com/google/api/codegen/metadatagen/PackageMetadataGeneratorTest.java
+++ b/src/test/java/com/google/api/codegen/metadatagen/PackageMetadataGeneratorTest.java
@@ -83,6 +83,7 @@ public class PackageMetadataGeneratorTest extends ConfigBaselineTestCase {
     options.set(PackageMetadataGenerator.API_DEFAULTS_FILE, defaultsConfigPath);
     options.set(PackageMetadataGenerator.SHORT_API_NAME, "library");
     options.set(PackageMetadataGenerator.LONG_API_NAME, "Google Library Example");
+    options.set(PackageMetadataGenerator.PACKAGE_NAME, "google-cloud-library-v1");
     options.set(PackageMetadataGenerator.API_VERSION, "v1");
     options.set(PackageMetadataGenerator.API_PATH, "google/example/library");
     Map<String, Doc> generatedDocs =

--- a/src/test/java/com/google/api/codegen/metadatagen/testdata/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/metadatagen/testdata/python_library.baseline
@@ -26,7 +26,7 @@ install_requires = [
 ]
 
 setuptools.setup(
-  name='grpc-google-library-v1',
+  name='grpc-google-cloud-library-v1',
   version='0.13.0',
   author='Google Inc',
   author_email='googleapis-packages@google.com',
@@ -55,7 +55,7 @@ setuptools.setup(
 ============== file: README.rst ==============
 gRPC library for google-library-v1
 
-grpc-google-library-v1 is the IDL-derived library for the library (v1) service in the googleapis_ repository.
+grpc-google-cloud-library-v1 is the IDL-derived library for the library (v1) service in the googleapis_ repository.
 
 .. _`googleapis`: https://github.com/googleapis/googleapis/tree/master/google/example/library/v1
 


### PR DESCRIPTION
Previously, the generated package name could be inconsistent with the GAPIC package name derived from the artman `api_name` configuration value. That value will be removed as part of googleapis/artman#116 and replaced by

- `short_name` (e.g., `logging`)
- `version` (e.g., `v1`)

and optionally

- `package_name`

Using `google-cloud-{short_name}-{version}` as the default package base name follows the logic of googleapis/googleapis#68.

The default value is overridable using `package_name` for non-cloud APIs (e.g., LRO).

Updates googleapis/artman#116