### PR TITLE
Fix some template mistakes

### DIFF
--- a/src/main/resources/com/google/api/codegen/metadatagen/py/README.rst.snip
+++ b/src/main/resources/com/google/api/codegen/metadatagen/py/README.rst.snip
@@ -1,8 +1,8 @@
 @snippet generate(metadata)
     gRPC library for {@metadata.fullName}
 
-    grpc-{@metadata.packageName} is the IDL-derived library for the {@metadata.shortName} ({@metadata.majorVersion}) service in the googleapis_ repository.
+    grpc-{@metadata.packageName} is the IDL-derived library for the {@metadata.fullName} ({@metadata.majorVersion}) service in the googleapis_ repository.
 
-    .. _`googleapis`: https://github.com/googleapis/googleapis/tree/master/{@metadata.protoPath}/{@metadata.majorVersion}
+    .. _`googleapis`: https://github.com/googleapis/googleapis/tree/master/{@metadata.protoPath}
 
 @end

--- a/src/main/resources/com/google/api/codegen/py/README.rst.snip
+++ b/src/main/resources/com/google/api/codegen/py/README.rst.snip
@@ -2,7 +2,7 @@
   GAPIC library for the {@metadata.fullName}
   ================================================================================
   
-  {@metadata.packageName} uses google-gax_ (Google API extensions) to provide an
+  gapic-{@metadata.packageName} uses google-gax_ (Google API extensions) to provide an
   easy-to-use client library for the `{@metadata.fullName}`_ ({@metadata.majorVersion}) defined in the googleapis_ git repository
   
   
@@ -13,7 +13,7 @@
   Getting started
   ---------------
   
-  {@metadata.packageName} will allow you to connect to the
+  gapic-{@metadata.packageName} will allow you to connect to the
   {@metadata.fullName} and access all its methods. In order to do this, you need
   to set up authentication as well as install the library locally.
   
@@ -62,7 +62,7 @@
       pip install virtualenv
       virtualenv <your-env>
       source <your-env>/bin/activate
-      <your-env>/bin/pip install {@metadata.packageName}
+      <your-env>/bin/pip install gapic-{@metadata.packageName}
   
   
   Windows
@@ -73,7 +73,7 @@
       pip install virtualenv
       virtualenv <your-env>
       <your-env>\Scripts\activate
-      <your-env>\Scripts\pip.exe install {@metadata.packageName}
+      <your-env>\Scripts\pip.exe install gapic-{@metadata.packageName}
   
   
   At this point you are all set to continue.

--- a/src/main/resources/com/google/api/codegen/py/requirements.txt.snip
+++ b/src/main/resources/com/google/api/codegen/py/requirements.txt.snip
@@ -2,6 +2,6 @@
   googleapis-common-protos>={@metadata.commonProtosVersionBound.lower}, <{@metadata.commonProtosVersionBound.upper}
   google-gax>={@metadata.gaxVersionBound.lower}, <{@metadata.gaxVersionBound.upper}
   grpc-{@metadata.packageName}>={@metadata.packageVersionBound.lower}, <{@metadata.packageVersionBound.upper}
-  oauth2client>={@metadata.gaxVersionBound.lower}, <{@metadata.gaxVersionBound.upper}
+  oauth2client>={@metadata.authVersionBound.lower}, <{@metadata.authVersionBound.upper}
 
 @end

--- a/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/library_pkg.yaml
+++ b/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/library_pkg.yaml
@@ -1,7 +1,7 @@
 # Common configuration
 short_name: library
 major_version: v1
-proto_path: google/example/library
+proto_path: google/example/library/v1
 author: Google, Inc.
 email: googleapis-packages@google.com
 homepage: https://github.com/googleapis/googleapis

--- a/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/python_library.baseline
@@ -258,7 +258,7 @@ setuptools.setup(
 ============== file: README.rst ==============
 gRPC library for Google Example Library API
 
-grpc-google-cloud-library-v1 is the IDL-derived library for the library (v1) service in the googleapis_ repository.
+grpc-google-cloud-library-v1 is the IDL-derived library for the Google Example Library API (v1) service in the googleapis_ repository.
 
 .. _`googleapis`: https://github.com/googleapis/googleapis/tree/master/google/example/library/v1
 

--- a/src/test/java/com/google/api/codegen/testdata/python_README_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_README_library.baseline
@@ -2,7 +2,7 @@
 GAPIC library for the Google Example Library API
 ================================================================================
 
-google-cloud-library-v1 uses google-gax_ (Google API extensions) to provide an
+gapic-google-cloud-library-v1 uses google-gax_ (Google API extensions) to provide an
 easy-to-use client library for the `Google Example Library API`_ (v1) defined in the googleapis_ git repository
 
 
@@ -13,7 +13,7 @@ easy-to-use client library for the `Google Example Library API`_ (v1) defined in
 Getting started
 ---------------
 
-google-cloud-library-v1 will allow you to connect to the
+gapic-google-cloud-library-v1 will allow you to connect to the
 Google Example Library API and access all its methods. In order to do this, you need
 to set up authentication as well as install the library locally.
 
@@ -62,7 +62,7 @@ Mac/Linux
     pip install virtualenv
     virtualenv <your-env>
     source <your-env>/bin/activate
-    <your-env>/bin/pip install google-cloud-library-v1
+    <your-env>/bin/pip install gapic-google-cloud-library-v1
 
 
 Windows
@@ -73,7 +73,7 @@ Windows
     pip install virtualenv
     virtualenv <your-env>
     <your-env>\Scripts\activate
-    <your-env>\Scripts\pip.exe install google-cloud-library-v1
+    <your-env>\Scripts\pip.exe install gapic-google-cloud-library-v1
 
 
 At this point you are all set to continue.

--- a/src/test/java/com/google/api/codegen/testdata/python_README_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_README_no_path_templates.baseline
@@ -2,7 +2,7 @@
 GAPIC library for the Google Fake API
 ================================================================================
 
-google-cloud-library-v1 uses google-gax_ (Google API extensions) to provide an
+gapic-google-cloud-library-v1 uses google-gax_ (Google API extensions) to provide an
 easy-to-use client library for the `Google Fake API`_ (v1) defined in the googleapis_ git repository
 
 
@@ -13,7 +13,7 @@ easy-to-use client library for the `Google Fake API`_ (v1) defined in the google
 Getting started
 ---------------
 
-google-cloud-library-v1 will allow you to connect to the
+gapic-google-cloud-library-v1 will allow you to connect to the
 Google Fake API and access all its methods. In order to do this, you need
 to set up authentication as well as install the library locally.
 
@@ -62,7 +62,7 @@ Mac/Linux
     pip install virtualenv
     virtualenv <your-env>
     source <your-env>/bin/activate
-    <your-env>/bin/pip install google-cloud-library-v1
+    <your-env>/bin/pip install gapic-google-cloud-library-v1
 
 
 Windows
@@ -73,7 +73,7 @@ Windows
     pip install virtualenv
     virtualenv <your-env>
     <your-env>\Scripts\activate
-    <your-env>\Scripts\pip.exe install google-cloud-library-v1
+    <your-env>\Scripts\pip.exe install gapic-google-cloud-library-v1
 
 
 At this point you are all set to continue.

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_README_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_README_library.baseline
@@ -2,7 +2,7 @@
 GAPIC library for the Google Example Library API
 ================================================================================
 
-google-cloud-library-v1 uses google-gax_ (Google API extensions) to provide an
+gapic-google-cloud-library-v1 uses google-gax_ (Google API extensions) to provide an
 easy-to-use client library for the `Google Example Library API`_ (v1) defined in the googleapis_ git repository
 
 
@@ -13,7 +13,7 @@ easy-to-use client library for the `Google Example Library API`_ (v1) defined in
 Getting started
 ---------------
 
-google-cloud-library-v1 will allow you to connect to the
+gapic-google-cloud-library-v1 will allow you to connect to the
 Google Example Library API and access all its methods. In order to do this, you need
 to set up authentication as well as install the library locally.
 
@@ -62,7 +62,7 @@ Mac/Linux
     pip install virtualenv
     virtualenv <your-env>
     source <your-env>/bin/activate
-    <your-env>/bin/pip install google-cloud-library-v1
+    <your-env>/bin/pip install gapic-google-cloud-library-v1
 
 
 Windows
@@ -73,7 +73,7 @@ Windows
     pip install virtualenv
     virtualenv <your-env>
     <your-env>\Scripts\activate
-    <your-env>\Scripts\pip.exe install google-cloud-library-v1
+    <your-env>\Scripts\pip.exe install gapic-google-cloud-library-v1
 
 
 At this point you are all set to continue.

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_requirements_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_requirements_library.baseline
@@ -2,5 +2,5 @@
 googleapis-common-protos>=1.5.0, <2.0dev
 google-gax>=0.14.0, <0.15.0
 grpc-google-cloud-library-v1>=0.14.0, <0.15dev
-oauth2client>=0.14.0, <0.15.0
+oauth2client>=2.0.0, <4.0dev
 

--- a/src/test/java/com/google/api/codegen/testdata/python_requirements_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_requirements_library.baseline
@@ -2,5 +2,5 @@
 googleapis-common-protos>=1.5.0, <2.0dev
 google-gax>=0.14.0, <0.15.0
 grpc-google-cloud-library-v1>=0.14.0, <0.15dev
-oauth2client>=0.14.0, <0.15.0
+oauth2client>=2.0.0, <4.0dev
 

--- a/src/test/java/com/google/api/codegen/testdata/python_requirements_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_requirements_no_path_templates.baseline
@@ -2,5 +2,5 @@
 googleapis-common-protos>=1.5.0, <2.0dev
 google-gax>=0.14.0, <0.15.0
 grpc-google-cloud-library-v1>=0.14.0, <0.15dev
-oauth2client>=0.14.0, <0.15.0
+oauth2client>=2.0.0, <4.0dev
 


### PR DESCRIPTION
This change corrects some superficial errors in the templates that either had not been fixable before the templates had been ported from `packman` to `toolkit`, or were introduced in the process of porting them.

(See [this PR](https://github.com/googleapis/api-client-staging/pull/154/commits/ecfc1ce6e0980186ec235e5744e00537f1b778cd) for an example of how the generated output is currently hand edited.)
