### PR TITLE
fix Go top-level enum

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/go/GoModelTypeNameConverter.java
+++ b/src/main/java/com/google/api/codegen/transformer/go/GoModelTypeNameConverter.java
@@ -273,7 +273,16 @@ public class GoModelTypeNameConverter implements ModelTypeNameConverter {
 
   @Override
   public TypedValue getEnumValue(TypeRef type, EnumValue value) {
-    return TypedValue.create(
-        getTypeName(type.getEnumType().getParent(), false), "%s_" + value.getSimpleName());
+    // Go names enums in two different ways.
+    // If the enum is nested in a message, the format is <message type>_<enum value>,
+    // respecting the C++ scoping rule used by protobuf,
+    // where enum values are scoped at the same level as the enum type, not as its children.
+    // On the other hand, if the enum is at top-level, there is no parent message,
+    // and the format is <enum type>_<enum value>
+    ProtoElement parent = type.getEnumType().getParent();
+    if (parent instanceof ProtoFile) {
+      parent = type.getEnumType();
+    }
+    return TypedValue.create(getTypeName(parent, false), "%s_" + value.getSimpleName());
   }
 }

--- a/src/test/java/com/google/api/codegen/testdata/library.proto
+++ b/src/test/java/com/google/api/codegen/testdata/library.proto
@@ -570,3 +570,8 @@ message GetBigBookMetadata {
     // Approximate percentage of the book processed thus far.
     int32 progress_percent = 1;
 }
+
+enum TopLevelEnum {
+  FOO = 0;
+  BAR = 1;
+}

--- a/src/test/java/com/google/api/codegen/testdata/ruby_doc_message_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_doc_message_library.baseline
@@ -1229,6 +1229,12 @@ module Google
         #   @return [Integer]
         #     Approximate percentage of the book processed thus far.
         class GetBigBookMetadata; end
+
+        module TopLevelEnum
+          FOO = 0
+
+          BAR = 1
+        end
       end
     end
   end

--- a/src/test/java/com/google/api/codegen/transformer/go/GoModelTypeNameConverterTest.java
+++ b/src/test/java/com/google/api/codegen/transformer/go/GoModelTypeNameConverterTest.java
@@ -83,5 +83,11 @@ public class GoModelTypeNameConverterTest {
     Truth.assertThat(
             converter.getEnumValue(type, value).getValueAndSaveTypeNicknameIn(new GoTypeTable()))
         .isEqualTo("librarypb.Book_GOOD");
+
+    type = ModelTypeNameConverterTestUtil.getTestType(tempDir, "TopLevelEnum");
+    value = type.getEnumType().getValues().get(0);
+    Truth.assertThat(
+            converter.getEnumValue(type, value).getValueAndSaveTypeNicknameIn(new GoTypeTable()))
+        .isEqualTo("librarypb.TopLevelEnum_FOO");
   }
 }


### PR DESCRIPTION
also adding @eoogbe since this touches cross-language enum code
and @swcloud since this touches Ruby baseline; I think this is expected behavior, but wanted to make sure.


Go names enums in two different ways.
If the enum is nested in a message, the format is <messagetype>_<enum value>,
respecting the C++ scoping rule used by protobuf,
where enum values are scoped at the same level as the
enum type, not as its children.
On the other hand, if the enum is at top-level,
there is no parent message,
and the format is <enum type>_<enum value>