### PR TITLE
Add support for the "version_module" field in discovery

### DIFF
--- a/src/main/java/com/google/api/codegen/ApiaryConfig.java
+++ b/src/main/java/com/google/api/codegen/ApiaryConfig.java
@@ -98,6 +98,15 @@ public class ApiaryConfig {
    */
   private String apiVersion;
 
+  /*
+   * Whether or not this service should be qualified with its version.
+   *
+   * Not all client library generators honor this field, but the ones that do
+   * require that the version of the API be specified in the package if
+   * "version_module" is true.
+   */
+  private boolean versionModule;
+
   /**
    * Maps method name to set of auth scope URLs, e.g.,
    * https://www.googleapis.com/auth/cloud-platform.
@@ -215,6 +224,14 @@ public class ApiaryConfig {
 
   public void setApiVersion(String apiVersion) {
     this.apiVersion = apiVersion;
+  }
+
+  public boolean getVersionModule() {
+    return versionModule;
+  }
+
+  public void setVersionModule(boolean versionModule) {
+    this.versionModule = versionModule;
   }
 
   public String getServiceCanonicalName() {

--- a/src/main/java/com/google/api/codegen/DiscoveryImporter.java
+++ b/src/main/java/com/google/api/codegen/DiscoveryImporter.java
@@ -141,6 +141,17 @@ public class DiscoveryImporter {
     importer.config.setApiName(serv.getApis(0).getName());
     importer.config.setApiVersion(serv.getApis(0).getVersion());
 
+    boolean versionModule = false;
+    JsonNode versionModuleNode = disco.get("version_module");
+    if (versionModuleNode != null) {
+      // Annoyingly, "version_module" seems to be arbitrary defined either as
+      // the string "True" or an actual boolean.
+      versionModule =
+          disco.get("version_module").asText().equals("True")
+              || disco.get("version_module").asBoolean();
+    }
+    importer.config.setVersionModule(versionModule);
+
     importer.config.getTypes().putAll(importer.types);
     for (Type type : importer.types.values()) {
       for (Field field : type.getFieldsList()) {

--- a/src/main/java/com/google/api/codegen/DiscoveryImporter.java
+++ b/src/main/java/com/google/api/codegen/DiscoveryImporter.java
@@ -144,7 +144,7 @@ public class DiscoveryImporter {
     boolean versionModule = false;
     JsonNode versionModuleNode = disco.get("version_module");
     if (versionModuleNode != null) {
-      // Annoyingly, "version_module" seems to be arbitrary defined either as
+      // Annoyingly, "version_module" seems to be arbitrarily defined either as
       // the string "True" or an actual boolean.
       versionModule =
           disco.get("version_module").asText().equals("True")

--- a/src/main/java/com/google/api/codegen/discovery/config/ApiaryConfigToSampleConfigConverter.java
+++ b/src/main/java/com/google/api/codegen/discovery/config/ApiaryConfigToSampleConfigConverter.java
@@ -69,6 +69,7 @@ public class ApiaryConfigToSampleConfigConverter {
         .apiCanonicalName(apiaryConfig.getServiceCanonicalName())
         .apiName(apiName)
         .apiVersion(apiVersion)
+        .versionModule(apiaryConfig.getVersionModule())
         .apiTypeName(apiTypeName)
         .packagePrefix(
             typeNameGenerator.getPackagePrefix(

--- a/src/main/java/com/google/api/codegen/discovery/config/SampleConfig.java
+++ b/src/main/java/com/google/api/codegen/discovery/config/SampleConfig.java
@@ -80,6 +80,10 @@ public abstract class SampleConfig {
   @JsonProperty("apiVersion")
   public abstract String apiVersion();
 
+  /** Returns true if clients should be qualified with the API version. */
+  @JsonProperty("versionModule")
+  public abstract boolean versionModule();
+
   /**
    * Returns the API's type name.
    *
@@ -125,6 +129,9 @@ public abstract class SampleConfig {
 
     @JsonProperty("apiVersion")
     public abstract Builder apiVersion(String val);
+
+    @JsonProperty("versionModule")
+    public abstract Builder versionModule(boolean val);
 
     @JsonProperty("apiTypeName")
     public abstract Builder apiTypeName(String val);

--- a/src/main/java/com/google/api/codegen/discovery/config/SampleConfig.java
+++ b/src/main/java/com/google/api/codegen/discovery/config/SampleConfig.java
@@ -80,7 +80,7 @@ public abstract class SampleConfig {
   @JsonProperty("apiVersion")
   public abstract String apiVersion();
 
-  /** Returns true if clients should be qualified with the API version. */
+  /** Returns whether or not the client package should be qualified with the API version. */
   @JsonProperty("versionModule")
   public abstract boolean versionModule();
 

--- a/src/main/java/com/google/api/codegen/discovery/config/java/JavaTypeNameGenerator.java
+++ b/src/main/java/com/google/api/codegen/discovery/config/java/JavaTypeNameGenerator.java
@@ -22,15 +22,6 @@ import java.util.List;
 
 public class JavaTypeNameGenerator extends TypeNameGenerator {
 
-  private static final String PACKAGE_PREFIX = "com.google.api.services";
-  private static final String NON_REQUEST_SUBPACKAGE = "model";
-
-  @Override
-  public String getPackagePrefix(String apiName, String apiCanonicalName, String apiVersion) {
-    // Most Java libraries don't include the apiVersion in their package.
-    return Joiner.on('.').join(PACKAGE_PREFIX, apiName);
-  }
-
   @Override
   public String getRequestTypeName(List<String> methodNameComponents) {
     LinkedList<String> copy = new LinkedList<>(methodNameComponents);
@@ -39,14 +30,6 @@ public class JavaTypeNameGenerator extends TypeNameGenerator {
       copy.set(i, Name.lowerCamel(copy.get(i)).toUpperCamel());
     }
     return Joiner.on('.').join(copy);
-  }
-
-  @Override
-  public String getSubpackage(boolean isRequest) {
-    if (!isRequest) {
-      return NON_REQUEST_SUBPACKAGE;
-    }
-    return "";
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/discovery/transformer/java/JavaSampleMethodToViewTransformer.java
+++ b/src/main/java/com/google/api/codegen/discovery/transformer/java/JavaSampleMethodToViewTransformer.java
@@ -52,7 +52,9 @@ public class JavaSampleMethodToViewTransformer implements SampleMethodToViewTran
   public ViewModel transform(Method method, SampleConfig sampleConfig) {
     SampleTypeTable sampleTypeTable =
         new SampleTypeTable(
-            new JavaTypeTable(""), new JavaSampleTypeNameConverter(sampleConfig.packagePrefix()));
+            new JavaTypeTable(""),
+            new JavaSampleTypeNameConverter(
+                sampleConfig.apiName(), sampleConfig.apiVersion(), sampleConfig.versionModule()));
     JavaSampleNamer javaSampleNamer = new JavaSampleNamer();
     SampleTransformerContext context =
         SampleTransformerContext.create(

--- a/src/main/java/com/google/api/codegen/discovery/transformer/java/JavaSampleTypeNameConverter.java
+++ b/src/main/java/com/google/api/codegen/discovery/transformer/java/JavaSampleTypeNameConverter.java
@@ -22,7 +22,6 @@ import com.google.api.codegen.util.TypeNameConverter;
 import com.google.api.codegen.util.TypedValue;
 import com.google.api.codegen.util.java.JavaTypeTable;
 import com.google.common.base.Joiner;
-import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.Field;
 
@@ -62,9 +61,14 @@ class JavaSampleTypeNameConverter implements SampleTypeNameConverter {
   private final TypeNameConverter typeNameConverter;
   private final String packagePrefix;
 
-  public JavaSampleTypeNameConverter(String packagePrefix) {
+  public JavaSampleTypeNameConverter(String apiName, String apiVersion, boolean versionModule) {
     this.typeNameConverter = new JavaTypeTable("");
-    this.packagePrefix = packagePrefix;
+    StringBuilder stringBuilder = new StringBuilder("com.google.api.services.").append(apiName);
+    if (versionModule) {
+      stringBuilder.append('.');
+      stringBuilder.append(apiVersion);
+    }
+    this.packagePrefix = stringBuilder.toString();
   }
 
   @Override
@@ -72,19 +76,11 @@ class JavaSampleTypeNameConverter implements SampleTypeNameConverter {
     return typeNameConverter.getTypeName(Joiner.on('.').join(packagePrefix, apiTypeName));
   }
 
-  /** Returns packagePrefix with subpackage appended if not empty. */
-  private String packagePrefix(String subpackage) {
-    if (!Strings.isNullOrEmpty(subpackage)) {
-      return new StringBuilder(packagePrefix).append('.').append(subpackage).toString();
-    }
-    return packagePrefix;
-  }
-
   @Override
   public TypeName getRequestTypeName(String apiTypeName, TypeInfo typeInfo) {
     MessageTypeInfo type = typeInfo.message();
     return new TypeName(
-        Joiner.on('.').join(packagePrefix(type.subpackage()), apiTypeName, type.typeName()),
+        Joiner.on('.').join(packagePrefix, "model", apiTypeName, type.typeName()),
         Joiner.on('.').join(apiTypeName, type.typeName()));
   }
 
@@ -93,7 +89,7 @@ class JavaSampleTypeNameConverter implements SampleTypeNameConverter {
     if (typeInfo.isMessage()) {
       MessageTypeInfo messageInfo = typeInfo.message();
       return typeNameConverter.getTypeName(
-          Joiner.on('.').join(packagePrefix(messageInfo.subpackage()), messageInfo.typeName()));
+          Joiner.on('.').join(packagePrefix, "model", messageInfo.typeName()));
     }
     return getNonMessageTypeName(typeInfo);
   }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/clouddebugger.v2.json.overrides
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/clouddebugger.v2.json.overrides
@@ -1,5 +1,0 @@
-{
-  "java": {
-    "packagePrefix": "com.google.api.services.clouddebugger.v2"
-  }
-}

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/cloudtrace.v1.json.overrides
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/cloudtrace.v1.json.overrides
@@ -1,5 +1,0 @@
-{
-  "java": {
-    "packagePrefix": "com.google.api.services.cloudtrace.v1"
-  }
-}

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/datastore.v1.json.overrides
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/datastore.v1.json.overrides
@@ -1,5 +1,0 @@
-{
-  "java": {
-    "packagePrefix": "com.google.api.services.datastore.v1"
-  }
-}

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/logging.v2beta1.json.overrides
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/logging.v2beta1.json.overrides
@@ -12,8 +12,5 @@
         "isPageStreaming": false
       }
     }
-  },
-  "java": {
-    "packagePrefix": "com.google.api.services.logging.v2beta1"
   }
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/sheets.v4.json.overrides
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/sheets.v4.json.overrides
@@ -1,6 +1,5 @@
 {
   "java": {
-    "packagePrefix": "com.google.api.services.sheets.v4",
     "methods": {
       "sheets.spreadsheets.sheets.copyTo": {
         "requestType": {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/storagetransfer.v1.json.overrides
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/storagetransfer.v1.json.overrides
@@ -19,7 +19,6 @@
     }
   },
   "java": {
-    "packagePrefix": "com.google.api.services.storagetransfer.v1",
     "methods": {
       "storagetransfer.getGoogleServiceAccount": {
         "requestType": {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/vision.v1.json.overrides
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/vision.v1.json.overrides
@@ -1,5 +1,0 @@
-{
-  "java": {
-    "packagePrefix": "com.google.api.services.vision.v1"
-  }
-}


### PR DESCRIPTION
"version_module" determines whether or not an API's version should be
included in the import path of Java discovery client library classes.
This commit adds support for that field and removes the corresponding
overrides.