### PR TITLE
Exposed longrunnung descriptors and operations client.

### DIFF
--- a/src/main/java/com/google/api/codegen/nodejs/NodeJSGapicContext.java
+++ b/src/main/java/com/google/api/codegen/nodejs/NodeJSGapicContext.java
@@ -440,7 +440,7 @@ public class NodeJSGapicContext extends GapicContext implements NodeJSContext {
       builder.add("STREAM_DESCRIPTORS");
     }
     if (messages().filterLongrunningMethods(ifaceConfig, methods).iterator().hasNext()) {
-      builder.add("longrunningDescriptors");
+      builder.add("self.longrunningDescriptors");
     }
     return builder.build();
   }

--- a/src/main/resources/com/google/api/codegen/nodejs/main.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/main.snip
@@ -271,7 +271,7 @@
 
         @if longrunningMethods
 
-          var operationsClient = new gax.lro({
+          this.operationsClient = new gax.lro({
             auth: gaxGrpc.auth,
             grpc: gaxGrpc.grpc
           }).operationsClient({
@@ -283,11 +283,11 @@
             appVersion: appVersion
           });
           
-          var longrunningDescriptors = {
+          this.longrunningDescriptors = {
             @join method : longrunningMethods on {@", "}.add(BREAK)
               @let longrunningConfig = context.getApiConfig.getInterfaceConfig(service).getMethodConfig(method).getLongRunningConfig;
                 {@methodName(method)}: new gax.LongrunningDescriptor(
-                  operationsClient,
+                  this.operationsClient,
                   grpcClients.{@longrunningConfig.getReturnType}.decode,
                   grpcClients.{@longrunningConfig.getMetadataType}.decode)
               @end

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_doc_main_library.baseline
@@ -125,7 +125,7 @@ function LibraryServiceClient(gaxGrpc, grpcClients, opts) {
       gax.createByteLengthFunction(grpcClients.google.example.library.v1.Book))
   };
 
-  var operationsClient = new gax.lro({
+  this.operationsClient = new gax.lro({
     auth: gaxGrpc.auth,
     grpc: gaxGrpc.grpc
   }).operationsClient({
@@ -137,13 +137,13 @@ function LibraryServiceClient(gaxGrpc, grpcClients, opts) {
     appVersion: appVersion
   });
 
-  var longrunningDescriptors = {
+  this.longrunningDescriptors = {
     getBigBook: new gax.LongrunningDescriptor(
-      operationsClient,
+      this.operationsClient,
       grpcClients.google.example.library.v1.Book.decode,
       grpcClients.google.example.library.v1.GetBigBookMetadata.decode),
     getBigNothing: new gax.LongrunningDescriptor(
-      operationsClient,
+      this.operationsClient,
       grpcClients.google.protobuf.Empty.decode,
       grpcClients.google.example.library.v1.GetBigBookMetadata.decode)
   };
@@ -196,7 +196,7 @@ function LibraryServiceClient(gaxGrpc, grpcClients, opts) {
         }
       }),
       defaults[methodName],
-      PAGE_DESCRIPTORS[methodName] || bundleDescriptors[methodName] || STREAM_DESCRIPTORS[methodName] || longrunningDescriptors[methodName]);
+      PAGE_DESCRIPTORS[methodName] || bundleDescriptors[methodName] || STREAM_DESCRIPTORS[methodName] || self.longrunningDescriptors[methodName]);
   });
 
   var labelerStub = gaxGrpc.createStub(
@@ -216,7 +216,7 @@ function LibraryServiceClient(gaxGrpc, grpcClients, opts) {
         }
       }),
       defaults[methodName],
-      PAGE_DESCRIPTORS[methodName] || bundleDescriptors[methodName] || STREAM_DESCRIPTORS[methodName] || longrunningDescriptors[methodName]);
+      PAGE_DESCRIPTORS[methodName] || bundleDescriptors[methodName] || STREAM_DESCRIPTORS[methodName] || self.longrunningDescriptors[methodName]);
   });
 }
 

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_main_library.baseline
@@ -125,7 +125,7 @@ function LibraryServiceClient(gaxGrpc, grpcClients, opts) {
       gax.createByteLengthFunction(grpcClients.google.example.library.v1.Book))
   };
 
-  var operationsClient = new gax.lro({
+  this.operationsClient = new gax.lro({
     auth: gaxGrpc.auth,
     grpc: gaxGrpc.grpc
   }).operationsClient({
@@ -137,13 +137,13 @@ function LibraryServiceClient(gaxGrpc, grpcClients, opts) {
     appVersion: appVersion
   });
 
-  var longrunningDescriptors = {
+  this.longrunningDescriptors = {
     getBigBook: new gax.LongrunningDescriptor(
-      operationsClient,
+      this.operationsClient,
       grpcClients.google.example.library.v1.Book.decode,
       grpcClients.google.example.library.v1.GetBigBookMetadata.decode),
     getBigNothing: new gax.LongrunningDescriptor(
-      operationsClient,
+      this.operationsClient,
       grpcClients.google.protobuf.Empty.decode,
       grpcClients.google.example.library.v1.GetBigBookMetadata.decode)
   };
@@ -196,7 +196,7 @@ function LibraryServiceClient(gaxGrpc, grpcClients, opts) {
         }
       }),
       defaults[methodName],
-      PAGE_DESCRIPTORS[methodName] || bundleDescriptors[methodName] || STREAM_DESCRIPTORS[methodName] || longrunningDescriptors[methodName]);
+      PAGE_DESCRIPTORS[methodName] || bundleDescriptors[methodName] || STREAM_DESCRIPTORS[methodName] || self.longrunningDescriptors[methodName]);
   });
 
   var labelerStub = gaxGrpc.createStub(
@@ -216,7 +216,7 @@ function LibraryServiceClient(gaxGrpc, grpcClients, opts) {
         }
       }),
       defaults[methodName],
-      PAGE_DESCRIPTORS[methodName] || bundleDescriptors[methodName] || STREAM_DESCRIPTORS[methodName] || longrunningDescriptors[methodName]);
+      PAGE_DESCRIPTORS[methodName] || bundleDescriptors[methodName] || STREAM_DESCRIPTORS[methodName] || self.longrunningDescriptors[methodName]);
   });
 }
 


### PR DESCRIPTION
This will cause the `gax.operation` method to be much more usable.
See https://github.com/googleapis/gax-nodejs/issues/83#issuecomment-268316087.