### PR TITLE
update Go header

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformer.java
@@ -317,8 +317,7 @@ public class GoGapicSurfaceTransformer implements ModelToViewTransformer {
   void addXApiImports(SurfaceTransformerContext context, Collection<Method> methods) {
     ModelTypeTable typeTable = context.getTypeTable();
     typeTable.saveNicknameFor("fmt;;;");
-    typeTable.saveNicknameFor("runtime;;;");
-    typeTable.saveNicknameFor("strings;;;");
+    typeTable.saveNicknameFor("cloud.google.com/go/internal/version;;;");
     typeTable.saveNicknameFor("golang.org/x/net/context;;;");
     typeTable.saveNicknameFor("google.golang.org/grpc;;;");
     typeTable.saveNicknameFor("github.com/googleapis/gax-go;gax;;");

--- a/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformer.java
@@ -321,7 +321,6 @@ public class GoGapicSurfaceTransformer implements ModelToViewTransformer {
     typeTable.saveNicknameFor("strings;;;");
     typeTable.saveNicknameFor("golang.org/x/net/context;;;");
     typeTable.saveNicknameFor("google.golang.org/grpc;;;");
-    typeTable.saveNicknameFor("google.golang.org/grpc/metadata;;;");
     typeTable.saveNicknameFor("github.com/googleapis/gax-go;gax;;");
     typeTable.saveNicknameFor("google.golang.org/api/option;;;");
     typeTable.saveNicknameFor("google.golang.org/api/transport;;;");

--- a/src/main/resources/com/google/api/codegen/go/doc.snip
+++ b/src/main/resources/com/google/api/codegen/go/doc.snip
@@ -15,5 +15,20 @@
     @end
     package {@view.fileHeader.localPackageName} // import "{@view.importPath}"
 
-    const gapicNameVersion = "gapic/20170208"
+    import (
+        "golang.org/x/net/context"
+        "google.golang.org/grpc/metadata"
+    )
+
+    const (
+        gapicName = "gapic"
+        gapicVersion = "20170208"
+    )
+
+    func insertXGoog(ctx context.Context, val string) context.Context {
+        md, _ := metadata.FromContext(ctx)
+        md = md.Copy()
+        md["x-goog-api-client"] = []string{val}
+        return metadata.NewContext(ctx, md)
+    }
 @end

--- a/src/main/resources/com/google/api/codegen/go/doc.snip
+++ b/src/main/resources/com/google/api/codegen/go/doc.snip
@@ -15,5 +15,5 @@
     @end
     package {@view.fileHeader.localPackageName} // import "{@view.importPath}"
 
-    const gapicNameVersion = "gapic/0.1.0"
+    const gapicNameVersion = "gapic/20170208"
 @end

--- a/src/main/resources/com/google/api/codegen/go/doc.snip
+++ b/src/main/resources/com/google/api/codegen/go/doc.snip
@@ -20,11 +20,6 @@
         "google.golang.org/grpc/metadata"
     )
 
-    const (
-        gapicName = "gapic"
-        gapicVersion = "20170208"
-    )
-
     func insertXGoog(ctx context.Context, val string) context.Context {
         md, _ := metadata.FromContext(ctx)
         md = md.Copy()

--- a/src/main/resources/com/google/api/codegen/go/main.snip
+++ b/src/main/resources/com/google/api/codegen/go/main.snip
@@ -96,7 +96,7 @@
                 {@stub.name}: {@stub.createStubFunctionName}(conn),
             @end
         }
-        c.SetGoogleClientInfo(gapicName, gapicVersion)
+        c.SetGoogleClientInfo("gapic", version.Repo)
         return c, nil
     }
 
@@ -114,9 +114,8 @@
     // SetGoogleClientInfo sets the name and version of the application in
     // the `x-goog-api-client` header passed on each request. Intended for
     // use by Google-written clients.
-    func (c *{@view.clientTypeName}) SetGoogleClientInfo(name, version string) {
-        goVersion := strings.Replace(runtime.Version(), " ", "_", -1)
-        c.xGoogHeader = fmt.Sprintf("gl-go/%s %s/%s gax/%s", goVersion, name, version, gax.Version)
+    func (c *{@view.clientTypeName}) SetGoogleClientInfo(clientName, clientVersion string) {
+        c.xGoogHeader = fmt.Sprintf("gl-go/%s %s/%s gax/%s grpc/UNKNOWN", version.Go(), clientName, clientVersion, gax.Version)
     }
 
     @join getter : view.pathTemplateGetters

--- a/src/main/resources/com/google/api/codegen/go/main.snip
+++ b/src/main/resources/com/google/api/codegen/go/main.snip
@@ -74,7 +74,7 @@
         CallOptions *{@view.callOptionsTypeName}
 
         // The metadata to be sent with each request.
-        metadata metadata.MD
+        xGoogHeader string
     }
 
     // {@view.clientConstructorName} creates a new {@view.servicePhraseName} client.
@@ -96,7 +96,7 @@
                 {@stub.name}: {@stub.createStubFunctionName}(conn),
             @end
         }
-        c.SetGoogleClientInfo("gax", gax.Version)
+        c.SetGoogleClientInfo(gapicName, gapicVersion)
         return c, nil
     }
 
@@ -116,8 +116,7 @@
     // use by Google-written clients.
     func (c *{@view.clientTypeName}) SetGoogleClientInfo(name, version string) {
         goVersion := strings.Replace(runtime.Version(), " ", "_", -1)
-        v := fmt.Sprintf("%s/%s %s gax/%s gl-go/%s", name, version, gapicNameVersion, gax.Version, goVersion)
-        c.metadata = metadata.Pairs("x-goog-api-client", v)
+        c.xGoogHeader = fmt.Sprintf("gl-go/%s %s/%s gax/%s", goVersion, name, version, gax.Version)
     }
 
     @join getter : view.pathTemplateGetters
@@ -448,6 +447,5 @@
 @end
 
 @private mergeMetadata()
-    md, _ := metadata.FromContext(ctx)
-    ctx = metadata.NewContext(ctx, metadata.Join(md, c.metadata))
+    ctx = insertXGoog(ctx, c.xGoogHeader)
 @end

--- a/src/main/resources/com/google/api/codegen/go/main.snip
+++ b/src/main/resources/com/google/api/codegen/go/main.snip
@@ -116,7 +116,7 @@
     // use by Google-written clients.
     func (c *{@view.clientTypeName}) SetGoogleClientInfo(name, version string) {
         goVersion := strings.Replace(runtime.Version(), " ", "_", -1)
-        v := fmt.Sprintf("%s/%s %s gax/%s go/%s", name, version, gapicNameVersion, gax.Version, goVersion)
+        v := fmt.Sprintf("%s/%s %s gax/%s gl-go/%s", name, version, gapicNameVersion, gax.Version, goVersion)
         c.metadata = metadata.Pairs("x-goog-api-client", v)
     }
 

--- a/src/test/java/com/google/api/codegen/testdata/go_doc_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_doc_library.baseline
@@ -28,11 +28,6 @@ import (
     "google.golang.org/grpc/metadata"
 )
 
-const (
-    gapicName = "gapic"
-    gapicVersion = "20170208"
-)
-
 func insertXGoog(ctx context.Context, val string) context.Context {
     md, _ := metadata.FromContext(ctx)
     md = md.Copy()

--- a/src/test/java/com/google/api/codegen/testdata/go_doc_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_doc_library.baseline
@@ -23,4 +23,19 @@
 // Use the client at cloud.google.com/go/library in preference to this.
 package library // import "cloud.google.com/go/library/apiv1"
 
-const gapicNameVersion = "gapic/20170208"
+import (
+    "golang.org/x/net/context"
+    "google.golang.org/grpc/metadata"
+)
+
+const (
+    gapicName = "gapic"
+    gapicVersion = "20170208"
+)
+
+func insertXGoog(ctx context.Context, val string) context.Context {
+    md, _ := metadata.FromContext(ctx)
+    md = md.Copy()
+    md["x-goog-api-client"] = []string{val}
+    return metadata.NewContext(ctx, md)
+}

--- a/src/test/java/com/google/api/codegen/testdata/go_doc_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_doc_library.baseline
@@ -23,4 +23,4 @@
 // Use the client at cloud.google.com/go/library in preference to this.
 package library // import "cloud.google.com/go/library/apiv1"
 
-const gapicNameVersion = "gapic/0.1.0"
+const gapicNameVersion = "gapic/20170208"

--- a/src/test/java/com/google/api/codegen/testdata/go_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_main_library.baseline
@@ -36,7 +36,6 @@ import (
     taggerpb "google.golang.org/genproto/googleapis/tagger/v1"
     "google.golang.org/grpc"
     "google.golang.org/grpc/codes"
-    "google.golang.org/grpc/metadata"
 )
 
 var (
@@ -141,7 +140,7 @@ type Client struct {
     CallOptions *CallOptions
 
     // The metadata to be sent with each request.
-    metadata metadata.MD
+    xGoogHeader string
 }
 
 // NewClient creates a new library service client.
@@ -172,7 +171,7 @@ func NewClient(ctx context.Context, opts ...option.ClientOption) (*Client, error
         client: librarypb.NewLibraryServiceClient(conn),
         labelerClient: taggerpb.NewLabelerClient(conn),
     }
-    c.SetGoogleClientInfo("gax", gax.Version)
+    c.SetGoogleClientInfo(gapicName, gapicVersion)
     return c, nil
 }
 
@@ -192,8 +191,7 @@ func (c *Client) Close() error {
 // use by Google-written clients.
 func (c *Client) SetGoogleClientInfo(name, version string) {
     goVersion := strings.Replace(runtime.Version(), " ", "_", -1)
-    v := fmt.Sprintf("%s/%s %s gax/%s gl-go/%s", name, version, gapicNameVersion, gax.Version, goVersion)
-    c.metadata = metadata.Pairs("x-goog-api-client", v)
+    c.xGoogHeader = fmt.Sprintf("gl-go/%s %s/%s gax/%s", goVersion, name, version, gax.Version)
 }
 
 // LibraryShelfPath returns the path for the shelf resource.
@@ -240,8 +238,7 @@ func (c *Client) BookIAM(book *librarypb.Book) *iam.Handle {
 
 // CreateShelf creates a shelf, and returns the new Shelf.
 func (c *Client) CreateShelf(ctx context.Context, req *librarypb.CreateShelfRequest) (*librarypb.Shelf, error) {
-    md, _ := metadata.FromContext(ctx)
-    ctx = metadata.NewContext(ctx, metadata.Join(md, c.metadata))
+    ctx = insertXGoog(ctx, c.xGoogHeader)
     var resp *librarypb.Shelf
     err := gax.Invoke(ctx, func(ctx context.Context) error {
         var err error
@@ -256,8 +253,7 @@ func (c *Client) CreateShelf(ctx context.Context, req *librarypb.CreateShelfRequ
 
 // GetShelf gets a shelf.
 func (c *Client) GetShelf(ctx context.Context, req *librarypb.GetShelfRequest) (*librarypb.Shelf, error) {
-    md, _ := metadata.FromContext(ctx)
-    ctx = metadata.NewContext(ctx, metadata.Join(md, c.metadata))
+    ctx = insertXGoog(ctx, c.xGoogHeader)
     var resp *librarypb.Shelf
     err := gax.Invoke(ctx, func(ctx context.Context) error {
         var err error
@@ -272,8 +268,7 @@ func (c *Client) GetShelf(ctx context.Context, req *librarypb.GetShelfRequest) (
 
 // ListShelves lists shelves.
 func (c *Client) ListShelves(ctx context.Context, req *librarypb.ListShelvesRequest) *ShelfIterator {
-    md, _ := metadata.FromContext(ctx)
-    ctx = metadata.NewContext(ctx, metadata.Join(md, c.metadata))
+    ctx = insertXGoog(ctx, c.xGoogHeader)
     it := &ShelfIterator{}
     it.InternalFetch = func(pageSize int, pageToken string) ([]*librarypb.Shelf, string, error) {
         var resp *librarypb.ListShelvesResponse
@@ -307,8 +302,7 @@ func (c *Client) ListShelves(ctx context.Context, req *librarypb.ListShelvesRequ
 
 // DeleteShelf deletes a shelf.
 func (c *Client) DeleteShelf(ctx context.Context, req *librarypb.DeleteShelfRequest) error {
-    md, _ := metadata.FromContext(ctx)
-    ctx = metadata.NewContext(ctx, metadata.Join(md, c.metadata))
+    ctx = insertXGoog(ctx, c.xGoogHeader)
     err := gax.Invoke(ctx, func(ctx context.Context) error {
         var err error
         _, err = c.client.DeleteShelf(ctx, req)
@@ -321,8 +315,7 @@ func (c *Client) DeleteShelf(ctx context.Context, req *librarypb.DeleteShelfRequ
 // `other_shelf_name` to shelf `name`, and deletes
 // `other_shelf_name`. Returns the updated shelf.
 func (c *Client) MergeShelves(ctx context.Context, req *librarypb.MergeShelvesRequest) (*librarypb.Shelf, error) {
-    md, _ := metadata.FromContext(ctx)
-    ctx = metadata.NewContext(ctx, metadata.Join(md, c.metadata))
+    ctx = insertXGoog(ctx, c.xGoogHeader)
     var resp *librarypb.Shelf
     err := gax.Invoke(ctx, func(ctx context.Context) error {
         var err error
@@ -337,8 +330,7 @@ func (c *Client) MergeShelves(ctx context.Context, req *librarypb.MergeShelvesRe
 
 // CreateBook creates a book.
 func (c *Client) CreateBook(ctx context.Context, req *librarypb.CreateBookRequest) (*librarypb.Book, error) {
-    md, _ := metadata.FromContext(ctx)
-    ctx = metadata.NewContext(ctx, metadata.Join(md, c.metadata))
+    ctx = insertXGoog(ctx, c.xGoogHeader)
     var resp *librarypb.Book
     err := gax.Invoke(ctx, func(ctx context.Context) error {
         var err error
@@ -353,8 +345,7 @@ func (c *Client) CreateBook(ctx context.Context, req *librarypb.CreateBookReques
 
 // PublishSeries creates a series of books.
 func (c *Client) PublishSeries(ctx context.Context, req *librarypb.PublishSeriesRequest) (*librarypb.PublishSeriesResponse, error) {
-    md, _ := metadata.FromContext(ctx)
-    ctx = metadata.NewContext(ctx, metadata.Join(md, c.metadata))
+    ctx = insertXGoog(ctx, c.xGoogHeader)
     var resp *librarypb.PublishSeriesResponse
     err := gax.Invoke(ctx, func(ctx context.Context) error {
         var err error
@@ -369,8 +360,7 @@ func (c *Client) PublishSeries(ctx context.Context, req *librarypb.PublishSeries
 
 // GetBook gets a book.
 func (c *Client) GetBook(ctx context.Context, req *librarypb.GetBookRequest) (*librarypb.Book, error) {
-    md, _ := metadata.FromContext(ctx)
-    ctx = metadata.NewContext(ctx, metadata.Join(md, c.metadata))
+    ctx = insertXGoog(ctx, c.xGoogHeader)
     var resp *librarypb.Book
     err := gax.Invoke(ctx, func(ctx context.Context) error {
         var err error
@@ -385,8 +375,7 @@ func (c *Client) GetBook(ctx context.Context, req *librarypb.GetBookRequest) (*l
 
 // ListBooks lists books in a shelf.
 func (c *Client) ListBooks(ctx context.Context, req *librarypb.ListBooksRequest) *BookIterator {
-    md, _ := metadata.FromContext(ctx)
-    ctx = metadata.NewContext(ctx, metadata.Join(md, c.metadata))
+    ctx = insertXGoog(ctx, c.xGoogHeader)
     it := &BookIterator{}
     it.InternalFetch = func(pageSize int, pageToken string) ([]*librarypb.Book, string, error) {
         var resp *librarypb.ListBooksResponse
@@ -420,8 +409,7 @@ func (c *Client) ListBooks(ctx context.Context, req *librarypb.ListBooksRequest)
 
 // DeleteBook deletes a book.
 func (c *Client) DeleteBook(ctx context.Context, req *librarypb.DeleteBookRequest) error {
-    md, _ := metadata.FromContext(ctx)
-    ctx = metadata.NewContext(ctx, metadata.Join(md, c.metadata))
+    ctx = insertXGoog(ctx, c.xGoogHeader)
     err := gax.Invoke(ctx, func(ctx context.Context) error {
         var err error
         _, err = c.client.DeleteBook(ctx, req)
@@ -432,8 +420,7 @@ func (c *Client) DeleteBook(ctx context.Context, req *librarypb.DeleteBookReques
 
 // UpdateBook updates a book.
 func (c *Client) UpdateBook(ctx context.Context, req *librarypb.UpdateBookRequest) (*librarypb.Book, error) {
-    md, _ := metadata.FromContext(ctx)
-    ctx = metadata.NewContext(ctx, metadata.Join(md, c.metadata))
+    ctx = insertXGoog(ctx, c.xGoogHeader)
     var resp *librarypb.Book
     err := gax.Invoke(ctx, func(ctx context.Context) error {
         var err error
@@ -448,8 +435,7 @@ func (c *Client) UpdateBook(ctx context.Context, req *librarypb.UpdateBookReques
 
 // MoveBook moves a book to another shelf, and returns the new book.
 func (c *Client) MoveBook(ctx context.Context, req *librarypb.MoveBookRequest) (*librarypb.Book, error) {
-    md, _ := metadata.FromContext(ctx)
-    ctx = metadata.NewContext(ctx, metadata.Join(md, c.metadata))
+    ctx = insertXGoog(ctx, c.xGoogHeader)
     var resp *librarypb.Book
     err := gax.Invoke(ctx, func(ctx context.Context) error {
         var err error
@@ -464,8 +450,7 @@ func (c *Client) MoveBook(ctx context.Context, req *librarypb.MoveBookRequest) (
 
 // ListStrings lists a primitive resource. To test go page streaming.
 func (c *Client) ListStrings(ctx context.Context, req *librarypb.ListStringsRequest) *StringIterator {
-    md, _ := metadata.FromContext(ctx)
-    ctx = metadata.NewContext(ctx, metadata.Join(md, c.metadata))
+    ctx = insertXGoog(ctx, c.xGoogHeader)
     it := &StringIterator{}
     it.InternalFetch = func(pageSize int, pageToken string) ([]string, string, error) {
         var resp *librarypb.ListStringsResponse
@@ -499,8 +484,7 @@ func (c *Client) ListStrings(ctx context.Context, req *librarypb.ListStringsRequ
 
 // AddComments adds comments to a book
 func (c *Client) AddComments(ctx context.Context, req *librarypb.AddCommentsRequest) error {
-    md, _ := metadata.FromContext(ctx)
-    ctx = metadata.NewContext(ctx, metadata.Join(md, c.metadata))
+    ctx = insertXGoog(ctx, c.xGoogHeader)
     err := gax.Invoke(ctx, func(ctx context.Context) error {
         var err error
         _, err = c.client.AddComments(ctx, req)
@@ -511,8 +495,7 @@ func (c *Client) AddComments(ctx context.Context, req *librarypb.AddCommentsRequ
 
 // GetBookFromArchive gets a book from an archive.
 func (c *Client) GetBookFromArchive(ctx context.Context, req *librarypb.GetBookFromArchiveRequest) (*librarypb.BookFromArchive, error) {
-    md, _ := metadata.FromContext(ctx)
-    ctx = metadata.NewContext(ctx, metadata.Join(md, c.metadata))
+    ctx = insertXGoog(ctx, c.xGoogHeader)
     var resp *librarypb.BookFromArchive
     err := gax.Invoke(ctx, func(ctx context.Context) error {
         var err error
@@ -527,8 +510,7 @@ func (c *Client) GetBookFromArchive(ctx context.Context, req *librarypb.GetBookF
 
 // GetBookFromAnywhere gets a book from a shelf or archive.
 func (c *Client) GetBookFromAnywhere(ctx context.Context, req *librarypb.GetBookFromAnywhereRequest) (*librarypb.BookFromAnywhere, error) {
-    md, _ := metadata.FromContext(ctx)
-    ctx = metadata.NewContext(ctx, metadata.Join(md, c.metadata))
+    ctx = insertXGoog(ctx, c.xGoogHeader)
     var resp *librarypb.BookFromAnywhere
     err := gax.Invoke(ctx, func(ctx context.Context) error {
         var err error
@@ -543,8 +525,7 @@ func (c *Client) GetBookFromAnywhere(ctx context.Context, req *librarypb.GetBook
 
 // UpdateBookIndex updates the index of a book.
 func (c *Client) UpdateBookIndex(ctx context.Context, req *librarypb.UpdateBookIndexRequest) error {
-    md, _ := metadata.FromContext(ctx)
-    ctx = metadata.NewContext(ctx, metadata.Join(md, c.metadata))
+    ctx = insertXGoog(ctx, c.xGoogHeader)
     err := gax.Invoke(ctx, func(ctx context.Context) error {
         var err error
         _, err = c.client.UpdateBookIndex(ctx, req)
@@ -556,8 +537,7 @@ func (c *Client) UpdateBookIndex(ctx context.Context, req *librarypb.UpdateBookI
 // StreamShelves test server streaming
 // gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
 func (c *Client) StreamShelves(ctx context.Context, req *librarypb.StreamShelvesRequest) (librarypb.LibraryService_StreamShelvesClient, error) {
-    md, _ := metadata.FromContext(ctx)
-    ctx = metadata.NewContext(ctx, metadata.Join(md, c.metadata))
+    ctx = insertXGoog(ctx, c.xGoogHeader)
     var resp librarypb.LibraryService_StreamShelvesClient
     err := gax.Invoke(ctx, func(ctx context.Context) error {
         var err error
@@ -573,8 +553,7 @@ func (c *Client) StreamShelves(ctx context.Context, req *librarypb.StreamShelves
 // StreamBooks test server streaming, non-paged responses.
 // gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
 func (c *Client) StreamBooks(ctx context.Context, req *librarypb.StreamBooksRequest) (librarypb.LibraryService_StreamBooksClient, error) {
-    md, _ := metadata.FromContext(ctx)
-    ctx = metadata.NewContext(ctx, metadata.Join(md, c.metadata))
+    ctx = insertXGoog(ctx, c.xGoogHeader)
     var resp librarypb.LibraryService_StreamBooksClient
     err := gax.Invoke(ctx, func(ctx context.Context) error {
         var err error
@@ -590,8 +569,7 @@ func (c *Client) StreamBooks(ctx context.Context, req *librarypb.StreamBooksRequ
 // DiscussBook test bidi-streaming.
 // gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
 func (c *Client) DiscussBook(ctx context.Context) (librarypb.LibraryService_DiscussBookClient, error) {
-    md, _ := metadata.FromContext(ctx)
-    ctx = metadata.NewContext(ctx, metadata.Join(md, c.metadata))
+    ctx = insertXGoog(ctx, c.xGoogHeader)
     var resp librarypb.LibraryService_DiscussBookClient
     err := gax.Invoke(ctx, func(ctx context.Context) error {
         var err error
@@ -607,8 +585,7 @@ func (c *Client) DiscussBook(ctx context.Context) (librarypb.LibraryService_Disc
 // MonologAboutBook test client streaming.
 // gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
 func (c *Client) MonologAboutBook(ctx context.Context) (librarypb.LibraryService_MonologAboutBookClient, error) {
-    md, _ := metadata.FromContext(ctx)
-    ctx = metadata.NewContext(ctx, metadata.Join(md, c.metadata))
+    ctx = insertXGoog(ctx, c.xGoogHeader)
     var resp librarypb.LibraryService_MonologAboutBookClient
     err := gax.Invoke(ctx, func(ctx context.Context) error {
         var err error
@@ -623,8 +600,7 @@ func (c *Client) MonologAboutBook(ctx context.Context) (librarypb.LibraryService
 
 // FindRelatedBooks
 func (c *Client) FindRelatedBooks(ctx context.Context, req *librarypb.FindRelatedBooksRequest) *StringIterator {
-    md, _ := metadata.FromContext(ctx)
-    ctx = metadata.NewContext(ctx, metadata.Join(md, c.metadata))
+    ctx = insertXGoog(ctx, c.xGoogHeader)
     it := &StringIterator{}
     it.InternalFetch = func(pageSize int, pageToken string) ([]string, string, error) {
         var resp *librarypb.FindRelatedBooksResponse
@@ -658,8 +634,7 @@ func (c *Client) FindRelatedBooks(ctx context.Context, req *librarypb.FindRelate
 
 // addLabel adds a label to the entity.
 func (c *Client) addLabel(ctx context.Context, req *taggerpb.AddLabelRequest) (*taggerpb.AddLabelResponse, error) {
-    md, _ := metadata.FromContext(ctx)
-    ctx = metadata.NewContext(ctx, metadata.Join(md, c.metadata))
+    ctx = insertXGoog(ctx, c.xGoogHeader)
     var resp *taggerpb.AddLabelResponse
     err := gax.Invoke(ctx, func(ctx context.Context) error {
         var err error
@@ -674,8 +649,7 @@ func (c *Client) addLabel(ctx context.Context, req *taggerpb.AddLabelRequest) (*
 
 // GetBigBook test long-running operations
 func (c *Client) GetBigBook(ctx context.Context, req *librarypb.GetBookRequest) (*BookOperation, error) {
-    md, _ := metadata.FromContext(ctx)
-    ctx = metadata.NewContext(ctx, metadata.Join(md, c.metadata))
+    ctx = insertXGoog(ctx, c.xGoogHeader)
     var resp *longrunningpb.Operation
     err := gax.Invoke(ctx, func(ctx context.Context) error {
         var err error
@@ -692,8 +666,7 @@ func (c *Client) GetBigBook(ctx context.Context, req *librarypb.GetBookRequest) 
 
 // GetBigNothing test long-running operations with empty return type.
 func (c *Client) GetBigNothing(ctx context.Context, req *librarypb.GetBookRequest) (*EmptyOperation, error) {
-    md, _ := metadata.FromContext(ctx)
-    ctx = metadata.NewContext(ctx, metadata.Join(md, c.metadata))
+    ctx = insertXGoog(ctx, c.xGoogHeader)
     var resp *longrunningpb.Operation
     err := gax.Invoke(ctx, func(ctx context.Context) error {
         var err error

--- a/src/test/java/com/google/api/codegen/testdata/go_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_main_library.baseline
@@ -192,7 +192,7 @@ func (c *Client) Close() error {
 // use by Google-written clients.
 func (c *Client) SetGoogleClientInfo(name, version string) {
     goVersion := strings.Replace(runtime.Version(), " ", "_", -1)
-    v := fmt.Sprintf("%s/%s %s gax/%s go/%s", name, version, gapicNameVersion, gax.Version, goVersion)
+    v := fmt.Sprintf("%s/%s %s gax/%s gl-go/%s", name, version, gapicNameVersion, gax.Version, goVersion)
     c.metadata = metadata.Pairs("x-goog-api-client", v)
 }
 

--- a/src/test/java/com/google/api/codegen/testdata/go_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_main_library.baseline
@@ -20,11 +20,10 @@ package library
 import (
     "fmt"
     "math"
-    "runtime"
-    "strings"
     "time"
 
     "cloud.google.com/go/iam"
+    "cloud.google.com/go/internal/version"
     "cloud.google.com/go/longrunning"
     gax "github.com/googleapis/gax-go"
     "golang.org/x/net/context"
@@ -171,7 +170,7 @@ func NewClient(ctx context.Context, opts ...option.ClientOption) (*Client, error
         client: librarypb.NewLibraryServiceClient(conn),
         labelerClient: taggerpb.NewLabelerClient(conn),
     }
-    c.SetGoogleClientInfo(gapicName, gapicVersion)
+    c.SetGoogleClientInfo("gapic", version.Repo)
     return c, nil
 }
 
@@ -189,9 +188,8 @@ func (c *Client) Close() error {
 // SetGoogleClientInfo sets the name and version of the application in
 // the `x-goog-api-client` header passed on each request. Intended for
 // use by Google-written clients.
-func (c *Client) SetGoogleClientInfo(name, version string) {
-    goVersion := strings.Replace(runtime.Version(), " ", "_", -1)
-    c.xGoogHeader = fmt.Sprintf("gl-go/%s %s/%s gax/%s", goVersion, name, version, gax.Version)
+func (c *Client) SetGoogleClientInfo(clientName, clientVersion string) {
+    c.xGoogHeader = fmt.Sprintf("gl-go/%s %s/%s gax/%s grpc/UNKNOWN", version.Go(), clientName, clientVersion, gax.Version)
 }
 
 // LibraryShelfPath returns the path for the shelf resource.


### PR DESCRIPTION
A couple things of note:

The GRPC library doesn't expose a version yet, so that's not available
right now

The version string is in YYYYMMDD format. Rationale:
The semver spec states that "Once a versioned package has been released,
the contents of that version MUST NOT be modified". Since "go get" just
downloads the master branch, we are technically modifying the version
every time we submit code. If our users use the version package for
their own telemetry, they might be unpleasantly surprised.