### PR TITLE
Handle construction of oneof from null resource name

### DIFF
--- a/src/main/resources/com/google/api/codegen/java/main.snip
+++ b/src/main/resources/com/google/api/codegen/java/main.snip
@@ -518,6 +518,7 @@
   @join requestObjectParam : requestObjectParams
     @if requestObjectParam.hasTransformParamFunction
       .{@requestObjectParam.setCallName}(\
+        {@requestObjectParam.name} == null ? null : \
         {@requestObjectParam.transformParamFunctionName}({@requestObjectParam.name}))
     @else
       .{@requestObjectParam.setCallName}({@requestObjectParam.name})

--- a/src/test/java/com/google/api/codegen/testdata/java_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_main_library.baseline
@@ -1609,7 +1609,7 @@ public class LibraryServiceClient implements AutoCloseable {
     GetBookFromAnywhereRequest request =
         GetBookFromAnywhereRequest.newBuilder()
         .setNameWithBookNameOneof(name)
-        .setAltBookNameWithBookNameOneof(BookNameOneof.from(altBookName))
+        .setAltBookNameWithBookNameOneof(altBookName == null ? null : BookNameOneof.from(altBookName))
         .build();
     return getBookFromAnywhere(request);
   }


### PR DESCRIPTION
This case is the only null-handling not handled by the extended get/set methods on the proto types