### PR TITLE
Accept AsyncOperationFlattenedMethod as example.

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTransformer.java
@@ -316,6 +316,10 @@ public class JavaGapicSurfaceTransformer implements ModelToViewTransformer {
       exampleApiMethod = searchExampleMethod(methods, ClientMethodType.RequestObjectMethod);
     }
     if (exampleApiMethod == null) {
+      exampleApiMethod =
+          searchExampleMethod(methods, ClientMethodType.AsyncOperationFlattenedMethod);
+    }
+    if (exampleApiMethod == null) {
       throw new RuntimeException("Could not find method to use as an example method");
     }
     return exampleApiMethod;


### PR DESCRIPTION
One of the new APIs only has a method of type `AsyncOperationFlattenedMethod`, and the static languages build because there are no valid example methods.

@garrettjonesgoogle I am mostly (~80%) sure this change is necessary, but I am _not_ sure that it is sufficient. As I ran into it building a Java library, please take a look and make sure, as I am not the domain expert there.