### PR TITLE
Add "proto_deps" to Metadata generation

### DIFF
--- a/src/main/java/com/google/api/codegen/config/PackageMetadataConfig.java
+++ b/src/main/java/com/google/api/codegen/config/PackageMetadataConfig.java
@@ -22,7 +22,9 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.yaml.snakeyaml.Yaml;
@@ -42,13 +44,13 @@ public abstract class PackageMetadataConfig {
 
   protected abstract Map<TargetLanguage, VersionBound> protoVersionBound();
 
-  protected abstract Map<TargetLanguage, VersionBound> commonProtosVersionBound();
-
   protected abstract Map<TargetLanguage, VersionBound> authVersionBound();
 
   protected abstract Map<TargetLanguage, VersionBound> generatedPackageVersionBound();
 
   protected abstract Map<TargetLanguage, String> packageName();
+
+  protected abstract Map<TargetLanguage, Map<String, VersionBound>> protoPackageDependencies();
 
   /** The version of GAX that this package depends on. Configured per language. */
   public VersionBound gaxVersionBound(TargetLanguage language) {
@@ -68,14 +70,6 @@ public abstract class PackageMetadataConfig {
     return protoVersionBound().get(language);
   }
 
-  /**
-   * The version of the googleapis common protos package that this package depends on. Configured
-   * per language.
-   */
-  public VersionBound commonProtosVersionBound(TargetLanguage language) {
-    return commonProtosVersionBound().get(language);
-  }
-
   /** The version the client library package. E.g., "0.14.0". Configured per language. */
   public VersionBound generatedPackageVersionBound(TargetLanguage language) {
     return generatedPackageVersionBound().get(language);
@@ -84,6 +78,11 @@ public abstract class PackageMetadataConfig {
   /** The version the auth library package that this package depends on. Configured per language. */
   public VersionBound authVersionBound(TargetLanguage language) {
     return authVersionBound().get(language);
+  }
+
+  /** The versions of the proto packages that this package depends on. Configured per language. */
+  public Map<String, VersionBound> protoPackageDependencies(TargetLanguage language) {
+    return protoPackageDependencies().get(language);
   }
 
   /**
@@ -127,13 +126,13 @@ public abstract class PackageMetadataConfig {
 
     abstract Builder protoVersionBound(Map<TargetLanguage, VersionBound> val);
 
-    abstract Builder commonProtosVersionBound(Map<TargetLanguage, VersionBound> val);
-
     abstract Builder authVersionBound(Map<TargetLanguage, VersionBound> val);
 
     abstract Builder packageName(Map<TargetLanguage, String> val);
 
     abstract Builder generatedPackageVersionBound(Map<TargetLanguage, VersionBound> val);
+
+    abstract Builder protoPackageDependencies(Map<TargetLanguage, Map<String, VersionBound>> val);
 
     abstract Builder shortName(String val);
 
@@ -160,9 +159,9 @@ public abstract class PackageMetadataConfig {
         .grpcVersionBound(ImmutableMap.<TargetLanguage, VersionBound>of())
         .protoVersionBound(ImmutableMap.<TargetLanguage, VersionBound>of())
         .packageName(ImmutableMap.<TargetLanguage, String>of())
-        .commonProtosVersionBound(ImmutableMap.<TargetLanguage, VersionBound>of())
         .authVersionBound(ImmutableMap.<TargetLanguage, VersionBound>of())
         .generatedPackageVersionBound(ImmutableMap.<TargetLanguage, VersionBound>of())
+        .protoPackageDependencies(ImmutableMap.<TargetLanguage, Map<String, VersionBound>>of())
         .shortName("")
         .apiVersion("")
         .protoPath("")
@@ -185,15 +184,13 @@ public abstract class PackageMetadataConfig {
             createVersionMap((Map<String, Map<String, String>>) configMap.get("grpc_version")))
         .protoVersionBound(
             createVersionMap((Map<String, Map<String, String>>) configMap.get("proto_version")))
-        .commonProtosVersionBound(
-            createVersionMap(
-                (Map<String, Map<String, String>>) configMap.get("common_protos_version")))
         .authVersionBound(
             createVersionMap((Map<String, Map<String, String>>) configMap.get("auth_version")))
         .generatedPackageVersionBound(
             createVersionMap(
                 (Map<String, Map<String, String>>) configMap.get("generated_package_version")))
-        .packageName(createPackageNameMap((Map<String, String>) configMap.get("package_name")))
+        .protoPackageDependencies(createProtoPackageDependencies(configMap))
+        .packageName(buildMapWithDefault((Map<String, String>) configMap.get("package_name")))
         .shortName((String) configMap.get("short_name"))
         .apiVersion((String) configMap.get("major_version"))
         .protoPath((String) configMap.get("proto_path"))
@@ -202,6 +199,42 @@ public abstract class PackageMetadataConfig {
         .homepage((String) configMap.get("homepage"))
         .licenseName((String) configMap.get("license"))
         .build();
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<TargetLanguage, Map<String, VersionBound>> createProtoPackageDependencies(
+      Map<String, Object> configMap) {
+    Map<TargetLanguage, Map<String, VersionBound>> packageDependencies = new HashMap<>();
+    List<String> packages = (List<String>) configMap.get("proto_gen_pkg_deps");
+
+    for (String packageName : packages) {
+      Map<String, Map<String, String>> config =
+          (Map<String, Map<String, String>>) configMap.get(packageName + "_version");
+      if (config == null) {
+        throw new IllegalArgumentException(
+            "'" + packageName + "' in proto_gen_pkg_deps was " + "not found in dependency list.");
+      }
+
+      Map<TargetLanguage, Map<String, String>> versionMap = buildMapWithDefault(config);
+      for (Entry<TargetLanguage, Map<String, String>> entry : versionMap.entrySet()) {
+        if (entry.getValue() == null) {
+          continue;
+        }
+        if (!packageDependencies.containsKey(entry.getKey())) {
+          packageDependencies.put(entry.getKey(), new HashMap<String, VersionBound>());
+        }
+
+        String languageName = entry.getValue().get("name_override");
+        if (languageName == null) {
+          languageName = packageName;
+        }
+        VersionBound version =
+            VersionBound.create(entry.getValue().get("lower"), entry.getValue().get("upper"));
+        packageDependencies.get(entry.getKey()).put(languageName, version);
+      }
+    }
+
+    return packageDependencies;
   }
 
   private static Map<TargetLanguage, VersionBound> createVersionMap(
@@ -220,10 +253,6 @@ public abstract class PackageMetadataConfig {
             return VersionBound.create(versionMap.get("lower"), versionMap.get("upper"));
           }
         });
-  }
-
-  private static Map<TargetLanguage, String> createPackageNameMap(Map<String, String> inputMap) {
-    return buildMapWithDefault(inputMap);
   }
 
   /**

--- a/src/main/java/com/google/api/codegen/config/PackageMetadataConfig.java
+++ b/src/main/java/com/google/api/codegen/config/PackageMetadataConfig.java
@@ -205,14 +205,14 @@ public abstract class PackageMetadataConfig {
   private static Map<TargetLanguage, Map<String, VersionBound>> createProtoPackageDependencies(
       Map<String, Object> configMap) {
     Map<TargetLanguage, Map<String, VersionBound>> packageDependencies = new HashMap<>();
-    List<String> packages = (List<String>) configMap.get("proto_gen_pkg_deps");
+    List<String> packages = (List<String>) configMap.get("proto_deps");
 
     for (String packageName : packages) {
       Map<String, Map<String, String>> config =
           (Map<String, Map<String, String>>) configMap.get(packageName + "_version");
       if (config == null) {
         throw new IllegalArgumentException(
-            "'" + packageName + "' in proto_gen_pkg_deps was " + "not found in dependency list.");
+            "'" + packageName + "' in proto_deps was not found in dependency list.");
       }
 
       Map<TargetLanguage, Map<String, String>> versionMap = buildMapWithDefault(config);

--- a/src/main/java/com/google/api/codegen/grpcmetadatagen/GrpcMetadataGenerator.java
+++ b/src/main/java/com/google/api/codegen/grpcmetadatagen/GrpcMetadataGenerator.java
@@ -30,12 +30,14 @@ import com.google.api.tools.framework.tools.ToolOptions.Option;
 import com.google.api.tools.framework.tools.ToolUtil;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * ToolDriver for PackageMetadataGenerator; creates and sets the ToolOptions and builds the Model
@@ -56,6 +58,11 @@ public class GrpcMetadataGenerator extends ToolDriverBase {
   private static final Map<TargetLanguage, GrpcPackageCopier> COPIERS =
       new ImmutableMap.Builder<TargetLanguage, GrpcPackageCopier>()
           .put(TargetLanguage.PYTHON, new PythonPackageCopier())
+          .build();
+
+  private static final Map<TargetLanguage, Set<String>> PROTO_PACKAGE_DEPENDENCY_WHITELIST =
+      new ImmutableMap.Builder<TargetLanguage, Set<String>>()
+          .put(TargetLanguage.PYTHON, Sets.newHashSet("googleapis-common-protos"))
           .build();
 
   public static final Option<String> OUTPUT_DIR =
@@ -100,7 +107,12 @@ public class GrpcMetadataGenerator extends ToolDriverBase {
       PackageMetadataView view =
           transformer
               .generateMetadataView(
-                  config, model, snippetFilename, outputPath(snippetFilename), language)
+                  config,
+                  model,
+                  snippetFilename,
+                  outputPath(snippetFilename),
+                  language,
+                  PROTO_PACKAGE_DEPENDENCY_WHITELIST.get(language))
               // Set language-specific GrpcCopierResults here.
               .namespacePackages(copierResults.namespacePackages())
               .build();

--- a/src/main/java/com/google/api/codegen/transformer/PackageMetadataTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/PackageMetadataTransformer.java
@@ -53,13 +53,15 @@ public class PackageMetadataTransformer {
     }
 
     List<PackageDependencyView> protoPackageDependencies = new ArrayList<>();
-    for (Map.Entry<String, VersionBound> entry :
-        packageConfig.protoPackageDependencies(language).entrySet()) {
-      if (entry.getValue() != null
-          && (whitelistedDependencies == null
-              || whitelistedDependencies.contains(entry.getKey()))) {
-        protoPackageDependencies.add(
-            PackageDependencyView.create(entry.getKey(), entry.getValue()));
+    if (packageConfig.protoPackageDependencies(language) != null) {
+      for (Map.Entry<String, VersionBound> entry :
+          packageConfig.protoPackageDependencies(language).entrySet()) {
+        if (entry.getValue() != null
+            && (whitelistedDependencies == null
+                || whitelistedDependencies.contains(entry.getKey()))) {
+          protoPackageDependencies.add(
+              PackageDependencyView.create(entry.getKey(), entry.getValue()));
+        }
       }
     }
 

--- a/src/main/java/com/google/api/codegen/transformer/PackageMetadataTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/PackageMetadataTransformer.java
@@ -16,8 +16,14 @@ package com.google.api.codegen.transformer;
 
 import com.google.api.codegen.TargetLanguage;
 import com.google.api.codegen.config.PackageMetadataConfig;
+import com.google.api.codegen.config.VersionBound;
+import com.google.api.codegen.viewmodel.metadata.PackageDependencyView;
 import com.google.api.codegen.viewmodel.metadata.PackageMetadataView;
 import com.google.api.tools.framework.model.Model;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /** Constructs a partial ViewModel for producing package metadata related views */
 public class PackageMetadataTransformer {
@@ -27,6 +33,16 @@ public class PackageMetadataTransformer {
       String template,
       String outputPath,
       TargetLanguage language) {
+    return generateMetadataView(packageConfig, model, template, outputPath, language, null);
+  }
+
+  public PackageMetadataView.Builder generateMetadataView(
+      PackageMetadataConfig packageConfig,
+      Model model,
+      String template,
+      String outputPath,
+      TargetLanguage language,
+      Set<String> whitelistedDependencies) {
     // Note that internally, this is overridable in the service config, but the component is not
     // available externally. See:
     //   https://github.com/googleapis/toolkit/issues/933
@@ -34,6 +50,17 @@ public class PackageMetadataTransformer {
     int dotIndex = discoveryApiName.indexOf(".");
     if (dotIndex > 0) {
       discoveryApiName = discoveryApiName.substring(0, dotIndex).replace("-", "_");
+    }
+
+    List<PackageDependencyView> protoPackageDependencies = new ArrayList<>();
+    for (Map.Entry<String, VersionBound> entry :
+        packageConfig.protoPackageDependencies(language).entrySet()) {
+      if (entry.getValue() != null
+          && (whitelistedDependencies == null
+              || whitelistedDependencies.contains(entry.getKey()))) {
+        protoPackageDependencies.add(
+            PackageDependencyView.create(entry.getKey(), entry.getValue()));
+      }
     }
 
     return PackageMetadataView.newBuilder()
@@ -45,7 +72,7 @@ public class PackageMetadataTransformer {
         .gaxVersionBound(packageConfig.gaxVersionBound(language))
         .grpcVersionBound(packageConfig.grpcVersionBound(language))
         .protoVersionBound(packageConfig.protoVersionBound(language))
-        .commonProtosVersionBound(packageConfig.commonProtosVersionBound(language))
+        .protoPackageDependencies(protoPackageDependencies)
         .authVersionBound(packageConfig.authVersionBound(language))
         .protoPackageName("proto-" + packageConfig.packageName(language))
         .gapicPackageName("gapic-" + packageConfig.packageName(language))

--- a/src/main/java/com/google/api/codegen/transformer/PackageMetadataTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/PackageMetadataTransformer.java
@@ -21,6 +21,7 @@ import com.google.api.codegen.viewmodel.metadata.PackageDependencyView;
 import com.google.api.codegen.viewmodel.metadata.PackageMetadataView;
 import com.google.api.tools.framework.model.Model;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -63,6 +64,8 @@ public class PackageMetadataTransformer {
               PackageDependencyView.create(entry.getKey(), entry.getValue()));
         }
       }
+      // Ensures deterministic test results.
+      Collections.sort(protoPackageDependencies);
     }
 
     return PackageMetadataView.newBuilder()

--- a/src/main/java/com/google/api/codegen/transformer/PackageMetadataTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/PackageMetadataTransformer.java
@@ -28,6 +28,11 @@ import java.util.Set;
 
 /** Constructs a partial ViewModel for producing package metadata related views */
 public class PackageMetadataTransformer {
+
+  /**
+   * Construct a partial ViewModel, represented by its Builder, using all of the proto package
+   * dependencies specified in the package config.
+   */
   public PackageMetadataView.Builder generateMetadataView(
       PackageMetadataConfig packageConfig,
       Model model,
@@ -37,6 +42,10 @@ public class PackageMetadataTransformer {
     return generateMetadataView(packageConfig, model, template, outputPath, language, null);
   }
 
+  /**
+   * Construct a partial ViewModel, represented by its Builder, from the config. Proto package
+   * dependencies are included only if whitelisted.
+   */
   public PackageMetadataView.Builder generateMetadataView(
       PackageMetadataConfig packageConfig,
       Model model,

--- a/src/main/java/com/google/api/codegen/viewmodel/metadata/PackageDependencyView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/metadata/PackageDependencyView.java
@@ -1,0 +1,33 @@
+/* Copyright 2016 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.viewmodel.metadata;
+
+import com.google.api.codegen.config.VersionBound;
+import com.google.auto.value.AutoValue;
+
+/** Represents a dependency of the package being generated. */
+@AutoValue
+public abstract class PackageDependencyView {
+
+  /** The name of the dependency package */
+  public abstract String name();
+
+  /** The version bounds on the dependency */
+  public abstract VersionBound versionBound();
+
+  public static PackageDependencyView create(String name, VersionBound versionBound) {
+    return new AutoValue_PackageDependencyView(name, versionBound);
+  }
+}

--- a/src/main/java/com/google/api/codegen/viewmodel/metadata/PackageDependencyView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/metadata/PackageDependencyView.java
@@ -19,7 +19,7 @@ import com.google.auto.value.AutoValue;
 
 /** Represents a dependency of the package being generated. */
 @AutoValue
-public abstract class PackageDependencyView {
+public abstract class PackageDependencyView implements Comparable<PackageDependencyView> {
 
   /** The name of the dependency package */
   public abstract String name();
@@ -29,5 +29,10 @@ public abstract class PackageDependencyView {
 
   public static PackageDependencyView create(String name, VersionBound versionBound) {
     return new AutoValue_PackageDependencyView(name, versionBound);
+  }
+
+  @Override
+  public int compareTo(PackageDependencyView other) {
+    return this.name().compareTo(other.name());
   }
 }

--- a/src/main/java/com/google/api/codegen/viewmodel/metadata/PackageMetadataView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/metadata/PackageMetadataView.java
@@ -47,7 +47,7 @@ public abstract class PackageMetadataView implements ViewModel {
   public abstract VersionBound protoVersionBound();
 
   @Nullable
-  public abstract VersionBound commonProtosVersionBound();
+  public abstract List<PackageDependencyView> protoPackageDependencies();
 
   @Nullable
   public abstract VersionBound authVersionBound();
@@ -109,7 +109,7 @@ public abstract class PackageMetadataView implements ViewModel {
 
     public abstract Builder protoVersionBound(VersionBound val);
 
-    public abstract Builder commonProtosVersionBound(VersionBound val);
+    public abstract Builder protoPackageDependencies(List<PackageDependencyView> val);
 
     public abstract Builder authVersionBound(VersionBound val);
 

--- a/src/main/resources/com/google/api/codegen/metadatagen/py/setup.py.snip
+++ b/src/main/resources/com/google/api/codegen/metadatagen/py/setup.py.snip
@@ -13,9 +13,11 @@
     from setuptools import setup, find_packages
 
     install_requires = [
+      @join packageDep : metadata.protoPackageDependencies
+        '{@packageDep.name}[grpc]>={@packageDep.versionBound.lower}, <{@packageDep.versionBound.upper}'
+      @end
       'oauth2client>={@metadata.authVersionBound.lower}, <{@metadata.authVersionBound.upper}',
       'grpcio>={@metadata.grpcVersionBound.lower}, <{@metadata.grpcVersionBound.upper}',
-      'googleapis-common-protos[grpc]>={@metadata.commonProtosVersionBound.lower}, <{@metadata.commonProtosVersionBound.upper}'
     ]
 
     setuptools.setup(

--- a/src/main/resources/com/google/api/codegen/nodejs/package.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/package.snip
@@ -10,7 +10,9 @@
       "src"
     ],
     "dependencies": {
-      "google-proto-files": "^{@metadata.commonProtosVersionBound.lower}",
+      @join packageDep : metadata.protoPackageDependencies
+        "{@packageDep.name}": "^{@packageDep.versionBound.lower}",
+      @end
       "google-gax": "^{@metadata.gaxVersionBound.lower}",
       @if metadata.hasMultipleServices
         "lodash.union": "^4.6.0",

--- a/src/main/resources/com/google/api/codegen/py/requirements.txt.snip
+++ b/src/main/resources/com/google/api/codegen/py/requirements.txt.snip
@@ -1,6 +1,9 @@
 @snippet generate(metadata)
-  googleapis-common-protos>={@metadata.commonProtosVersionBound.lower}, <{@metadata.commonProtosVersionBound.upper}
-  google-gax>={@metadata.gaxVersionBound.lower}, <{@metadata.gaxVersionBound.upper}
+  @join packageDep : metadata.protoPackageDependencies
+    {@packageDep.name}>={@packageDep.versionBound.lower}, <{@packageDep.versionBound.upper}
+  @end
+  {@BREAK}google-gax>={@metadata.gaxVersionBound.lower}, <{@metadata.gaxVersionBound.upper}
   {@metadata.protoPackageName}>={@metadata.packageVersionBound.lower}, <{@metadata.packageVersionBound.upper}
   oauth2client>={@metadata.authVersionBound.lower}, <{@metadata.authVersionBound.upper}
+
 @end

--- a/src/main/resources/com/google/api/codegen/py/setup.py.snip
+++ b/src/main/resources/com/google/api/codegen/py/setup.py.snip
@@ -12,7 +12,9 @@
   import sys
 
   install_requires = [
-      'googleapis-common-protos>={@metadata.commonProtosVersionBound.lower}, <{@metadata.commonProtosVersionBound.upper}',
+      @join packageDep : metadata.protoPackageDependencies
+        '{@packageDep.name}>={@packageDep.versionBound.lower}, <{@packageDep.versionBound.upper}',
+      @end
       'google-gax>={@metadata.gaxVersionBound.lower}, <{@metadata.gaxVersionBound.upper}',
       '{@metadata.protoPackageName}>={@metadata.packageVersionBound.lower}, <{@metadata.packageVersionBound.upper}',
       'oauth2client>={@metadata.authVersionBound.lower}, <{@metadata.authVersionBound.upper}',

--- a/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/library_pkg.yaml
+++ b/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/library_pkg.yaml
@@ -6,6 +6,9 @@ author: Google, Inc.
 email: googleapis-packages@google.com
 homepage: https://github.com/googleapis/googleapis
 license: Apache-2.0
+proto_gen_pkg_deps:
+- google-common-protos
+- google-some-other-package-v1
 
 # Language-dependent configuration
 package_name:
@@ -45,9 +48,19 @@ auth_version:
   nodejs:
     lower: '0.1.1'
 
-common_protos_version:
+google-common-protos_version:
   python:
+    name_override: googleapis-common-protos
     lower: '1.5.0'
     upper: '2.0.0dev'
   nodejs:
     lower: '0.8.2'
+
+google-some-other-package-v1_version:
+  python:
+    name_override: python-other-package
+    lower: '12.1.0'
+    upper: '13.5.1'
+  nodejs:
+    name_override: node-pkg
+    lower: '0.2.1'

--- a/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/library_pkg.yaml
+++ b/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/library_pkg.yaml
@@ -6,7 +6,7 @@ author: Google, Inc.
 email: googleapis-packages@google.com
 homepage: https://github.com/googleapis/googleapis
 license: Apache-2.0
-proto_gen_pkg_deps:
+proto_deps:
 - google-common-protos
 - google-some-other-package-v1
 

--- a/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/python_library.baseline
@@ -223,9 +223,9 @@ import setuptools
 from setuptools import setup, find_packages
 
 install_requires = [
+  'googleapis-common-protos[grpc]>=1.5.0, <2.0.0dev'
   'oauth2client>=2.0.0, <4.0.0dev',
   'grpcio>=1.0.0, <2.0.0dev',
-  'googleapis-common-protos[grpc]>=1.5.0, <2.0.0dev'
 ]
 
 setuptools.setup(

--- a/src/test/java/com/google/api/codegen/testdata/library_pkg.yaml
+++ b/src/test/java/com/google/api/codegen/testdata/library_pkg.yaml
@@ -6,6 +6,9 @@ author: Google, Inc.
 email: googleapis-packages@google.com
 homepage: https://github.com/googleapis/googleapis
 license: Apache-2.0
+proto_gen_pkg_deps:
+- google-common-protos
+- google-some-other-package-v1
 
 # Language-dependent configuration
 package_name:
@@ -55,9 +58,19 @@ proto_version:
   php:
     lower: '0.7.*'
 
-common_protos_version:
+google-common-protos_version:
   python:
+    name_override: googleapis-common-protos
     lower: '1.5.0'
     upper: '2.0dev'
   nodejs:
+    name_override: google-proto-files
     lower: '0.8.2'
+
+google-some-other-package-v1_version:
+  python:
+    name_override: python-other-package
+    lower: '12.1.0'
+    upper: '13.5.1'
+  nodejs:
+    lower: '0.2.1'

--- a/src/test/java/com/google/api/codegen/testdata/library_pkg.yaml
+++ b/src/test/java/com/google/api/codegen/testdata/library_pkg.yaml
@@ -6,7 +6,7 @@ author: Google, Inc.
 email: googleapis-packages@google.com
 homepage: https://github.com/googleapis/googleapis
 license: Apache-2.0
-proto_gen_pkg_deps:
+proto_deps:
 - google-common-protos
 - google-some-other-package-v1
 

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_doc_package_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_doc_package_library.baseline
@@ -10,6 +10,7 @@
     "src"
   ],
   "dependencies": {
+    "google-some-other-package-v1": "^0.2.1",
     "google-proto-files": "^0.8.2",
     "google-gax": "^^0.7.0",
     "extend": "^3.0.0"

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_doc_package_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_doc_package_library.baseline
@@ -10,8 +10,8 @@
     "src"
   ],
   "dependencies": {
-    "google-some-other-package-v1": "^0.2.1",
     "google-proto-files": "^0.8.2",
+    "google-some-other-package-v1": "^0.2.1",
     "google-gax": "^^0.7.0",
     "extend": "^3.0.0"
   },

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_package_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_package_library.baseline
@@ -10,6 +10,7 @@
     "src"
   ],
   "dependencies": {
+    "google-some-other-package-v1": "^0.2.1",
     "google-proto-files": "^0.8.2",
     "google-gax": "^^0.7.0",
     "extend": "^3.0.0"

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_package_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_package_library.baseline
@@ -10,8 +10,8 @@
     "src"
   ],
   "dependencies": {
-    "google-some-other-package-v1": "^0.2.1",
     "google-proto-files": "^0.8.2",
+    "google-some-other-package-v1": "^0.2.1",
     "google-gax": "^^0.7.0",
     "extend": "^3.0.0"
   },

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_package_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_package_no_path_templates.baseline
@@ -10,6 +10,7 @@
     "src"
   ],
   "dependencies": {
+    "google-some-other-package-v1": "^0.2.1",
     "google-proto-files": "^0.8.2",
     "google-gax": "^^0.7.0",
     "extend": "^3.0.0"

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_package_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_package_no_path_templates.baseline
@@ -10,8 +10,8 @@
     "src"
   ],
   "dependencies": {
-    "google-some-other-package-v1": "^0.2.1",
     "google-proto-files": "^0.8.2",
+    "google-some-other-package-v1": "^0.2.1",
     "google-gax": "^^0.7.0",
     "extend": "^3.0.0"
   },

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_requirements_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_requirements_library.baseline
@@ -1,5 +1,7 @@
 ============== file: requirements.txt ==============
+python-other-package>=12.1.0, <13.5.1
 googleapis-common-protos>=1.5.0, <2.0dev
 google-gax>=0.15.0, <0.16.0
 proto-google-cloud-library-v1>=0.15.0, <0.16dev
 oauth2client>=2.0.0, <4.0dev
+

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_requirements_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_requirements_library.baseline
@@ -1,6 +1,6 @@
 ============== file: requirements.txt ==============
-python-other-package>=12.1.0, <13.5.1
 googleapis-common-protos>=1.5.0, <2.0dev
+python-other-package>=12.1.0, <13.5.1
 google-gax>=0.15.0, <0.16.0
 proto-google-cloud-library-v1>=0.15.0, <0.16dev
 oauth2client>=2.0.0, <4.0dev

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_setup_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_setup_library.baseline
@@ -10,8 +10,8 @@ from setuptools import setup, find_packages
 import sys
 
 install_requires = [
-    'python-other-package>=12.1.0, <13.5.1',
     'googleapis-common-protos>=1.5.0, <2.0dev',
+    'python-other-package>=12.1.0, <13.5.1',
     'google-gax>=0.15.0, <0.16.0',
     'proto-google-cloud-library-v1>=0.15.0, <0.16dev',
     'oauth2client>=2.0.0, <4.0dev',

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_setup_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_setup_library.baseline
@@ -10,6 +10,7 @@ from setuptools import setup, find_packages
 import sys
 
 install_requires = [
+    'python-other-package>=12.1.0, <13.5.1',
     'googleapis-common-protos>=1.5.0, <2.0dev',
     'google-gax>=0.15.0, <0.16.0',
     'proto-google-cloud-library-v1>=0.15.0, <0.16dev',

--- a/src/test/java/com/google/api/codegen/testdata/python_requirements_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_requirements_library.baseline
@@ -1,5 +1,7 @@
 ============== file: requirements.txt ==============
+python-other-package>=12.1.0, <13.5.1
 googleapis-common-protos>=1.5.0, <2.0dev
 google-gax>=0.15.0, <0.16.0
 proto-google-cloud-library-v1>=0.15.0, <0.16dev
 oauth2client>=2.0.0, <4.0dev
+

--- a/src/test/java/com/google/api/codegen/testdata/python_requirements_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_requirements_library.baseline
@@ -1,6 +1,6 @@
 ============== file: requirements.txt ==============
-python-other-package>=12.1.0, <13.5.1
 googleapis-common-protos>=1.5.0, <2.0dev
+python-other-package>=12.1.0, <13.5.1
 google-gax>=0.15.0, <0.16.0
 proto-google-cloud-library-v1>=0.15.0, <0.16dev
 oauth2client>=2.0.0, <4.0dev

--- a/src/test/java/com/google/api/codegen/testdata/python_requirements_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_requirements_no_path_templates.baseline
@@ -1,5 +1,7 @@
 ============== file: requirements.txt ==============
+python-other-package>=12.1.0, <13.5.1
 googleapis-common-protos>=1.5.0, <2.0dev
 google-gax>=0.15.0, <0.16.0
 proto-google-cloud-library-v1>=0.15.0, <0.16dev
 oauth2client>=2.0.0, <4.0dev
+

--- a/src/test/java/com/google/api/codegen/testdata/python_requirements_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_requirements_no_path_templates.baseline
@@ -1,6 +1,6 @@
 ============== file: requirements.txt ==============
-python-other-package>=12.1.0, <13.5.1
 googleapis-common-protos>=1.5.0, <2.0dev
+python-other-package>=12.1.0, <13.5.1
 google-gax>=0.15.0, <0.16.0
 proto-google-cloud-library-v1>=0.15.0, <0.16dev
 oauth2client>=2.0.0, <4.0dev

--- a/src/test/java/com/google/api/codegen/testdata/python_setup_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_setup_library.baseline
@@ -10,8 +10,8 @@ from setuptools import setup, find_packages
 import sys
 
 install_requires = [
-    'python-other-package>=12.1.0, <13.5.1',
     'googleapis-common-protos>=1.5.0, <2.0dev',
+    'python-other-package>=12.1.0, <13.5.1',
     'google-gax>=0.15.0, <0.16.0',
     'proto-google-cloud-library-v1>=0.15.0, <0.16dev',
     'oauth2client>=2.0.0, <4.0dev',

--- a/src/test/java/com/google/api/codegen/testdata/python_setup_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_setup_library.baseline
@@ -10,6 +10,7 @@ from setuptools import setup, find_packages
 import sys
 
 install_requires = [
+    'python-other-package>=12.1.0, <13.5.1',
     'googleapis-common-protos>=1.5.0, <2.0dev',
     'google-gax>=0.15.0, <0.16.0',
     'proto-google-cloud-library-v1>=0.15.0, <0.16dev',

--- a/src/test/java/com/google/api/codegen/testdata/python_setup_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_setup_no_path_templates.baseline
@@ -10,8 +10,8 @@ from setuptools import setup, find_packages
 import sys
 
 install_requires = [
-    'python-other-package>=12.1.0, <13.5.1',
     'googleapis-common-protos>=1.5.0, <2.0dev',
+    'python-other-package>=12.1.0, <13.5.1',
     'google-gax>=0.15.0, <0.16.0',
     'proto-google-cloud-library-v1>=0.15.0, <0.16dev',
     'oauth2client>=2.0.0, <4.0dev',

--- a/src/test/java/com/google/api/codegen/testdata/python_setup_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_setup_no_path_templates.baseline
@@ -10,6 +10,7 @@ from setuptools import setup, find_packages
 import sys
 
 install_requires = [
+    'python-other-package>=12.1.0, <13.5.1',
     'googleapis-common-protos>=1.5.0, <2.0dev',
     'google-gax>=0.15.0, <0.16.0',
     'proto-google-cloud-library-v1>=0.15.0, <0.16dev',


### PR DESCRIPTION
This field already specifies the package's proto package
dependencies in the Artman config. Reading it in allow metadata
generation to specify these additional dependencies, e.g., PubSub's
dependency on the IAM proto package.

Note that because this field was previously only used by
Java/Packman, some additional configuration to specify the
language-specific package name is added via the "name_override"
field.

To be merged simultaneously with: https://github.com/googleapis/artman/pull/138, https://github.com/googleapis/googleapis/pull/248