### PR TITLE
make Go handle LRO returning empty properly

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/ApiMethodTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ApiMethodTransformer.java
@@ -449,7 +449,12 @@ public class ApiMethodTransformer {
     methodViewBuilder.grpcStreamingType(context.getMethodConfig().getGrpcStreamingType());
 
     ServiceMessages messages = new ServiceMessages();
-    methodViewBuilder.hasReturnValue(!messages.isEmptyType(context.getMethod().getOutputType()));
+    if (context.getMethodConfig().isLongRunningOperation()) {
+      methodViewBuilder.hasReturnValue(
+          !messages.isEmptyType(context.getMethodConfig().getLongRunningConfig().getReturnType()));
+    } else {
+      methodViewBuilder.hasReturnValue(!messages.isEmptyType(context.getMethod().getOutputType()));
+    }
   }
 
   private void setListMethodFields(

--- a/src/main/java/com/google/api/codegen/transformer/LongRunningTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/LongRunningTransformer.java
@@ -14,6 +14,7 @@
  */
 package com.google.api.codegen.transformer;
 
+import com.google.api.codegen.ServiceMessages;
 import com.google.api.codegen.config.LongRunningConfig;
 import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.viewmodel.LongRunningOperationDetailView;
@@ -36,6 +37,7 @@ public class LongRunningTransformer {
         .constructorName(namer.getTypeConstructor(clientReturnTypeName))
         .clientReturnTypeName(clientReturnTypeName)
         .operationPayloadTypeName(namer.valueType(operationPayloadTypeName))
+        .isEmptyOperation(ServiceMessages.s_isEmptyType(lroConfig.getReturnType()))
         .metadataTypeName(namer.valueType(metadataTypeName))
         .implementsDelete(lroConfig.implementsDelete())
         .implementsCancel(lroConfig.implementsCancel())

--- a/src/main/java/com/google/api/codegen/transformer/TestCaseTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/TestCaseTransformer.java
@@ -84,11 +84,17 @@ public class TestCaseTransformer {
       responseTypeName = methodContext.getTypeTable().getAndSaveNicknameFor(method.getOutputType());
     }
 
+    boolean hasReturnValue = !ServiceMessages.s_isEmptyType(method.getOutputType());
+    if (methodConfig.isLongRunningOperation()) {
+      hasReturnValue =
+          !ServiceMessages.s_isEmptyType(methodConfig.getLongRunningConfig().getReturnType());
+    }
+
     return TestCaseView.newBuilder()
         .asserts(initCodeTransformer.generateRequestAssertViews(methodContext, initCodeContext))
         .clientMethodType(clientMethodType)
         .grpcStreamingType(methodConfig.getGrpcStreamingType())
-        .hasReturnValue(!ServiceMessages.s_isEmptyType(method.getOutputType()))
+        .hasReturnValue(hasReturnValue)
         .initCode(initCodeTransformer.generateInitCode(methodContext, initCodeContext))
         .mockResponse(createMockResponseView(methodContext, initCodeContext.symbolTable()))
         .mockServiceVarName(namer.getMockServiceVarName(methodContext.getTargetInterface()))

--- a/src/main/java/com/google/api/codegen/transformer/go/GoModelTypeNameConverter.java
+++ b/src/main/java/com/google/api/codegen/transformer/go/GoModelTypeNameConverter.java
@@ -160,7 +160,7 @@ public class GoModelTypeNameConverter implements ModelTypeNameConverter {
     String localName = null;
     if (importPath.lastIndexOf(';') >= 0) {
       int semicolonPos = importPath.lastIndexOf(';');
-      localName = importPath.substring(semicolonPos + 1);
+      localName = importPath.substring(semicolonPos + 1) + "pb";
       importPath = importPath.substring(0, semicolonPos);
     } else {
       // The import path might be versioned:

--- a/src/main/java/com/google/api/codegen/viewmodel/LongRunningOperationDetailView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/LongRunningOperationDetailView.java
@@ -25,6 +25,8 @@ public abstract class LongRunningOperationDetailView {
 
   public abstract String operationPayloadTypeName();
 
+  public abstract boolean isEmptyOperation();
+
   public abstract String metadataTypeName();
 
   public abstract boolean implementsDelete();
@@ -42,6 +44,8 @@ public abstract class LongRunningOperationDetailView {
     public abstract Builder clientReturnTypeName(String val);
 
     public abstract Builder operationPayloadTypeName(String val);
+
+    public abstract Builder isEmptyOperation(boolean val);
 
     public abstract Builder metadataTypeName(String val);
 

--- a/src/main/resources/com/google/api/codegen/go/example.snip
+++ b/src/main/resources/com/google/api/codegen/go/example.snip
@@ -170,12 +170,17 @@
             // TODO: Handle error.
         }
 
-        resp, err := op.Wait(ctx)
-        if err != nil {
+        @if method.hasReturnValue
+            resp, err := op.Wait(ctx)
+            if err != nil {
+                // TODO: Handle error.
+            }
+            // TODO: Use resp.
+            _ = resp
+        @else
+            err = op.Wait(ctx)
             // TODO: Handle error.
-        }
-        // TODO: Use resp.
-        _ = resp
+        @end
     }
 @end
 

--- a/src/main/resources/com/google/api/codegen/go/main.snip
+++ b/src/main/resources/com/google/api/codegen/go/main.snip
@@ -326,7 +326,12 @@
 @end
 
 @private lroWrapper(view, lro)
-    // {@lro.clientReturnTypeName} manages a long-running operation yielding {@lro.operationPayloadTypeName}.
+    @if lro.isEmptyOperation
+        // {@lro.clientReturnTypeName} manages a long-running operation with no result.
+    @else
+        // {@lro.clientReturnTypeName} manages a long-running operation yielding {@lro.operationPayloadTypeName}.
+    @end
+
     type {@lro.clientReturnTypeName} struct {
         lro *longrunning.Operation
     }
@@ -339,36 +344,56 @@
         }
     }
 
-    // Wait blocks until the long-running operation is completed, returning the response and any errors encountered.
-    //
-    // See documentation of Poll for error-handling information.
-    func (op *{@lro.clientReturnTypeName}) Wait(ctx context.Context) (*{@lro.operationPayloadTypeName}, error) {
-        var resp {@lro.operationPayloadTypeName}
-        if err := op.lro.Wait(ctx, &resp); err != nil {
-            return nil, err
+    @if lro.isEmptyOperation
+        // Wait blocks until the long-running operation is completed, returning any error encountered.
+        //
+        // See documentation of Poll for error-handling information.
+        func (op *{@lro.clientReturnTypeName}) Wait(ctx context.Context) error {
+            return op.lro.Wait(ctx, nil)
         }
-        return &resp, nil
-    }
 
-    // Poll fetches the latest state of the long-running operation.
-    //
-    // Poll also fetches the latest metadata, which can be retrieved by Metadata.
-    //
-    // If Poll fails, the error is returned and op is unmodified. If Poll succeeds and
-    // the operation has completed with failure, the error is returned and op.Done will return true.
-    // If Poll succeeds and the operation has completed successfully,
-    // op.Done will return true, and the response of the operation is returned.
-    // If Poll succeeds and the operation has not completed, the returned response and error are both nil.
-    func (op *{@lro.clientReturnTypeName}) Poll(ctx context.Context) (*{@lro.operationPayloadTypeName}, error) {
-        var resp {@lro.operationPayloadTypeName}
-        if err := op.lro.Poll(ctx, &resp); err != nil {
-            return nil, err
+        // Poll fetches the latest state of the long-running operation.
+        //
+        // Poll also fetches the latest metadata, which can be retrieved by Metadata.
+        //
+        // If Poll fails, the error is returned and op is unmodified. If Poll succeeds and
+        // the operation has completed with failure, the error is returned and op.Done will return true.
+        // If Poll succeeds and the operation has completed successfully, op.Done will return true.
+        func (op *{@lro.clientReturnTypeName}) Poll(ctx context.Context) error {
+            return op.lro.Poll(ctx, nil)
         }
-        if !op.Done() {
-            return nil, nil
+    @else
+        // Wait blocks until the long-running operation is completed, returning the response and any errors encountered.
+        //
+        // See documentation of Poll for error-handling information.
+        func (op *{@lro.clientReturnTypeName}) Wait(ctx context.Context) (*{@lro.operationPayloadTypeName}, error) {
+            var resp {@lro.operationPayloadTypeName}
+            if err := op.lro.Wait(ctx, &resp); err != nil {
+                return nil, err
+            }
+            return &resp, nil
         }
-        return &resp, nil
-    }
+
+        // Poll fetches the latest state of the long-running operation.
+        //
+        // Poll also fetches the latest metadata, which can be retrieved by Metadata.
+        //
+        // If Poll fails, the error is returned and op is unmodified. If Poll succeeds and
+        // the operation has completed with failure, the error is returned and op.Done will return true.
+        // If Poll succeeds and the operation has completed successfully,
+        // op.Done will return true, and the response of the operation is returned.
+        // If Poll succeeds and the operation has not completed, the returned response and error are both nil.
+        func (op *{@lro.clientReturnTypeName}) Poll(ctx context.Context) (*{@lro.operationPayloadTypeName}, error) {
+            var resp {@lro.operationPayloadTypeName}
+            if err := op.lro.Poll(ctx, &resp); err != nil {
+                return nil, err
+            }
+            if !op.Done() {
+                return nil, nil
+            }
+            return &resp, nil
+        }
+    @end
 
     // Metadata returns metadata associated with the long-running operation.
     // Metadata itself does not contact the server, but Poll does.

--- a/src/main/resources/com/google/api/codegen/go/mock.snip
+++ b/src/main/resources/com/google/api/codegen/go/mock.snip
@@ -273,7 +273,7 @@
         }
         resp, err := stream.Recv()
     @case "ServerStreaming"
-        stream, err := c.{@test.clientMethodName}(context.Background())
+        stream, err := c.{@test.clientMethodName}(context.Background(), request)
         if err != nil {
             t.Fatal(err)
         }
@@ -293,7 +293,11 @@
             if err != nil {
                 t.Fatal(err)
             }
-            resp, err := respLRO.Wait(context.Background())
+            @if test.hasReturnValue
+                resp, err := respLRO.Wait(context.Background())
+            @else
+                err = respLRO.Wait(context.Background())
+            @end
         @case "RequestObjectMethod"
             @if test.hasReturnValue
                 resp, err := c.{@test.clientMethodName}(context.Background(), request)

--- a/src/test/java/com/google/api/codegen/testdata/client_config_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/client_config_json_library.baseline
@@ -149,6 +149,11 @@
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
+        },
+        "GetBigNothing": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
         }
       }
     }

--- a/src/test/java/com/google/api/codegen/testdata/csharp_gapic_client_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/csharp_gapic_client_library.baseline
@@ -72,6 +72,7 @@ namespace Google.Example.Library.V1
             AddTagSettings = existing.AddTagSettings;
             AddLabelSettings = existing.AddLabelSettings;
             GetBigBookSettings = existing.GetBigBookSettings;
+            GetBigNothingSettings = existing.GetBigNothingSettings;
         }
 
         /// <summary>
@@ -752,6 +753,35 @@ namespace Google.Example.Library.V1
         /// Default RPC expiration is 30000 milliseconds.
         /// </remarks>
         public CallSettings GetBigBookSettings { get; set; } = CallSettings.FromCallTiming(
+            CallTiming.FromRetry(new RetrySettings(
+                retryBackoff: GetDefaultRetryBackoff(),
+                timeoutBackoff: GetDefaultTimeoutBackoff(),
+                totalExpiration: Expiration.FromTimeout(TimeSpan.FromMilliseconds(30000)),
+                retryFilter: NonIdempotentRetryFilter
+            )));
+
+        /// <summary>
+        /// <see cref="CallSettings"/> for synchronous and asynchronous calls to
+        /// <c>LibraryServiceClient.GetBigNothing</c> and <c>LibraryServiceClient.GetBigNothingAsync</c>.
+        /// </summary>
+        /// <remarks>
+        /// The default <c>LibraryServiceClient.GetBigNothing</c> and
+        /// <c>LibraryServiceClient.GetBigNothingAsync</c> <see cref="RetrySettings"/> are:
+        /// <list type="bullet">
+        /// <item><description>Initial retry delay: 100 milliseconds</description></item>
+        /// <item><description>Retry delay multiplier: 1.2</description></item>
+        /// <item><description>Retry maximum delay: 1000 milliseconds</description></item>
+        /// <item><description>Initial timeout: 300 milliseconds</description></item>
+        /// <item><description>Timeout multiplier: 1.3</description></item>
+        /// <item><description>Timeout maximum delay: 3000 milliseconds</description></item>
+        /// </list>
+        /// Retry will be attempted on the following response status codes:
+        /// <list>
+        /// <item><description>No status codes</description></item>
+        /// </list>
+        /// Default RPC expiration is 30000 milliseconds.
+        /// </remarks>
+        public CallSettings GetBigNothingSettings { get; set; } = CallSettings.FromCallTiming(
             CallTiming.FromRetry(new RetrySettings(
                 retryBackoff: GetDefaultRetryBackoff(),
                 timeoutBackoff: GetDefaultTimeoutBackoff(),
@@ -3487,6 +3517,104 @@ namespace Google.Example.Library.V1
             throw new NotImplementedException();
         }
 
+        /// <summary>
+        /// Test long-running operations with empty return type.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to retrieve.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<Operation> GetBigNothingAsync(
+            BookName name,
+            CallSettings callSettings = null) => GetBigNothingAsync(
+                new GetBookRequest
+                {
+                    BookName = name,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Test long-running operations with empty return type.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to retrieve.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> to use for this RPC.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<Operation> GetBigNothingAsync(
+            BookName name,
+            CancellationToken cancellationToken) => GetBigNothingAsync(
+                name,
+                CallSettings.FromCancellationToken(cancellationToken));
+
+        /// <summary>
+        /// Test long-running operations with empty return type.
+        /// </summary>
+        /// <param name="name">
+        /// The name of the book to retrieve.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual Operation GetBigNothing(
+            BookName name,
+            CallSettings callSettings = null) => GetBigNothing(
+                new GetBookRequest
+                {
+                    BookName = name,
+                },
+                callSettings);
+
+        /// <summary>
+        /// Test long-running operations with empty return type.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public virtual Task<Operation> GetBigNothingAsync(
+            GetBookRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Test long-running operations with empty return type.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public virtual Operation GetBigNothing(
+            GetBookRequest request,
+            CallSettings callSettings = null)
+        {
+            throw new NotImplementedException();
+        }
+
     }
 
     /// <summary>
@@ -3516,6 +3644,7 @@ namespace Google.Example.Library.V1
         private readonly ApiCall<AddTagRequest, AddTagResponse> _callAddTag;
         private readonly ApiCall<AddLabelRequest, AddLabelResponse> _callAddLabel;
         private readonly ApiCall<GetBookRequest, Operation> _callGetBigBook;
+        private readonly ApiCall<GetBookRequest, Operation> _callGetBigNothing;
 
         /// <summary>
         /// Constructs a client wrapper for the LibraryService service, with the specified gRPC client and settings.
@@ -3570,6 +3699,8 @@ namespace Google.Example.Library.V1
                 grpcLabelerClient.AddLabelAsync, grpcLabelerClient.AddLabel, effectiveSettings.AddLabelSettings);
             _callGetBigBook = _clientHelper.BuildApiCall<GetBookRequest, Operation>(
                 GrpcClient.GetBigBookAsync, GrpcClient.GetBigBook, effectiveSettings.GetBigBookSettings);
+            _callGetBigNothing = _clientHelper.BuildApiCall<GetBookRequest, Operation>(
+                GrpcClient.GetBigNothingAsync, GrpcClient.GetBigNothing, effectiveSettings.GetBigNothingSettings);
         }
 
         /// <summary>
@@ -3598,6 +3729,7 @@ namespace Google.Example.Library.V1
         partial void Modify_FindRelatedBooksRequest(ref FindRelatedBooksRequest request, ref CallSettings settings);
         partial void Modify_AddTagRequest(ref AddTagRequest request, ref CallSettings settings);
         partial void Modify_AddLabelRequest(ref AddLabelRequest request, ref CallSettings settings);
+        partial void Modify_GetBookRequest(ref GetBookRequest request, ref CallSettings settings);
         partial void Modify_GetBookRequest(ref GetBookRequest request, ref CallSettings settings);
 
         /// <summary>
@@ -4442,6 +4574,46 @@ namespace Google.Example.Library.V1
         {
             Modify_GetBookRequest(ref request, ref callSettings);
             return _callGetBigBook.Sync(request, callSettings);
+        }
+
+        /// <summary>
+        /// Test long-running operations with empty return type.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// A Task containing the RPC response.
+        /// </returns>
+        public override Task<Operation> GetBigNothingAsync(
+            GetBookRequest request,
+            CallSettings callSettings = null)
+        {
+            Modify_GetBookRequest(ref request, ref callSettings);
+            return _callGetBigNothing.Async(request, callSettings);
+        }
+
+        /// <summary>
+        /// Test long-running operations with empty return type.
+        /// </summary>
+        /// <param name="request">
+        /// The request object containing all of the parameters for the API call.
+        /// </param>
+        /// <param name="callSettings">
+        /// If not null, applies overrides to this RPC call.
+        /// </param>
+        /// <returns>
+        /// The RPC response.
+        /// </returns>
+        public override Operation GetBigNothing(
+            GetBookRequest request,
+            CallSettings callSettings = null)
+        {
+            Modify_GetBookRequest(ref request, ref callSettings);
+            _callGetBigNothing.Sync(request, callSettings);
         }
 
     }

--- a/src/test/java/com/google/api/codegen/testdata/csharp_gapic_snippets_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/csharp_gapic_snippets_library.baseline
@@ -1947,6 +1947,61 @@ namespace Google.Example.Library.V1.Snippets
             // End snippet
         }
 
+        public async Task GetBigNothingAsync()
+        {
+            // Snippet: GetBigNothingAsync(BookName,CallSettings)
+            // Additional: GetBigNothingAsync(BookName,CancellationToken)
+            // Create client
+            LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
+            // Initialize request argument(s)
+            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            // Make the request
+            await libraryServiceClient.GetBigNothingAsync(name);
+            // End snippet
+        }
+
+        public void GetBigNothing()
+        {
+            // Snippet: GetBigNothing(BookName,CallSettings)
+            // Create client
+            LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
+            // Initialize request argument(s)
+            BookName name = new BookName("[SHELF_ID]", "[BOOK_ID]");
+            // Make the request
+            libraryServiceClient.GetBigNothing(name);
+            // End snippet
+        }
+
+        public async Task GetBigNothingAsync_RequestObject()
+        {
+            // Snippet: GetBigNothingAsync(GetBookRequest,CallSettings)
+            // Create client
+            LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
+            // Initialize request argument(s)
+            GetBookRequest request = new GetBookRequest
+            {
+                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+            };
+            // Make the request
+            await libraryServiceClient.GetBigNothingAsync(request);
+            // End snippet
+        }
+
+        public void GetBigNothing_RequestObject()
+        {
+            // Snippet: GetBigNothing(GetBookRequest,CallSettings)
+            // Create client
+            LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
+            // Initialize request argument(s)
+            GetBookRequest request = new GetBookRequest
+            {
+                BookName = new BookName("[SHELF_ID]", "[BOOK_ID]"),
+            };
+            // Make the request
+            libraryServiceClient.GetBigNothing(request);
+            // End snippet
+        }
+
     }
 }
 

--- a/src/test/java/com/google/api/codegen/testdata/go_example_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_example_library.baseline
@@ -496,4 +496,23 @@ func ExampleClient_GetBigBook() {
     _ = resp
 }
 
+func ExampleClient_GetBigNothing() {
+    ctx := context.Background()
+    c, err := library.NewClient(ctx)
+    if err != nil {
+        // TODO: Handle error.
+    }
+
+    req := &librarypb.GetBookRequest{
+        // TODO: Fill request struct fields.
+    }
+    op, err := c.GetBigNothing(ctx, req)
+    if err != nil {
+        // TODO: Handle error.
+    }
+
+    err = op.Wait(ctx)
+    // TODO: Handle error.
+}
+
 

--- a/src/test/java/com/google/api/codegen/testdata/go_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_main_library.baseline
@@ -70,6 +70,7 @@ type CallOptions struct {
     FindRelatedBooks []gax.CallOption
     AddLabel []gax.CallOption
     GetBigBook []gax.CallOption
+    GetBigNothing []gax.CallOption
 }
 
 func defaultClientOptions() []option.ClientOption {
@@ -121,6 +122,7 @@ func defaultCallOptions() *CallOptions {
         FindRelatedBooks: retry[[2]string{"default", "idempotent"}],
         AddLabel: retry[[2]string{"default", "non_idempotent"}],
         GetBigBook: retry[[2]string{"default", "non_idempotent"}],
+        GetBigNothing: retry[[2]string{"default", "non_idempotent"}],
     }
 }
 
@@ -667,6 +669,24 @@ func (c *Client) GetBigBook(ctx context.Context, req *librarypb.GetBookRequest) 
     }, nil
 }
 
+// GetBigNothing test long-running operations with empty return type.
+func (c *Client) GetBigNothing(ctx context.Context, req *librarypb.GetBookRequest) (*EmptyOperation, error) {
+    md, _ := metadata.FromContext(ctx)
+    ctx = metadata.NewContext(ctx, metadata.Join(md, c.metadata))
+    var resp *longrunningpb.Operation
+    err := gax.Invoke(ctx, func(ctx context.Context) error {
+        var err error
+        resp, err = c.client.GetBigNothing(ctx, req)
+        return err
+    }, c.CallOptions.GetBigNothing...)
+    if err != nil {
+        return nil, err
+    }
+    return &EmptyOperation{
+        lro: longrunning.InternalNewOperation(c.Connection(), resp),
+    }, nil
+}
+
 
 // BookIterator manages a stream of *librarypb.Book.
 type BookIterator struct {
@@ -873,3 +893,66 @@ func (op *BookOperation) Cancel(ctx context.Context) error {
     return op.lro.Cancel(ctx)
 }
 
+// EmptyOperation manages a long-running operation with no result.
+type EmptyOperation struct {
+    lro *longrunning.Operation
+}
+
+// EmptyOperation returns a new EmptyOperation from a given name.
+// The name must be that of a previously created EmptyOperation, possibly from a different process.
+func (c *Client) EmptyOperation(name string) *EmptyOperation {
+    return &EmptyOperation{
+        lro: longrunning.InternalNewOperation(c.Connection(), &longrunningpb.Operation{Name: name}),
+    }
+}
+
+// Wait blocks until the long-running operation is completed, returning any error encountered.
+//
+// See documentation of Poll for error-handling information.
+func (op *EmptyOperation) Wait(ctx context.Context) error {
+    return op.lro.Wait(ctx, nil)
+}
+
+// Poll fetches the latest state of the long-running operation.
+//
+// Poll also fetches the latest metadata, which can be retrieved by Metadata.
+//
+// If Poll fails, the error is returned and op is unmodified. If Poll succeeds and
+// the operation has completed with failure, the error is returned and op.Done will return true.
+// If Poll succeeds and the operation has completed successfully, op.Done will return true.
+func (op *EmptyOperation) Poll(ctx context.Context) error {
+    return op.lro.Poll(ctx, nil)
+}
+
+// Metadata returns metadata associated with the long-running operation.
+// Metadata itself does not contact the server, but Poll does.
+// To get the latest metadata, call this method after a successful call to Poll.
+// If the metadata is not available, the returned metadata and error are both nil.
+func (op *EmptyOperation) Metadata() (*librarypb.GetBigBookMetadata, error) {
+    var meta librarypb.GetBigBookMetadata
+    if err := op.lro.Metadata(&meta); err == longrunning.ErrNoMetadata {
+        return nil, nil
+    } else if err != nil {
+        return nil, err
+    }
+    return &meta, nil
+}
+
+// Done reports whether the long-running operation has completed.
+func (op *EmptyOperation) Done() bool {
+    return op.lro.Done()
+}
+
+// Name returns the name of the long-running operation.
+// The name is assigned by the server and is unique within the service from which the operation is created.
+func (op *EmptyOperation) Name() string {
+    return op.lro.Name()
+}
+
+
+// Delete deletes a long-running operation.
+// This method indicates that the client is no longer interested in the operation result.
+// It does not cancel the operation.
+func (op *EmptyOperation) Delete(ctx context.Context) error {
+    return op.lro.Delete(ctx)
+}

--- a/src/test/java/com/google/api/codegen/testdata/go_mock_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_mock_library.baseline
@@ -262,6 +262,14 @@ func (s *mockLibraryServer) GetBigBook(_ context.Context, req *librarypb.GetBook
     return s.resps[0].(*longrunningpb.Operation), nil
 }
 
+func (s *mockLibraryServer) GetBigNothing(_ context.Context, req *librarypb.GetBookRequest) (*longrunningpb.Operation, error) {
+    s.reqs = append(s.reqs, req)
+    if s.err != nil {
+        return nil, s.err
+    }
+    return s.resps[0].(*longrunningpb.Operation), nil
+}
+
 type mockLabelerServer struct {
     reqs []proto.Message
 
@@ -1406,7 +1414,7 @@ func TestLibraryServiceStreamShelves(t *testing.T) {
         t.Fatal(err)
     }
 
-    stream, err := c.StreamShelves(context.Background())
+    stream, err := c.StreamShelves(context.Background(), request)
     if err != nil {
         t.Fatal(err)
     }
@@ -1436,7 +1444,7 @@ func TestLibraryServiceStreamShelvesError(t *testing.T) {
         t.Fatal(err)
     }
 
-    stream, err := c.StreamShelves(context.Background())
+    stream, err := c.StreamShelves(context.Background(), request)
     if err != nil {
         t.Fatal(err)
     }
@@ -1474,7 +1482,7 @@ func TestLibraryServiceStreamBooks(t *testing.T) {
         t.Fatal(err)
     }
 
-    stream, err := c.StreamBooks(context.Background())
+    stream, err := c.StreamBooks(context.Background(), request)
     if err != nil {
         t.Fatal(err)
     }
@@ -1507,7 +1515,7 @@ func TestLibraryServiceStreamBooksError(t *testing.T) {
         t.Fatal(err)
     }
 
-    stream, err := c.StreamBooks(context.Background())
+    stream, err := c.StreamBooks(context.Background(), request)
     if err != nil {
         t.Fatal(err)
     }
@@ -1819,4 +1827,80 @@ func TestLibraryServiceGetBigBookError(t *testing.T) {
         t.Errorf("got error code %q, want %q", c, errCode)
     }
     _ = resp
+}
+func TestLibraryServiceGetBigNothing(t *testing.T) {
+    var expectedResponse *google_protobuf.Empty = &google_protobuf.Empty{}
+
+    mockLibrary.err = nil
+    mockLibrary.reqs = nil
+
+    any, err := ptypes.MarshalAny(expectedResponse)
+    if err != nil {
+        t.Fatal(err)
+    }
+    mockLibrary.resps = append(mockLibrary.resps[:0], &longrunningpb.Operation{
+        Name: "longrunning-test",
+        Done: true,
+        Result: &longrunningpb.Operation_Response{ Response: any },
+    })
+
+    var formattedName string = LibraryBookPath("[SHELF_ID]", "[BOOK_ID]")
+    var request = &librarypb.GetBookRequest{
+        Name: formattedName,
+    }
+
+    c, err := NewClient(context.Background(), clientOpt)
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    respLRO, err := c.GetBigNothing(context.Background(), request)
+    if err != nil {
+        t.Fatal(err)
+    }
+    err = respLRO.Wait(context.Background())
+
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    if want, got := request, mockLibrary.reqs[0]; !proto.Equal(want, got) {
+        t.Errorf("wrong request %q, want %q", got, want)
+    }
+
+}
+
+func TestLibraryServiceGetBigNothingError(t *testing.T) {
+    errCode := codes.Internal
+    mockLibrary.err = nil
+    mockLibrary.resps = append(mockLibrary.resps[:0], &longrunningpb.Operation{
+        Name: "longrunning-test",
+        Done: true,
+        Result: &longrunningpb.Operation_Error{
+            Error: &status.Status{
+                Code: int32(errCode),
+                Message: "test error",
+            },
+        },
+    })
+
+    var formattedName string = LibraryBookPath("[SHELF_ID]", "[BOOK_ID]")
+    var request = &librarypb.GetBookRequest{
+        Name: formattedName,
+    }
+
+    c, err := NewClient(context.Background(), clientOpt)
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    respLRO, err := c.GetBigNothing(context.Background(), request)
+    if err != nil {
+        t.Fatal(err)
+    }
+    err = respLRO.Wait(context.Background())
+
+    if c := grpc.Code(err); c != errCode {
+        t.Errorf("got error code %q, want %q", c, errCode)
+    }
 }

--- a/src/test/java/com/google/api/codegen/testdata/java_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_main_library.baseline
@@ -189,6 +189,8 @@ public class LibraryServiceClient implements AutoCloseable {
   private final UnaryCallable<AddLabelRequest, AddLabelResponse> addLabelCallable;
   private final UnaryCallable<GetBookRequest, Operation> getBigBookCallable;
   private final OperationCallable<GetBookRequest, Book> getBigBookOperationCallable;
+  private final UnaryCallable<GetBookRequest, Operation> getBigNothingCallable;
+  private final OperationCallable<GetBookRequest, Empty> getBigNothingOperationCallable;
 
 
 
@@ -264,6 +266,8 @@ public class LibraryServiceClient implements AutoCloseable {
     this.addLabelCallable = UnaryCallable.create(settings.addLabelSettings(), this.channel, this.executor);
     this.getBigBookCallable = UnaryCallable.create(settings.getBigBookSettings().getInitialCallSettings(), this.channel, this.executor);
     this.getBigBookOperationCallable = OperationCallable.create(settings.getBigBookSettings(),this.channel, this.executor, this.operationsClient);
+    this.getBigNothingCallable = UnaryCallable.create(settings.getBigNothingSettings().getInitialCallSettings(), this.channel, this.executor);
+    this.getBigNothingOperationCallable = OperationCallable.create(settings.getBigNothingSettings(),this.channel, this.executor, this.operationsClient);
 
     if (settings.getChannelProvider().shouldAutoClose()) {
       closeables.add(
@@ -2216,6 +2220,94 @@ public class LibraryServiceClient implements AutoCloseable {
    */
   public final UnaryCallable<GetBookRequest, Operation> getBigBookCallable() {
     return getBigBookCallable;
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Test long-running operations with empty return type.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   BookName name = BookName.create("[SHELF_ID]", "[BOOK_ID]");
+   *   Empty response = libraryServiceClient.getBigNothingAsync(name).get();
+   * }
+   * </code></pre>
+   *
+   * @param name The name of the book to retrieve.
+   * @throws com.google.api.gax.grpc.ApiException if the remote call fails
+   */
+  public final OperationFuture<Empty> getBigNothingAsync(BookName name) {
+
+    GetBookRequest request =
+        GetBookRequest.newBuilder()
+        .setNameWithBookName(name)
+        .build();
+    return getBigNothingAsync(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Test long-running operations with empty return type.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   BookName name = BookName.create("[SHELF_ID]", "[BOOK_ID]");
+   *   GetBookRequest request = GetBookRequest.newBuilder()
+   *     .setNameWithBookName(name)
+   *     .build();
+   *   Empty response = libraryServiceClient.getBigNothingAsync(request).get();
+   * }
+   * </code></pre>
+   *
+   * @param request The request object containing all of the parameters for the API call.
+   * @throws com.google.api.gax.grpc.ApiException if the remote call fails
+   */
+  public final OperationFuture<Empty> getBigNothingAsync(GetBookRequest request) {
+    return getBigNothingOperationCallable().futureCall(request);
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Test long-running operations with empty return type.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   BookName name = BookName.create("[SHELF_ID]", "[BOOK_ID]");
+   *   GetBookRequest request = GetBookRequest.newBuilder()
+   *     .setNameWithBookName(name)
+   *     .build();
+   *   OperationFuture&lt;Operation&gt; future = libraryServiceClient.getBigNothingOperationCallable().futureCall(request);
+   *   // Do something
+   *   Empty response = future.get();
+   * }
+   * </code></pre>
+   */
+  public final OperationCallable<GetBookRequest, Empty> getBigNothingOperationCallable() {
+    return getBigNothingOperationCallable;
+  }
+
+  // AUTO-GENERATED DOCUMENTATION AND METHOD
+  /**
+   * Test long-running operations with empty return type.
+   *
+   * Sample code:
+   * <pre><code>
+   * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
+   *   BookName name = BookName.create("[SHELF_ID]", "[BOOK_ID]");
+   *   GetBookRequest request = GetBookRequest.newBuilder()
+   *     .setNameWithBookName(name)
+   *     .build();
+   *   ListenableFuture&lt;Operation&gt; future = libraryServiceClient.getBigNothingCallable().futureCall(request);
+   *   // Do something
+   *   future.get();
+   * }
+   * </code></pre>
+   */
+  public final UnaryCallable<GetBookRequest, Operation> getBigNothingCallable() {
+    return getBigNothingCallable;
   }
 
   /**

--- a/src/test/java/com/google/api/codegen/testdata/java_mock_service_impl_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_mock_service_impl_library.baseline
@@ -528,4 +528,19 @@ public class MockLibraryServiceImpl extends LibraryServiceImplBase {
     }
   }
 
+  @Override
+  public void getBigNothing(GetBookRequest request,
+    StreamObserver<Operation> responseObserver) {
+    Object response = responses.remove();
+    if (response instanceof Operation) {
+      requests.add(request);
+      responseObserver.onNext((Operation) response);
+      responseObserver.onCompleted();
+    } else if (response instanceof Exception) {
+      responseObserver.onError((Exception) response);
+    } else {
+      responseObserver.onError(new IllegalArgumentException("Unrecognized response type"));
+    }
+  }
+
 }

--- a/src/test/java/com/google/api/codegen/testdata/java_settings_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_settings_library.baseline
@@ -171,6 +171,7 @@ public class LibraryServiceSettings extends ClientSettings {
   private final SimpleCallSettings<AddTagRequest, AddTagResponse> addTagSettings;
   private final SimpleCallSettings<AddLabelRequest, AddLabelResponse> addLabelSettings;
   private final OperationCallSettings<GetBookRequest, Book> getBigBookSettings;
+  private final OperationCallSettings<GetBookRequest, Empty> getBigNothingSettings;
 
   /**
    * Returns the object with the settings used for calls to createShelf.
@@ -340,6 +341,13 @@ public class LibraryServiceSettings extends ClientSettings {
     return getBigBookSettings;
   }
 
+  /**
+   * Returns the object with the settings used for calls to getBigNothing.
+   */
+  public OperationCallSettings<GetBookRequest, Empty> getBigNothingSettings() {
+    return getBigNothingSettings;
+  }
+
 
   /**
    * Returns a builder for the default ExecutorProvider for this service.
@@ -438,6 +446,7 @@ public class LibraryServiceSettings extends ClientSettings {
     addTagSettings = settingsBuilder.addTagSettings().build();
     addLabelSettings = settingsBuilder.addLabelSettings().build();
     getBigBookSettings = settingsBuilder.getBigBookSettings().build();
+    getBigNothingSettings = settingsBuilder.getBigNothingSettings().build();
   }
 
   private static final PagedListDescriptor<ListShelvesRequest, ListShelvesResponse, Shelf> LIST_SHELVES_PAGE_STR_DESC =
@@ -710,6 +719,7 @@ public class LibraryServiceSettings extends ClientSettings {
     private final SimpleCallSettings.Builder<AddTagRequest, AddTagResponse> addTagSettings;
     private final SimpleCallSettings.Builder<AddLabelRequest, AddLabelResponse> addLabelSettings;
     private final OperationCallSettings.Builder<GetBookRequest, Book> getBigBookSettings;
+    private final OperationCallSettings.Builder<GetBookRequest, Empty> getBigNothingSettings;
 
     private static final ImmutableMap<String, ImmutableSet<Status.Code>> RETRYABLE_CODE_DEFINITIONS;
 
@@ -804,6 +814,11 @@ public class LibraryServiceSettings extends ClientSettings {
       getBigBookSettings = OperationCallSettings.newBuilder(
           LibraryServiceGrpc.METHOD_GET_BIG_BOOK,
           Book.class);
+
+
+      getBigNothingSettings = OperationCallSettings.newBuilder(
+          LibraryServiceGrpc.METHOD_GET_BIG_NOTHING,
+          Empty.class);
 
 
       unaryMethodSettingsBuilders = ImmutableList.<UnaryCallSettings.Builder>of(
@@ -922,6 +937,9 @@ public class LibraryServiceSettings extends ClientSettings {
       builder.getBigBookSettings().getInitialCallSettings()
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
           .setRetrySettingsBuilder(RETRY_PARAM_DEFINITIONS.get("default"));
+      builder.getBigNothingSettings().getInitialCallSettings()
+          .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
+          .setRetrySettingsBuilder(RETRY_PARAM_DEFINITIONS.get("default"));
 
       return builder;
     }
@@ -953,6 +971,7 @@ public class LibraryServiceSettings extends ClientSettings {
       addTagSettings = settings.addTagSettings.toBuilder();
       addLabelSettings = settings.addLabelSettings.toBuilder();
       getBigBookSettings = settings.getBigBookSettings.toBuilder();
+      getBigNothingSettings = settings.getBigNothingSettings.toBuilder();
 
       unaryMethodSettingsBuilders = ImmutableList.<UnaryCallSettings.Builder>of(
           createShelfSettings,
@@ -1168,6 +1187,13 @@ public class LibraryServiceSettings extends ClientSettings {
      */
     public OperationCallSettings.Builder<GetBookRequest, Book> getBigBookSettings() {
       return getBigBookSettings;
+    }
+
+    /**
+     * Returns the builder for the settings used for calls to getBigNothing.
+     */
+    public OperationCallSettings.Builder<GetBookRequest, Empty> getBigNothingSettings() {
+      return getBigNothingSettings;
     }
 
     @Override

--- a/src/test/java/com/google/api/codegen/testdata/java_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_test_library.baseline
@@ -1398,4 +1398,48 @@ public class LibraryServiceTest {
   }
 
 
+  @Test
+  @SuppressWarnings("all")
+  public void getBigNothingTest() throws Exception {
+    Empty expectedResponse = Empty.newBuilder().build();
+    Operation resultOperation =
+        Operation.newBuilder()
+            .setName("getBigNothingTest")
+            .setDone(true)
+            .setResponse(Any.pack(expectedResponse))
+            .build();
+    mockLibraryService.addResponse(resultOperation);
+
+    BookName name = BookName.create("[SHELF_ID]", "[BOOK_ID]");
+
+    Empty actualResponse =
+        client.getBigNothingAsync(name).get();
+    Assert.assertEquals(expectedResponse, actualResponse);
+
+    List<GeneratedMessageV3> actualRequests = mockLibraryService.getRequests();
+    Assert.assertEquals(1, actualRequests.size());
+    GetBookRequest actualRequest = (GetBookRequest)actualRequests.get(0);
+
+    Assert.assertEquals(name, actualRequest.getNameAsBookName());
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  public void getBigNothingExceptionTest() throws Exception {
+    StatusRuntimeException exception = new StatusRuntimeException(Status.INTERNAL);
+    mockLibraryService.addException(exception);
+
+    try {
+      BookName name = BookName.create("[SHELF_ID]", "[BOOK_ID]");
+
+      client.getBigNothingAsync(name).get();
+      Assert.fail("No exception raised");
+    } catch (ExecutionException e) {
+      Assert.assertEquals(ApiException.class, e.getCause().getClass());
+      ApiException apiException = (ApiException) e.getCause();
+      Assert.assertEquals(Status.INTERNAL.getCode(), apiException.getStatusCode());
+    }
+  }
+
+
 }

--- a/src/test/java/com/google/api/codegen/testdata/library.proto
+++ b/src/test/java/com/google/api/codegen/testdata/library.proto
@@ -20,7 +20,7 @@ import "tagger.proto";
 option java_multiple_files = true;
 option java_outer_classname = "LibraryProto";
 option java_package = "com.google.example.library.v1";
-option go_package = "google.golang.org/genproto/googleapis/example/library/v1";
+option go_package = "google.golang.org/genproto/googleapis/example/library/v1;library";
 
 // This API represents a simple digital library.  It lets you manage Shelf
 // resources and Book resources in the library. It defines the following
@@ -155,6 +155,11 @@ service LibraryService {
   // Test long-running operations
   rpc GetBigBook(GetBookRequest) returns (google.longrunning.Operation) {
     option (google.api.http) = { get: "/v1/{name=bookShelves/*/books/*}:big" };
+  }
+
+  // Test long-running operations with empty return type.
+  rpc GetBigNothing(GetBookRequest) returns (google.longrunning.Operation) {
+    option (google.api.http) = { get: "/v1/{name=bookShelves/*/books/*}:bignothing" };
   }
 }
 

--- a/src/test/java/com/google/api/codegen/testdata/library_config.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/library_config.baseline
@@ -374,4 +374,17 @@ interfaces:
     field_name_patterns:
       name: book_2
     timeout_millis: 60000
+  - name: GetBigNothing
+    flattening:
+      groups:
+      - parameters:
+        - name
+    required_fields:
+    - name
+    request_object_method: false
+    retry_codes_name: idempotent
+    retry_params_name: default
+    field_name_patterns:
+      name: book_2
+    timeout_millis: 60000
 

--- a/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
@@ -506,6 +506,24 @@ interfaces:
       return_type: google.example.library.v1.Book
       metadata_type: google.example.library.v1.GetBigBookMetadata
       implements_cancel: true
+  - name: GetBigNothing
+    flattening:
+      groups:
+      - parameters:
+        - name
+    required_fields:
+    - name
+    request_object_method: true
+    resource_name_treatment: STATIC_TYPES
+    retry_codes_name: non_idempotent
+    retry_params_name: default
+    field_name_patterns:
+      name: book
+    timeout_millis: 60000
+    long_running:
+      return_type: google.protobuf.Empty
+      metadata_type: google.example.library.v1.GetBigBookMetadata
+      implements_delete: true
 resource_name_generation:
 - message_name: Book
   field_entity_map:

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_doc_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_doc_json_library.baseline
@@ -149,6 +149,11 @@
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
+        },
+        "GetBigNothing": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
         }
       }
     }

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_doc_main_library.baseline
@@ -141,6 +141,10 @@ function LibraryServiceClient(gaxGrpc, grpcClients, opts) {
     getBigBook: new gax.LongrunningDescriptor(
       operationsClient,
       grpcClients.google.example.library.v1.Book.decode,
+      grpcClients.google.example.library.v1.GetBigBookMetadata.decode),
+    getBigNothing: new gax.LongrunningDescriptor(
+      operationsClient,
+      grpcClients.google.protobuf.Empty.decode,
       grpcClients.google.example.library.v1.GetBigBookMetadata.decode)
   };
 
@@ -180,7 +184,8 @@ function LibraryServiceClient(gaxGrpc, grpcClients, opts) {
     'discussBook',
     'findRelatedBooks',
     'addTag',
-    'getBigBook'
+    'getBigBook',
+    'getBigNothing'
   ];
   libraryServiceStubMethods.forEach(function(methodName) {
     self['_' + methodName] = gax.createApiCall(
@@ -1784,6 +1789,86 @@ LibraryServiceClient.prototype.getBigBook = function(request, options, callback)
   }
 
   return this._getBigBook(request, options, callback);
+};
+
+/**
+ * Test long-running operations with empty return type.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   The name of the book to retrieve.
+ * @param {Object=} options
+ *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+ *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+ * @param {function(?Error, ?Object)=} callback
+ *   The function which will be called with the result of the API call.
+ *
+ *   The second parameter to the callback is a [gax.Operation]{@link https://googleapis.github.io/gax-nodejs/Operation} object.
+ * @return {Promise} - The promise which resolves to an array.
+ *   The first element of the array is a [gax.Operation]{@link https://googleapis.github.io/gax-nodejs/Operation} object.
+ *   The promise has a method named "cancel" which cancels the ongoing API call.
+ *
+ * @example
+ *
+ * var client = libraryV1.libraryServiceClient();
+ * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
+ *
+ * // Handle the operation using the promise pattern.
+ * client.getBigNothing({name: formattedName}).then(function(responses) {
+ *     var operation = responses[0];
+ *     var initialApiResponse = responses[1];
+ *
+ *     // Operation#promise starts polling for the completion of the LRO.
+ *     return operation.promise();
+ * }).then(function(responses) {
+ *     // The final result of the operation.
+ *     var result = responses[0];
+ *
+ *     // The metadata value of the completed operation.
+ *     var metadata = responses[1];
+ *
+ *     // The response of the api call returning the complete operation.
+ *     var finalApiResponse = responses[2];
+ * }).catch(function(err) {
+ *     console.error(err);
+ * });
+ *
+ * // Handle the operation using the event emitter pattern.
+ * client.getBigNothing({name: formattedName}).then(function(responses) {
+ *     var operation = responses[0];
+ *     var initialApiResponse = responses[1];
+ *
+ *     // Adding a listener for the "complete" event starts polling for the
+ *     // completion of the operation.
+ *     operation.on('complete', function(result, metadata, finalApiResponse) {
+ *       // doSomethingWith(result);
+ *     });
+ *
+ *     // Adding a listener for the "progress" event causes the callback to be
+ *     // called on any change in metadata when the operation is polled.
+ *     operation.on('progress', function(metadata, apiResponse) {
+ *       // doSomethingWith(metadata)
+ *     })
+ *
+ *     // Adding a listener for the "error" event handles any errors found during polling.
+ *     operation.on('error', function(err) {
+ *       // throw(err);
+ *     })
+ * }).catch(function(err) {
+ *     console.error(err);
+ * });
+ */
+LibraryServiceClient.prototype.getBigNothing = function(request, options, callback) {
+  if (options instanceof Function && callback === undefined) {
+    callback = options;
+    options = {};
+  }
+  if (options === undefined) {
+    options = {};
+  }
+
+  return this._getBigNothing(request, options, callback);
 };
 
 function LibraryServiceClientBuilder(gaxGrpc) {

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_json_library.baseline
@@ -149,6 +149,11 @@
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
+        },
+        "GetBigNothing": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
         }
       }
     }

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_main_library.baseline
@@ -141,6 +141,10 @@ function LibraryServiceClient(gaxGrpc, grpcClients, opts) {
     getBigBook: new gax.LongrunningDescriptor(
       operationsClient,
       grpcClients.google.example.library.v1.Book.decode,
+      grpcClients.google.example.library.v1.GetBigBookMetadata.decode),
+    getBigNothing: new gax.LongrunningDescriptor(
+      operationsClient,
+      grpcClients.google.protobuf.Empty.decode,
       grpcClients.google.example.library.v1.GetBigBookMetadata.decode)
   };
 
@@ -180,7 +184,8 @@ function LibraryServiceClient(gaxGrpc, grpcClients, opts) {
     'discussBook',
     'findRelatedBooks',
     'addTag',
-    'getBigBook'
+    'getBigBook',
+    'getBigNothing'
   ];
   libraryServiceStubMethods.forEach(function(methodName) {
     self['_' + methodName] = gax.createApiCall(
@@ -1784,6 +1789,86 @@ LibraryServiceClient.prototype.getBigBook = function(request, options, callback)
   }
 
   return this._getBigBook(request, options, callback);
+};
+
+/**
+ * Test long-running operations with empty return type.
+ *
+ * @param {Object} request
+ *   The request object that will be sent.
+ * @param {string} request.name
+ *   The name of the book to retrieve.
+ * @param {Object=} options
+ *   Optional parameters. You can override the default settings for this call, e.g, timeout,
+ *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
+ * @param {function(?Error, ?Object)=} callback
+ *   The function which will be called with the result of the API call.
+ *
+ *   The second parameter to the callback is a [gax.Operation]{@link https://googleapis.github.io/gax-nodejs/Operation} object.
+ * @return {Promise} - The promise which resolves to an array.
+ *   The first element of the array is a [gax.Operation]{@link https://googleapis.github.io/gax-nodejs/Operation} object.
+ *   The promise has a method named "cancel" which cancels the ongoing API call.
+ *
+ * @example
+ *
+ * var client = libraryV1.libraryServiceClient();
+ * var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
+ *
+ * // Handle the operation using the promise pattern.
+ * client.getBigNothing({name: formattedName}).then(function(responses) {
+ *     var operation = responses[0];
+ *     var initialApiResponse = responses[1];
+ *
+ *     // Operation#promise starts polling for the completion of the LRO.
+ *     return operation.promise();
+ * }).then(function(responses) {
+ *     // The final result of the operation.
+ *     var result = responses[0];
+ *
+ *     // The metadata value of the completed operation.
+ *     var metadata = responses[1];
+ *
+ *     // The response of the api call returning the complete operation.
+ *     var finalApiResponse = responses[2];
+ * }).catch(function(err) {
+ *     console.error(err);
+ * });
+ *
+ * // Handle the operation using the event emitter pattern.
+ * client.getBigNothing({name: formattedName}).then(function(responses) {
+ *     var operation = responses[0];
+ *     var initialApiResponse = responses[1];
+ *
+ *     // Adding a listener for the "complete" event starts polling for the
+ *     // completion of the operation.
+ *     operation.on('complete', function(result, metadata, finalApiResponse) {
+ *       // doSomethingWith(result);
+ *     });
+ *
+ *     // Adding a listener for the "progress" event causes the callback to be
+ *     // called on any change in metadata when the operation is polled.
+ *     operation.on('progress', function(metadata, apiResponse) {
+ *       // doSomethingWith(metadata)
+ *     })
+ *
+ *     // Adding a listener for the "error" event handles any errors found during polling.
+ *     operation.on('error', function(err) {
+ *       // throw(err);
+ *     })
+ * }).catch(function(err) {
+ *     console.error(err);
+ * });
+ */
+LibraryServiceClient.prototype.getBigNothing = function(request, options, callback) {
+  if (options instanceof Function && callback === undefined) {
+    callback = options;
+    options = {};
+  }
+  if (options === undefined) {
+    options = {};
+  }
+
+  return this._getBigNothing(request, options, callback);
 };
 
 function LibraryServiceClientBuilder(gaxGrpc) {

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_test_library.baseline
@@ -691,4 +691,26 @@ describe('LibraryServiceClient', function() {
     });
   });
 
+  describe('getBigNothingAsync', function() {
+    it('invokes getBigNothingAsync without error', function(done) {
+      var client = service.libraryServiceClient();
+      // Mock request
+      var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
+      var request = {
+          name : formattedName
+      };
+
+      // Mock Grpc layer
+      client._getBigNothingAsync = function(actualRequest, options, callback) {
+        assert.deepStrictEqual(actualRequest, request);
+        callback(null);
+      };
+
+      client.getBigNothingAsync(request, function(err) {
+        assert.ifError(err);
+        done();
+      });
+    });
+  });
+
 });

--- a/src/test/java/com/google/api/codegen/testdata/php_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php_json_library.baseline
@@ -149,6 +149,11 @@
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
+        },
+        "GetBigNothing": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
         }
       }
     }

--- a/src/test/java/com/google/api/codegen/testdata/php_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php_main_library.baseline
@@ -373,6 +373,7 @@ class LibraryServiceClient
             'addTag' => $defaultDescriptors,
             'addLabel' => $defaultDescriptors,
             'getBigBook' => $defaultDescriptors,
+            'getBigNothing' => $defaultDescriptors,
         ];
         $pageStreamingDescriptors = self::getPageStreamingDescriptors();
         foreach ($pageStreamingDescriptors as $method => $pageStreamingDescriptor) {
@@ -1552,6 +1553,53 @@ class LibraryServiceClient
             new CallSettings($optionalArgs));
         $callable = ApiCallable::createApiCall(
             $this->libraryServiceStub, 'GetBigBook', $mergedSettings, $this->descriptors['getBigBook']);
+
+        return $callable(
+            $request,
+            [],
+            ['call_credentials_callback' => $this->createCredentialsCallback()]);
+    }
+
+    /**
+     * Test long-running operations with empty return type.
+     *
+     * Sample code:
+     * ```
+     * try {
+     *     $libraryServiceClient = new LibraryServiceClient();
+     *     $formattedName = LibraryServiceClient::formatBookName("[SHELF_ID]", "[BOOK_ID]");
+     *     $response = $libraryServiceClient->getBigNothing($formattedName);
+     * } finally {
+     *     if (isset($libraryServiceClient)) {
+     *         $libraryServiceClient->close();
+     *     }
+     * }
+     * ```
+     *
+     * @param string $name The name of the book to retrieve.
+     * @param array $optionalArgs {
+     *     Optional.
+     *     @type \Google\GAX\RetrySettings $retrySettings
+     *          Retry settings to use for this call. If present, then
+     *          $timeoutMillis is ignored.
+     *     @type int $timeoutMillis
+     *          Timeout to use for this call. Only used if $retrySettings
+     *          is not set.
+     * }
+     *
+     * @return \google\longrunning\Operation
+     *
+     * @throws \Google\GAX\ApiException if the remote call fails
+     */
+    public function getBigNothing($name, $optionalArgs = [])
+    {
+        $request = new GetBookRequest();
+        $request->setName($name);
+
+        $mergedSettings = $this->defaultCallSettings['getBigNothing']->merge(
+            new CallSettings($optionalArgs));
+        $callable = ApiCallable::createApiCall(
+            $this->libraryServiceStub, 'GetBigNothing', $mergedSettings, $this->descriptors['getBigNothing']);
 
         return $callable(
             $request,

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_json_library.baseline
@@ -149,6 +149,11 @@
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
+        },
+        "GetBigNothing": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
         }
       }
     }

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
@@ -370,6 +370,9 @@ class LibraryServiceClient(object):
         self._get_big_book = api_callable.create_api_call(
             self.library_service_stub.GetBigBook,
             settings=defaults['get_big_book'])
+        self._get_big_nothing = api_callable.create_api_call(
+            self.library_service_stub.GetBigNothing,
+            settings=defaults['get_big_nothing'])
 
     # Service calls
     def create_shelf(
@@ -1235,4 +1238,33 @@ class LibraryServiceClient(object):
         request = library_pb2.GetBookRequest(
             name=name)
         return self._get_big_book(request, options)
+
+    def get_big_nothing(
+            self,
+            name,
+            options=None):
+        """
+        Test long-running operations with empty return type.
+
+        Example:
+          >>> from google.cloud.gapic.example.library.v1 import library_service_client
+          >>> api = library_service_client.LibraryServiceClient()
+          >>> name = api.book_path('[SHELF_ID]', '[BOOK_ID]')
+          >>> response = api.get_big_nothing(name)
+
+        Args:
+          name (string): The name of the book to retrieve.
+          options (:class:`google.gax.CallOptions`): Overrides the default
+            settings for this call, e.g, timeout, retries etc.
+
+        Returns:
+          A :class:`google.longrunning.operations_pb2.Operation` instance.
+
+        Raises:
+          :exc:`google.gax.errors.GaxError` if the RPC is aborted.
+          :exc:`ValueError` if the parameters are invalid.
+        """
+        request = library_pb2.GetBookRequest(
+            name=name)
+        return self._get_big_nothing(request, options)
 

--- a/src/test/java/com/google/api/codegen/testdata/python_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_json_library.baseline
@@ -149,6 +149,11 @@
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
+        },
+        "GetBigNothing": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
         }
       }
     }

--- a/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
@@ -370,6 +370,9 @@ class LibraryServiceClient(object):
         self._get_big_book = api_callable.create_api_call(
             self.library_service_stub.GetBigBook,
             settings=defaults['get_big_book'])
+        self._get_big_nothing = api_callable.create_api_call(
+            self.library_service_stub.GetBigNothing,
+            settings=defaults['get_big_nothing'])
 
     # Service calls
     def create_shelf(
@@ -1235,4 +1238,33 @@ class LibraryServiceClient(object):
         request = library_pb2.GetBookRequest(
             name=name)
         return self._get_big_book(request, options)
+
+    def get_big_nothing(
+            self,
+            name,
+            options=None):
+        """
+        Test long-running operations with empty return type.
+
+        Example:
+          >>> from google.cloud.gapic.example.library.v1 import library_service_client
+          >>> api = library_service_client.LibraryServiceClient()
+          >>> name = api.book_path('[SHELF_ID]', '[BOOK_ID]')
+          >>> response = api.get_big_nothing(name)
+
+        Args:
+          name (string): The name of the book to retrieve.
+          options (:class:`google.gax.CallOptions`): Overrides the default
+            settings for this call, e.g, timeout, retries etc.
+
+        Returns:
+          A :class:`google.longrunning.operations_pb2.Operation` instance.
+
+        Raises:
+          :exc:`google.gax.errors.GaxError` if the RPC is aborted.
+          :exc:`ValueError` if the parameters are invalid.
+        """
+        request = library_pb2.GetBookRequest(
+            name=name)
+        return self._get_big_nothing(request, options)
 

--- a/src/test/java/com/google/api/codegen/testdata/ruby_doc_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_doc_json_library.baseline
@@ -149,6 +149,11 @@
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
+        },
+        "GetBigNothing": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
         }
       }
     }

--- a/src/test/java/com/google/api/codegen/testdata/ruby_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_doc_main_library.baseline
@@ -375,6 +375,10 @@ module Library
           @library_service_stub.method(:get_big_book),
           defaults["get_big_book"]
         )
+        @get_big_nothing = Google::Gax.create_api_call(
+          @library_service_stub.method(:get_big_nothing),
+          defaults["get_big_nothing"]
+        )
         @add_label = Google::Gax.create_api_call(
           @labeler_stub.method(:add_label),
           defaults["add_label"]
@@ -1263,6 +1267,67 @@ module Library
           @get_big_book.call(req, options),
           @operations_client,
           Google::Example::Library::V1::Book,
+          Google::Example::Library::V1::GetBigBookMetadata,
+          call_options: options
+        )
+        operation.on_done { |operation| yield(operation) } if block_given?
+        operation
+      end
+
+      # Test long-running operations with empty return type.
+      #
+      # @param name [String]
+      #   The name of the book to retrieve.
+      # @param options [Google::Gax::CallOptions]
+      #   Overrides the default settings for this call, e.g, timeout,
+      #   retries, etc.
+      # @return [Google::Gax::Operation]
+      # @raise [Google::Gax::GaxError] if the RPC is aborted.
+      # @example
+      #   require "library/v1/library_service_client"
+      #
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #
+      #   library_service_client = LibraryServiceClient.new
+      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #
+      #   # Register a callback during the method call.
+      #   operation = library_service_client.get_big_nothing(formatted_name) do |op|
+      #     raise op.results.message if op.error?
+      #     results = op.results
+      #     # Process the results.
+      #
+      #     metadata = op.metadata
+      #     # Process the metadata.
+      #   end
+      #
+      #   # Or use the return value to register a callback.
+      #   operation.on_done do |op|
+      #     raise op.results.message if op.error?
+      #     results = op.results
+      #     # Process the results.
+      #
+      #     metadata = op.metadata
+      #     # Process the metadata.
+      #   end
+      #
+      #   # Manually reload the operation.
+      #   operation.reload!
+      #
+      #   # Or block until the operation completes, triggering callbacks on
+      #   # completion.
+      #   operation.wait_until_done!
+
+      def get_big_nothing \
+          name,
+          options: nil
+        req = Google::Example::Library::V1::GetBookRequest.new({
+          name: name
+        }.delete_if { |_, v| v.nil? })
+        operation = Google::Gax::Operation.new(
+          @get_big_nothing.call(req, options),
+          @operations_client,
+          Google::Protobuf::Empty,
           Google::Example::Library::V1::GetBigBookMetadata,
           call_options: options
         )

--- a/src/test/java/com/google/api/codegen/testdata/ruby_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_json_library.baseline
@@ -149,6 +149,11 @@
           "timeout_millis": 60000,
           "retry_codes_name": "non_idempotent",
           "retry_params_name": "default"
+        },
+        "GetBigNothing": {
+          "timeout_millis": 60000,
+          "retry_codes_name": "non_idempotent",
+          "retry_params_name": "default"
         }
       }
     }

--- a/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
@@ -375,6 +375,10 @@ module Library
           @library_service_stub.method(:get_big_book),
           defaults["get_big_book"]
         )
+        @get_big_nothing = Google::Gax.create_api_call(
+          @library_service_stub.method(:get_big_nothing),
+          defaults["get_big_nothing"]
+        )
         @add_label = Google::Gax.create_api_call(
           @labeler_stub.method(:add_label),
           defaults["add_label"]
@@ -1263,6 +1267,67 @@ module Library
           @get_big_book.call(req, options),
           @operations_client,
           Google::Example::Library::V1::Book,
+          Google::Example::Library::V1::GetBigBookMetadata,
+          call_options: options
+        )
+        operation.on_done { |operation| yield(operation) } if block_given?
+        operation
+      end
+
+      # Test long-running operations with empty return type.
+      #
+      # @param name [String]
+      #   The name of the book to retrieve.
+      # @param options [Google::Gax::CallOptions]
+      #   Overrides the default settings for this call, e.g, timeout,
+      #   retries, etc.
+      # @return [Google::Gax::Operation]
+      # @raise [Google::Gax::GaxError] if the RPC is aborted.
+      # @example
+      #   require "library/v1/library_service_client"
+      #
+      #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #
+      #   library_service_client = LibraryServiceClient.new
+      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #
+      #   # Register a callback during the method call.
+      #   operation = library_service_client.get_big_nothing(formatted_name) do |op|
+      #     raise op.results.message if op.error?
+      #     results = op.results
+      #     # Process the results.
+      #
+      #     metadata = op.metadata
+      #     # Process the metadata.
+      #   end
+      #
+      #   # Or use the return value to register a callback.
+      #   operation.on_done do |op|
+      #     raise op.results.message if op.error?
+      #     results = op.results
+      #     # Process the results.
+      #
+      #     metadata = op.metadata
+      #     # Process the metadata.
+      #   end
+      #
+      #   # Manually reload the operation.
+      #   operation.reload!
+      #
+      #   # Or block until the operation completes, triggering callbacks on
+      #   # completion.
+      #   operation.wait_until_done!
+
+      def get_big_nothing \
+          name,
+          options: nil
+        req = Google::Example::Library::V1::GetBookRequest.new({
+          name: name
+        }.delete_if { |_, v| v.nil? })
+        operation = Google::Gax::Operation.new(
+          @get_big_nothing.call(req, options),
+          @operations_client,
+          Google::Protobuf::Empty,
           Google::Example::Library::V1::GetBigBookMetadata,
           call_options: options
         )

--- a/src/test/java/com/google/api/codegen/transformer/go/GoModelTypeNameConverterTest.java
+++ b/src/test/java/com/google/api/codegen/transformer/go/GoModelTypeNameConverterTest.java
@@ -65,6 +65,6 @@ public class GoModelTypeNameConverterTest {
                 .getTypeName(
                     "google.golang.org/genproto/zip/zap;smack", "foo.bar", "Baz", isPointerFalse)
                 .getNickname())
-        .isEqualTo("smack.Baz");
+        .isEqualTo("smackpb.Baz");
   }
 }


### PR DESCRIPTION
A new method GetBigNothing is added to library.proto and corresponding
config to test this behavior.

Package naming also changed slightly:
Previously, if a proto file declare a go_package option with
package name, the name is used in imports.
If the proto file does not declare the name,
we infer the name from the package declaration and add "pb" to it.

Now, all proto files in googleapis has been updated with go_package,
following above rules will drop "pb" from the import name.
This is still correct but causes a large amount of useless diff.
The fix is to add the "pb" back.