### PR TITLE
Fix duplicative API API.

### DIFF
--- a/src/main/resources/com/google/api/codegen/py/README.rst.snip
+++ b/src/main/resources/com/google/api/codegen/py/README.rst.snip
@@ -1,81 +1,81 @@
 @snippet generate(metadata)
   GAPIC library for the {@metadata.fullName}
   ================================================================================
-  
+
   {@metadata.gapicPackageName} uses google-gax_ (Google API extensions) to provide an
   easy-to-use client library for the `{@metadata.fullName}`_ ({@metadata.majorVersion}) defined in the googleapis_ git repository
-  
-  
+
+
   .. _`googleapis`: https://github.com/googleapis/googleapis/tree/master/{@metadata.protoPath}
   .. _`google-gax`: https://github.com/googleapis/gax-python
-  .. _`{@metadata.fullName} API`: https://developers.google.com/apis-explorer/?hl=en_US#p/{@metadata.discoveryApiName}/{@metadata.majorVersion}
-  
+  .. _`{@metadata.fullName}`: https://developers.google.com/apis-explorer/?hl=en_US#p/{@metadata.discoveryApiName}/{@metadata.majorVersion}
+
   Getting started
   ---------------
-  
+
   {@metadata.gapicPackageName} will allow you to connect to the
   {@metadata.fullName} and access all its methods. In order to do this, you need
   to set up authentication as well as install the library locally.
-  
-  
+
+
   Setup Authentication
   ~~~~~~~~~~~~~~~~~~~~
-  
+
   To authenticate all your API calls, first install and setup the `Google Cloud SDK`_.
   Once done, you can then run the following command in your terminal:
-  
+
   .. code-block:: console
-  
+
       $ gcloud beta auth application-default login
-  
+
   or
-  
+
   .. code-block:: console
-  
+
       $ gcloud auth login
-  
+
   Please see `gcloud beta auth application-default login`_ document for the difference between these commands.
-  
+
   .. _Google Cloud SDK: https://cloud.google.com/sdk/
   .. _gcloud beta auth application-default login: https://cloud.google.com/sdk/gcloud/reference/beta/auth/application-default/login
-  
-  
+
+
   Installation
   ~~~~~~~~~~~~
-  
+
   Install this library in a `virtualenv`_ using pip. `virtualenv`_ is a tool to
   create isolated Python environments. The basic problem it addresses is one of
   dependencies and versions, and indirectly permissions.
-  
+
   With `virtualenv`_, it's possible to install this library without needing system
   install permissions, and without clashing with the installed system
   dependencies.
-  
+
   .. _`virtualenv`: https://virtualenv.pypa.io/en/latest/
-  
-  
+
+
   Mac/Linux
   ~~~~~~~~~~
-  
+
   .. code-block:: console
-  
+
       pip install virtualenv
       virtualenv <your-env>
       source <your-env>/bin/activate
       <your-env>/bin/pip install {@metadata.gapicPackageName}
-  
-  
+
+
   Windows
   ~~~~~~~
-  
+
   .. code-block:: console
-  
+
       pip install virtualenv
       virtualenv <your-env>
       <your-env>\Scripts\activate
       <your-env>\Scripts\pip.exe install {@metadata.gapicPackageName}
-  
-  
+
+
   At this point you are all set to continue.
 
 @end

--- a/src/test/java/com/google/api/codegen/testdata/python_README_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_README_library.baseline
@@ -8,7 +8,7 @@ easy-to-use client library for the `Google Example Library API`_ (v1) defined in
 
 .. _`googleapis`: https://github.com/googleapis/googleapis/tree/master/google/library
 .. _`google-gax`: https://github.com/googleapis/gax-python
-.. _`Google Example Library API API`: https://developers.google.com/apis-explorer/?hl=en_US#p/library_example/v1
+.. _`Google Example Library API`: https://developers.google.com/apis-explorer/?hl=en_US#p/library_example/v1
 
 Getting started
 ---------------

--- a/src/test/java/com/google/api/codegen/testdata/python_README_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_README_no_path_templates.baseline
@@ -8,7 +8,7 @@ easy-to-use client library for the `Google Fake API`_ (v1) defined in the google
 
 .. _`googleapis`: https://github.com/googleapis/googleapis/tree/master/google/library
 .. _`google-gax`: https://github.com/googleapis/gax-python
-.. _`Google Fake API API`: https://developers.google.com/apis-explorer/?hl=en_US#p/no_path_templates/v1
+.. _`Google Fake API`: https://developers.google.com/apis-explorer/?hl=en_US#p/no_path_templates/v1
 
 Getting started
 ---------------

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_README_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_README_library.baseline
@@ -8,7 +8,7 @@ easy-to-use client library for the `Google Example Library API`_ (v1) defined in
 
 .. _`googleapis`: https://github.com/googleapis/googleapis/tree/master/google/library
 .. _`google-gax`: https://github.com/googleapis/gax-python
-.. _`Google Example Library API API`: https://developers.google.com/apis-explorer/?hl=en_US#p/library_example/v1
+.. _`Google Example Library API`: https://developers.google.com/apis-explorer/?hl=en_US#p/library_example/v1
 
 Getting started
 ---------------


### PR DESCRIPTION
This fixes a duplicative "API API" string that causes a broken README link in ReST.