### PR TITLE
Use license config in generated Python

### DIFF
--- a/src/main/resources/com/google/api/codegen/py/main.snip
+++ b/src/main/resources/com/google/api/codegen/py/main.snip
@@ -25,19 +25,13 @@
 @end
 
 @private licenseSection(service)
-    @# Copyright 2016 Google Inc. All rights reserved.
-    @#
-    @# Licensed under the Apache License, Version 2.0 (the "License");
-    @# you may not use this file except in compliance with the License.
-    @# You may obtain a copy of the License at
-    @#
-    @# http://www.apache.org/licenses/LICENSE-2.0
-    @#
-    @# Unless required by applicable law or agreed to in writing, software
-    @# distributed under the License is distributed on an "AS IS" BASIS,
-    @# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    @# See the License for the specific language governing permissions and
-    @# limitations under the License.
+    @join line : context.getApiConfig.getCopyrightLines
+      @# {@line}
+    @end
+    {@BREAK}@#
+    @join line : context.getApiConfig.getLicenseLines
+      @# {@line}
+    @end
     @#
     @# EDITING INSTRUCTIONS
     @# This file was generated from the file

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
@@ -1,11 +1,11 @@
 ============== file: google/cloud/gapic/example/library/v1/library_service_client.py ==============
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016, Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
@@ -1,11 +1,11 @@
 ============== file: google/cloud/gapic/example/library/v1/library_service_client.py ==============
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016, Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/test/java/com/google/api/codegen/testdata/python_main_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_main_no_path_templates.baseline
@@ -1,11 +1,11 @@
 ============== file: example/no_templates_api_service_client.py ==============
-# Copyright 2016 Google Inc. All rights reserved.
+# Copyright 2016, Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-# http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
Replaces hard-coded Apache license with configurable license in generated Python.