### PR TITLE
update copyright header and corresponding tests from 2016 to 2017

### DIFF
--- a/src/main/resources/com/google/api/codegen/copyright-google.txt
+++ b/src/main/resources/com/google/api/codegen/copyright-google.txt
@@ -1,1 +1,1 @@
-Copyright 2016, Google Inc. All rights reserved.
+Copyright 2017, Google Inc. All rights reserved.

--- a/src/test/java/com/google/api/codegen/testdata/csharp_gapic_client_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/csharp_gapic_client_library.baseline
@@ -1,5 +1,5 @@
 ============== file: Google/Example/Library/V1/LibraryServiceClient.cs ==============
-// Copyright 2016, Google Inc. All rights reserved.
+// Copyright 2017, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/api/codegen/testdata/csharp_gapic_resourcenames_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/csharp_gapic_resourcenames_library.baseline
@@ -1,5 +1,5 @@
 ============== file: Google/Example/Library/V1/ResourceNames.cs ==============
-// Copyright 2016, Google Inc. All rights reserved.
+// Copyright 2017, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/api/codegen/testdata/csharp_gapic_snippets_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/csharp_gapic_snippets_library.baseline
@@ -1,5 +1,5 @@
 ============== file: Google/Example/Library/V1/LibraryServiceClientSnippets.g.cs ==============
-// Copyright 2016, Google Inc. All rights reserved.
+// Copyright 2017, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/api/codegen/testdata/go_doc_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_doc_library.baseline
@@ -1,5 +1,5 @@
 ============== file: cloud.google.com/go/library/apiv1/doc.go ==============
-// Copyright 2016, Google Inc. All rights reserved.
+// Copyright 2017, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/api/codegen/testdata/go_example_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_example_library.baseline
@@ -1,5 +1,5 @@
 ============== file: cloud.google.com/go/library/apiv1/library_client_example_test.go ==============
-// Copyright 2016, Google Inc. All rights reserved.
+// Copyright 2017, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/api/codegen/testdata/go_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_main_library.baseline
@@ -1,5 +1,5 @@
 ============== file: cloud.google.com/go/library/apiv1/library_client.go ==============
-// Copyright 2016, Google Inc. All rights reserved.
+// Copyright 2017, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/api/codegen/testdata/go_mock_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_mock_library.baseline
@@ -1,5 +1,5 @@
 ============== file: cloud.google.com/go/library/apiv1/mock_test.go ==============
-// Copyright 2016, Google Inc. All rights reserved.
+// Copyright 2017, Google Inc. All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/api/codegen/testdata/java_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_main_library.baseline
@@ -1,6 +1,6 @@
 ============== file: src/main/java/com/google/gcloud/pubsub/spi/LibraryServiceClient.java ==============
 /*
- * Copyright 2016, Google Inc. All rights reserved.
+ * Copyright 2017, Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/api/codegen/testdata/java_main_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_main_no_path_templates.baseline
@@ -1,6 +1,6 @@
 ============== file: src/main/java/com/google/gcloud/example/NoTemplatesApiServiceClient.java ==============
 /*
- * Copyright 2016, Google Inc. All rights reserved.
+ * Copyright 2017, Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/api/codegen/testdata/java_mock_service_impl_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_mock_service_impl_library.baseline
@@ -1,6 +1,6 @@
 ============== file: src/test/java/com/google/gcloud/pubsub/spi/MockLabelerImpl.java ==============
 /*
- * Copyright 2016, Google Inc. All rights reserved.
+ * Copyright 2017, Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,7 +76,7 @@ public class MockLabelerImpl extends LabelerImplBase {
 }
 ============== file: src/test/java/com/google/gcloud/pubsub/spi/MockLibraryServiceImpl.java ==============
 /*
- * Copyright 2016, Google Inc. All rights reserved.
+ * Copyright 2017, Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/api/codegen/testdata/java_mock_service_impl_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_mock_service_impl_no_path_templates.baseline
@@ -1,6 +1,6 @@
 ============== file: src/test/java/com/google/gcloud/example/MockNoTemplatesAPIServiceImpl.java ==============
 /*
- * Copyright 2016, Google Inc. All rights reserved.
+ * Copyright 2017, Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/api/codegen/testdata/java_mock_service_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_mock_service_library.baseline
@@ -1,6 +1,6 @@
 ============== file: src/test/java/com/google/gcloud/pubsub/spi/MockLabeler.java ==============
 /*
- * Copyright 2016, Google Inc. All rights reserved.
+ * Copyright 2017, Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,7 +60,7 @@ public class MockLabeler implements MockGrpcService  {
 }
 ============== file: src/test/java/com/google/gcloud/pubsub/spi/MockLibraryService.java ==============
 /*
- * Copyright 2016, Google Inc. All rights reserved.
+ * Copyright 2017, Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/api/codegen/testdata/java_mock_service_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_mock_service_no_path_templates.baseline
@@ -1,6 +1,6 @@
 ============== file: src/test/java/com/google/gcloud/example/MockNoTemplatesAPIService.java ==============
 /*
- * Copyright 2016, Google Inc. All rights reserved.
+ * Copyright 2017, Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/api/codegen/testdata/java_package-info_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_package-info_library.baseline
@@ -1,6 +1,6 @@
 ============== file: src/main/java/com/google/gcloud/pubsub/spi/package-info.java ==============
 /*
- * Copyright 2016, Google Inc. All rights reserved.
+ * Copyright 2017, Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/api/codegen/testdata/java_package-info_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_package-info_no_path_templates.baseline
@@ -1,6 +1,6 @@
 ============== file: src/main/java/com/google/gcloud/example/package-info.java ==============
 /*
- * Copyright 2016, Google Inc. All rights reserved.
+ * Copyright 2017, Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/api/codegen/testdata/java_page_streaming_response_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_page_streaming_response_library.baseline
@@ -1,6 +1,6 @@
 ============== file: src/main/java/com/google/gcloud/pubsub/spi/PagedResponseWrappers.java ==============
 /*
- * Copyright 2016, Google Inc. All rights reserved.
+ * Copyright 2017, Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/api/codegen/testdata/java_settings_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_settings_library.baseline
@@ -1,6 +1,6 @@
 ============== file: src/main/java/com/google/gcloud/pubsub/spi/LibraryServiceSettings.java ==============
 /*
- * Copyright 2016, Google Inc. All rights reserved.
+ * Copyright 2017, Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/api/codegen/testdata/java_settings_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_settings_no_path_templates.baseline
@@ -1,6 +1,6 @@
 ============== file: src/main/java/com/google/gcloud/example/NoTemplatesApiServiceSettings.java ==============
 /*
- * Copyright 2016, Google Inc. All rights reserved.
+ * Copyright 2017, Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/api/codegen/testdata/java_smoke_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_smoke_test_library.baseline
@@ -1,6 +1,6 @@
 ============== file: src/test/java/com/google/gcloud/pubsub/spi/LibraryServiceSmokeTest.java ==============
 /*
- * Copyright 2016, Google Inc. All rights reserved.
+ * Copyright 2017, Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/api/codegen/testdata/java_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_test_library.baseline
@@ -1,6 +1,6 @@
 ============== file: src/test/java/com/google/gcloud/pubsub/spi/LibraryServiceClientTest.java ==============
 /*
- * Copyright 2016, Google Inc. All rights reserved.
+ * Copyright 2017, Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/api/codegen/testdata/java_test_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_test_no_path_templates.baseline
@@ -1,6 +1,6 @@
 ============== file: src/test/java/com/google/gcloud/example/NoTemplatesApiServiceClientTest.java ==============
 /*
- * Copyright 2016, Google Inc. All rights reserved.
+ * Copyright 2017, Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/api/codegen/testdata/php_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php_main_library.baseline
@@ -1,7 +1,7 @@
 ============== file: src/Example/Library/V1/LibraryServiceClient.php ==============
 <?php
 /*
- * Copyright 2016, Google Inc. All rights reserved.
+ * Copyright 2017, Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/api/codegen/testdata/php_mock_service_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php_mock_service_library.baseline
@@ -1,7 +1,7 @@
 ============== file: tests/unit/Example/Library/V1/MockLabelerImpl.php ==============
 <?php
 /*
- * Copyright 2016, Google Inc. All rights reserved.
+ * Copyright 2017, Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ class MockLabelerImpl extends LabelerGrpcClient
 ============== file: tests/unit/Example/Library/V1/MockLibraryServiceImpl.php ==============
 <?php
 /*
- * Copyright 2016, Google Inc. All rights reserved.
+ * Copyright 2017, Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/api/codegen/testdata/php_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php_test_library.baseline
@@ -1,7 +1,7 @@
 ============== file: tests/unit/Example/Library/V1/LibraryServiceClientTest.php ==============
 <?php
 /*
- * Copyright 2016, Google Inc. All rights reserved.
+ * Copyright 2017, Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
@@ -1,5 +1,5 @@
 ============== file: google/cloud/gapic/example/library/v1/library_service_client.py ==============
-# Copyright 2016, Google Inc. All rights reserved.
+# Copyright 2017, Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
@@ -1,5 +1,5 @@
 ============== file: google/cloud/gapic/example/library/v1/library_service_client.py ==============
-# Copyright 2016, Google Inc. All rights reserved.
+# Copyright 2017, Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/test/java/com/google/api/codegen/testdata/python_main_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_main_no_path_templates.baseline
@@ -1,5 +1,5 @@
 ============== file: example/no_templates_api_service_client.py ==============
-# Copyright 2016, Google Inc. All rights reserved.
+# Copyright 2017, Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This is to fix issue #968
  * update copyright header from 2016 to 2017
  * update copyright header in baselines from 2016 to 2017