### PR TITLE
Fix missing `@` escape in template

### DIFF
--- a/src/main/resources/com/google/api/codegen/py/docs/conf.py.snip
+++ b/src/main/resources/com/google/api/codegen/py/docs/conf.py.snip
@@ -295,7 +295,7 @@
   @# How to display URL addresses: 'footnote', 'no', or 'inline'.
   @#texinfo_show_urls = 'footnote'
   
-  @# If true, do not generate a @detailmenu in the "Top" node's menu.
+  @# If true, do not generate a @@detailmenu in the "Top" node's menu.
   @#texinfo_no_detailmenu = False
   
   

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_docs_conf_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_docs_conf_library.baseline
@@ -295,7 +295,7 @@ texinfo_documents = [
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
 #texinfo_show_urls = 'footnote'
 
-# If true, do not generate a @etailmenu in the "Top" node's menu.
+# If true, do not generate a @detailmenu in the "Top" node's menu.
 #texinfo_no_detailmenu = False
 
 

--- a/src/test/java/com/google/api/codegen/testdata/python_docs_conf_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_docs_conf_library.baseline
@@ -295,7 +295,7 @@ texinfo_documents = [
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
 #texinfo_show_urls = 'footnote'
 
-# If true, do not generate a @etailmenu in the "Top" node's menu.
+# If true, do not generate a @detailmenu in the "Top" node's menu.
 #texinfo_no_detailmenu = False
 
 

--- a/src/test/java/com/google/api/codegen/testdata/python_docs_conf_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_docs_conf_no_path_templates.baseline
@@ -295,7 +295,7 @@ texinfo_documents = [
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
 #texinfo_show_urls = 'footnote'
 
-# If true, do not generate a @etailmenu in the "Top" node's menu.
+# If true, do not generate a @detailmenu in the "Top" node's menu.
 #texinfo_no_detailmenu = False
 
 


### PR DESCRIPTION
See googleapis/api-client-staging#157 for context

cc: @bjwatson 