### PR TITLE
Auto-generate index.js for NodeJS

### DIFF
--- a/src/main/java/com/google/api/codegen/gapic/MainGapicProviderFactory.java
+++ b/src/main/java/com/google/api/codegen/gapic/MainGapicProviderFactory.java
@@ -38,6 +38,7 @@ import com.google.api.codegen.transformer.go.GoGapicSurfaceTransformer;
 import com.google.api.codegen.transformer.java.JavaGapicSurfaceTestTransformer;
 import com.google.api.codegen.transformer.java.JavaGapicSurfaceTransformer;
 import com.google.api.codegen.transformer.nodejs.NodeJSGapicSurfaceTestTransformer;
+import com.google.api.codegen.transformer.nodejs.NodeJSGapicSurfaceTransformer;
 import com.google.api.codegen.transformer.nodejs.NodeJSPackageMetadataTransformer;
 import com.google.api.codegen.transformer.php.PhpGapicSurfaceTransformer;
 import com.google.api.codegen.util.CommonRenderingUtil;
@@ -176,6 +177,7 @@ public class MainGapicProviderFactory
     } else if (id.equals(NODEJS) || id.equals(NODEJS_DOC)) {
       if (generatorConfig.enableSurfaceGenerator()) {
         GapicCodePathMapper nodeJSPathMapper = new NodeJSCodePathMapper();
+        // TODO: Replace mainProvider with surfaceProvider once NodeJS is MVVM ready
         GapicProvider<? extends Object> mainProvider =
             CommonGapicProvider.<Interface>newBuilder()
                 .setModel(model)
@@ -193,6 +195,13 @@ public class MainGapicProviderFactory
                 .setSnippetSetRunner(new CommonSnippetSetRunner(new CommonRenderingUtil()))
                 .setModelToViewTransformer(new NodeJSPackageMetadataTransformer())
                 .build();
+        GapicProvider<? extends Object> surfaceProvider =
+            ViewModelGapicProvider.newBuilder()
+                .setModel(model)
+                .setApiConfig(apiConfig)
+                .setSnippetSetRunner(new CommonSnippetSetRunner(new CommonRenderingUtil()))
+                .setModelToViewTransformer(new NodeJSGapicSurfaceTransformer())
+                .build();
         GapicProvider<? extends Object> clientConfigProvider =
             CommonGapicProvider.<Interface>newBuilder()
                 .setModel(model)
@@ -206,6 +215,7 @@ public class MainGapicProviderFactory
                 .build();
 
         providers.add(mainProvider);
+        providers.add(surfaceProvider);
         providers.add(metadataProvider);
         providers.add(clientConfigProvider);
 

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTestTransformer.java
@@ -119,6 +119,7 @@ public class NodeJSGapicSurfaceTestTransformer implements ModelToViewTransformer
         .serviceImpls(impls)
         .mockServices(new ArrayList<MockServiceUsageView>())
         .testClasses(testClasses)
+        .apiWrapperModuleName(namer.getApiWrapperModuleName())
         .templateFileName(TEST_TEMPLATE_FILE)
         .fileHeader(
             fileHeaderTransformer.generateFileHeader(apiConfig, typeTable.getImports(), namer))

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTransformer.java
@@ -1,0 +1,75 @@
+/* Copyright 2016 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.transformer.nodejs;
+
+import com.google.api.codegen.InterfaceView;
+import com.google.api.codegen.config.ApiConfig;
+import com.google.api.codegen.transformer.ModelToViewTransformer;
+import com.google.api.codegen.viewmodel.ViewModel;
+import com.google.api.codegen.viewmodel.metadata.IndexRequireView;
+import com.google.api.codegen.viewmodel.metadata.IndexView;
+import com.google.api.tools.framework.model.Interface;
+import com.google.api.tools.framework.model.Model;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Responsible for producing GAPIC surface views for NodeJS
+ *
+ * <p>NOTE: Currently NodeJS is not MVVM yet. This transformer only produces views for index.js.
+ */
+public class NodeJSGapicSurfaceTransformer implements ModelToViewTransformer {
+  private static final String INDEX_TEMPLATE_FILE = "nodejs/index.snip";
+
+  @Override
+  public List<String> getTemplateFileNames() {
+    return Collections.singletonList(INDEX_TEMPLATE_FILE);
+  }
+
+  @Override
+  public List<ViewModel> transform(Model model, ApiConfig apiConfig) {
+    Iterable<Interface> services = new InterfaceView().getElementIterable(model);
+    List<ViewModel> models = new ArrayList<ViewModel>();
+    NodeJSSurfaceNamer surfaceNamer = new NodeJSSurfaceNamer(apiConfig.getPackageName());
+    models.add(generateIndexView(services, surfaceNamer));
+
+    return models;
+  }
+
+  private ViewModel generateIndexView(Iterable<Interface> services, NodeJSSurfaceNamer namer) {
+    ArrayList<IndexRequireView> requireViews = new ArrayList<>();
+    for (Interface service : services) {
+      requireViews.add(
+          IndexRequireView.newBuilder()
+              .clientName(namer.getApiWrapperClassName(service))
+              .fileName(namer.getClientFileName(service))
+              .build());
+    }
+    String version = namer.getApiWrapperModuleVersion();
+    boolean hasVersion = version != null && !version.isEmpty();
+    String outputPath = hasVersion ? "src/" + version + "/index.js" : "src/index.js";
+    IndexView.Builder builder =
+        IndexView.newBuilder()
+            .templateFileName(INDEX_TEMPLATE_FILE)
+            .outputPath(outputPath)
+            .requireViews(requireViews)
+            .primaryService(requireViews.get(0));
+    if (hasVersion) {
+      builder.apiVersion(version);
+    }
+    return builder.build();
+  }
+}

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSPackageMetadataTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSPackageMetadataTransformer.java
@@ -28,7 +28,6 @@ import java.util.List;
 /** Responsible for producing package metadata related views for NodeJS */
 public class NodeJSPackageMetadataTransformer implements ModelToViewTransformer {
   private static final String PACKAGE_FILE = "nodejs/package.snip";
-  private static final String INDEX_FILE = "nodejs/index.snip";
 
   // TODO: Retrieve the following values from static file
   // Github issue: https://github.com/googleapis/toolkit/issues/848
@@ -41,7 +40,6 @@ public class NodeJSPackageMetadataTransformer implements ModelToViewTransformer 
   public List<String> getTemplateFileNames() {
     List<String> fileNames = new ArrayList<>();
     fileNames.add(PACKAGE_FILE);
-    fileNames.add(INDEX_FILE);
     return fileNames;
   }
 
@@ -50,10 +48,10 @@ public class NodeJSPackageMetadataTransformer implements ModelToViewTransformer 
     Iterable<Interface> services = new InterfaceView().getElementIterable(model);
     boolean hasMultipleServices = Iterables.size(services) > 1;
     List<ViewModel> models = new ArrayList<ViewModel>();
-    NodeJSPackageMetadataNamer metadataNamer =
+    NodeJSPackageMetadataNamer namer =
         new NodeJSPackageMetadataNamer(
             apiConfig.getPackageName(), apiConfig.getDomainLayerLocation());
-    models.add(generateMetadataView(metadataNamer, hasMultipleServices));
+    models.add(generateMetadataView(namer, hasMultipleServices));
     return models;
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSPackageMetadataTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSPackageMetadataTransformer.java
@@ -23,6 +23,7 @@ import com.google.api.tools.framework.model.Interface;
 import com.google.api.tools.framework.model.Model;
 import com.google.common.collect.Iterables;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /** Responsible for producing package metadata related views for NodeJS */
@@ -38,9 +39,7 @@ public class NodeJSPackageMetadataTransformer implements ModelToViewTransformer 
 
   @Override
   public List<String> getTemplateFileNames() {
-    List<String> fileNames = new ArrayList<>();
-    fileNames.add(PACKAGE_FILE);
-    return fileNames;
+    return Arrays.asList(PACKAGE_FILE);
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSPackageMetadataTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSPackageMetadataTransformer.java
@@ -18,8 +18,6 @@ import com.google.api.codegen.InterfaceView;
 import com.google.api.codegen.config.ApiConfig;
 import com.google.api.codegen.transformer.ModelToViewTransformer;
 import com.google.api.codegen.viewmodel.ViewModel;
-import com.google.api.codegen.viewmodel.metadata.IndexRequireView;
-import com.google.api.codegen.viewmodel.metadata.IndexView;
 import com.google.api.codegen.viewmodel.metadata.PackageMetadataView;
 import com.google.api.tools.framework.model.Interface;
 import com.google.api.tools.framework.model.Model;
@@ -56,10 +54,6 @@ public class NodeJSPackageMetadataTransformer implements ModelToViewTransformer 
         new NodeJSPackageMetadataNamer(
             apiConfig.getPackageName(), apiConfig.getDomainLayerLocation());
     models.add(generateMetadataView(metadataNamer, hasMultipleServices));
-
-    NodeJSSurfaceNamer surfaceNamer = new NodeJSSurfaceNamer(apiConfig.getPackageName());
-    models.add(generateIndexView(services, surfaceNamer));
-
     return models;
   }
 
@@ -76,29 +70,5 @@ public class NodeJSPackageMetadataTransformer implements ModelToViewTransformer 
         .serviceName(namer.getMetadataName())
         .hasMultipleServices(hasMultipleServices)
         .build();
-  }
-
-  private ViewModel generateIndexView(Iterable<Interface> services, NodeJSSurfaceNamer namer) {
-    ArrayList<IndexRequireView> requireViews = new ArrayList<>();
-    for (Interface service : services) {
-      requireViews.add(
-          IndexRequireView.newBuilder()
-              .clientName(namer.getApiWrapperClassName(service))
-              .fileName(namer.getClientFileName(service))
-              .build());
-    }
-    String version = namer.getApiWrapperModuleVersion();
-    boolean hasVersion = version != null && !version.isEmpty();
-    String outputPath = hasVersion ? "src/" + version + "/index.js" : "src/index.js";
-    IndexView.Builder builder =
-        IndexView.newBuilder()
-            .templateFileName(INDEX_FILE)
-            .outputPath(outputPath)
-            .requireViews(requireViews)
-            .primaryService(requireViews.get(0));
-    if (hasVersion) {
-      builder.apiVersion(version);
-    }
-    return builder.build();
   }
 }

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSSurfaceNamer.java
@@ -112,6 +112,10 @@ public class NodeJSSurfaceNamer extends SurfaceNamer {
         + ".json";
   }
 
+  public String getClientFileName(Interface service) {
+    return Name.upperCamel(service.getSimpleName()).join("client").toLowerUnderscore();
+  }
+
   @Override
   public boolean shouldImportRequestObjectParamType(Field field) {
     return field.getType().isMap();

--- a/src/main/java/com/google/api/codegen/viewmodel/metadata/IndexRequireView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/metadata/IndexRequireView.java
@@ -1,0 +1,38 @@
+/* Copyright 2016 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.viewmodel.metadata;
+
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class IndexRequireView {
+
+  public abstract String clientName();
+
+  public abstract String fileName();
+
+  public static Builder newBuilder() {
+    return new AutoValue_IndexRequireView.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder clientName(String val);
+
+    public abstract Builder fileName(String val);
+
+    public abstract IndexRequireView build();
+  }
+}

--- a/src/main/java/com/google/api/codegen/viewmodel/metadata/IndexView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/metadata/IndexView.java
@@ -12,13 +12,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.api.codegen.viewmodel;
+package com.google.api.codegen.viewmodel.metadata;
 
 import com.google.api.codegen.SnippetSetRunner;
+import com.google.api.codegen.viewmodel.ViewModel;
 import com.google.auto.value.AutoValue;
+import java.util.List;
 
 @AutoValue
-public abstract class PackageMetadataView implements ViewModel {
+public abstract class IndexView implements ViewModel {
 
   @Override
   public String resourceRoot() {
@@ -31,20 +33,19 @@ public abstract class PackageMetadataView implements ViewModel {
   @Override
   public abstract String outputPath();
 
-  public abstract String identifier();
+  public abstract IndexRequireView primaryService();
 
-  public abstract String version();
+  public abstract String apiVersion();
 
-  public abstract String gaxVersion();
+  public abstract List<IndexRequireView> requireViews();
 
-  public abstract String protoVersion();
-
-  public abstract String serviceName();
-
-  public abstract String url();
+  public boolean hasMultipleServices() {
+    return requireViews().size() > 1;
+  }
 
   public static Builder newBuilder() {
-    return new AutoValue_PackageMetadataView.Builder();
+    // Use v1 as the default version.
+    return new AutoValue_IndexView.Builder().apiVersion("v1");
   }
 
   @AutoValue.Builder
@@ -53,18 +54,12 @@ public abstract class PackageMetadataView implements ViewModel {
 
     public abstract Builder templateFileName(String val);
 
-    public abstract Builder identifier(String val);
+    public abstract Builder primaryService(IndexRequireView val);
 
-    public abstract Builder version(String val);
+    public abstract Builder apiVersion(String val);
 
-    public abstract Builder gaxVersion(String val);
+    public abstract Builder requireViews(List<IndexRequireView> val);
 
-    public abstract Builder protoVersion(String val);
-
-    public abstract Builder serviceName(String val);
-
-    public abstract Builder url(String val);
-
-    public abstract PackageMetadataView build();
+    public abstract IndexView build();
   }
 }

--- a/src/main/java/com/google/api/codegen/viewmodel/metadata/PackageMetadataView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/metadata/PackageMetadataView.java
@@ -1,0 +1,75 @@
+/* Copyright 2016 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.viewmodel.metadata;
+
+import com.google.api.codegen.SnippetSetRunner;
+import com.google.api.codegen.viewmodel.ViewModel;
+import com.google.auto.value.AutoValue;
+
+@AutoValue
+public abstract class PackageMetadataView implements ViewModel {
+
+  @Override
+  public String resourceRoot() {
+    return SnippetSetRunner.SNIPPET_RESOURCE_ROOT;
+  }
+
+  @Override
+  public abstract String templateFileName();
+
+  @Override
+  public abstract String outputPath();
+
+  public abstract String identifier();
+
+  public abstract String version();
+
+  public abstract String gaxVersion();
+
+  public abstract String protoVersion();
+
+  public abstract String serviceName();
+
+  public abstract boolean hasMultipleServices();
+
+  public abstract String url();
+
+  public static Builder newBuilder() {
+    return new AutoValue_PackageMetadataView.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder outputPath(String val);
+
+    public abstract Builder templateFileName(String val);
+
+    public abstract Builder identifier(String val);
+
+    public abstract Builder version(String val);
+
+    public abstract Builder gaxVersion(String val);
+
+    public abstract Builder protoVersion(String val);
+
+    public abstract Builder serviceName(String val);
+
+    public abstract Builder hasMultipleServices(boolean val);
+
+    public abstract Builder url(String val);
+
+    public abstract PackageMetadataView build();
+  }
+}

--- a/src/main/java/com/google/api/codegen/viewmodel/testing/ClientTestClassView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/testing/ClientTestClassView.java
@@ -14,7 +14,6 @@
  */
 package com.google.api.codegen.viewmodel.testing;
 
-import com.google.api.codegen.viewmodel.testing.MockServiceImplView.Builder;
 import com.google.auto.value.AutoValue;
 import java.util.List;
 

--- a/src/main/java/com/google/api/codegen/viewmodel/testing/MockCombinedView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/testing/MockCombinedView.java
@@ -19,6 +19,7 @@ import com.google.api.codegen.viewmodel.FileHeaderView;
 import com.google.api.codegen.viewmodel.ViewModel;
 import com.google.auto.value.AutoValue;
 import java.util.List;
+import javax.annotation.Nullable;
 
 /**
  * MockCombinedView gathers unit-test-related classes. Used in languages that idiomatically put
@@ -33,6 +34,9 @@ public abstract class MockCombinedView implements ViewModel {
   public abstract List<ClientTestClassView> testClasses();
 
   public abstract List<MockServiceUsageView> mockServices();
+
+  @Nullable
+  public abstract String apiWrapperModuleName();
 
   @Override
   public String resourceRoot() {
@@ -58,6 +62,8 @@ public abstract class MockCombinedView implements ViewModel {
     public abstract Builder testClasses(List<ClientTestClassView> val);
 
     public abstract Builder mockServices(List<MockServiceUsageView> val);
+
+    public abstract Builder apiWrapperModuleName(String val);
 
     public abstract Builder outputPath(String val);
 

--- a/src/main/resources/com/google/api/codegen/nodejs/index.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/index.snip
@@ -1,0 +1,43 @@
+@extends "nodejs/common.snip"
+
+@snippet generate(index)
+  /*
+   {@copyright()}
+   */
+  'use strict';
+
+  @join require : index.requireViews
+    var {@require.clientName} = require('./{@require.fileName}');
+  @end
+  var gax = require('google-gax');
+  var extend = require('extend');
+  @if index.hasMultipleServices
+    var union = require('lodash.union');
+  @end
+
+  function {@index.apiVersion}(options) {
+    options = extend({
+      scopes: {@index.apiVersion}.ALL_SCOPES
+    }, options);
+    var gaxGrpc = gax.grpc(options);
+    var result = {};
+    @join require : index.requireViews
+      extend(result, {@require.clientName}(gaxGrpc));
+    @end
+    return result;
+  }
+
+  {@index.apiVersion}.SERVICE_ADDRESS = {@index.primaryService.clientName}.SERVICE_ADDRESS;
+  @if index.hasMultipleServices
+    {@index.apiVersion}.ALL_SCOPES = union(
+      @join require : index.requireViews on ", ".add(BREAK)
+        {@require.clientName}.ALL_SCOPES
+      @end
+    );
+  @else
+    {@index.apiVersion}.ALL_SCOPES = {@index.primaryService.clientName}.ALL_SCOPES;
+  @end
+
+  module.exports = {@index.apiVersion};
+@end
+

--- a/src/main/resources/com/google/api/codegen/nodejs/index.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/index.snip
@@ -20,11 +20,15 @@
       scopes: {@index.apiVersion}.ALL_SCOPES
     }, options);
     var gaxGrpc = gax.grpc(options);
-    var result = {};
-    @join require : index.requireViews
-      extend(result, {@require.clientName}(gaxGrpc));
+    @if index.hasMultipleServices
+      var result = {};
+      @join require : index.requireViews
+        extend(result, {@require.clientName}(gaxGrpc));
+      @end
+      return result;
+    @else
+      return {@index.primaryService.clientName}(gaxGrpc);
     @end
-    return result;
   }
 
   {@index.apiVersion}.SERVICE_ADDRESS = {@index.primaryService.clientName}.SERVICE_ADDRESS;

--- a/src/main/resources/com/google/api/codegen/nodejs/package.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/package.snip
@@ -12,6 +12,9 @@
     "dependencies": {
       "google-proto-files": "{@metadata.protoVersion}",
       "google-gax": "{@metadata.gaxVersion}",
+      @if metadata.hasMultipleServices
+        "lodash.union": "^4.6.0",
+      @end
       "extend": "^3.0.0"
     },
     "devDependencies": {

--- a/src/main/resources/com/google/api/codegen/nodejs/test.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/test.snip
@@ -95,14 +95,14 @@
       client._{@test.clientMethodName} = function(actualRequest, options, callback) {
         assert.deepStrictEqual(actualRequest, request);
         @join pagedResponse : test.pageStreamingResponseViews
-          callback([null, expectedResponse.{@pagedResponse.resourcesFieldGetterName}]);
+          callback(null, expectedResponse.{@pagedResponse.resourcesFieldGetterName});
         @end
       };
 
       client.{@test.clientMethodName}(request, function(err, response) {
         assert.ifError(err);
         @join pagedResponse : test.pageStreamingResponseViews
-          assert.deepStrictEqual(response[0], expectedResponse.{@pagedResponse.resourcesFieldGetterName});
+          assert.deepStrictEqual(response, expectedResponse.{@pagedResponse.resourcesFieldGetterName});
         @end
         done();
       });

--- a/src/main/resources/com/google/api/codegen/nodejs/test.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/test.snip
@@ -6,35 +6,35 @@
    {@copyright()}
    */
 
-  {@imports(apiTest.fileHeader)}
+  {@imports(apiTest)}
 
   @join testClass : apiTest.testClasses
     describe('{@testClass.apiClassName}', function() {
       @join test : testClass.testCases
-        {@testCase(test)}
+        {@testCase(test, apiTest.apiWrapperModuleName)}
 
       @end
     });
   @end
 @end
 
-@private imports(header)
+@private imports(apiTest)
   var assert = require('assert');
-  @if @header.hasVersion
-    var service = require('../src/').{@header.version}();
+  @if apiTest.fileHeader.hasVersion
+    var {@apiTest.apiWrapperModuleName} = require('../src/').{@apiTest.fileHeader.version}();
   @else
-    var service = require('../src/')();
+    var {@apiTest.apiWrapperModuleName} = require('../src/')();
   @end
 @end
 
-@private testCase(test)
+@private testCase(test, moduleName)
   @switch test.grpcStreamingType
   @case "NonStreaming"
     @switch test.clientMethodType
     @case "RequestObjectMethod"
-      {@requestObjectTestCase(test)}
+      {@requestObjectTestCase(test, moduleName)}
     @case "PagedRequestObjectMethod"
-      {@pagedRequestObjectTestCase(test)}
+      {@pagedRequestObjectTestCase(test, moduleName)}
     @default
       $unhandled case: {@test.clientMethodType.toString}$
     @end
@@ -43,10 +43,10 @@
   @end
 @end
 
-@private requestObjectTestCase(test)
+@private requestObjectTestCase(test, moduleName)
   describe('{@test.clientMethodName}', function() {
     it('invokes {@test.clientMethodName} without error', function(done) {
-      var client = service.{@test.serviceConstructorName}();
+      var client = {@moduleName}.{@test.serviceConstructorName}();
       // Mock request
       {@initCodeLines(test.initCode)}
 
@@ -81,10 +81,10 @@
   });
 @end
 
-@private pagedRequestObjectTestCase(test)
+@private pagedRequestObjectTestCase(test, moduleName)
   describe('{@test.clientMethodName}', function() {
     it('invokes {@test.clientMethodName} without error', function(done) {
-      var client = service.{@test.serviceConstructorName}();
+      var client = {@moduleName}.{@test.serviceConstructorName}();
       // Mock request
       {@initCodeLines(test.initCode)}
 

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_doc_index_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_doc_index_library.baseline
@@ -1,0 +1,36 @@
+============== file: src/v1/index.js ==============
+/*
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+var LibraryServiceClient = require('./library_service_client');
+var gax = require('google-gax');
+var extend = require('extend');
+
+function v1(options) {
+  options = extend({
+    scopes: v1.ALL_SCOPES
+  }, options);
+  var gaxGrpc = gax.grpc(options);
+  var result = {};
+  extend(result, LibraryServiceClient(gaxGrpc));
+  return result;
+}
+
+v1.SERVICE_ADDRESS = LibraryServiceClient.SERVICE_ADDRESS;
+v1.ALL_SCOPES = LibraryServiceClient.ALL_SCOPES;
+
+module.exports = v1;

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_doc_index_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_doc_index_library.baseline
@@ -25,9 +25,7 @@ function v1(options) {
     scopes: v1.ALL_SCOPES
   }, options);
   var gaxGrpc = gax.grpc(options);
-  var result = {};
-  extend(result, LibraryServiceClient(gaxGrpc));
-  return result;
+  return LibraryServiceClient(gaxGrpc);
 }
 
 v1.SERVICE_ADDRESS = LibraryServiceClient.SERVICE_ADDRESS;

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_index_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_index_library.baseline
@@ -1,0 +1,36 @@
+============== file: src/v1/index.js ==============
+/*
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+var LibraryServiceClient = require('./library_service_client');
+var gax = require('google-gax');
+var extend = require('extend');
+
+function v1(options) {
+  options = extend({
+    scopes: v1.ALL_SCOPES
+  }, options);
+  var gaxGrpc = gax.grpc(options);
+  var result = {};
+  extend(result, LibraryServiceClient(gaxGrpc));
+  return result;
+}
+
+v1.SERVICE_ADDRESS = LibraryServiceClient.SERVICE_ADDRESS;
+v1.ALL_SCOPES = LibraryServiceClient.ALL_SCOPES;
+
+module.exports = v1;

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_index_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_index_library.baseline
@@ -25,9 +25,7 @@ function v1(options) {
     scopes: v1.ALL_SCOPES
   }, options);
   var gaxGrpc = gax.grpc(options);
-  var result = {};
-  extend(result, LibraryServiceClient(gaxGrpc));
-  return result;
+  return LibraryServiceClient(gaxGrpc);
 }
 
 v1.SERVICE_ADDRESS = LibraryServiceClient.SERVICE_ADDRESS;

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_index_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_index_no_path_templates.baseline
@@ -25,9 +25,7 @@ function v1(options) {
     scopes: v1.ALL_SCOPES
   }, options);
   var gaxGrpc = gax.grpc(options);
-  var result = {};
-  extend(result, NoTemplatesApiServiceClient(gaxGrpc));
-  return result;
+  return NoTemplatesApiServiceClient(gaxGrpc);
 }
 
 v1.SERVICE_ADDRESS = NoTemplatesApiServiceClient.SERVICE_ADDRESS;

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_index_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_index_no_path_templates.baseline
@@ -1,0 +1,36 @@
+============== file: src/index.js ==============
+/*
+ * Copyright 2016 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+'use strict';
+
+var NoTemplatesApiServiceClient = require('./no_templates_api_service_client');
+var gax = require('google-gax');
+var extend = require('extend');
+
+function v1(options) {
+  options = extend({
+    scopes: v1.ALL_SCOPES
+  }, options);
+  var gaxGrpc = gax.grpc(options);
+  var result = {};
+  extend(result, NoTemplatesApiServiceClient(gaxGrpc));
+  return result;
+}
+
+v1.SERVICE_ADDRESS = NoTemplatesApiServiceClient.SERVICE_ADDRESS;
+v1.ALL_SCOPES = NoTemplatesApiServiceClient.ALL_SCOPES;
+
+module.exports = v1;

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_test_library.baseline
@@ -16,12 +16,12 @@
  */
 
 var assert = require('assert');
-var service = require('../src/').v1();
+var libraryV1 = require('../src/').v1();
 
 describe('LibraryServiceClient', function() {
   describe('createShelf', function() {
     it('invokes createShelf without error', function(done) {
-      var client = service.libraryServiceClient();
+      var client = libraryV1.libraryServiceClient();
       // Mock request
       var shelf = {};
       var request = {
@@ -54,7 +54,7 @@ describe('LibraryServiceClient', function() {
 
   describe('getShelf', function() {
     it('invokes getShelf without error', function(done) {
-      var client = service.libraryServiceClient();
+      var client = libraryV1.libraryServiceClient();
       // Mock request
       var formattedName = client.shelfPath("[SHELF_ID]");
       var options = 'options-1249474914';
@@ -89,7 +89,7 @@ describe('LibraryServiceClient', function() {
 
   describe('listShelves', function() {
     it('invokes listShelves without error', function(done) {
-      var client = service.libraryServiceClient();
+      var client = libraryV1.libraryServiceClient();
       // Mock request
       var request = {};
 
@@ -118,7 +118,7 @@ describe('LibraryServiceClient', function() {
 
   describe('deleteShelf', function() {
     it('invokes deleteShelf without error', function(done) {
-      var client = service.libraryServiceClient();
+      var client = libraryV1.libraryServiceClient();
       // Mock request
       var formattedName = client.shelfPath("[SHELF_ID]");
       var request = {
@@ -140,7 +140,7 @@ describe('LibraryServiceClient', function() {
 
   describe('mergeShelves', function() {
     it('invokes mergeShelves without error', function(done) {
-      var client = service.libraryServiceClient();
+      var client = libraryV1.libraryServiceClient();
       // Mock request
       var formattedName = client.shelfPath("[SHELF_ID]");
       var formattedOtherShelfName = client.shelfPath("[SHELF_ID]");
@@ -175,7 +175,7 @@ describe('LibraryServiceClient', function() {
 
   describe('createBook', function() {
     it('invokes createBook without error', function(done) {
-      var client = service.libraryServiceClient();
+      var client = libraryV1.libraryServiceClient();
       // Mock request
       var formattedName = client.shelfPath("[SHELF_ID]");
       var book = {};
@@ -212,7 +212,7 @@ describe('LibraryServiceClient', function() {
 
   describe('publishSeries', function() {
     it('invokes publishSeries without error', function(done) {
-      var client = service.libraryServiceClient();
+      var client = libraryV1.libraryServiceClient();
       // Mock request
       var shelf = {};
       var books = [];
@@ -244,7 +244,7 @@ describe('LibraryServiceClient', function() {
 
   describe('getBook', function() {
     it('invokes getBook without error', function(done) {
-      var client = service.libraryServiceClient();
+      var client = libraryV1.libraryServiceClient();
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
       var request = {
@@ -279,7 +279,7 @@ describe('LibraryServiceClient', function() {
 
   describe('listBooks', function() {
     it('invokes listBooks without error', function(done) {
-      var client = service.libraryServiceClient();
+      var client = libraryV1.libraryServiceClient();
       // Mock request
       var formattedName = client.shelfPath("[SHELF_ID]");
       var request = {
@@ -311,7 +311,7 @@ describe('LibraryServiceClient', function() {
 
   describe('deleteBook', function() {
     it('invokes deleteBook without error', function(done) {
-      var client = service.libraryServiceClient();
+      var client = libraryV1.libraryServiceClient();
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
       var request = {
@@ -333,7 +333,7 @@ describe('LibraryServiceClient', function() {
 
   describe('updateBook', function() {
     it('invokes updateBook without error', function(done) {
-      var client = service.libraryServiceClient();
+      var client = libraryV1.libraryServiceClient();
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
       var book = {};
@@ -370,7 +370,7 @@ describe('LibraryServiceClient', function() {
 
   describe('moveBook', function() {
     it('invokes moveBook without error', function(done) {
-      var client = service.libraryServiceClient();
+      var client = libraryV1.libraryServiceClient();
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
       var formattedOtherShelfName = client.shelfPath("[SHELF_ID]");
@@ -407,7 +407,7 @@ describe('LibraryServiceClient', function() {
 
   describe('listStrings', function() {
     it('invokes listStrings without error', function(done) {
-      var client = service.libraryServiceClient();
+      var client = libraryV1.libraryServiceClient();
       // Mock request
       var request = {};
 
@@ -436,7 +436,7 @@ describe('LibraryServiceClient', function() {
 
   describe('addComments', function() {
     it('invokes addComments without error', function(done) {
-      var client = service.libraryServiceClient();
+      var client = libraryV1.libraryServiceClient();
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
       var comment = '95';
@@ -468,7 +468,7 @@ describe('LibraryServiceClient', function() {
 
   describe('getBookFromArchive', function() {
     it('invokes getBookFromArchive without error', function(done) {
-      var client = service.libraryServiceClient();
+      var client = libraryV1.libraryServiceClient();
       // Mock request
       var formattedName = client.archivedBookPath("[ARCHIVE_PATH]", "[BOOK_ID]");
       var request = {
@@ -503,7 +503,7 @@ describe('LibraryServiceClient', function() {
 
   describe('getBookFromAnywhere', function() {
     it('invokes getBookFromAnywhere without error', function(done) {
-      var client = service.libraryServiceClient();
+      var client = libraryV1.libraryServiceClient();
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
       var formattedAltBookName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
@@ -540,7 +540,7 @@ describe('LibraryServiceClient', function() {
 
   describe('updateBookIndex', function() {
     it('invokes updateBookIndex without error', function(done) {
-      var client = service.libraryServiceClient();
+      var client = libraryV1.libraryServiceClient();
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
       var indexName = 'default index';
@@ -567,7 +567,7 @@ describe('LibraryServiceClient', function() {
 
   describe('findRelatedBooks', function() {
     it('invokes findRelatedBooks without error', function(done) {
-      var client = service.libraryServiceClient();
+      var client = libraryV1.libraryServiceClient();
       // Mock request
       var namesElement = 'namesElement-249113339';
       var names = [namesElement];
@@ -602,7 +602,7 @@ describe('LibraryServiceClient', function() {
 
   describe('addTag', function() {
     it('invokes addTag without error', function(done) {
-      var client = service.libraryServiceClient();
+      var client = libraryV1.libraryServiceClient();
       // Mock request
       var formattedResource = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
       var tag = 'tag114586';
@@ -630,7 +630,7 @@ describe('LibraryServiceClient', function() {
 
   describe('addLabel', function() {
     it('invokes addLabel without error', function(done) {
-      var client = service.libraryServiceClient();
+      var client = libraryV1.libraryServiceClient();
       // Mock request
       var formattedResource = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
       var label = 'label102727412';
@@ -658,7 +658,7 @@ describe('LibraryServiceClient', function() {
 
   describe('getBigBookAsync', function() {
     it('invokes getBigBookAsync without error', function(done) {
-      var client = service.libraryServiceClient();
+      var client = libraryV1.libraryServiceClient();
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
       var request = {

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_test_library.baseline
@@ -693,7 +693,7 @@ describe('LibraryServiceClient', function() {
 
   describe('getBigNothingAsync', function() {
     it('invokes getBigNothingAsync without error', function(done) {
-      var client = service.libraryServiceClient();
+      var client = libraryV1.libraryServiceClient();
       // Mock request
       var formattedName = client.bookPath("[SHELF_ID]", "[BOOK_ID]");
       var request = {

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_test_library.baseline
@@ -105,12 +105,12 @@ describe('LibraryServiceClient', function() {
       // Mock Grpc layer
       client._listShelves = function(actualRequest, options, callback) {
         assert.deepStrictEqual(actualRequest, request);
-        callback([null, expectedResponse.shelves]);
+        callback(null, expectedResponse.shelves);
       };
 
       client.listShelves(request, function(err, response) {
         assert.ifError(err);
-        assert.deepStrictEqual(response[0], expectedResponse.shelves);
+        assert.deepStrictEqual(response, expectedResponse.shelves);
         done();
       });
     });
@@ -298,12 +298,12 @@ describe('LibraryServiceClient', function() {
       // Mock Grpc layer
       client._listBooks = function(actualRequest, options, callback) {
         assert.deepStrictEqual(actualRequest, request);
-        callback([null, expectedResponse.books]);
+        callback(null, expectedResponse.books);
       };
 
       client.listBooks(request, function(err, response) {
         assert.ifError(err);
-        assert.deepStrictEqual(response[0], expectedResponse.books);
+        assert.deepStrictEqual(response, expectedResponse.books);
         done();
       });
     });
@@ -423,12 +423,12 @@ describe('LibraryServiceClient', function() {
       // Mock Grpc layer
       client._listStrings = function(actualRequest, options, callback) {
         assert.deepStrictEqual(actualRequest, request);
-        callback([null, expectedResponse.strings]);
+        callback(null, expectedResponse.strings);
       };
 
       client.listStrings(request, function(err, response) {
         assert.ifError(err);
-        assert.deepStrictEqual(response[0], expectedResponse.strings);
+        assert.deepStrictEqual(response, expectedResponse.strings);
         done();
       });
     });
@@ -589,12 +589,12 @@ describe('LibraryServiceClient', function() {
       // Mock Grpc layer
       client._findRelatedBooks = function(actualRequest, options, callback) {
         assert.deepStrictEqual(actualRequest, request);
-        callback([null, expectedResponse.names]);
+        callback(null, expectedResponse.names);
       };
 
       client.findRelatedBooks(request, function(err, response) {
         assert.ifError(err);
-        assert.deepStrictEqual(response[0], expectedResponse.names);
+        assert.deepStrictEqual(response, expectedResponse.names);
         done();
       });
     });

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_test_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_test_no_path_templates.baseline
@@ -16,12 +16,12 @@
  */
 
 var assert = require('assert');
-var service = require('../src/')();
+var example = require('../src/')();
 
 describe('NoTemplatesApiServiceClient', function() {
   describe('increment', function() {
     it('invokes increment without error', function(done) {
-      var client = service.noTemplatesApiServiceClient();
+      var client = example.noTemplatesApiServiceClient();
       // Mock request
       var request = {};
 


### PR DESCRIPTION
- Auto-generate support for src/index.js
- Fixed an issue in paged method tests
- Add `lodash.union` dependency to package.json if the service contains more than one interface
- Fixed service var name

Tests:
- Baselines
- Manual tests passed for cloudtrace and errorreporting 

cc/ @bjwatson 