### PR TITLE
Add docs to flag vkit as pre-beta

### DIFF
--- a/src/main/resources/com/google/api/codegen/php/main.snip
+++ b/src/main/resources/com/google/api/codegen/php/main.snip
@@ -53,7 +53,8 @@
    * and updates to that file get reflected here through a refresh process.
    *
    * EXPERIMENTAL: the code generation tool used to create this class has not yet been declared
-   * beta. This class may change more frequently than those which have been declared beta or 1.0.
+   * beta. This class may change more frequently than those which have been declared beta or 1.0,
+   * including changes which break backwards compatibility.
    */
 @end
 
@@ -74,7 +75,8 @@
     @end
      *
      * EXPERIMENTAL: the code generation tool used to create this class has not yet been declared
-     * beta. This class may change more frequently than those which have been declared beta or 1.0.
+     * beta. This class may change more frequently than those which have been declared beta or 1.0,
+     * including changes which break backwards compatibility.
      *
      * This class provides the ability to make remote calls to the backing service through method
      * calls that map to API methods. Sample code to get started:

--- a/src/main/resources/com/google/api/codegen/php/main.snip
+++ b/src/main/resources/com/google/api/codegen/php/main.snip
@@ -51,6 +51,9 @@
    * This file was generated from the file
    * https://github.com/google/googleapis/blob/master/{@xapiClass.protoFilename}
    * and updates to that file get reflected here through a refresh process.
+   *
+   * EXPERIMENTAL: the code generation tool used to create this class has not yet been declared
+   * beta. This class may change more frequently than those which have been declared beta or 1.0.
    */
 @end
 
@@ -69,6 +72,9 @@
             {@""} * {@commentLine}
         @end
     @end
+     *
+     * EXPERIMENTAL: the code generation tool used to create this class has not yet been declared
+     * beta. This class may change more frequently than those which have been declared beta or 1.0.
      *
      * This class provides the ability to make remote calls to the backing service through method
      * calls that map to API methods. Sample code to get started:

--- a/src/test/java/com/google/api/codegen/testdata/php_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php_main_library.baseline
@@ -19,6 +19,9 @@
  * This file was generated from the file
  * https://github.com/google/googleapis/blob/master/library.proto
  * and updates to that file get reflected here through a refresh process.
+ *
+ * EXPERIMENTAL: the code generation tool used to create this class has not yet been declared
+ * beta. This class may change more frequently than those which have been declared beta or 1.0.
  */
 
 namespace Google\Example\Library\V1;
@@ -73,6 +76,9 @@ use google\tagger\v1\LabelerClient as LabelerGrpcClient;
  *
  * Check out [cloud docs!](/library/example/link).
  * This is [not a cloud link](http://www.google.com).
+ *
+ * EXPERIMENTAL: the code generation tool used to create this class has not yet been declared
+ * beta. This class may change more frequently than those which have been declared beta or 1.0.
  *
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods. Sample code to get started:

--- a/src/test/java/com/google/api/codegen/testdata/php_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php_main_library.baseline
@@ -21,7 +21,8 @@
  * and updates to that file get reflected here through a refresh process.
  *
  * EXPERIMENTAL: the code generation tool used to create this class has not yet been declared
- * beta. This class may change more frequently than those which have been declared beta or 1.0.
+ * beta. This class may change more frequently than those which have been declared beta or 1.0,
+ * including changes which break backwards compatibility.
  */
 
 namespace Google\Example\Library\V1;
@@ -78,7 +79,8 @@ use google\tagger\v1\LabelerClient as LabelerGrpcClient;
  * This is [not a cloud link](http://www.google.com).
  *
  * EXPERIMENTAL: the code generation tool used to create this class has not yet been declared
- * beta. This class may change more frequently than those which have been declared beta or 1.0.
+ * beta. This class may change more frequently than those which have been declared beta or 1.0,
+ * including changes which break backwards compatibility.
  *
  * This class provides the ability to make remote calls to the backing service through method
  * calls that map to API methods. Sample code to get started:


### PR DESCRIPTION
Added comment at the top of the file and in the class doc block to indicate that vkit is pre-beta.