### PR TITLE
Treat google.iam as common proto package

### DIFF
--- a/src/main/java/com/google/api/codegen/py/PythonImportHandler.java
+++ b/src/main/java/com/google/api/codegen/py/PythonImportHandler.java
@@ -40,6 +40,7 @@ public class PythonImportHandler {
   // TODO (geigerj): Read this from configuration?
   private final List<String> COMMON_PROTOS =
       Lists.newArrayList(
+          "google.iam",
           "google.protobuf",
           "google.api",
           "google.longrunning",


### PR DESCRIPTION
Context is the same as with https://github.com/googleapis/googleapis/pull/209; this is needed to prevent Python codegen from changing the package to `google.cloud.grpc.iam.[...]`.