### PR TITLE
make Go tests forward-compatible

### DIFF
--- a/src/main/resources/com/google/api/codegen/go/mock.snip
+++ b/src/main/resources/com/google/api/codegen/go/mock.snip
@@ -33,6 +33,11 @@
 
     @join impl : view.serviceImpls
         type {@impl.name} struct {
+            // Embed for forward compatibility.
+            // Tests will keep working if more methods are added
+            // in the future.
+            {@impl.grpcClassName}
+
             reqs []proto.Message
 
             // If set, all calls return this error.

--- a/src/test/java/com/google/api/codegen/testdata/go_mock_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_mock_library.baseline
@@ -46,6 +46,11 @@ var _ = ptypes.MarshalAny
 var _ status.Status
 
 type mockLibraryServer struct {
+    // Embed for forward compatibility.
+    // Tests will keep working if more methods are added
+    // in the future.
+    librarypb.LibraryServiceServer
+
     reqs []proto.Message
 
     // If set, all calls return this error.
@@ -271,6 +276,11 @@ func (s *mockLibraryServer) GetBigNothing(_ context.Context, req *librarypb.GetB
 }
 
 type mockLabelerServer struct {
+    // Embed for forward compatibility.
+    // Tests will keep working if more methods are added
+    // in the future.
+    taggerpb.LabelerServer
+
     reqs []proto.Message
 
     // If set, all calls return this error.


### PR DESCRIPTION
When mocking servers, we generate all methods to satisfy the server
interface. On the other hand, adding more methods to services is
considered non-breaking change in protobuf.
This breaks the existing tests though, since the newly added method
won't be implemented.

This change fixes the problem by embedding a nil server interface
in the mock. This way the mock always implements the interface,
even though some methods might not actually be implemented.
The methods on both the client and the mock will just be added
the next time the generator is run.