### PR TITLE
Fixed ruby readme link.

### DIFF
--- a/src/main/resources/com/google/api/codegen/ruby/README.md.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/README.md.snip
@@ -6,7 +6,7 @@
   easy-to-use client library for the [{@metadata.fullName}][] ({@metadata.majorVersion}) defined in the [googleapis][] git repository
 
 
-  [googleapis]: https://github.com/googleapis/googleapis/tree/master/{@metadata.protoPath}/{@metadata.majorVersion}
+  [googleapis]: https://github.com/googleapis/googleapis/tree/master/{@metadata.protoPath}
   [google-gax]: https://github.com/googleapis/gax-ruby
   [Google {@metadata.fullName} API]: https://developers.google.com/apis-explorer/#p/{@metadata.shortName}/{@metadata.majorVersion}/
 

--- a/src/test/java/com/google/api/codegen/testdata/ruby_README_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_README_library.baseline
@@ -6,7 +6,7 @@ Google Example Library API uses [Google API extensions][google-gax] to provide a
 easy-to-use client library for the [Google Example Library API][] (v1) defined in the [googleapis][] git repository
 
 
-[googleapis]: https://github.com/googleapis/googleapis/tree/master/google/library/v1
+[googleapis]: https://github.com/googleapis/googleapis/tree/master/google/library
 [google-gax]: https://github.com/googleapis/gax-ruby
 [Google Google Example Library API API]: https://developers.google.com/apis-explorer/#p/library/v1/
 

--- a/src/test/java/com/google/api/codegen/testdata/ruby_doc_README_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_doc_README_library.baseline
@@ -6,7 +6,7 @@ Google Example Library API uses [Google API extensions][google-gax] to provide a
 easy-to-use client library for the [Google Example Library API][] (v1) defined in the [googleapis][] git repository
 
 
-[googleapis]: https://github.com/googleapis/googleapis/tree/master/google/library/v1
+[googleapis]: https://github.com/googleapis/googleapis/tree/master/google/library
 [google-gax]: https://github.com/googleapis/gax-ruby
 [Google Google Example Library API API]: https://developers.google.com/apis-explorer/#p/library/v1/
 


### PR DESCRIPTION
The `protoPath` for the library test data does not accurately depict the paths found in google apis which caused us to miss this. When generating clients the link would have the version repeated. 

ie: `https://github.com/googleapis/googleapis/tree/master/google/cloud/speech/v1beta1/v1beta1`