### PR TITLE
Change baseline Python docs to 0.15.0.

### DIFF
--- a/src/main/resources/com/google/api/codegen/py/docs/conf.py.snip
+++ b/src/main/resources/com/google/api/codegen/py/docs/conf.py.snip
@@ -317,5 +317,4 @@
   napoleon_use_ivar = False
   napoleon_use_param = True
   napoleon_use_rtype = True
-
 @end

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_docs_conf_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_docs_conf_library.baseline
@@ -21,7 +21,7 @@ import shlex
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('..'))
 
-__version__ = '0.14.0'
+__version__ = '0.15.0'
 
 # -- General configuration ------------------------------------------------
 
@@ -317,4 +317,3 @@ napoleon_use_admonition_for_references = False
 napoleon_use_ivar = False
 napoleon_use_param = True
 napoleon_use_rtype = True
-

--- a/src/test/java/com/google/api/codegen/testdata/python_docs_conf_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_docs_conf_library.baseline
@@ -21,7 +21,7 @@ import shlex
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('..'))
 
-__version__ = '0.14.0'
+__version__ = '0.15.0'
 
 # -- General configuration ------------------------------------------------
 
@@ -317,4 +317,3 @@ napoleon_use_admonition_for_references = False
 napoleon_use_ivar = False
 napoleon_use_param = True
 napoleon_use_rtype = True
-

--- a/src/test/java/com/google/api/codegen/testdata/python_docs_conf_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_docs_conf_no_path_templates.baseline
@@ -21,7 +21,7 @@ import shlex
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath('..'))
 
-__version__ = '0.14.0'
+__version__ = '0.15.0'
 
 # -- General configuration ------------------------------------------------
 
@@ -317,4 +317,3 @@ napoleon_use_admonition_for_references = False
 napoleon_use_ivar = False
 napoleon_use_param = True
 napoleon_use_rtype = True
-


### PR DESCRIPTION
Since we released the 0.15.0 releases of our tools this morning, the toolkit tests have started failing. I believe the version might be read from `googleapis`, which is now updated.

The ultimate fix is probably to make these independent, but for the moment, just updating the versions to make the tests pass again.
