### PR TITLE
Change the default lib_version from '0.0' to 'UNKNOWN'.

### DIFF
--- a/src/main/resources/com/google/api/codegen/py/main.snip
+++ b/src/main/resources/com/google/api/codegen/py/main.snip
@@ -187,9 +187,9 @@
                 scopes=None,
                 client_config=None,
                 app_name=None,
-                app_version='0.0',
+                app_version='UNKNOWN',
                 lib_name=None,
-                lib_version='0.0',
+                lib_version='UNKNOWN',
                 metrics_headers=()):
             """Constructor.
 

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
@@ -231,9 +231,9 @@ class LibraryServiceClient(object):
             scopes=None,
             client_config=None,
             app_name=None,
-            app_version='0.0',
+            app_version='UNKNOWN',
             lib_name=None,
-            lib_version='0.0',
+            lib_version='UNKNOWN',
             metrics_headers=()):
         """Constructor.
 

--- a/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
@@ -231,9 +231,9 @@ class LibraryServiceClient(object):
             scopes=None,
             client_config=None,
             app_name=None,
-            app_version='0.0',
+            app_version='UNKNOWN',
             lib_name=None,
-            lib_version='0.0',
+            lib_version='UNKNOWN',
             metrics_headers=()):
         """Constructor.
 

--- a/src/test/java/com/google/api/codegen/testdata/python_main_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_main_no_path_templates.baseline
@@ -59,9 +59,9 @@ class NoTemplatesAPIServiceClient(object):
             scopes=None,
             client_config=None,
             app_name=None,
-            app_version='0.0',
+            app_version='UNKNOWN',
             lib_name=None,
-            lib_version='0.0',
+            lib_version='UNKNOWN',
             metrics_headers=()):
         """Constructor.
 


### PR DESCRIPTION
@geigerj @bjwatson I just realized that there is one place where a potential unknown version is relevant for Python, which is the default `lib_version`. This corrects that.