### PR TITLE
Exclude pyc files in MANIFEST.in

### DIFF
--- a/src/main/resources/com/google/api/codegen/metadatagen/py/MANIFEST.in.snip
+++ b/src/main/resources/com/google/api/codegen/metadatagen/py/MANIFEST.in.snip
@@ -1,4 +1,5 @@
 @snippet generate(context)
     include README.rst LICENSE
+    global-exclude *.pyc
 
 @end

--- a/src/main/resources/com/google/api/codegen/py/MANIFEST.in.snip
+++ b/src/main/resources/com/google/api/codegen/py/MANIFEST.in.snip
@@ -2,6 +2,7 @@
   include README.rst LICENSE
   global-include *.json
   graft google
+  global-exclude *.pyc
   prune .tox
 
 @end

--- a/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/python_library.baseline
@@ -293,6 +293,7 @@ E.g,
 
 ============== file: MANIFEST.in ==============
 include README.rst LICENSE
+global-exclude *.pyc
 
 ============== file: test/nested/v1/test_pb2.py ==============
 # Test text.

--- a/src/test/java/com/google/api/codegen/testdata/python_MANIFEST_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_MANIFEST_library.baseline
@@ -2,5 +2,6 @@
 include README.rst LICENSE
 global-include *.json
 graft google
+global-exclude *.pyc
 prune .tox
 

--- a/src/test/java/com/google/api/codegen/testdata/python_MANIFEST_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_MANIFEST_no_path_templates.baseline
@@ -2,5 +2,6 @@
 include README.rst LICENSE
 global-include *.json
 graft google
+global-exclude *.pyc
 prune .tox
 

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_MANIFEST_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_MANIFEST_library.baseline
@@ -2,5 +2,6 @@
 include README.rst LICENSE
 global-include *.json
 graft google
+global-exclude *.pyc
 prune .tox
 


### PR DESCRIPTION
Updates #892 

(Note -- not closing that bug yet because this doesn't address `__pycache__`.)