### PR TITLE
Add grpc streaming support to NodeJS tests

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTestTransformer.java
@@ -132,14 +132,11 @@ public class NodeJSGapicSurfaceTestTransformer implements ModelToViewTransformer
     for (Method method : context.getSupportedMethods()) {
       MethodTransformerContext methodContext = context.asRequestMethodContext(method);
 
-      if (methodContext.getMethodConfig().isGrpcStreaming()) {
-        // TODO(shinfan): Remove this check once grpc streaming is supported by test
-        continue;
-      }
-
       ClientMethodType clientMethodType = ClientMethodType.RequestObjectMethod;
       if (methodContext.getMethodConfig().isPageStreaming()) {
         clientMethodType = ClientMethodType.PagedRequestObjectMethod;
+      } else if (methodContext.getMethodConfig().isGrpcStreaming()) {
+        clientMethodType = ClientMethodType.AsyncRequestObjectMethod;
       }
 
       Iterable<FieldConfig> fieldConfigs =

--- a/src/main/java/com/google/api/codegen/viewmodel/testing/ClientTestClassView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/testing/ClientTestClassView.java
@@ -14,7 +14,6 @@
  */
 package com.google.api.codegen.viewmodel.testing;
 
-import com.google.api.codegen.config.GrpcStreamingConfig.GrpcStreamingType;
 import com.google.auto.value.AutoValue;
 import java.util.List;
 
@@ -30,15 +29,6 @@ public abstract class ClientTestClassView {
   public abstract List<MockServiceUsageView> mockServices();
 
   public abstract List<TestCaseView> testCases();
-
-  public boolean hasGrpcStreaming() {
-    for (TestCaseView testCase : testCases()) {
-      if (testCase.grpcStreamingType() != GrpcStreamingType.NonStreaming) {
-        return true;
-      }
-    }
-    return false;
-  }
 
   public static Builder newBuilder() {
     return new AutoValue_ClientTestClassView.Builder();

--- a/src/main/java/com/google/api/codegen/viewmodel/testing/ClientTestClassView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/testing/ClientTestClassView.java
@@ -14,6 +14,7 @@
  */
 package com.google.api.codegen.viewmodel.testing;
 
+import com.google.api.codegen.config.GrpcStreamingConfig.GrpcStreamingType;
 import com.google.auto.value.AutoValue;
 import java.util.List;
 
@@ -29,6 +30,15 @@ public abstract class ClientTestClassView {
   public abstract List<MockServiceUsageView> mockServices();
 
   public abstract List<TestCaseView> testCases();
+
+  public boolean hasGrpcStreaming() {
+    for (TestCaseView testCase : testCases()) {
+      if (testCase.grpcStreamingType() != GrpcStreamingType.NonStreaming) {
+        return true;
+      }
+    }
+    return false;
+  }
 
   public static Builder newBuilder() {
     return new AutoValue_ClientTestClassView.Builder();

--- a/src/main/java/com/google/api/codegen/viewmodel/testing/MockCombinedView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/testing/MockCombinedView.java
@@ -15,6 +15,7 @@
 package com.google.api.codegen.viewmodel.testing;
 
 import com.google.api.codegen.SnippetSetRunner;
+import com.google.api.codegen.config.GrpcStreamingConfig.GrpcStreamingType;
 import com.google.api.codegen.viewmodel.FileHeaderView;
 import com.google.api.codegen.viewmodel.ViewModel;
 import com.google.auto.value.AutoValue;
@@ -34,6 +35,17 @@ public abstract class MockCombinedView implements ViewModel {
   public abstract List<ClientTestClassView> testClasses();
 
   public abstract List<MockServiceUsageView> mockServices();
+
+  public boolean hasGrpcStreaming() {
+    for (ClientTestClassView testClass : testClasses()) {
+      for (TestCaseView testCase : testClass.testCases()) {
+        if (testCase.grpcStreamingType() != GrpcStreamingType.NonStreaming) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
 
   @Nullable
   public abstract String apiWrapperModuleName();

--- a/src/main/resources/com/google/api/codegen/nodejs/package.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/package.snip
@@ -18,7 +18,8 @@
       "extend": "^3.0.0"
     },
     "devDependencies": {
-      "mocha": "3.2.0"
+      "mocha": "3.2.0",
+      "through2": "2.0.3"
     },
     "license": "Apache-2.0",
     "engines": {

--- a/src/main/resources/com/google/api/codegen/nodejs/test.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/test.snip
@@ -128,9 +128,18 @@
       {@initCodeLines(test.mockResponse.initCode)}
 
       // Mock Grpc layer
-      client._{@test.clientMethodName} = function() {
-        return new MockStream(request, expectedResponse);
-      };
+      @switch test.grpcStreamingType
+      @case "ServerStreaming"
+        client._{@test.clientMethodName} = function(request) {
+          assert.deepStrictEqual(request, this.expectedRequest);
+          var mockStream = new MockStream(request, expectedResponse);
+          return mockStream.emitImmediately();
+        };
+      @case "BidiStreaming"
+        client._{@test.clientMethodName} = function() {
+          return new MockStream(request, expectedResponse);
+        };
+      @end
 
       @switch test.grpcStreamingType
       @case "ServerStreaming"

--- a/src/main/resources/com/google/api/codegen/nodejs/test.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/test.snip
@@ -26,7 +26,7 @@
     var {@apiTest.apiWrapperModuleName} = require('../src/')();
   @end
   @if apiTest.hasGrpcStreaming
-    var MockStream = require('google-gax').MockStream;
+    var through2 = require('through2');
   @end
 @end
 
@@ -127,17 +127,24 @@
       // Mock response
       {@initCodeLines(test.mockResponse.initCode)}
 
-      // Mock Grpc layer
       @switch test.grpcStreamingType
       @case "ServerStreaming"
-        var mockStream = new MockStream(request, expectedResponse);
+        var mockStream = through2.obj(function (chunk, enc, callback) {
+          callback(null, expectedResponse);
+        });
+
         client._{@test.clientMethodName} = function(actualRequest) {
           assert.deepStrictEqual(actualRequest, request);
           return mockStream;
         };
       @case "BidiStreaming"
+        var mockStream = through2.obj(function (chunk, enc, callback) {
+          assert.deepStrictEqual(chunk, request);
+          callback(null, expectedResponse);
+        });
+
         client._{@test.clientMethodName} = function() {
-          return new MockStream(request, expectedResponse);
+          return mockStream;
         };
       @end
 
@@ -150,7 +157,8 @@
           done(err);
         });
 
-        mockStream.emitImmediately();
+        // Manually invoke the data event.
+        mockStream.write();
       @case "BidiStreaming"
         var stream = client.{@test.clientMethodName}().on('data', function(response) {
           assert.deepStrictEqual(response, expectedResponse);

--- a/src/main/resources/com/google/api/codegen/nodejs/test.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/test.snip
@@ -137,11 +137,15 @@
         client.{@test.clientMethodName}(request).on('data', function(response) {
           assert.deepStrictEqual(response, expectedResponse);
           done()
+        }).on('error', function(err) {
+          done(err);
         });
       @case "BidiStreaming"
         var stream = client.{@test.clientMethodName}().on('data', function(response) {
           assert.deepStrictEqual(response, expectedResponse);
           done()
+        }).on('error', function(err) {
+          done(err);
         });
 
         stream.write(request);

--- a/src/main/resources/com/google/api/codegen/nodejs/test.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/test.snip
@@ -132,12 +132,22 @@
         return new MockStream(request, expectedResponse);
       };
 
-      var stream = client.{@test.clientMethodName}().on('data', function(response) {
-        assert.deepStrictEqual(response, expectedResponse);
-        done()
-      });
+      @switch test.grpcStreamingType
+      @case "ServerStreaming"
+        client.{@test.clientMethodName}(request).on('data', function(response) {
+          assert.deepStrictEqual(response, expectedResponse);
+          done()
+        });
+      @case "BidiStreaming"
+        var stream = client.{@test.clientMethodName}().on('data', function(response) {
+          assert.deepStrictEqual(response, expectedResponse);
+          done()
+        });
 
-      stream.write(request);
+        stream.write(request);
+      @default
+        $unhandled case: {@test.grpcStreamingType.toString}$
+      @end
     });
   });
 @end

--- a/src/main/resources/com/google/api/codegen/nodejs/test.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/test.snip
@@ -128,29 +128,29 @@
       {@initCodeLines(test.mockResponse.initCode)}
 
       // Mock Grpc layer
-      var mockStream = new MockStream(request, expectedResponse);
       @switch test.grpcStreamingType
       @case "ServerStreaming"
+        var mockStream = new MockStream(request, expectedResponse);
         client._{@test.clientMethodName} = function(actualRequest) {
           assert.deepStrictEqual(actualRequest, request);
           return mockStream;
         };
       @case "BidiStreaming"
         client._{@test.clientMethodName} = function() {
-          return mockStream;
+          return new MockStream(request, expectedResponse);
         };
       @end
 
       @switch test.grpcStreamingType
       @case "ServerStreaming"
-        var stream = client.{@test.clientMethodName}(request).on('data', function(response) {
+        client.{@test.clientMethodName}(request).on('data', function(response) {
           assert.deepStrictEqual(response, expectedResponse);
           done()
         }).on('error', function(err) {
           done(err);
         });
 
-        stream.emitImmediately();
+        mockStream.emitImmediately();
       @case "BidiStreaming"
         var stream = client.{@test.clientMethodName}().on('data', function(response) {
           assert.deepStrictEqual(response, expectedResponse);

--- a/src/main/resources/com/google/api/codegen/nodejs/test.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/test.snip
@@ -25,10 +25,8 @@
   @else
     var {@apiTest.apiWrapperModuleName} = require('../src/')();
   @end
-  @join testClass : apiTest.testClasses
-    @if testClass.hasGrpcStreaming
-      MockStream = require('google-gax').MockStream;
-    @end
+  @if apiTest.hasGrpcStreaming
+    var MockStream = require('google-gax').MockStream;
   @end
 @end
 
@@ -44,8 +42,6 @@
       $unhandled case: {@test.clientMethodType.toString}$
     @end
   @case "ServerStreaming"
-    {@streamingTestCase(test, moduleName)}
-  @case "ClientStreaming"
     {@streamingTestCase(test, moduleName)}
   @case "BidiStreaming"
     {@streamingTestCase(test, moduleName)}

--- a/src/main/resources/com/google/api/codegen/nodejs/test.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/test.snip
@@ -25,6 +25,11 @@
   @else
     var {@apiTest.apiWrapperModuleName} = require('../src/')();
   @end
+  @join testClass : apiTest.testClasses
+    @if testClass.hasGrpcStreaming
+      MockStream = require('google-gax').MockStream;
+    @end
+  @end
 @end
 
 @private testCase(test, moduleName)
@@ -38,6 +43,12 @@
     @default
       $unhandled case: {@test.clientMethodType.toString}$
     @end
+  @case "ServerStreaming"
+    {@streamingTestCase(test, moduleName)}
+  @case "ClientStreaming"
+    {@streamingTestCase(test, moduleName)}
+  @case "BidiStreaming"
+    {@streamingTestCase(test, moduleName)}
   @default
     $unhandled case: {@test.grpcStreamingType.toString}$
   @end
@@ -106,6 +117,31 @@
         @end
         done();
       });
+    });
+  });
+@end
+
+@private streamingTestCase(test, moduleName)
+  describe('{@test.clientMethodName}', function() {
+    it('invokes {@test.clientMethodName} without error', function(done) {
+      var client = {@moduleName}.{@test.serviceConstructorName}();
+      // Mock request
+      {@initCodeLines(test.initCode)}
+
+      // Mock response
+      {@initCodeLines(test.mockResponse.initCode)}
+
+      // Mock Grpc layer
+      client._{@test.clientMethodName} = function() {
+        return new MockStream(request, expectedResponse);
+      };
+
+      var stream = client.{@test.clientMethodName}().on('data', function(response) {
+        assert.deepStrictEqual(response, expectedResponse);
+        done()
+      });
+
+      stream.write(request);
     });
   });
 @end

--- a/src/main/resources/com/google/api/codegen/nodejs/test.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/test.snip
@@ -127,23 +127,23 @@
       // Mock response
       {@initCodeLines(test.mockResponse.initCode)}
 
+      // Mock Grpc layer
       @switch test.grpcStreamingType
       @case "ServerStreaming"
-        var mockStream = through2.obj(function (chunk, enc, callback) {
-          callback(null, expectedResponse);
-        });
-
         client._{@test.clientMethodName} = function(actualRequest) {
           assert.deepStrictEqual(actualRequest, request);
+          var mockStream = through2.obj(function (chunk, enc, callback) {
+            callback(null, expectedResponse);
+          });
+          mockStream.write();
           return mockStream;
         };
       @case "BidiStreaming"
-        var mockStream = through2.obj(function (chunk, enc, callback) {
-          assert.deepStrictEqual(chunk, request);
-          callback(null, expectedResponse);
-        });
-
         client._{@test.clientMethodName} = function() {
+          var mockStream = through2.obj(function (chunk, enc, callback) {
+            assert.deepStrictEqual(chunk, request);
+            callback(null, expectedResponse);
+          });
           return mockStream;
         };
       @end
@@ -156,9 +156,6 @@
         }).on('error', function(err) {
           done(err);
         });
-
-        // Manually invoke the data event.
-        mockStream.write();
       @case "BidiStreaming"
         var stream = client.{@test.clientMethodName}().on('data', function(response) {
           assert.deepStrictEqual(response, expectedResponse);

--- a/src/main/resources/com/google/api/codegen/nodejs/test.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/test.snip
@@ -128,27 +128,29 @@
       {@initCodeLines(test.mockResponse.initCode)}
 
       // Mock Grpc layer
+      var mockStream = new MockStream(request, expectedResponse);
       @switch test.grpcStreamingType
       @case "ServerStreaming"
-        client._{@test.clientMethodName} = function(request) {
-          assert.deepStrictEqual(request, this.expectedRequest);
-          var mockStream = new MockStream(request, expectedResponse);
-          return mockStream.emitImmediately();
+        client._{@test.clientMethodName} = function(actualRequest) {
+          assert.deepStrictEqual(actualRequest, request);
+          return mockStream;
         };
       @case "BidiStreaming"
         client._{@test.clientMethodName} = function() {
-          return new MockStream(request, expectedResponse);
+          return mockStream;
         };
       @end
 
       @switch test.grpcStreamingType
       @case "ServerStreaming"
-        client.{@test.clientMethodName}(request).on('data', function(response) {
+        var stream = client.{@test.clientMethodName}(request).on('data', function(response) {
           assert.deepStrictEqual(response, expectedResponse);
           done()
         }).on('error', function(err) {
           done(err);
         });
+
+        stream.emitImmediately();
       @case "BidiStreaming"
         var stream = client.{@test.clientMethodName}().on('data', function(response) {
           assert.deepStrictEqual(response, expectedResponse);

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_doc_package_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_doc_package_library.baseline
@@ -15,7 +15,8 @@
     "extend": "^3.0.0"
   },
   "devDependencies": {
-    "mocha": "3.2.0"
+    "mocha": "3.2.0",
+    "through2": "2.0.3"
   },
   "license": "Apache-2.0",
   "engines": {

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_package_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_package_library.baseline
@@ -15,7 +15,8 @@
     "extend": "^3.0.0"
   },
   "devDependencies": {
-    "mocha": "3.2.0"
+    "mocha": "3.2.0",
+    "through2": "2.0.3"
   },
   "license": "Apache-2.0",
   "engines": {

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_package_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_package_no_path_templates.baseline
@@ -15,7 +15,8 @@
     "extend": "^3.0.0"
   },
   "devDependencies": {
-    "mocha": "3.2.0"
+    "mocha": "3.2.0",
+    "through2": "2.0.3"
   },
   "license": "Apache-2.0",
   "engines": {

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_test_library.baseline
@@ -17,7 +17,7 @@
 
 var assert = require('assert');
 var libraryV1 = require('../src/').v1();
-var MockStream = require('google-gax').MockStream;
+var through2 = require('through2');
 
 describe('LibraryServiceClient', function() {
   describe('createShelf', function() {
@@ -575,8 +575,10 @@ describe('LibraryServiceClient', function() {
       // Mock response
       var expectedResponse = {};
 
-      // Mock Grpc layer
-      var mockStream = new MockStream(request, expectedResponse);
+      var mockStream = through2.obj(function (chunk, enc, callback) {
+        callback(null, expectedResponse);
+      });
+
       client._streamShelves = function(actualRequest) {
         assert.deepStrictEqual(actualRequest, request);
         return mockStream;
@@ -589,7 +591,8 @@ describe('LibraryServiceClient', function() {
         done(err);
       });
 
-      mockStream.emitImmediately();
+      // Manually invoke the data event.
+      mockStream.write();
     });
   });
 
@@ -614,8 +617,10 @@ describe('LibraryServiceClient', function() {
           read : read
       };
 
-      // Mock Grpc layer
-      var mockStream = new MockStream(request, expectedResponse);
+      var mockStream = through2.obj(function (chunk, enc, callback) {
+        callback(null, expectedResponse);
+      });
+
       client._streamBooks = function(actualRequest) {
         assert.deepStrictEqual(actualRequest, request);
         return mockStream;
@@ -628,7 +633,8 @@ describe('LibraryServiceClient', function() {
         done(err);
       });
 
-      mockStream.emitImmediately();
+      // Manually invoke the data event.
+      mockStream.write();
     });
   });
 
@@ -649,9 +655,13 @@ describe('LibraryServiceClient', function() {
           comment : comment
       };
 
-      // Mock Grpc layer
+      var mockStream = through2.obj(function (chunk, enc, callback) {
+        assert.deepStrictEqual(chunk, request);
+        callback(null, expectedResponse);
+      });
+
       client._discussBook = function() {
-        return new MockStream(request, expectedResponse);
+        return mockStream;
       };
 
       var stream = client.discussBook().on('data', function(response) {

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_test_library.baseline
@@ -17,6 +17,7 @@
 
 var assert = require('assert');
 var libraryV1 = require('../src/').v1();
+MockStream = require('google-gax').MockStream;
 
 describe('LibraryServiceClient', function() {
   describe('createShelf', function() {
@@ -562,6 +563,95 @@ describe('LibraryServiceClient', function() {
         assert.ifError(err);
         done();
       });
+    });
+  });
+
+  describe('streamShelves', function() {
+    it('invokes streamShelves without error', function(done) {
+      var client = libraryV1.libraryServiceClient();
+      // Mock request
+      var request = {};
+
+      // Mock response
+      var expectedResponse = {};
+
+      // Mock Grpc layer
+      client._streamShelves = function() {
+        return new MockStream(request, expectedResponse);
+      };
+
+      var stream = client.streamShelves().on('data', function(response) {
+        assert.deepStrictEqual(response, expectedResponse);
+        done()
+      });
+
+      stream.write(request);
+    });
+  });
+
+  describe('streamBooks', function() {
+    it('invokes streamBooks without error', function(done) {
+      var client = libraryV1.libraryServiceClient();
+      // Mock request
+      var name = 'name3373707';
+      var request = {
+          name : name
+      };
+
+      // Mock response
+      var name2 = 'name2-1052831874';
+      var author = 'author-1406328437';
+      var title = 'title110371416';
+      var read = true;
+      var expectedResponse = {
+          name : name2,
+          author : author,
+          title : title,
+          read : read
+      };
+
+      // Mock Grpc layer
+      client._streamBooks = function() {
+        return new MockStream(request, expectedResponse);
+      };
+
+      var stream = client.streamBooks().on('data', function(response) {
+        assert.deepStrictEqual(response, expectedResponse);
+        done()
+      });
+
+      stream.write(request);
+    });
+  });
+
+  describe('discussBook', function() {
+    it('invokes discussBook without error', function(done) {
+      var client = libraryV1.libraryServiceClient();
+      // Mock request
+      var name = 'name3373707';
+      var request = {
+          name : name
+      };
+
+      // Mock response
+      var userName = 'userName339340927';
+      var comment = '95';
+      var expectedResponse = {
+          userName : userName,
+          comment : comment
+      };
+
+      // Mock Grpc layer
+      client._discussBook = function() {
+        return new MockStream(request, expectedResponse);
+      };
+
+      var stream = client.discussBook().on('data', function(response) {
+        assert.deepStrictEqual(response, expectedResponse);
+        done()
+      });
+
+      stream.write(request);
     });
   });
 

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_test_library.baseline
@@ -580,12 +580,10 @@ describe('LibraryServiceClient', function() {
         return new MockStream(request, expectedResponse);
       };
 
-      var stream = client.streamShelves().on('data', function(response) {
+      client.streamShelves(request).on('data', function(response) {
         assert.deepStrictEqual(response, expectedResponse);
         done()
       });
-
-      stream.write(request);
     });
   });
 
@@ -615,12 +613,10 @@ describe('LibraryServiceClient', function() {
         return new MockStream(request, expectedResponse);
       };
 
-      var stream = client.streamBooks().on('data', function(response) {
+      client.streamBooks(request).on('data', function(response) {
         assert.deepStrictEqual(response, expectedResponse);
         done()
       });
-
-      stream.write(request);
     });
   });
 

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_test_library.baseline
@@ -575,12 +575,13 @@ describe('LibraryServiceClient', function() {
       // Mock response
       var expectedResponse = {};
 
-      var mockStream = through2.obj(function (chunk, enc, callback) {
-        callback(null, expectedResponse);
-      });
-
+      // Mock Grpc layer
       client._streamShelves = function(actualRequest) {
         assert.deepStrictEqual(actualRequest, request);
+        var mockStream = through2.obj(function (chunk, enc, callback) {
+          callback(null, expectedResponse);
+        });
+        mockStream.write();
         return mockStream;
       };
 
@@ -590,9 +591,6 @@ describe('LibraryServiceClient', function() {
       }).on('error', function(err) {
         done(err);
       });
-
-      // Manually invoke the data event.
-      mockStream.write();
     });
   });
 
@@ -617,12 +615,13 @@ describe('LibraryServiceClient', function() {
           read : read
       };
 
-      var mockStream = through2.obj(function (chunk, enc, callback) {
-        callback(null, expectedResponse);
-      });
-
+      // Mock Grpc layer
       client._streamBooks = function(actualRequest) {
         assert.deepStrictEqual(actualRequest, request);
+        var mockStream = through2.obj(function (chunk, enc, callback) {
+          callback(null, expectedResponse);
+        });
+        mockStream.write();
         return mockStream;
       };
 
@@ -632,9 +631,6 @@ describe('LibraryServiceClient', function() {
       }).on('error', function(err) {
         done(err);
       });
-
-      // Manually invoke the data event.
-      mockStream.write();
     });
   });
 
@@ -655,12 +651,12 @@ describe('LibraryServiceClient', function() {
           comment : comment
       };
 
-      var mockStream = through2.obj(function (chunk, enc, callback) {
-        assert.deepStrictEqual(chunk, request);
-        callback(null, expectedResponse);
-      });
-
+      // Mock Grpc layer
       client._discussBook = function() {
+        var mockStream = through2.obj(function (chunk, enc, callback) {
+          assert.deepStrictEqual(chunk, request);
+          callback(null, expectedResponse);
+        });
         return mockStream;
       };
 

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_test_library.baseline
@@ -17,7 +17,7 @@
 
 var assert = require('assert');
 var libraryV1 = require('../src/').v1();
-MockStream = require('google-gax').MockStream;
+var MockStream = require('google-gax').MockStream;
 
 describe('LibraryServiceClient', function() {
   describe('createShelf', function() {

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_test_library.baseline
@@ -583,6 +583,8 @@ describe('LibraryServiceClient', function() {
       client.streamShelves(request).on('data', function(response) {
         assert.deepStrictEqual(response, expectedResponse);
         done()
+      }).on('error', function(err) {
+        done(err);
       });
     });
   });
@@ -616,6 +618,8 @@ describe('LibraryServiceClient', function() {
       client.streamBooks(request).on('data', function(response) {
         assert.deepStrictEqual(response, expectedResponse);
         done()
+      }).on('error', function(err) {
+        done(err);
       });
     });
   });
@@ -645,6 +649,8 @@ describe('LibraryServiceClient', function() {
       var stream = client.discussBook().on('data', function(response) {
         assert.deepStrictEqual(response, expectedResponse);
         done()
+      }).on('error', function(err) {
+        done(err);
       });
 
       stream.write(request);

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_test_library.baseline
@@ -576,18 +576,20 @@ describe('LibraryServiceClient', function() {
       var expectedResponse = {};
 
       // Mock Grpc layer
-      client._streamShelves = function(request) {
-        assert.deepStrictEqual(request, this.expectedRequest);
-        var mockStream = new MockStream(request, expectedResponse);
-        return mockStream.emitImmediately();
+      var mockStream = new MockStream(request, expectedResponse);
+      client._streamShelves = function(actualRequest) {
+        assert.deepStrictEqual(actualRequest, request);
+        return mockStream;
       };
 
-      client.streamShelves(request).on('data', function(response) {
+      var stream = client.streamShelves(request).on('data', function(response) {
         assert.deepStrictEqual(response, expectedResponse);
         done()
       }).on('error', function(err) {
         done(err);
       });
+
+      stream.emitImmediately();
     });
   });
 
@@ -613,18 +615,20 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._streamBooks = function(request) {
-        assert.deepStrictEqual(request, this.expectedRequest);
-        var mockStream = new MockStream(request, expectedResponse);
-        return mockStream.emitImmediately();
+      var mockStream = new MockStream(request, expectedResponse);
+      client._streamBooks = function(actualRequest) {
+        assert.deepStrictEqual(actualRequest, request);
+        return mockStream;
       };
 
-      client.streamBooks(request).on('data', function(response) {
+      var stream = client.streamBooks(request).on('data', function(response) {
         assert.deepStrictEqual(response, expectedResponse);
         done()
       }).on('error', function(err) {
         done(err);
       });
+
+      stream.emitImmediately();
     });
   });
 
@@ -646,8 +650,9 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
+      var mockStream = new MockStream(request, expectedResponse);
       client._discussBook = function() {
-        return new MockStream(request, expectedResponse);
+        return mockStream;
       };
 
       var stream = client.discussBook().on('data', function(response) {

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_test_library.baseline
@@ -582,14 +582,14 @@ describe('LibraryServiceClient', function() {
         return mockStream;
       };
 
-      var stream = client.streamShelves(request).on('data', function(response) {
+      client.streamShelves(request).on('data', function(response) {
         assert.deepStrictEqual(response, expectedResponse);
         done()
       }).on('error', function(err) {
         done(err);
       });
 
-      stream.emitImmediately();
+      mockStream.emitImmediately();
     });
   });
 
@@ -621,14 +621,14 @@ describe('LibraryServiceClient', function() {
         return mockStream;
       };
 
-      var stream = client.streamBooks(request).on('data', function(response) {
+      client.streamBooks(request).on('data', function(response) {
         assert.deepStrictEqual(response, expectedResponse);
         done()
       }).on('error', function(err) {
         done(err);
       });
 
-      stream.emitImmediately();
+      mockStream.emitImmediately();
     });
   });
 
@@ -650,9 +650,8 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      var mockStream = new MockStream(request, expectedResponse);
       client._discussBook = function() {
-        return mockStream;
+        return new MockStream(request, expectedResponse);
       };
 
       var stream = client.discussBook().on('data', function(response) {

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_test_library.baseline
@@ -576,8 +576,10 @@ describe('LibraryServiceClient', function() {
       var expectedResponse = {};
 
       // Mock Grpc layer
-      client._streamShelves = function() {
-        return new MockStream(request, expectedResponse);
+      client._streamShelves = function(request) {
+        assert.deepStrictEqual(request, this.expectedRequest);
+        var mockStream = new MockStream(request, expectedResponse);
+        return mockStream.emitImmediately();
       };
 
       client.streamShelves(request).on('data', function(response) {
@@ -611,8 +613,10 @@ describe('LibraryServiceClient', function() {
       };
 
       // Mock Grpc layer
-      client._streamBooks = function() {
-        return new MockStream(request, expectedResponse);
+      client._streamBooks = function(request) {
+        assert.deepStrictEqual(request, this.expectedRequest);
+        var mockStream = new MockStream(request, expectedResponse);
+        return mockStream.emitImmediately();
       };
 
       client.streamBooks(request).on('data', function(response) {


### PR DESCRIPTION
_Note:_ This PR depends on the GAX change: https://github.com/googleapis/gax-nodejs/pull/101