### PR TITLE
rename Java test file

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
@@ -926,7 +926,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
 
   /** The unit test class name for the given API service. */
   public String getUnitTestClassName(Interface service) {
-    return publicClassName(Name.upperCamel(service.getSimpleName(), "Test"));
+    return publicClassName(Name.upperCamel(service.getSimpleName(), "Client", "Test"));
   }
 
   /** The smoke test class name for the given API service. */

--- a/src/test/java/com/google/api/codegen/testdata/java_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_test_library.baseline
@@ -1,4 +1,4 @@
-============== file: src/test/java/com/google/gcloud/pubsub/spi/LibraryServiceTest.java ==============
+============== file: src/test/java/com/google/gcloud/pubsub/spi/LibraryServiceClientTest.java ==============
 /*
  * Copyright 2016, Google Inc. All rights reserved.
  *
@@ -93,7 +93,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 @javax.annotation.Generated("by GAPIC")
-public class LibraryServiceTest {
+public class LibraryServiceClientTest {
   private static MockLibraryService mockLibraryService;
   private static MockLabeler mockLabeler;
   private static MockServiceHelper serviceHelper;

--- a/src/test/java/com/google/api/codegen/testdata/java_test_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_test_no_path_templates.baseline
@@ -1,4 +1,4 @@
-============== file: src/test/java/com/google/gcloud/example/NoTemplatesApiServiceTest.java ==============
+============== file: src/test/java/com/google/gcloud/example/NoTemplatesApiServiceClientTest.java ==============
 /*
  * Copyright 2016, Google Inc. All rights reserved.
  *
@@ -35,7 +35,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 @javax.annotation.Generated("by GAPIC")
-public class NoTemplatesApiServiceTest {
+public class NoTemplatesApiServiceClientTest {
   private static MockNoTemplatesAPIService mockNoTemplatesAPIService;
   private static MockServiceHelper serviceHelper;
   private NoTemplatesApiServiceClient client;

--- a/src/test/java/com/google/api/codegen/testdata/php_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php_test_library.baseline
@@ -1,4 +1,4 @@
-============== file: tests/unit/Example/Library/V1/LibraryServiceTest.php ==============
+============== file: tests/unit/Example/Library/V1/LibraryServiceClientTest.php ==============
 <?php
 /*
  * Copyright 2016, Google Inc. All rights reserved.
@@ -69,7 +69,7 @@ use \google\tagger\v1\LabelerGrpcClient;
  * @group library
  * @group grpc
  */
-class LibraryServiceTest extends PHPUnit_Framework_TestCase
+class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
 {
     public function createMockLibraryServiceImpl($hostname, $opts)
     {


### PR DESCRIPTION
This commit renames generated unit test from
FooBarTest to FooBarClientTest.
See
https://google.github.io/styleguide/javaguide.html#s5.2.2-class-names

This change also affects PHP. I'm not sure what the naming convention
is.

Fixes #938