### PR TITLE
C# bug fixes

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/ParamWithSimpleDoc.java
+++ b/src/main/java/com/google/api/codegen/transformer/ParamWithSimpleDoc.java
@@ -80,8 +80,6 @@ public abstract class ParamWithSimpleDoc {
         .paramName(name())
         .typeName(typeName())
         .lines(docLines())
-        //.firstLine(docLines().get(0))
-        //.remainingLines(docLines().subList(0, docLines().size()))
         .lines(docLines())
         .build();
   }

--- a/src/main/java/com/google/api/codegen/transformer/PathTemplateTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/PathTemplateTransformer.java
@@ -211,6 +211,7 @@ public class PathTemplateTransformer {
         ResourceProtoFieldView fieldView =
             ResourceProtoFieldView.newBuilder()
                 .typeName(fieldTypeName)
+                .parseMethodTypeName(namer.getPackageName() + "." + fieldTypeName)
                 .docTypeName(fieldDocTypeName)
                 .elementTypeName(fieldElementTypeName)
                 .isAny(fieldConfig.getResourceNameType() == ResourceNameType.ANY)

--- a/src/main/java/com/google/api/codegen/viewmodel/ResourceProtoFieldView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/ResourceProtoFieldView.java
@@ -21,6 +21,8 @@ public abstract class ResourceProtoFieldView {
 
   public abstract String typeName();
 
+  public abstract String parseMethodTypeName();
+
   public abstract String docTypeName();
 
   public abstract String elementTypeName();
@@ -42,6 +44,8 @@ public abstract class ResourceProtoFieldView {
   @AutoValue.Builder
   public abstract static class Builder {
     public abstract Builder typeName(String val);
+
+    public abstract Builder parseMethodTypeName(String val);
 
     public abstract Builder docTypeName(String val);
 

--- a/src/main/resources/com/google/api/codegen/csharp/gapic_resourcenames.snip
+++ b/src/main/resources/com/google/api/codegen/csharp/gapic_resourcenames.snip
@@ -426,15 +426,15 @@
                     public {@field.typeName} {@field.propertyName}
                     {
                         @if field.isAny
-                            get { return UnknownResourceName.Parse({@field.underlyingPropertyName}); }
+                            get { return string.IsNullOrEmpty({@field.underlyingPropertyName}) ? null : UnknownResourceName.Parse({@field.underlyingPropertyName}); }
                         @else
                             @if field.isOneof
-                                get { return {@field.typeName}.Parse({@field.underlyingPropertyName}, true); }
+                                get { return string.IsNullOrEmpty({@field.underlyingPropertyName}) ? null : {@field.parseMethodTypeName}.Parse({@field.underlyingPropertyName}, true); }
                             @else
-                                get { return {@field.typeName}.Parse({@field.underlyingPropertyName}); }
+                                get { return string.IsNullOrEmpty({@field.underlyingPropertyName}) ? null : {@field.parseMethodTypeName}.Parse({@field.underlyingPropertyName}); }
                             @end
                         @end
-                        set { {@field.underlyingPropertyName} = GaxPreconditions.CheckNotNull(value, nameof(value)).ToString(); }
+                        set { {@field.underlyingPropertyName} = value != null ? value.ToString() : ""; }
                     }
                 @end
 

--- a/src/test/java/com/google/api/codegen/testdata/csharp_gapic_resourcenames_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/csharp_gapic_resourcenames_library.baseline
@@ -692,8 +692,8 @@ namespace Google.Example.Library.V1
         /// </summary>
         public BookName BookName
         {
-            get { return BookName.Parse(Name); }
-            set { Name = GaxPreconditions.CheckNotNull(value, nameof(value)).ToString(); }
+            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.BookName.Parse(Name); }
+            set { Name = value != null ? value.ToString() : ""; }
         }
 
     }
@@ -705,8 +705,8 @@ namespace Google.Example.Library.V1
         /// </summary>
         public BookNameOneof BookNameOneof
         {
-            get { return BookNameOneof.Parse(Name, true); }
-            set { Name = GaxPreconditions.CheckNotNull(value, nameof(value)).ToString(); }
+            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.BookNameOneof.Parse(Name, true); }
+            set { Name = value != null ? value.ToString() : ""; }
         }
 
     }
@@ -718,8 +718,8 @@ namespace Google.Example.Library.V1
         /// </summary>
         public ArchivedBookName ArchivedBookName
         {
-            get { return ArchivedBookName.Parse(Name); }
-            set { Name = GaxPreconditions.CheckNotNull(value, nameof(value)).ToString(); }
+            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.ArchivedBookName.Parse(Name); }
+            set { Name = value != null ? value.ToString() : ""; }
         }
 
     }
@@ -731,8 +731,8 @@ namespace Google.Example.Library.V1
         /// </summary>
         public ShelfName ShelfName
         {
-            get { return ShelfName.Parse(Name); }
-            set { Name = GaxPreconditions.CheckNotNull(value, nameof(value)).ToString(); }
+            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.ShelfName.Parse(Name); }
+            set { Name = value != null ? value.ToString() : ""; }
         }
 
     }
@@ -744,8 +744,8 @@ namespace Google.Example.Library.V1
         /// </summary>
         public BookName BookName
         {
-            get { return BookName.Parse(Name); }
-            set { Name = GaxPreconditions.CheckNotNull(value, nameof(value)).ToString(); }
+            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.BookName.Parse(Name); }
+            set { Name = value != null ? value.ToString() : ""; }
         }
 
     }
@@ -757,8 +757,8 @@ namespace Google.Example.Library.V1
         /// </summary>
         public ShelfName ShelfName
         {
-            get { return ShelfName.Parse(Name); }
-            set { Name = GaxPreconditions.CheckNotNull(value, nameof(value)).ToString(); }
+            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.ShelfName.Parse(Name); }
+            set { Name = value != null ? value.ToString() : ""; }
         }
 
     }
@@ -799,8 +799,8 @@ namespace Google.Example.Library.V1
         /// </summary>
         public BookNameOneof BookNameOneof
         {
-            get { return BookNameOneof.Parse(Name, true); }
-            set { Name = GaxPreconditions.CheckNotNull(value, nameof(value)).ToString(); }
+            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.BookNameOneof.Parse(Name, true); }
+            set { Name = value != null ? value.ToString() : ""; }
         }
 
         /// <summary>
@@ -808,8 +808,8 @@ namespace Google.Example.Library.V1
         /// </summary>
         public BookNameOneof AltBookNameAsBookNameOneof
         {
-            get { return BookNameOneof.Parse(AltBookName, true); }
-            set { AltBookName = GaxPreconditions.CheckNotNull(value, nameof(value)).ToString(); }
+            get { return string.IsNullOrEmpty(AltBookName) ? null : Google.Example.Library.V1.BookNameOneof.Parse(AltBookName, true); }
+            set { AltBookName = value != null ? value.ToString() : ""; }
         }
 
     }
@@ -821,8 +821,8 @@ namespace Google.Example.Library.V1
         /// </summary>
         public ArchivedBookName ArchivedBookName
         {
-            get { return ArchivedBookName.Parse(Name); }
-            set { Name = GaxPreconditions.CheckNotNull(value, nameof(value)).ToString(); }
+            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.ArchivedBookName.Parse(Name); }
+            set { Name = value != null ? value.ToString() : ""; }
         }
 
     }
@@ -834,8 +834,8 @@ namespace Google.Example.Library.V1
         /// </summary>
         public BookName BookName
         {
-            get { return BookName.Parse(Name); }
-            set { Name = GaxPreconditions.CheckNotNull(value, nameof(value)).ToString(); }
+            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.BookName.Parse(Name); }
+            set { Name = value != null ? value.ToString() : ""; }
         }
 
     }
@@ -847,8 +847,8 @@ namespace Google.Example.Library.V1
         /// </summary>
         public ShelfName ShelfName
         {
-            get { return ShelfName.Parse(Name); }
-            set { Name = GaxPreconditions.CheckNotNull(value, nameof(value)).ToString(); }
+            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.ShelfName.Parse(Name); }
+            set { Name = value != null ? value.ToString() : ""; }
         }
 
     }
@@ -860,8 +860,8 @@ namespace Google.Example.Library.V1
         /// </summary>
         public ShelfName ShelfName
         {
-            get { return ShelfName.Parse(Name); }
-            set { Name = GaxPreconditions.CheckNotNull(value, nameof(value)).ToString(); }
+            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.ShelfName.Parse(Name); }
+            set { Name = value != null ? value.ToString() : ""; }
         }
 
     }
@@ -873,8 +873,8 @@ namespace Google.Example.Library.V1
         /// </summary>
         public IResourceName AsResourceName
         {
-            get { return UnknownResourceName.Parse(Name); }
-            set { Name = GaxPreconditions.CheckNotNull(value, nameof(value)).ToString(); }
+            get { return string.IsNullOrEmpty(Name) ? null : UnknownResourceName.Parse(Name); }
+            set { Name = value != null ? value.ToString() : ""; }
         }
 
     }
@@ -897,8 +897,8 @@ namespace Google.Example.Library.V1
         /// </summary>
         public ShelfName ShelfName
         {
-            get { return ShelfName.Parse(Name); }
-            set { Name = GaxPreconditions.CheckNotNull(value, nameof(value)).ToString(); }
+            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.ShelfName.Parse(Name); }
+            set { Name = value != null ? value.ToString() : ""; }
         }
 
         /// <summary>
@@ -906,8 +906,8 @@ namespace Google.Example.Library.V1
         /// </summary>
         public ShelfName OtherShelfNameAsShelfName
         {
-            get { return ShelfName.Parse(OtherShelfName); }
-            set { OtherShelfName = GaxPreconditions.CheckNotNull(value, nameof(value)).ToString(); }
+            get { return string.IsNullOrEmpty(OtherShelfName) ? null : Google.Example.Library.V1.ShelfName.Parse(OtherShelfName); }
+            set { OtherShelfName = value != null ? value.ToString() : ""; }
         }
 
     }
@@ -919,8 +919,8 @@ namespace Google.Example.Library.V1
         /// </summary>
         public BookName BookName
         {
-            get { return BookName.Parse(Name); }
-            set { Name = GaxPreconditions.CheckNotNull(value, nameof(value)).ToString(); }
+            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.BookName.Parse(Name); }
+            set { Name = value != null ? value.ToString() : ""; }
         }
 
         /// <summary>
@@ -928,8 +928,8 @@ namespace Google.Example.Library.V1
         /// </summary>
         public ShelfName OtherShelfNameAsShelfName
         {
-            get { return ShelfName.Parse(OtherShelfName); }
-            set { OtherShelfName = GaxPreconditions.CheckNotNull(value, nameof(value)).ToString(); }
+            get { return string.IsNullOrEmpty(OtherShelfName) ? null : Google.Example.Library.V1.ShelfName.Parse(OtherShelfName); }
+            set { OtherShelfName = value != null ? value.ToString() : ""; }
         }
 
     }
@@ -941,8 +941,8 @@ namespace Google.Example.Library.V1
         /// </summary>
         public ShelfName ShelfName
         {
-            get { return ShelfName.Parse(Name); }
-            set { Name = GaxPreconditions.CheckNotNull(value, nameof(value)).ToString(); }
+            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.ShelfName.Parse(Name); }
+            set { Name = value != null ? value.ToString() : ""; }
         }
 
     }
@@ -954,8 +954,8 @@ namespace Google.Example.Library.V1
         /// </summary>
         public BookName BookName
         {
-            get { return BookName.Parse(Name); }
-            set { Name = GaxPreconditions.CheckNotNull(value, nameof(value)).ToString(); }
+            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.BookName.Parse(Name); }
+            set { Name = value != null ? value.ToString() : ""; }
         }
 
     }
@@ -967,8 +967,8 @@ namespace Google.Example.Library.V1
         /// </summary>
         public BookName BookName
         {
-            get { return BookName.Parse(Name); }
-            set { Name = GaxPreconditions.CheckNotNull(value, nameof(value)).ToString(); }
+            get { return string.IsNullOrEmpty(Name) ? null : Google.Example.Library.V1.BookName.Parse(Name); }
+            set { Name = value != null ? value.ToString() : ""; }
         }
 
     }


### PR DESCRIPTION
Fixes #852 - Now uses faully qualified name to call Parse() method

Updates #834 - Allows ResourceName properties to take and return null