### PR TITLE
Use fullName instead of shortName where it makes sense

### DIFF
--- a/src/main/resources/com/google/api/codegen/metadatagen/py/README.rst.snip
+++ b/src/main/resources/com/google/api/codegen/metadatagen/py/README.rst.snip
@@ -1,5 +1,5 @@
 @snippet generate(context)
-    gRPC library for google-{@context.getApiNameInfo.shortName}-{@context.getApiNameInfo.majorVersion}
+    gRPC library for {@context.getApiNameInfo.fullName}
 
     grpc-{@context.getApiNameInfo.packageName} is the IDL-derived library for the {@context.getApiNameInfo.shortName} ({@context.getApiNameInfo.majorVersion}) service in the googleapis_ repository.
 

--- a/src/main/resources/com/google/api/codegen/metadatagen/py/setup.py.snip
+++ b/src/main/resources/com/google/api/codegen/metadatagen/py/setup.py.snip
@@ -1,5 +1,5 @@
 @snippet generate(context)
-    """A setup module for the GRPC google-{@context.getApiNameInfo.shortName} service.
+    """A setup module for the GRPC {@context.getApiNameInfo.fullName} service.
 
     See:
     https://packaging.python.org/en/latest/distributing.html

--- a/src/test/java/com/google/api/codegen/metadatagen/testdata/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/metadatagen/testdata/python_library.baseline
@@ -8,7 +8,7 @@ __import__('pkg_resources').declare_namespace(__name__)
 __import__('pkg_resources').declare_namespace(__name__)
 
 ============== file: setup.py ==============
-"""A setup module for the GRPC google-library service.
+"""A setup module for the GRPC Google Library Example service.
 
 See:
 https://packaging.python.org/en/latest/distributing.html
@@ -53,7 +53,7 @@ setuptools.setup(
 )
 
 ============== file: README.rst ==============
-gRPC library for google-library-v1
+gRPC library for Google Library Example
 
 grpc-google-cloud-library-v1 is the IDL-derived library for the library (v1) service in the googleapis_ repository.
 


### PR DESCRIPTION
This is an essentially superficial change that improves the descriptions of the gRPC packages by including the full API name.

Fixes #814 