### PR TITLE
Flatten retry_codes_def object from GAPIC client config

### DIFF
--- a/src/main/resources/com/google/api/codegen/clientconfig/json.snip
+++ b/src/main/resources/com/google/api/codegen/clientconfig/json.snip
@@ -47,19 +47,17 @@
     @let interfaceConfig = context.getApiConfig.getInterfaceConfig(service), \
             codes = context.entrySet(interfaceConfig.getRetryCodesDefinition)
         @if codes
-            "retry_codes_def": {
-              @join retryDef : codes on ",".add(BREAK)
-                  @if retryDef.getValue
-                      "{@retryDef.getKey}": [
-                        @join code : retryDef.getValue on ",".add(BREAK)
-                            "{@code}"
-                        @end
-                      ]
-                  @else
-                      "{@retryDef.getKey}": []
-                  @end
-              @end
-            }
+            @join retryDef : codes on ",".add(BREAK)
+                @if retryDef.getValue
+                    "{@retryDef.getKey}": [
+                      @join code : retryDef.getValue on ",".add(BREAK)
+                          "{@code}"
+                      @end
+                    ]
+                @else
+                    "{@retryDef.getKey}": []
+                @end
+            @end
         @else
         @end
     @end

--- a/src/test/java/com/google/api/codegen/testdata/client_config_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/client_config_json_library.baseline
@@ -3,13 +3,11 @@
   "interfaces": {
     "google.example.library.v1.LibraryService": {
       "retry_codes": {
-        "retry_codes_def": {
-          "idempotent": [
-            "DEADLINE_EXCEEDED",
-            "UNAVAILABLE"
-          ],
-          "non_idempotent": []
-        }
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
+        "non_idempotent": []
       },
       "retry_params": {
         "default": {

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_doc_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_doc_json_library.baseline
@@ -3,13 +3,11 @@
   "interfaces": {
     "google.example.library.v1.LibraryService": {
       "retry_codes": {
-        "retry_codes_def": {
-          "idempotent": [
-            "DEADLINE_EXCEEDED",
-            "UNAVAILABLE"
-          ],
-          "non_idempotent": []
-        }
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
+        "non_idempotent": []
       },
       "retry_params": {
         "default": {

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_json_library.baseline
@@ -3,13 +3,11 @@
   "interfaces": {
     "google.example.library.v1.LibraryService": {
       "retry_codes": {
-        "retry_codes_def": {
-          "idempotent": [
-            "DEADLINE_EXCEEDED",
-            "UNAVAILABLE"
-          ],
-          "non_idempotent": []
-        }
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
+        "non_idempotent": []
       },
       "retry_params": {
         "default": {

--- a/src/test/java/com/google/api/codegen/testdata/php_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php_json_library.baseline
@@ -3,13 +3,11 @@
   "interfaces": {
     "google.example.library.v1.LibraryService": {
       "retry_codes": {
-        "retry_codes_def": {
-          "idempotent": [
-            "DEADLINE_EXCEEDED",
-            "UNAVAILABLE"
-          ],
-          "non_idempotent": []
-        }
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
+        "non_idempotent": []
       },
       "retry_params": {
         "default": {

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_json_library.baseline
@@ -3,13 +3,11 @@
   "interfaces": {
     "google.example.library.v1.LibraryService": {
       "retry_codes": {
-        "retry_codes_def": {
-          "idempotent": [
-            "DEADLINE_EXCEEDED",
-            "UNAVAILABLE"
-          ],
-          "non_idempotent": []
-        }
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
+        "non_idempotent": []
       },
       "retry_params": {
         "default": {

--- a/src/test/java/com/google/api/codegen/testdata/python_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_json_library.baseline
@@ -3,13 +3,11 @@
   "interfaces": {
     "google.example.library.v1.LibraryService": {
       "retry_codes": {
-        "retry_codes_def": {
-          "idempotent": [
-            "DEADLINE_EXCEEDED",
-            "UNAVAILABLE"
-          ],
-          "non_idempotent": []
-        }
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
+        "non_idempotent": []
       },
       "retry_params": {
         "default": {

--- a/src/test/java/com/google/api/codegen/testdata/ruby_doc_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_doc_json_library.baseline
@@ -3,13 +3,11 @@
   "interfaces": {
     "google.example.library.v1.LibraryService": {
       "retry_codes": {
-        "retry_codes_def": {
-          "idempotent": [
-            "DEADLINE_EXCEEDED",
-            "UNAVAILABLE"
-          ],
-          "non_idempotent": []
-        }
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
+        "non_idempotent": []
       },
       "retry_params": {
         "default": {

--- a/src/test/java/com/google/api/codegen/testdata/ruby_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_json_library.baseline
@@ -3,13 +3,11 @@
   "interfaces": {
     "google.example.library.v1.LibraryService": {
       "retry_codes": {
-        "retry_codes_def": {
-          "idempotent": [
-            "DEADLINE_EXCEEDED",
-            "UNAVAILABLE"
-          ],
-          "non_idempotent": []
-        }
+        "idempotent": [
+          "DEADLINE_EXCEEDED",
+          "UNAVAILABLE"
+        ],
+        "non_idempotent": []
       },
       "retry_params": {
         "default": {


### PR DESCRIPTION
This extra level of nesting is unexpected by the GAX libraries that
consume this client config