### PR TITLE
Support underscore suffix for disambiguating names

### DIFF
--- a/src/main/java/com/google/api/codegen/discovery/transformer/csharp/CSharpSampleMethodToViewTransformer.java
+++ b/src/main/java/com/google/api/codegen/discovery/transformer/csharp/CSharpSampleMethodToViewTransformer.java
@@ -70,7 +70,7 @@ public class CSharpSampleMethodToViewTransformer implements SampleMethodToViewTr
     MethodInfo methodInfo = config.methods().get(context.getMethodName());
     SampleNamer namer = context.getSampleNamer();
     SampleTypeTable typeTable = context.getSampleTypeTable();
-    SymbolTable symbolTable = SymbolTable.fromSeed(CSharpNameFormatter.RESERVED_IDENTIFIER_SET);
+    SymbolTable symbolTable = new SymbolTable().seed(CSharpNameFormatter.RESERVED_IDENTIFIER_SET);
 
     SampleView.Builder builder = SampleView.newBuilder();
 

--- a/src/main/java/com/google/api/codegen/discovery/transformer/go/GoSampleMethodToViewTransformer.java
+++ b/src/main/java/com/google/api/codegen/discovery/transformer/go/GoSampleMethodToViewTransformer.java
@@ -60,7 +60,7 @@ public class GoSampleMethodToViewTransformer implements SampleMethodToViewTransf
     MethodInfo methodInfo = config.methods().get(context.getMethodName());
     SampleNamer namer = context.getSampleNamer();
     SampleTypeTable typeTable = context.getSampleTypeTable();
-    SymbolTable symbolTable = SymbolTable.fromSeed(GoNameFormatter.RESERVED_IDENTIFIER_SET);
+    SymbolTable symbolTable = new SymbolTable().seed(GoNameFormatter.RESERVED_IDENTIFIER_SET);
     addStaticImports(context, symbolTable);
 
     SampleView.Builder builder = SampleView.newBuilder();

--- a/src/main/java/com/google/api/codegen/discovery/transformer/java/JavaSampleMethodToViewTransformer.java
+++ b/src/main/java/com/google/api/codegen/discovery/transformer/java/JavaSampleMethodToViewTransformer.java
@@ -66,7 +66,7 @@ public class JavaSampleMethodToViewTransformer implements SampleMethodToViewTran
     MethodInfo methodInfo = config.methods().get(context.getMethodName());
     SampleNamer namer = context.getSampleNamer();
     SampleTypeTable typeTable = context.getSampleTypeTable();
-    SymbolTable symbolTable = SymbolTable.fromSeed(JavaNameFormatter.RESERVED_IDENTIFIER_SET);
+    SymbolTable symbolTable = new SymbolTable().seed(JavaNameFormatter.RESERVED_IDENTIFIER_SET);
 
     SampleView.Builder builder = SampleView.newBuilder();
 

--- a/src/main/java/com/google/api/codegen/discovery/transformer/nodejs/NodeJSSampleMethodToViewTransformer.java
+++ b/src/main/java/com/google/api/codegen/discovery/transformer/nodejs/NodeJSSampleMethodToViewTransformer.java
@@ -27,6 +27,7 @@ import com.google.api.codegen.discovery.viewmodel.SamplePageStreamingView;
 import com.google.api.codegen.discovery.viewmodel.SampleView;
 import com.google.api.codegen.util.Name;
 import com.google.api.codegen.util.SymbolTable;
+import com.google.api.codegen.util.SymbolTable.DisambiguationStrategy;
 import com.google.api.codegen.util.nodejs.NodeJSNameFormatter;
 import com.google.api.codegen.util.nodejs.NodeJSTypeTable;
 import com.google.api.codegen.viewmodel.ViewModel;
@@ -56,7 +57,9 @@ public class NodeJSSampleMethodToViewTransformer implements SampleMethodToViewTr
     MethodInfo methodInfo = config.methods().get(context.getMethodName());
     SampleNamer namer = context.getSampleNamer();
     SampleTypeTable typeTable = context.getSampleTypeTable();
-    SymbolTable symbolTable = SymbolTable.fromSeed(NodeJSNameFormatter.RESERVED_IDENTIFIER_SET);
+    SymbolTable symbolTable =
+        new SymbolTable(DisambiguationStrategy.UNDERSCORE)
+            .seed(NodeJSNameFormatter.RESERVED_IDENTIFIER_SET);
 
     SampleView.Builder builder = SampleView.newBuilder();
 

--- a/src/main/java/com/google/api/codegen/discovery/transformer/php/PhpSampleMethodToViewTransformer.java
+++ b/src/main/java/com/google/api/codegen/discovery/transformer/php/PhpSampleMethodToViewTransformer.java
@@ -55,7 +55,7 @@ public class PhpSampleMethodToViewTransformer implements SampleMethodToViewTrans
     MethodInfo methodInfo = config.methods().get(context.getMethodName());
     SampleNamer namer = context.getSampleNamer();
     SampleTypeTable typeTable = context.getSampleTypeTable();
-    SymbolTable symbolTable = SymbolTable.fromSeed(PhpTypeTable.RESERVED_IDENTIFIER_SET);
+    SymbolTable symbolTable = new SymbolTable().seed(PhpTypeTable.RESERVED_IDENTIFIER_SET);
 
     SampleView.Builder builder = SampleView.newBuilder();
 

--- a/src/main/java/com/google/api/codegen/discovery/transformer/py/PythonSampleMethodToViewTransformer.java
+++ b/src/main/java/com/google/api/codegen/discovery/transformer/py/PythonSampleMethodToViewTransformer.java
@@ -28,6 +28,7 @@ import com.google.api.codegen.discovery.viewmodel.SamplePageStreamingView;
 import com.google.api.codegen.discovery.viewmodel.SampleView;
 import com.google.api.codegen.util.Name;
 import com.google.api.codegen.util.SymbolTable;
+import com.google.api.codegen.util.SymbolTable.DisambiguationStrategy;
 import com.google.api.codegen.util.py.PythonTypeTable;
 import com.google.api.codegen.viewmodel.ViewModel;
 import com.google.common.collect.Iterables;
@@ -56,7 +57,9 @@ public class PythonSampleMethodToViewTransformer implements SampleMethodToViewTr
     MethodInfo methodInfo = config.methods().get(context.getMethodName());
     SampleNamer namer = context.getSampleNamer();
     SampleTypeTable typeTable = context.getSampleTypeTable();
-    SymbolTable symbolTable = SymbolTable.fromSeed(PythonTypeTable.RESERVED_IDENTIFIER_SET);
+    SymbolTable symbolTable =
+        new SymbolTable(DisambiguationStrategy.UNDERSCORE)
+            .seed(PythonTypeTable.RESERVED_IDENTIFIER_SET);
 
     SampleView.Builder builder = SampleView.newBuilder();
 

--- a/src/main/java/com/google/api/codegen/discovery/transformer/ruby/RubySampleMethodToViewTransformer.java
+++ b/src/main/java/com/google/api/codegen/discovery/transformer/ruby/RubySampleMethodToViewTransformer.java
@@ -27,6 +27,7 @@ import com.google.api.codegen.discovery.viewmodel.SamplePageStreamingView;
 import com.google.api.codegen.discovery.viewmodel.SampleView;
 import com.google.api.codegen.util.Name;
 import com.google.api.codegen.util.SymbolTable;
+import com.google.api.codegen.util.SymbolTable.DisambiguationStrategy;
 import com.google.api.codegen.util.ruby.RubyNameFormatter;
 import com.google.api.codegen.util.ruby.RubyTypeTable;
 import com.google.api.codegen.viewmodel.ViewModel;
@@ -62,7 +63,9 @@ public class RubySampleMethodToViewTransformer implements SampleMethodToViewTran
     MethodInfo methodInfo = config.methods().get(context.getMethodName());
     SampleNamer namer = context.getSampleNamer();
     SampleTypeTable typeTable = context.getSampleTypeTable();
-    SymbolTable symbolTable = SymbolTable.fromSeed(RubyNameFormatter.RESERVED_IDENTIFIER_SET);
+    SymbolTable symbolTable =
+        new SymbolTable(DisambiguationStrategy.UNDERSCORE)
+            .seed(RubyNameFormatter.RESERVED_IDENTIFIER_SET);
 
     SampleView.Builder builder = SampleView.newBuilder();
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_appengine.v1beta5.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_appengine.v1beta5.json.baseline
@@ -344,9 +344,9 @@ request = service.apps().services().list(appsId=apps_id)
 while request is not None:
     response = request.execute()
 
-    for service2 in response['services']:
-        # TODO: Change code below to process each `service2` resource:
-        pprint(service2)
+    for service_ in response['services']:
+        # TODO: Change code below to process each `service_` resource:
+        pprint(service_)
 
     request = service.apps().services().list_next(previous_request=request, previous_response=response)
 """

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_deploymentmanager.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_deploymentmanager.v2.json.baseline
@@ -667,8 +667,8 @@ request = service.types().list(project=project)
 while request is not None:
     response = request.execute()
 
-    for type2 in response['types']:
-        # TODO: Change code below to process each `type2` resource:
-        pprint(type2)
+    for type_ in response['types']:
+        # TODO: Change code below to process each `type_` resource:
+        pprint(type_)
 
     request = service.types().list_next(previous_request=request, previous_response=response)

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_dfareporting.v2.6.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_dfareporting.v2.6.json.baseline
@@ -3138,9 +3138,9 @@ request = service.files().list(profileId=profile_id)
 while request is not None:
     response = request.execute()
 
-    for file2 in response['items']:
-        # TODO: Change code below to process each `file2` resource:
-        pprint(file2)
+    for file_ in response['items']:
+        # TODO: Change code below to process each `file_` resource:
+        pprint(file_)
 
     request = service.files().list_next(previous_request=request, previous_response=response)
 """
@@ -5584,9 +5584,9 @@ request = service.reports().files().list(profileId=profile_id, reportId=report_i
 while request is not None:
     response = request.execute()
 
-    for file2 in response['items']:
-        # TODO: Change code below to process each `file2` resource:
-        pprint(file2)
+    for file_ in response['items']:
+        # TODO: Change code below to process each `file_` resource:
+        pprint(file_)
 
     request = service.reports().files().list_next(previous_request=request, previous_response=response)
 """

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_storage.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_storage.v1.json.baseline
@@ -1148,9 +1148,9 @@ request = service.objects().list(bucket=bucket)
 while request is not None:
     response = request.execute()
 
-    for object2 in response['items']:
-        # TODO: Change code below to process each `object2` resource:
-        pprint(object2)
+    for object_ in response['items']:
+        # TODO: Change code below to process each `object_` resource:
+        pprint(object_)
 
     request = service.objects().list_next(previous_request=request, previous_response=response)
 """

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_appengine.v1beta5.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_appengine.v1beta5.json.baseline
@@ -333,9 +333,9 @@ services = service.fetch_all(items: :services) do |token|
   service.list_app_services(apps_id, page_token: token)
 end
 
-services.each do |service2|
-  # TODO: Change code below to process each `service2` resource:
-  puts JSON.pretty_generate(service2)
+services.each do |service_|
+  # TODO: Change code below to process each `service_` resource:
+  puts JSON.pretty_generate(service_)
 end
 # BEFORE RUNNING:
 # ---------------

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_cloudbilling.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_cloudbilling.v1.json.baseline
@@ -93,11 +93,11 @@ service.authorization = \
 name = ''  # TODO: Update placeholder value.
 # ex: 'billingAccounts/my-billingAccount'
 
-project_billing_info2 = service.fetch_all(items: :project_billing_info) do |token|
+project_billing_info_ = service.fetch_all(items: :project_billing_info) do |token|
   service.list_billing_account_projects(name, page_token: token)
 end
 
-project_billing_info2.each do |project_billing_info|
+project_billing_info_.each do |project_billing_info|
   # TODO: Change code below to process each `project_billing_info` resource:
   puts JSON.pretty_generate(project_billing_info)
 end

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_cloudmonitoring.v2beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_cloudmonitoring.v2beta2.json.baseline
@@ -143,11 +143,11 @@ youngest = ''  # TODO: Update placeholder value.
 # TODO: Assign values to desired members of `request_body`:
 request_body = Google::Apis::CloudmonitoringV2beta2::ListTimeseriesRequest.new
 
-timeseries2 = service.fetch_all(items: :timeseries) do |token|
+timeseries_ = service.fetch_all(items: :timeseries) do |token|
   service.list_timeseries(project, metric, youngest, request_body, page_token: token)
 end
 
-timeseries2.each do |timeseries|
+timeseries_.each do |timeseries|
   # TODO: Change code below to process each `timeseries` resource:
   puts JSON.pretty_generate(timeseries)
 end


### PR DESCRIPTION
Python and Ruby use the `UNDERSCORE` disambiguation strategy to resolve
name collisions in the symbol table.

Resolves #564