### PR TITLE
Revert some override functionality

### DIFF
--- a/src/main/java/com/google/api/codegen/discovery/ViewModelProvider.java
+++ b/src/main/java/com/google/api/codegen/discovery/ViewModelProvider.java
@@ -26,13 +26,11 @@ import com.google.api.codegen.discovery.transformer.SampleMethodToViewTransforme
 import com.google.api.codegen.rendering.CommonSnippetSetRunner;
 import com.google.api.codegen.viewmodel.ViewModel;
 import com.google.api.tools.framework.snippet.Doc;
-import com.google.common.collect.Lists;
 import com.google.protobuf.Method;
-import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.regex.Pattern;
 
 /*
  * Calls the MethodToViewTransformer on a method with the provided ApiaryConfig.
@@ -125,29 +123,28 @@ public class ViewModelProvider implements DiscoveryProvider {
    * @param overrideTree the JsonNode with values to overwrite tree with.
    */
   private static void merge(ObjectNode tree, ObjectNode overrideTree) {
-    // Sort patterns to ensure deterministic ordering of overrides
-    List<String> fieldPatterns = Lists.newArrayList(overrideTree.fieldNames());
-    Collections.sort(fieldPatterns);
-    for (String fieldPatternString : fieldPatterns) {
-      Pattern fieldPattern = Pattern.compile(fieldPatternString);
-      // Copy field name list to avoid concurrent modification
-      for (String fieldName : Lists.newArrayList(tree.fieldNames())) {
-        if (fieldPattern.matcher(fieldName).matches()) {
-          JsonNode defaultValue = tree.get(fieldName);
-          JsonNode overrideValue = overrideTree.get(fieldPatternString);
-          // Skip null nodes.
-          if (defaultValue != null && overrideValue.isNull()) {
-            // If a node is overridden as null, we pretend it was never specified
-            // altogether. We provide this functionality so nodes from an object can
-            // be deleted from both trees.
-            // TODO(saicheems): Verify that this is the best approach for this issue.
-            tree.remove(fieldName);
-          } else if (defaultValue.isObject() && overrideValue.isObject()) {
-            merge((ObjectNode) defaultValue, (ObjectNode) overrideValue);
-          } else if (overrideValue != null) {
-            tree.set(fieldName, overrideValue);
-          }
+    Iterator<String> fieldNames = overrideTree.fieldNames();
+    while (fieldNames.hasNext()) {
+      String fieldName = fieldNames.next();
+      JsonNode defaultValue = tree.get(fieldName);
+      JsonNode overrideValue = overrideTree.get(fieldName);
+      if (defaultValue == null) {
+        // If backupValue isn't null, then we add it to tree. This can happen if
+        // extra fields/properties are specified.
+        if (overrideValue != null) {
+          tree.set(fieldName, overrideValue);
         }
+        // Otherwise, skip null nodes.
+      } else if (overrideValue.isNull()) {
+        // If a node is overridden as null, we pretend it was never specified
+        // altogether. We provide this functionality so nodes from an object can
+        // be deleted from both trees.
+        // TODO(saicheems): Verify that this is the best approach for this issue.
+        tree.remove(fieldName);
+      } else if (defaultValue.isObject() && overrideValue.isObject()) {
+        merge((ObjectNode) defaultValue, (ObjectNode) overrideValue.deepCopy());
+      } else {
+        tree.set(fieldName, overrideTree.get(fieldName));
       }
     }
   }

--- a/src/main/java/com/google/api/codegen/discovery/transformer/go/GoSampleMethodToViewTransformer.java
+++ b/src/main/java/com/google/api/codegen/discovery/transformer/go/GoSampleMethodToViewTransformer.java
@@ -96,7 +96,10 @@ public class GoSampleMethodToViewTransformer implements SampleMethodToViewTransf
       fieldVarNames.add(requestBodyVarName);
     }
 
-    if (methodInfo.isPageStreaming()) {
+    // The Go client only considers methods whose verb is "GET" to be page
+    // streaming calls. This excludes "search" methods, for example.
+    boolean isPageStreaming = methodInfo.isPageStreaming() && methodInfo.verb().equals("GET");
+    if (isPageStreaming) {
       builder.pageStreaming(createSamplePageStreamingView(context, symbolTable));
     }
 
@@ -132,7 +135,7 @@ public class GoSampleMethodToViewTransformer implements SampleMethodToViewTransf
         .hasResponse(hasResponse)
         .fields(fields)
         .fieldVarNames(fieldVarNames)
-        .isPageStreaming(methodInfo.isPageStreaming())
+        .isPageStreaming(isPageStreaming)
         .hasMediaUpload(methodInfo.hasMediaUpload())
         .hasMediaDownload(methodInfo.hasMediaDownload())
         .servicePackageName(servicePackageName)

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/cloudmonitoring.v2beta2.json.overrides
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/cloudmonitoring.v2beta2.json.overrides
@@ -1,7 +1,13 @@
 {
   "csharp|java": {
     "methods": {
-      ".*list": {
+      "cloudmonitoring.metricDescriptors.list": {
+        "requestBodyType": null
+      },
+      "cloudmonitoring.timeseries.list": {
+        "requestBodyType": null
+      },
+      "cloudmonitoring.timeseriesDescriptors.list": {
         "requestBodyType": null
       }
     }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/cloudresourcemanager.v1.json.overrides
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/cloudresourcemanager.v1.json.overrides
@@ -1,9 +1,0 @@
-{
-  "go": {
-    "methods": {
-      "cloudresourcemanager.organizations.search": {
-        "isPageStreaming": false
-      }
-    }
-  }
-}

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/compute.v1.json.overrides
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/compute.v1.json.overrides
@@ -1,9 +1,0 @@
-{
-  "go": {
-    "methods": {
-      "compute.instanceGroups.listInstances": {
-        "isPageStreaming": false
-      }
-    }
-  }
-}

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/dfareporting.v2.6.json.overrides
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/dfareporting.v2.6.json.overrides
@@ -1,9 +1,0 @@
-{
-  "go": {
-    "methods": {
-      "dfareporting.dimensionValues.query": {
-        "isPageStreaming": false
-      }
-    }
-  }
-}

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/genomics.v1.json.overrides
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/genomics.v1.json.overrides
@@ -1,9 +1,0 @@
-{
-  "go": {
-    "methods": {
-      ".*search": {
-        "isPageStreaming": false
-      }
-    }
-  }
-}

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/logging.v2beta1.json.overrides
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/logging.v2beta1.json.overrides
@@ -1,9 +1,0 @@
-{
-  "go": {
-    "methods": {
-      "logging.entries.list": {
-        "isPageStreaming": false
-      }
-    }
-  }
-}

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/translate.v2.json.overrides
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/translate.v2.json.overrides
@@ -1,7 +1,17 @@
 {
   "nodejs": {
     "methods": {
-      "language.(detections|translations).list": {
+      "language.detections.list": {
+        "fields": {
+          "q": {
+            "type": {
+              "kind": "TYPE_STRING",
+              "isArray": false
+            }
+          }
+        }
+      },
+      "language.translations.list": {
         "fields": {
           "q": {
             "type": {


### PR DESCRIPTION
To allow introducing new fields to objects, this commit removes the pattern
matching feature from all fields except the root level language nodes.

It also adds configuration in the Go sample transformer to only consider
methods whose verb is "GET" to be page streaming calls as specified in the Go
client library generator.