### PR TITLE
Bump python version

### DIFF
--- a/src/test/java/com/google/api/codegen/testdata/python_doc_docs_conf_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_docs_conf_library.baseline
@@ -21,7 +21,7 @@ import shlex
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('..'))
 
-__version__ = '0.14.0'
+__version__ = '0.15.0'
 
 # -- General configuration ------------------------------------------------
 

--- a/src/test/java/com/google/api/codegen/testdata/python_docs_conf_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_docs_conf_library.baseline
@@ -21,7 +21,7 @@ import shlex
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('..'))
 
-__version__ = '0.14.0'
+__version__ = '0.15.0'
 
 # -- General configuration ------------------------------------------------
 

--- a/src/test/java/com/google/api/codegen/testdata/python_docs_conf_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_docs_conf_no_path_templates.baseline
@@ -21,7 +21,7 @@ import shlex
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('..'))
 
-__version__ = '0.14.0'
+__version__ = '0.15.0'
 
 # -- General configuration ------------------------------------------------
 


### PR DESCRIPTION
A previous PR (https://github.com/googleapis/toolkit/pull/924) seems to have broken travis, this fixes the problem. Likely caused by another PR that bumped the version being merged between the travis tests running for that PR and merging.