### PR TITLE
Support future years in the license check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -456,12 +456,13 @@ task verifyLicense << {
   def srcFiles = []
   sourceSets
       .collectMany{it.allJava.getSrcDirs()}
-      .each{it.eachFileRecurse(FileType.FILES, {srcFiles << it})}
+      .each{it.eachFileRecurse(FileType.FILES, {srcFiles << new Tuple(it, it.text)})}
   srcFiles = srcFiles
-      .findAll{!it.path.contains("/generated/") && it.path.endsWith(".java")}
-      .findAll{!it.text.startsWith(licenseText)}
+      .collect{new Tuple(it.get(0), it.get(1).replaceAll("Copyright 20[0-9]{2}", "Copyright 20xx"))}
+      .findAll{!it.get(0).path.contains("/generated/") && it.get(0).path.endsWith(".java")}
+      .findAll{!it.get(1).startsWith(licenseText)}
   if (srcFiles.asList().size() > 0) {
-    srcFiles.each({println 'missing license: ' + it})
+    srcFiles.each({println 'missing license: ' + it.get(0)})
     throw new IllegalStateException("Above files do not have licenses")
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -458,8 +458,8 @@ task verifyLicense << {
       .collectMany{it.allJava.getSrcDirs()}
       .each{it.eachFileRecurse(FileType.FILES, {srcFiles << new Tuple(it, it.text)})}
   srcFiles = srcFiles
-      .collect{new Tuple(it.get(0), it.get(1).replaceAll("Copyright 20[0-9]{2}", "Copyright 20xx"))}
       .findAll{!it.get(0).path.contains("/generated/") && it.get(0).path.endsWith(".java")}
+      .collect{new Tuple(it.get(0), it.get(1).replaceAll("Copyright 20[0-9]{2}", "Copyright 20xx"))}
       .findAll{!it.get(1).startsWith(licenseText)}
   if (srcFiles.asList().size() > 0) {
     srcFiles.each({println 'missing license: ' + it.get(0)})

--- a/license-header-javadoc.txt
+++ b/license-header-javadoc.txt
@@ -1,4 +1,4 @@
-/* Copyright 2016 Google Inc
+/* Copyright 20xx Google Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
The `verifyLicense` command compares each file's header to a hardcoded text
file that specifies the year as 2016. Since it's no longer 2016, and will not
be 2016 for the foreseeable future, the command now does an in-memory regex
replace for "Copyright 20[0-9]{2}" with "Copyright 20xx" before comparison.