### PR TITLE
replicate Go oneof bug

### DIFF
--- a/src/test/java/com/google/api/codegen/testdata/csharp_gapic_client_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/csharp_gapic_client_library.baseline
@@ -1728,6 +1728,9 @@ namespace Google.Example.Library.V1
         /// <param name="edition">
         /// The edition of the series
         /// </param>
+        /// <param name="seriesUuid">
+        /// Uniquely identifies the series to the publishing house.
+        /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
         /// </param>
@@ -1738,12 +1741,14 @@ namespace Google.Example.Library.V1
             Shelf shelf,
             IEnumerable<Book> books,
             uint edition,
+            SeriesUuid seriesUuid,
             CallSettings callSettings = null) => PublishSeriesAsync(
                 new PublishSeriesRequest
                 {
                     Shelf = shelf,
                     Books = { books },
                     Edition = edition,
+                    SeriesUuid = seriesUuid,
                 },
                 callSettings);
 
@@ -1759,6 +1764,9 @@ namespace Google.Example.Library.V1
         /// <param name="edition">
         /// The edition of the series
         /// </param>
+        /// <param name="seriesUuid">
+        /// Uniquely identifies the series to the publishing house.
+        /// </param>
         /// <param name="cancellationToken">
         /// A <see cref="CancellationToken"/> to use for this RPC.
         /// </param>
@@ -1769,10 +1777,12 @@ namespace Google.Example.Library.V1
             Shelf shelf,
             IEnumerable<Book> books,
             uint edition,
+            SeriesUuid seriesUuid,
             CancellationToken cancellationToken) => PublishSeriesAsync(
                 shelf,
                 books,
                 edition,
+                seriesUuid,
                 CallSettings.FromCancellationToken(cancellationToken));
 
         /// <summary>
@@ -1787,6 +1797,9 @@ namespace Google.Example.Library.V1
         /// <param name="edition">
         /// The edition of the series
         /// </param>
+        /// <param name="seriesUuid">
+        /// Uniquely identifies the series to the publishing house.
+        /// </param>
         /// <param name="callSettings">
         /// If not null, applies overrides to this RPC call.
         /// </param>
@@ -1797,12 +1810,14 @@ namespace Google.Example.Library.V1
             Shelf shelf,
             IEnumerable<Book> books,
             uint edition,
+            SeriesUuid seriesUuid,
             CallSettings callSettings = null) => PublishSeries(
                 new PublishSeriesRequest
                 {
                     Shelf = shelf,
                     Books = { books },
                     Edition = edition,
+                    SeriesUuid = seriesUuid,
                 },
                 callSettings);
 

--- a/src/test/java/com/google/api/codegen/testdata/csharp_gapic_snippets_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/csharp_gapic_snippets_library.baseline
@@ -587,6 +587,10 @@ namespace Google.Example.Library.V1.Snippets
             {
                 Shelf = new Shelf(),
                 Books = { },
+                SeriesUuid = new SeriesUuid
+                             {
+                                 SeriesString = "foobar",
+                             },
             };
             // Make the request
             PublishSeriesResponse response = await libraryServiceClient.PublishSeriesAsync(request);
@@ -603,6 +607,10 @@ namespace Google.Example.Library.V1.Snippets
             {
                 Shelf = new Shelf(),
                 Books = { },
+                SeriesUuid = new SeriesUuid
+                             {
+                                 SeriesString = "foobar",
+                             },
             };
             // Make the request
             PublishSeriesResponse response = libraryServiceClient.PublishSeries(request);

--- a/src/test/java/com/google/api/codegen/testdata/csharp_gapic_snippets_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/csharp_gapic_snippets_library.baseline
@@ -550,30 +550,38 @@ namespace Google.Example.Library.V1.Snippets
 
         public async Task PublishSeriesAsync()
         {
-            // Snippet: PublishSeriesAsync(Shelf,IEnumerable<Book>,uint,CallSettings)
-            // Additional: PublishSeriesAsync(Shelf,IEnumerable<Book>,uint,CancellationToken)
+            // Snippet: PublishSeriesAsync(Shelf,IEnumerable<Book>,uint,SeriesUuid,CallSettings)
+            // Additional: PublishSeriesAsync(Shelf,IEnumerable<Book>,uint,SeriesUuid,CancellationToken)
             // Create client
             LibraryServiceClient libraryServiceClient = await LibraryServiceClient.CreateAsync();
             // Initialize request argument(s)
             Shelf shelf = new Shelf();
             IEnumerable<Book> books = new List<Book>();
             uint edition = 0;
+            SeriesUuid seriesUuid = new SeriesUuid
+            {
+                SeriesString = "foobar",
+            };
             // Make the request
-            PublishSeriesResponse response = await libraryServiceClient.PublishSeriesAsync(shelf, books, edition);
+            PublishSeriesResponse response = await libraryServiceClient.PublishSeriesAsync(shelf, books, edition, seriesUuid);
             // End snippet
         }
 
         public void PublishSeries()
         {
-            // Snippet: PublishSeries(Shelf,IEnumerable<Book>,uint,CallSettings)
+            // Snippet: PublishSeries(Shelf,IEnumerable<Book>,uint,SeriesUuid,CallSettings)
             // Create client
             LibraryServiceClient libraryServiceClient = LibraryServiceClient.Create();
             // Initialize request argument(s)
             Shelf shelf = new Shelf();
             IEnumerable<Book> books = new List<Book>();
             uint edition = 0;
+            SeriesUuid seriesUuid = new SeriesUuid
+            {
+                SeriesString = "foobar",
+            };
             // Make the request
-            PublishSeriesResponse response = libraryServiceClient.PublishSeries(shelf, books, edition);
+            PublishSeriesResponse response = libraryServiceClient.PublishSeries(shelf, books, edition, seriesUuid);
             // End snippet
         }
 

--- a/src/test/java/com/google/api/codegen/testdata/go_mock_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_mock_library.baseline
@@ -732,9 +732,14 @@ func TestLibraryServicePublishSeries(t *testing.T) {
 
     var shelf *librarypb.Shelf = &librarypb.Shelf{}
     var books []*librarypb.Book = nil
+    var seriesString string = "foobar"
+    var seriesUuid = &librarypb.SeriesUuid{
+        SeriesString: seriesString,
+    }
     var request = &librarypb.PublishSeriesRequest{
         Shelf: shelf,
         Books: books,
+        SeriesUuid: seriesUuid,
     }
 
     c, err := NewClient(context.Background(), clientOpt)
@@ -763,9 +768,14 @@ func TestLibraryServicePublishSeriesError(t *testing.T) {
 
     var shelf *librarypb.Shelf = &librarypb.Shelf{}
     var books []*librarypb.Book = nil
+    var seriesString string = "foobar"
+    var seriesUuid = &librarypb.SeriesUuid{
+        SeriesString: seriesString,
+    }
     var request = &librarypb.PublishSeriesRequest{
         Shelf: shelf,
         Books: books,
+        SeriesUuid: seriesUuid,
     }
 
     c, err := NewClient(context.Background(), clientOpt)

--- a/src/test/java/com/google/api/codegen/testdata/java_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_main_library.baseline
@@ -852,9 +852,14 @@ public class LibraryServiceClient implements AutoCloseable {
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
    *   Shelf shelf = Shelf.newBuilder().build();
    *   List&lt;Book&gt; books = new ArrayList&lt;&gt;();
+   *   String seriesString = "foobar";
+   *   SeriesUuid seriesUuid = SeriesUuid.newBuilder()
+   *     .setSeriesString(seriesString)
+   *     .build();
    *   PublishSeriesRequest request = PublishSeriesRequest.newBuilder()
    *     .setShelf(shelf)
    *     .addAllBooks(books)
+   *     .setSeriesUuid(seriesUuid)
    *     .build();
    *   PublishSeriesResponse response = libraryServiceClient.publishSeries(request);
    * }
@@ -876,9 +881,14 @@ public class LibraryServiceClient implements AutoCloseable {
    * try (LibraryServiceClient libraryServiceClient = LibraryServiceClient.create()) {
    *   Shelf shelf = Shelf.newBuilder().build();
    *   List&lt;Book&gt; books = new ArrayList&lt;&gt;();
+   *   String seriesString = "foobar";
+   *   SeriesUuid seriesUuid = SeriesUuid.newBuilder()
+   *     .setSeriesString(seriesString)
+   *     .build();
    *   PublishSeriesRequest request = PublishSeriesRequest.newBuilder()
    *     .setShelf(shelf)
    *     .addAllBooks(books)
+   *     .setSeriesUuid(seriesUuid)
    *     .build();
    *   RpcFuture&lt;PublishSeriesResponse&gt; future = libraryServiceClient.publishSeriesCallable().futureCall(request);
    *   // Do something

--- a/src/test/java/com/google/api/codegen/testdata/java_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_main_library.baseline
@@ -54,6 +54,7 @@ import com.google.example.library.v1.MergeShelvesRequest;
 import com.google.example.library.v1.MoveBookRequest;
 import com.google.example.library.v1.PublishSeriesRequest;
 import com.google.example.library.v1.PublishSeriesResponse;
+import com.google.example.library.v1.SeriesUuid;
 import com.google.example.library.v1.Shelf;
 import com.google.example.library.v1.ShelfName;
 import com.google.example.library.v1.SomeMessage;
@@ -823,22 +824,28 @@ public class LibraryServiceClient implements AutoCloseable {
    *   Shelf shelf = Shelf.newBuilder().build();
    *   List&lt;Book&gt; books = new ArrayList&lt;&gt;();
    *   int edition = 0;
-   *   PublishSeriesResponse response = libraryServiceClient.publishSeries(shelf, books, edition);
+   *   String seriesString = "foobar";
+   *   SeriesUuid seriesUuid = SeriesUuid.newBuilder()
+   *     .setSeriesString(seriesString)
+   *     .build();
+   *   PublishSeriesResponse response = libraryServiceClient.publishSeries(shelf, books, edition, seriesUuid);
    * }
    * </code></pre>
    *
    * @param shelf The shelf in which the series is created.
    * @param books The books to publish in the series.
    * @param edition The edition of the series
+   * @param seriesUuid Uniquely identifies the series to the publishing house.
    * @throws com.google.api.gax.grpc.ApiException if the remote call fails
    */
-  public final PublishSeriesResponse publishSeries(Shelf shelf, List<Book> books, int edition) {
+  public final PublishSeriesResponse publishSeries(Shelf shelf, List<Book> books, int edition, SeriesUuid seriesUuid) {
 
     PublishSeriesRequest request =
         PublishSeriesRequest.newBuilder()
         .setShelf(shelf)
         .addAllBooks(books)
         .setEdition(edition)
+        .setSeriesUuid(seriesUuid)
         .build();
     return publishSeries(request);
   }

--- a/src/test/java/com/google/api/codegen/testdata/java_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_test_library.baseline
@@ -54,6 +54,7 @@ import com.google.example.library.v1.MergeShelvesRequest;
 import com.google.example.library.v1.MoveBookRequest;
 import com.google.example.library.v1.PublishSeriesRequest;
 import com.google.example.library.v1.PublishSeriesResponse;
+import com.google.example.library.v1.SeriesUuid;
 import com.google.example.library.v1.Shelf;
 import com.google.example.library.v1.ShelfName;
 import com.google.example.library.v1.SomeMessage;
@@ -483,9 +484,13 @@ public class LibraryServiceClientTest {
     Shelf shelf = Shelf.newBuilder().build();
     List<Book> books = new ArrayList<>();
     int edition = -1887963714;
+    String seriesString = "foobar";
+    SeriesUuid seriesUuid = SeriesUuid.newBuilder()
+      .setSeriesString(seriesString)
+      .build();
 
     PublishSeriesResponse actualResponse =
-        client.publishSeries(shelf, books, edition);
+        client.publishSeries(shelf, books, edition, seriesUuid);
     Assert.assertEquals(expectedResponse, actualResponse);
 
     List<GeneratedMessageV3> actualRequests = mockLibraryService.getRequests();
@@ -495,6 +500,7 @@ public class LibraryServiceClientTest {
     Assert.assertEquals(shelf, actualRequest.getShelf());
     Assert.assertEquals(books, actualRequest.getBooksList());
     Assert.assertEquals(edition, actualRequest.getEdition());
+    Assert.assertEquals(seriesUuid, actualRequest.getSeriesUuid());
   }
 
   @Test
@@ -507,8 +513,12 @@ public class LibraryServiceClientTest {
       Shelf shelf = Shelf.newBuilder().build();
       List<Book> books = new ArrayList<>();
       int edition = -1887963714;
+      String seriesString = "foobar";
+      SeriesUuid seriesUuid = SeriesUuid.newBuilder()
+        .setSeriesString(seriesString)
+        .build();
 
-      client.publishSeries(shelf, books, edition);
+      client.publishSeries(shelf, books, edition, seriesUuid);
       Assert.fail("No exception raised");
     } catch (ApiException e) {
       Assert.assertEquals(Status.INTERNAL.getCode(), e.getStatusCode());

--- a/src/test/java/com/google/api/codegen/testdata/library.proto
+++ b/src/test/java/com/google/api/codegen/testdata/library.proto
@@ -391,7 +391,14 @@ message PublishSeriesRequest {
   }
 
   // Uniquely identifies the series to the publishing house.
-  bytes series_uuid = 5;
+  SeriesUuid series_uuid = 5;
+}
+
+message SeriesUuid {
+  oneof source {
+    bytes series_bytes = 1;
+    string series_string = 2;
+  }
 }
 
 // Response message for LibraryService.PublishSeries.

--- a/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
@@ -195,6 +195,7 @@ interfaces:
         - shelf
         - books
         - edition
+        - series_uuid
     required_fields:
       - shelf
       - books

--- a/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
@@ -198,6 +198,7 @@ interfaces:
     required_fields:
       - shelf
       - books
+      - series_uuid
     retry_codes_name: non_idempotent
     retry_params_name: default
     timeout_millis: 7000
@@ -216,6 +217,8 @@ interfaces:
         subresponse_field: book_names
     request_object_method: true
     resource_name_treatment: STATIC_TYPES
+    sample_code_init_fields:
+    - series_uuid.series_string=foobar
   - name: GetBook
     flattening:
       groups:

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_doc_main_library.baseline
@@ -699,14 +699,14 @@ LibraryServiceClient.prototype.createBook = function(request, options, callback)
  *   The books to publish in the series.
  *
  *   This object should have the same structure as [Book]{@link Book}
+ * @param {Object} request.seriesUuid
+ *   Uniquely identifies the series to the publishing house.
+ *
+ *   This object should have the same structure as [SeriesUuid]{@link SeriesUuid}
  * @param {number=} request.edition
  *   The edition of the series
  * @param {boolean=} request.reviewCopy
  *   If the book is in a pre-publish state
- * @param {Object=} request.seriesUuid
- *   Uniquely identifies the series to the publishing house.
- *
- *   This object should have the same structure as [SeriesUuid]{@link SeriesUuid}
  * @param {Object=} options
  *   Optional parameters. You can override the default settings for this call, e.g, timeout,
  *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
@@ -723,9 +723,14 @@ LibraryServiceClient.prototype.createBook = function(request, options, callback)
  * var client = libraryV1.libraryServiceClient();
  * var shelf = {};
  * var books = [];
+ * var seriesString = 'foobar';
+ * var seriesUuid = {
+ *     seriesString : seriesString
+ * };
  * var request = {
  *     shelf: shelf,
- *     books: books
+ *     books: books,
+ *     seriesUuid: seriesUuid
  * };
  * client.publishSeries(request).then(function(responses) {
  *     var response = responses[0];

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_doc_main_library.baseline
@@ -703,8 +703,10 @@ LibraryServiceClient.prototype.createBook = function(request, options, callback)
  *   The edition of the series
  * @param {boolean=} request.reviewCopy
  *   If the book is in a pre-publish state
- * @param {string=} request.seriesUuid
+ * @param {Object=} request.seriesUuid
  *   Uniquely identifies the series to the publishing house.
+ *
+ *   This object should have the same structure as [SeriesUuid]{@link SeriesUuid}
  * @param {Object=} options
  *   Optional parameters. You can override the default settings for this call, e.g, timeout,
  *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_doc_message_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_doc_message_library.baseline
@@ -1323,13 +1323,27 @@ var CreateBookRequest = {
  * @property {boolean} reviewCopy
  *   If the book is in a pre-publish state
  *
- * @property {string} seriesUuid
+ * @property {Object} seriesUuid
  *   Uniquely identifies the series to the publishing house.
+ *
+ *   This object should have the same structure as [SeriesUuid]{@link SeriesUuid}
  *
  * @class
  * @see [google.example.library.v1.PublishSeriesRequest definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
  */
 var PublishSeriesRequest = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};
+
+/**
+ * @property {string} seriesBytes
+ *
+ * @property {string} seriesString
+ *
+ * @class
+ * @see [google.example.library.v1.SeriesUuid definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/library.proto}
+ */
+var SeriesUuid = {
   // This is for documentation. Actual contents will be loaded by gRPC.
 };
 

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_main_library.baseline
@@ -699,14 +699,14 @@ LibraryServiceClient.prototype.createBook = function(request, options, callback)
  *   The books to publish in the series.
  *
  *   This object should have the same structure as [Book]{@link Book}
+ * @param {Object} request.seriesUuid
+ *   Uniquely identifies the series to the publishing house.
+ *
+ *   This object should have the same structure as [SeriesUuid]{@link SeriesUuid}
  * @param {number=} request.edition
  *   The edition of the series
  * @param {boolean=} request.reviewCopy
  *   If the book is in a pre-publish state
- * @param {Object=} request.seriesUuid
- *   Uniquely identifies the series to the publishing house.
- *
- *   This object should have the same structure as [SeriesUuid]{@link SeriesUuid}
  * @param {Object=} options
  *   Optional parameters. You can override the default settings for this call, e.g, timeout,
  *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.
@@ -723,9 +723,14 @@ LibraryServiceClient.prototype.createBook = function(request, options, callback)
  * var client = libraryV1.libraryServiceClient();
  * var shelf = {};
  * var books = [];
+ * var seriesString = 'foobar';
+ * var seriesUuid = {
+ *     seriesString : seriesString
+ * };
  * var request = {
  *     shelf: shelf,
- *     books: books
+ *     books: books,
+ *     seriesUuid: seriesUuid
  * };
  * client.publishSeries(request).then(function(responses) {
  *     var response = responses[0];

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_main_library.baseline
@@ -703,8 +703,10 @@ LibraryServiceClient.prototype.createBook = function(request, options, callback)
  *   The edition of the series
  * @param {boolean=} request.reviewCopy
  *   If the book is in a pre-publish state
- * @param {string=} request.seriesUuid
+ * @param {Object=} request.seriesUuid
  *   Uniquely identifies the series to the publishing house.
+ *
+ *   This object should have the same structure as [SeriesUuid]{@link SeriesUuid}
  * @param {Object=} options
  *   Optional parameters. You can override the default settings for this call, e.g, timeout,
  *   retries, paginations, etc. See [gax.CallOptions]{@link https://googleapis.github.io/gax-nodejs/global.html#CallOptions} for the details.

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_test_library.baseline
@@ -317,9 +317,14 @@ describe('LibraryServiceClient', function() {
       // Mock request
       var shelf = {};
       var books = [];
+      var seriesString = 'foobar';
+      var seriesUuid = {
+          seriesString : seriesString
+      };
       var request = {
           shelf : shelf,
-          books : books
+          books : books,
+          seriesUuid : seriesUuid
       };
 
       // Mock response
@@ -344,9 +349,14 @@ describe('LibraryServiceClient', function() {
       // Mock request
       var shelf = {};
       var books = [];
+      var seriesString = 'foobar';
+      var seriesUuid = {
+          seriesString : seriesString
+      };
       var request = {
           shelf : shelf,
-          books : books
+          books : books,
+          seriesUuid : seriesUuid
       };
 
       // Mock Grpc layer

--- a/src/test/java/com/google/api/codegen/testdata/php_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php_main_library.baseline
@@ -60,6 +60,7 @@ use google\example\library\v1\ListStringsRequest;
 use google\example\library\v1\MergeShelvesRequest;
 use google\example\library\v1\MoveBookRequest;
 use google\example\library\v1\PublishSeriesRequest;
+use google\example\library\v1\SeriesUuid;
 use google\example\library\v1\Shelf;
 use google\example\library\v1\SomeMessage;
 use google\example\library\v1\StreamBooksRequest;
@@ -855,7 +856,7 @@ class LibraryServiceClient
      *          The edition of the series
      *     @type bool $reviewCopy
      *          If the book is in a pre-publish state
-     *     @type string $seriesUuid
+     *     @type SeriesUuid $seriesUuid
      *          Uniquely identifies the series to the publishing house.
      *     @type \Google\GAX\RetrySettings $retrySettings
      *          Retry settings to use for this call. If present, then

--- a/src/test/java/com/google/api/codegen/testdata/php_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php_main_library.baseline
@@ -842,7 +842,10 @@ class LibraryServiceClient
      *     $libraryServiceClient = new LibraryServiceClient();
      *     $shelf = new Shelf();
      *     $books = [];
-     *     $response = $libraryServiceClient->publishSeries($shelf, $books);
+     *     $seriesString = "foobar";
+     *     $seriesUuid = new SeriesUuid();
+     *     $seriesUuid->setSeriesString($seriesString);
+     *     $response = $libraryServiceClient->publishSeries($shelf, $books, $seriesUuid);
      * } finally {
      *     $libraryServiceClient->close();
      * }
@@ -850,14 +853,13 @@ class LibraryServiceClient
      *
      * @param Shelf $shelf The shelf in which the series is created.
      * @param Book[] $books The books to publish in the series.
+     * @param SeriesUuid $seriesUuid Uniquely identifies the series to the publishing house.
      * @param array $optionalArgs {
      *     Optional.
      *     @type int $edition
      *          The edition of the series
      *     @type bool $reviewCopy
      *          If the book is in a pre-publish state
-     *     @type SeriesUuid $seriesUuid
-     *          Uniquely identifies the series to the publishing house.
      *     @type \Google\GAX\RetrySettings $retrySettings
      *          Retry settings to use for this call. If present, then
      *          $timeoutMillis is ignored.
@@ -870,21 +872,19 @@ class LibraryServiceClient
      *
      * @throws \Google\GAX\ApiException if the remote call fails
      */
-    public function publishSeries($shelf, $books, $optionalArgs = [])
+    public function publishSeries($shelf, $books, $seriesUuid, $optionalArgs = [])
     {
         $request = new PublishSeriesRequest();
         $request->setShelf($shelf);
         foreach ($books as $elem) {
             $request->addBooks($elem);
         }
+        $request->setSeriesUuid($seriesUuid);
         if (isset($optionalArgs['edition'])) {
             $request->setEdition($optionalArgs['edition']);
         }
         if (isset($optionalArgs['reviewCopy'])) {
             $request->setReviewCopy($optionalArgs['reviewCopy']);
-        }
-        if (isset($optionalArgs['seriesUuid'])) {
-            $request->setSeriesUuid($optionalArgs['seriesUuid']);
         }
 
         $mergedSettings = $this->defaultCallSettings['publishSeries']->merge(

--- a/src/test/java/com/google/api/codegen/testdata/php_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php_test_library.baseline
@@ -56,6 +56,7 @@ use \google\example\library\v1\MergeShelvesRequest;
 use \google\example\library\v1\MoveBookRequest;
 use \google\example\library\v1\PublishSeriesRequest;
 use \google\example\library\v1\PublishSeriesResponse;
+use \google\example\library\v1\SeriesUuid;
 use \google\example\library\v1\Shelf;
 use \google\example\library\v1\SomeMessage2\SomeMessage3\Alignment;
 use \google\example\library\v1\UpdateBookIndexRequest;
@@ -347,8 +348,11 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         // Mock request
         $shelf = new Shelf();
         $books = [];
+        $seriesString = "foobar";
+        $seriesUuid = new SeriesUuid();
+        $seriesUuid->setSeriesString($seriesString);
 
-        $response = $client->publishSeries($shelf, $books);
+        $response = $client->publishSeries($shelf, $books, $seriesUuid);
         $this->assertEquals($expectedResponse, $response);
         $actualRequests = $grpcStub->getReceivedCalls();
         $this->assertSame(1, count($actualRequests));
@@ -358,6 +362,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals($shelf, $actualRequestObject->getShelf());
         $this->assertEquals($books, $actualRequestObject->getBooksList());
+        $this->assertEquals($seriesUuid, $actualRequestObject->getSeriesUuid());
 
         $this->assertTrue($grpcStub->isExhausted());
     }

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
@@ -601,9 +601,9 @@ class LibraryServiceClient(object):
             self,
             shelf,
             books,
+            series_uuid,
             edition=None,
             review_copy=None,
-            series_uuid=None,
             options=None):
         """
         Creates a series of books.
@@ -614,7 +614,9 @@ class LibraryServiceClient(object):
           >>> api = library_service_client.LibraryServiceClient()
           >>> shelf = library_pb2.Shelf()
           >>> books = []
-          >>> response = api.publish_series(shelf, books)
+          >>> series_string = ''
+          >>> series_uuid = library_pb2.SeriesUuid(series_string)
+          >>> response = api.publish_series(shelf, books, series_uuid)
 
         Args:
           shelf (:class:`google.cloud.proto.example.library.v1.library_pb2.Shelf`): The shelf in which the series is created.
@@ -632,14 +634,12 @@ class LibraryServiceClient(object):
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
           :exc:`ValueError` if the parameters are invalid.
         """
-        if series_uuid is None:
-            series_uuid = library_pb2.SeriesUuid()
         request = library_pb2.PublishSeriesRequest(
             shelf=shelf,
             books=books,
+            series_uuid=series_uuid,
             edition=edition,
-            review_copy=review_copy,
-            series_uuid=series_uuid)
+            review_copy=review_copy)
         return self._publish_series(request, options)
 
     def get_book(

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
@@ -603,7 +603,7 @@ class LibraryServiceClient(object):
             books,
             edition=None,
             review_copy=None,
-            series_uuid=b'',
+            series_uuid=None,
             options=None):
         """
         Creates a series of books.
@@ -621,7 +621,7 @@ class LibraryServiceClient(object):
           books (list[:class:`google.cloud.proto.example.library.v1.library_pb2.Book`]): The books to publish in the series.
           edition (int): The edition of the series
           review_copy (bool): If the book is in a pre-publish state
-          series_uuid (bytes): Uniquely identifies the series to the publishing house.
+          series_uuid (:class:`google.cloud.proto.example.library.v1.library_pb2.SeriesUuid`): Uniquely identifies the series to the publishing house.
           options (:class:`google.gax.CallOptions`): Overrides the default
             settings for this call, e.g, timeout, retries etc.
 
@@ -632,6 +632,8 @@ class LibraryServiceClient(object):
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
           :exc:`ValueError` if the parameters are invalid.
         """
+        if series_uuid is None:
+            series_uuid = library_pb2.SeriesUuid()
         request = library_pb2.PublishSeriesRequest(
             shelf=shelf,
             books=books,

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_message_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_message_library.baseline
@@ -1106,7 +1106,17 @@ class PublishSeriesRequest(object):
       books (list[:class:`google.cloud.proto.example.library.v1.library_pb2.Book`]): The books to publish in the series.
       edition (int): The edition of the series
       review_copy (bool): If the book is in a pre-publish state
-      series_uuid (bytes): Uniquely identifies the series to the publishing house.
+      series_uuid (:class:`google.cloud.proto.example.library.v1.library_pb2.SeriesUuid`): Uniquely identifies the series to the publishing house.
+
+    """
+    pass
+
+
+class SeriesUuid(object):
+    """
+    Attributes:
+      series_bytes (bytes)
+      series_string (string)
 
     """
     pass

--- a/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
@@ -601,9 +601,9 @@ class LibraryServiceClient(object):
             self,
             shelf,
             books,
+            series_uuid,
             edition=None,
             review_copy=None,
-            series_uuid=None,
             options=None):
         """
         Creates a series of books.
@@ -614,7 +614,9 @@ class LibraryServiceClient(object):
           >>> api = library_service_client.LibraryServiceClient()
           >>> shelf = library_pb2.Shelf()
           >>> books = []
-          >>> response = api.publish_series(shelf, books)
+          >>> series_string = ''
+          >>> series_uuid = library_pb2.SeriesUuid(series_string)
+          >>> response = api.publish_series(shelf, books, series_uuid)
 
         Args:
           shelf (:class:`google.cloud.proto.example.library.v1.library_pb2.Shelf`): The shelf in which the series is created.
@@ -632,14 +634,12 @@ class LibraryServiceClient(object):
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
           :exc:`ValueError` if the parameters are invalid.
         """
-        if series_uuid is None:
-            series_uuid = library_pb2.SeriesUuid()
         request = library_pb2.PublishSeriesRequest(
             shelf=shelf,
             books=books,
+            series_uuid=series_uuid,
             edition=edition,
-            review_copy=review_copy,
-            series_uuid=series_uuid)
+            review_copy=review_copy)
         return self._publish_series(request, options)
 
     def get_book(

--- a/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
@@ -603,7 +603,7 @@ class LibraryServiceClient(object):
             books,
             edition=None,
             review_copy=None,
-            series_uuid=b'',
+            series_uuid=None,
             options=None):
         """
         Creates a series of books.
@@ -621,7 +621,7 @@ class LibraryServiceClient(object):
           books (list[:class:`google.cloud.proto.example.library.v1.library_pb2.Book`]): The books to publish in the series.
           edition (int): The edition of the series
           review_copy (bool): If the book is in a pre-publish state
-          series_uuid (bytes): Uniquely identifies the series to the publishing house.
+          series_uuid (:class:`google.cloud.proto.example.library.v1.library_pb2.SeriesUuid`): Uniquely identifies the series to the publishing house.
           options (:class:`google.gax.CallOptions`): Overrides the default
             settings for this call, e.g, timeout, retries etc.
 
@@ -632,6 +632,8 @@ class LibraryServiceClient(object):
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
           :exc:`ValueError` if the parameters are invalid.
         """
+        if series_uuid is None:
+            series_uuid = library_pb2.SeriesUuid()
         request = library_pb2.PublishSeriesRequest(
             shelf=shelf,
             books=books,

--- a/src/test/java/com/google/api/codegen/testdata/ruby_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_doc_main_library.baseline
@@ -598,7 +598,7 @@ module Library
       #   The edition of the series
       # @param review_copy [true, false]
       #   If the book is in a pre-publish state
-      # @param series_uuid [String]
+      # @param series_uuid [Google::Example::Library::V1::SeriesUuid]
       #   Uniquely identifies the series to the publishing house.
       # @param options [Google::Gax::CallOptions]
       #   Overrides the default settings for this call, e.g, timeout,

--- a/src/test/java/com/google/api/codegen/testdata/ruby_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_doc_main_library.baseline
@@ -609,26 +609,30 @@ module Library
       #   require "library/v1/library_service_client"
       #
       #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   SeriesUuid = Google::Example::Library::V1::SeriesUuid
       #   Shelf = Google::Example::Library::V1::Shelf
       #
       #   library_service_client = LibraryServiceClient.new
       #   shelf = Shelf.new
       #   books = []
-      #   response = library_service_client.publish_series(shelf, books)
+      #   series_string = "foobar"
+      #   series_uuid = SeriesUuid.new
+      #   series_uuid.series_string = series_string
+      #   response = library_service_client.publish_series(shelf, books, series_uuid)
 
       def publish_series \
           shelf,
           books,
+          series_uuid,
           edition: nil,
           review_copy: nil,
-          series_uuid: nil,
           options: nil
         req = Google::Example::Library::V1::PublishSeriesRequest.new({
           shelf: shelf,
           books: books,
+          series_uuid: series_uuid,
           edition: edition,
-          review_copy: review_copy,
-          series_uuid: series_uuid
+          review_copy: review_copy
         }.delete_if { |_, v| v.nil? })
         @publish_series.call(req, options)
       end

--- a/src/test/java/com/google/api/codegen/testdata/ruby_doc_message_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_doc_message_library.baseline
@@ -1039,9 +1039,15 @@ module Google
         #   @return [true, false]
         #     If the book is in a pre-publish state
         # @!attribute [rw] series_uuid
-        #   @return [String]
+        #   @return [Google::Example::Library::V1::SeriesUuid]
         #     Uniquely identifies the series to the publishing house.
         class PublishSeriesRequest; end
+
+        # @!attribute [rw] series_bytes
+        #   @return [String]
+        # @!attribute [rw] series_string
+        #   @return [String]
+        class SeriesUuid; end
 
         # Response message for LibraryService.PublishSeries.
         # @!attribute [rw] book_names

--- a/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
@@ -598,7 +598,7 @@ module Library
       #   The edition of the series
       # @param review_copy [true, false]
       #   If the book is in a pre-publish state
-      # @param series_uuid [String]
+      # @param series_uuid [Google::Example::Library::V1::SeriesUuid]
       #   Uniquely identifies the series to the publishing house.
       # @param options [Google::Gax::CallOptions]
       #   Overrides the default settings for this call, e.g, timeout,

--- a/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
@@ -609,26 +609,30 @@ module Library
       #   require "library/v1/library_service_client"
       #
       #   LibraryServiceClient = Library::V1::LibraryServiceClient
+      #   SeriesUuid = Google::Example::Library::V1::SeriesUuid
       #   Shelf = Google::Example::Library::V1::Shelf
       #
       #   library_service_client = LibraryServiceClient.new
       #   shelf = Shelf.new
       #   books = []
-      #   response = library_service_client.publish_series(shelf, books)
+      #   series_string = "foobar"
+      #   series_uuid = SeriesUuid.new
+      #   series_uuid.series_string = series_string
+      #   response = library_service_client.publish_series(shelf, books, series_uuid)
 
       def publish_series \
           shelf,
           books,
+          series_uuid,
           edition: nil,
           review_copy: nil,
-          series_uuid: nil,
           options: nil
         req = Google::Example::Library::V1::PublishSeriesRequest.new({
           shelf: shelf,
           books: books,
+          series_uuid: series_uuid,
           edition: edition,
-          review_copy: review_copy,
-          series_uuid: series_uuid
+          review_copy: review_copy
         }.delete_if { |_, v| v.nil? })
         @publish_series.call(req, options)
       end


### PR DESCRIPTION
The bug is in Go mock test
```go
var seriesString string = "foobar"
var seriesUuid = &librarypb.SeriesUuid{
    SeriesString: seriesString,
}
```
should actually be
```go
var seriesString string = "foobar"
var seriesUuid = &librarypb.SeriesUuid{
    Source: &librarypb.SeriesUuid_SeriesString{
        SeriesString: seriesString,
    },
}
```

This PR does not contain the fix, only the replication, to make changes in baseline easier to review.