### PR TITLE
Python: Sending multiple "one of" arguments should raise an exception.

### DIFF
--- a/src/main/java/com/google/api/codegen/config/MethodConfig.java
+++ b/src/main/java/com/google/api/codegen/config/MethodConfig.java
@@ -30,6 +30,7 @@ import com.google.api.tools.framework.model.DiagCollector;
 import com.google.api.tools.framework.model.Field;
 import com.google.api.tools.framework.model.MessageType;
 import com.google.api.tools.framework.model.Method;
+import com.google.api.tools.framework.model.Oneof;
 import com.google.api.tools.framework.model.SimpleLocation;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Strings;
@@ -403,5 +404,19 @@ public abstract class MethodConfig {
 
   public Iterable<Field> getOptionalFields() {
     return FieldConfig.toFieldIterable(getOptionalFieldConfigs());
+  }
+
+  /** Return the list of "one of" instances associated with the fields. */
+  public Iterable<Oneof> getOneofs() {
+    ImmutableSet.Builder<Oneof> answer = ImmutableSet.builder();
+
+    for (Field field : getOptionalFields()) {
+      if (field.getOneof() == null) {
+        continue;
+      }
+      answer.add(field.getOneof());
+    }
+
+    return answer.build();
   }
 }

--- a/src/main/java/com/google/api/codegen/py/PythonImportHandler.java
+++ b/src/main/java/com/google/api/codegen/py/PythonImportHandler.java
@@ -21,6 +21,7 @@ import com.google.api.tools.framework.model.Field;
 import com.google.api.tools.framework.model.Interface;
 import com.google.api.tools.framework.model.MessageType;
 import com.google.api.tools.framework.model.Method;
+import com.google.api.tools.framework.model.Oneof;
 import com.google.api.tools.framework.model.ProtoElement;
 import com.google.api.tools.framework.model.ProtoFile;
 import com.google.api.tools.framework.model.TypeRef;
@@ -86,6 +87,13 @@ public class PythonImportHandler {
 
     // Add method request-type imports.
     for (MethodConfig methodConfig : apiConfig.getInterfaceConfig(service).getMethodConfigs()) {
+      // Add the import for gax.utils.oneof if and only if there is at
+      // least one "one of" argument set.
+      for (Oneof oneof : methodConfig.getOneofs()) {
+        addImportExternal("google.gax.utils", "oneof");
+        break;
+      }
+
       if (methodConfig.isLongRunningOperation()) {
         addImportExternal("google.gapic.longrunning", "operations_client");
         addImportForMessage(methodConfig.getLongRunningConfig().getReturnType().getMessageType());

--- a/src/main/resources/com/google/api/codegen/py/main.snip
+++ b/src/main/resources/com/google/api/codegen/py/main.snip
@@ -506,7 +506,7 @@
                         {@defaultMutableValues(optionalParams)}
                     @end
                     @if oneOfParams
-                      {@checkOneOfParams(oneOfParams)}
+                        {@checkOneOfParams(oneOfParams)}
                     @end
                     @# Create the request object.
                     @if requiredParams

--- a/src/main/resources/com/google/api/codegen/py/main.snip
+++ b/src/main/resources/com/google/api/codegen/py/main.snip
@@ -473,7 +473,8 @@
              documentation = methodComments(service, method), \
              methodConfig = context.getApiConfig.getInterfaceConfig(service).getMethodConfig(method), \
              requiredParams = methodConfig.getRequiredFields(), \
-             optionalParams = context.removePageTokenFromFields(methodConfig.getOptionalFields(), methodConfig)
+             optionalParams = context.removePageTokenFromFields(methodConfig.getOptionalFields(), methodConfig), \
+             oneOfParams = methodConfig.getOneofs()
         @if method.getRequestStreaming
             def {@methodName(method)}(
                     self,
@@ -504,6 +505,11 @@
                     @if {@defaultMutableValues(optionalParams)}
                         {@defaultMutableValues(optionalParams)}
                     @end
+                    @if oneOfParams
+                      {@checkOneOfParams(oneOfParams)}
+                    @end
+
+                    @# Create the request object.
                     @if requiredParams
                         @if optionalParams
                             request = {@methodInputElementPath}(
@@ -564,5 +570,34 @@
         @let paramName = {@field.getSimpleName()}
             {@paramName}={@context.python.wrapIfKeywordOrBuiltIn(field.getSimpleName())}
         @end
+    @end
+@end
+
+@private checkOneOfParams(oneOfs)
+    @join oneOf : oneOfs on BREAK
+
+        @# Sanity check: We have some fields which are mutually exclusive;
+        @# piece together what these are.
+        mutually_exclusive = [
+            @join oneOfField : oneOf.getFields() on ", ".add(BREAK)
+                {@oneOfField.getSimpleName()}
+            @end
+        ]
+
+        @# If any mutually exclusive fields are in conflict, raise an exception.
+        @#
+        @# Note: This code works because `any` stops consuming the iterable the
+        @#   first time it encounters a truthy value; thus this check only
+        @#   passes if there are two or more.
+        iterator = iter(mutually_exclusive)
+        if not (any(iterator) and not any(iterator)):
+            raise ValueError('Only one of {fields} should be set.'.format(
+                fields=', '.join(sorted({
+                    @join oneOfField : oneOf.getFields() on ", ".add(BREAK)
+                        '{@oneOfField.getSimpleName()}'
+                    @end
+                })),
+
+            ))
     @end
 @end

--- a/src/main/resources/com/google/api/codegen/py/main.snip
+++ b/src/main/resources/com/google/api/codegen/py/main.snip
@@ -576,28 +576,12 @@
 @private checkOneOfParams(oneOfs)
     @join oneOf : oneOfs on BREAK
         @# Sanity check: We have some fields which are mutually exclusive;
-        @# piece together what these are.
-        mutually_exclusive = [
-            @join oneOfField : oneOf.getFields() on ", ".add(BREAK)
-                {@oneOfField.getSimpleName()}
+        @# raise ValueError if more than one is sent.
+        oneof.check_oneof(
+            @join oneOfField : oneOf.getFields() on BREAK
+                {@oneOfField.getSimpleName()}={@oneOfField.getSimpleName},
             @end
-        ]
-
-        @# If any mutually exclusive fields are in conflict, raise an exception.
-        @#
-        @# Note: This code works because `any` stops consuming the iterable the
-        @#   first time it encounters a truthy value; thus this check only
-        @#   passes if there are two or more.
-        iterator = iter(mutually_exclusive)
-        if not (any(iterator) and not any(iterator)):
-            raise ValueError('Only one of {fields} should be set.'.format(
-                fields=', '.join(sorted({
-                    @join oneOfField : oneOf.getFields() on ", ".add(BREAK)
-                        '{@oneOfField.getSimpleName()}'
-                    @end
-                })),
-
-            ))
+        )
 
     @end
 @end

--- a/src/main/resources/com/google/api/codegen/py/main.snip
+++ b/src/main/resources/com/google/api/codegen/py/main.snip
@@ -508,7 +508,6 @@
                     @if oneOfParams
                       {@checkOneOfParams(oneOfParams)}
                     @end
-
                     @# Create the request object.
                     @if requiredParams
                         @if optionalParams
@@ -531,6 +530,7 @@
                     @if documentation
                         {@documentation}
                     @end
+                    # Create the request object.
                     request = {@methodInputElementPath}()
                     {@callLine(methodConfig, method, "request")}
             @end
@@ -575,7 +575,6 @@
 
 @private checkOneOfParams(oneOfs)
     @join oneOf : oneOfs on BREAK
-
         @# Sanity check: We have some fields which are mutually exclusive;
         @# piece together what these are.
         mutually_exclusive = [
@@ -599,5 +598,6 @@
                 })),
 
             ))
+
     @end
 @end

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
@@ -34,6 +34,7 @@ from google.gapic.longrunning import operations_client
 from google.gax import api_callable
 from google.gax import config
 from google.gax import path_template
+from google.gax.utils import oneof
 import google.gax
 
 from google.cloud.gapic.example.library.v1 import enums
@@ -668,26 +669,11 @@ class LibraryServiceClient(object):
           :exc:`ValueError` if the parameters are invalid.
         """
         # Sanity check: We have some fields which are mutually exclusive;
-        # piece together what these are.
-        mutually_exclusive = [
-            edition,
-            review_copy
-        ]
-
-        # If any mutually exclusive fields are in conflict, raise an exception.
-        #
-        # Note: This code works because `any` stops consuming the iterable the
-        #   first time it encounters a truthy value; thus this check only
-        #   passes if there are two or more.
-        iterator = iter(mutually_exclusive)
-        if not (any(iterator) and not any(iterator)):
-            raise ValueError('Only one of {fields} should be set.'.format(
-                fields=', '.join(sorted({
-                    'edition',
-                    'review_copy'
-                })),
-
-            ))
+        # raise ValueError if more than one is sent.
+        oneof.check_oneof(
+            edition=edition,
+            review_copy=review_copy,
+        )
 
         # Create the request object.
         request = library_pb2.PublishSeriesRequest(

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_main_library.baseline
@@ -445,6 +445,7 @@ class LibraryServiceClient(object):
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
           :exc:`ValueError` if the parameters are invalid.
         """
+        # Create the request object.
         request = library_pb2.CreateShelfRequest(
             shelf=shelf)
         return self._create_shelf(request, options)
@@ -485,6 +486,7 @@ class LibraryServiceClient(object):
             message = library_pb2.SomeMessage()
         if string_builder is None:
             string_builder = library_pb2.StringBuilder()
+        # Create the request object.
         request = library_pb2.GetShelfRequest(
             name=name,
             options=options_,
@@ -552,6 +554,7 @@ class LibraryServiceClient(object):
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
           :exc:`ValueError` if the parameters are invalid.
         """
+        # Create the request object.
         request = library_pb2.DeleteShelfRequest(
             name=name)
         self._delete_shelf(request, options)
@@ -586,6 +589,7 @@ class LibraryServiceClient(object):
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
           :exc:`ValueError` if the parameters are invalid.
         """
+        # Create the request object.
         request = library_pb2.MergeShelvesRequest(
             name=name,
             other_shelf_name=other_shelf_name)
@@ -620,6 +624,7 @@ class LibraryServiceClient(object):
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
           :exc:`ValueError` if the parameters are invalid.
         """
+        # Create the request object.
         request = library_pb2.CreateBookRequest(
             name=name,
             book=book)
@@ -662,6 +667,29 @@ class LibraryServiceClient(object):
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
           :exc:`ValueError` if the parameters are invalid.
         """
+        # Sanity check: We have some fields which are mutually exclusive;
+        # piece together what these are.
+        mutually_exclusive = [
+            edition,
+            review_copy
+        ]
+
+        # If any mutually exclusive fields are in conflict, raise an exception.
+        #
+        # Note: This code works because `any` stops consuming the iterable the
+        #   first time it encounters a truthy value; thus this check only
+        #   passes if there are two or more.
+        iterator = iter(mutually_exclusive)
+        if not (any(iterator) and not any(iterator)):
+            raise ValueError('Only one of {fields} should be set.'.format(
+                fields=', '.join(sorted({
+                    'edition',
+                    'review_copy'
+                })),
+
+            ))
+
+        # Create the request object.
         request = library_pb2.PublishSeriesRequest(
             shelf=shelf,
             books=books,
@@ -695,6 +723,7 @@ class LibraryServiceClient(object):
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
           :exc:`ValueError` if the parameters are invalid.
         """
+        # Create the request object.
         request = library_pb2.GetBookRequest(
             name=name)
         return self._get_book(request, options)
@@ -746,6 +775,7 @@ class LibraryServiceClient(object):
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
           :exc:`ValueError` if the parameters are invalid.
         """
+        # Create the request object.
         request = library_pb2.ListBooksRequest(
             name=name,
             page_size=page_size,
@@ -774,6 +804,7 @@ class LibraryServiceClient(object):
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
           :exc:`ValueError` if the parameters are invalid.
         """
+        # Create the request object.
         request = library_pb2.DeleteBookRequest(
             name=name)
         self._delete_book(request, options)
@@ -815,6 +846,7 @@ class LibraryServiceClient(object):
             update_mask = protobuf_field_mask_pb2.FieldMask()
         if physical_mask is None:
             physical_mask = v1_field_mask_pb2.FieldMask()
+        # Create the request object.
         request = library_pb2.UpdateBookRequest(
             name=name,
             book=book,
@@ -850,6 +882,7 @@ class LibraryServiceClient(object):
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
           :exc:`ValueError` if the parameters are invalid.
         """
+        # Create the request object.
         request = library_pb2.MoveBookRequest(
             name=name,
             other_shelf_name=other_shelf_name)
@@ -899,6 +932,7 @@ class LibraryServiceClient(object):
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
           :exc:`ValueError` if the parameters are invalid.
         """
+        # Create the request object.
         request = library_pb2.ListStringsRequest(
             name=name,
             page_size=page_size)
@@ -935,6 +969,7 @@ class LibraryServiceClient(object):
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
           :exc:`ValueError` if the parameters are invalid.
         """
+        # Create the request object.
         request = library_pb2.AddCommentsRequest(
             name=name,
             comments=comments)
@@ -965,6 +1000,7 @@ class LibraryServiceClient(object):
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
           :exc:`ValueError` if the parameters are invalid.
         """
+        # Create the request object.
         request = library_pb2.GetBookFromArchiveRequest(
             name=name)
         return self._get_book_from_archive(request, options)
@@ -998,6 +1034,7 @@ class LibraryServiceClient(object):
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
           :exc:`ValueError` if the parameters are invalid.
         """
+        # Create the request object.
         request = library_pb2.GetBookFromAnywhereRequest(
             name=name,
             alt_book_name=alt_book_name)
@@ -1032,6 +1069,7 @@ class LibraryServiceClient(object):
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
           :exc:`ValueError` if the parameters are invalid.
         """
+        # Create the request object.
         request = library_pb2.UpdateBookIndexRequest(
             name=name,
             index_name=index_name,
@@ -1093,6 +1131,7 @@ class LibraryServiceClient(object):
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
           :exc:`ValueError` if the parameters are invalid.
         """
+        # Create the request object.
         request = library_pb2.StreamBooksRequest(
             name=name)
         return self._stream_books(request, options)
@@ -1213,6 +1252,7 @@ class LibraryServiceClient(object):
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
           :exc:`ValueError` if the parameters are invalid.
         """
+        # Create the request object.
         request = library_pb2.FindRelatedBooksRequest(
             names=names,
             shelves=shelves,
@@ -1249,6 +1289,7 @@ class LibraryServiceClient(object):
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
           :exc:`ValueError` if the parameters are invalid.
         """
+        # Create the request object.
         request = tagger_pb2.AddTagRequest(
             resource=resource,
             tag=tag)
@@ -1284,6 +1325,7 @@ class LibraryServiceClient(object):
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
           :exc:`ValueError` if the parameters are invalid.
         """
+        # Create the request object.
         request = tagger_pb2.AddLabelRequest(
             resource=resource,
             label=label)
@@ -1323,6 +1365,7 @@ class LibraryServiceClient(object):
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
           :exc:`ValueError` if the parameters are invalid.
         """
+        # Create the request object.
         request = library_pb2.GetBookRequest(
             name=name)
         return google.gax._OperationFuture(
@@ -1366,6 +1409,7 @@ class LibraryServiceClient(object):
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
           :exc:`ValueError` if the parameters are invalid.
         """
+        # Create the request object.
         request = library_pb2.GetBookRequest(
             name=name)
         return google.gax._OperationFuture(
@@ -1374,4 +1418,3 @@ class LibraryServiceClient(object):
             empty_pb2.Empty,
             library_pb2.GetBigBookMetadata,
             options)
-

--- a/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
@@ -34,6 +34,7 @@ from google.gapic.longrunning import operations_client
 from google.gax import api_callable
 from google.gax import config
 from google.gax import path_template
+from google.gax.utils import oneof
 import google.gax
 
 from google.cloud.gapic.example.library.v1 import enums
@@ -668,26 +669,11 @@ class LibraryServiceClient(object):
           :exc:`ValueError` if the parameters are invalid.
         """
         # Sanity check: We have some fields which are mutually exclusive;
-        # piece together what these are.
-        mutually_exclusive = [
-            edition,
-            review_copy
-        ]
-
-        # If any mutually exclusive fields are in conflict, raise an exception.
-        #
-        # Note: This code works because `any` stops consuming the iterable the
-        #   first time it encounters a truthy value; thus this check only
-        #   passes if there are two or more.
-        iterator = iter(mutually_exclusive)
-        if not (any(iterator) and not any(iterator)):
-            raise ValueError('Only one of {fields} should be set.'.format(
-                fields=', '.join(sorted({
-                    'edition',
-                    'review_copy'
-                })),
-
-            ))
+        # raise ValueError if more than one is sent.
+        oneof.check_oneof(
+            edition=edition,
+            review_copy=review_copy,
+        )
 
         # Create the request object.
         request = library_pb2.PublishSeriesRequest(
@@ -1418,4 +1404,3 @@ class LibraryServiceClient(object):
             empty_pb2.Empty,
             library_pb2.GetBigBookMetadata,
             options)
-

--- a/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_main_library.baseline
@@ -445,6 +445,7 @@ class LibraryServiceClient(object):
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
           :exc:`ValueError` if the parameters are invalid.
         """
+        # Create the request object.
         request = library_pb2.CreateShelfRequest(
             shelf=shelf)
         return self._create_shelf(request, options)
@@ -485,6 +486,7 @@ class LibraryServiceClient(object):
             message = library_pb2.SomeMessage()
         if string_builder is None:
             string_builder = library_pb2.StringBuilder()
+        # Create the request object.
         request = library_pb2.GetShelfRequest(
             name=name,
             options=options_,
@@ -552,6 +554,7 @@ class LibraryServiceClient(object):
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
           :exc:`ValueError` if the parameters are invalid.
         """
+        # Create the request object.
         request = library_pb2.DeleteShelfRequest(
             name=name)
         self._delete_shelf(request, options)
@@ -586,6 +589,7 @@ class LibraryServiceClient(object):
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
           :exc:`ValueError` if the parameters are invalid.
         """
+        # Create the request object.
         request = library_pb2.MergeShelvesRequest(
             name=name,
             other_shelf_name=other_shelf_name)
@@ -620,6 +624,7 @@ class LibraryServiceClient(object):
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
           :exc:`ValueError` if the parameters are invalid.
         """
+        # Create the request object.
         request = library_pb2.CreateBookRequest(
             name=name,
             book=book)
@@ -662,6 +667,29 @@ class LibraryServiceClient(object):
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
           :exc:`ValueError` if the parameters are invalid.
         """
+        # Sanity check: We have some fields which are mutually exclusive;
+        # piece together what these are.
+        mutually_exclusive = [
+            edition,
+            review_copy
+        ]
+
+        # If any mutually exclusive fields are in conflict, raise an exception.
+        #
+        # Note: This code works because `any` stops consuming the iterable the
+        #   first time it encounters a truthy value; thus this check only
+        #   passes if there are two or more.
+        iterator = iter(mutually_exclusive)
+        if not (any(iterator) and not any(iterator)):
+            raise ValueError('Only one of {fields} should be set.'.format(
+                fields=', '.join(sorted({
+                    'edition',
+                    'review_copy'
+                })),
+
+            ))
+
+        # Create the request object.
         request = library_pb2.PublishSeriesRequest(
             shelf=shelf,
             books=books,
@@ -695,6 +723,7 @@ class LibraryServiceClient(object):
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
           :exc:`ValueError` if the parameters are invalid.
         """
+        # Create the request object.
         request = library_pb2.GetBookRequest(
             name=name)
         return self._get_book(request, options)
@@ -746,6 +775,7 @@ class LibraryServiceClient(object):
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
           :exc:`ValueError` if the parameters are invalid.
         """
+        # Create the request object.
         request = library_pb2.ListBooksRequest(
             name=name,
             page_size=page_size,
@@ -774,6 +804,7 @@ class LibraryServiceClient(object):
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
           :exc:`ValueError` if the parameters are invalid.
         """
+        # Create the request object.
         request = library_pb2.DeleteBookRequest(
             name=name)
         self._delete_book(request, options)
@@ -815,6 +846,7 @@ class LibraryServiceClient(object):
             update_mask = protobuf_field_mask_pb2.FieldMask()
         if physical_mask is None:
             physical_mask = v1_field_mask_pb2.FieldMask()
+        # Create the request object.
         request = library_pb2.UpdateBookRequest(
             name=name,
             book=book,
@@ -850,6 +882,7 @@ class LibraryServiceClient(object):
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
           :exc:`ValueError` if the parameters are invalid.
         """
+        # Create the request object.
         request = library_pb2.MoveBookRequest(
             name=name,
             other_shelf_name=other_shelf_name)
@@ -899,6 +932,7 @@ class LibraryServiceClient(object):
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
           :exc:`ValueError` if the parameters are invalid.
         """
+        # Create the request object.
         request = library_pb2.ListStringsRequest(
             name=name,
             page_size=page_size)
@@ -935,6 +969,7 @@ class LibraryServiceClient(object):
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
           :exc:`ValueError` if the parameters are invalid.
         """
+        # Create the request object.
         request = library_pb2.AddCommentsRequest(
             name=name,
             comments=comments)
@@ -965,6 +1000,7 @@ class LibraryServiceClient(object):
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
           :exc:`ValueError` if the parameters are invalid.
         """
+        # Create the request object.
         request = library_pb2.GetBookFromArchiveRequest(
             name=name)
         return self._get_book_from_archive(request, options)
@@ -998,6 +1034,7 @@ class LibraryServiceClient(object):
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
           :exc:`ValueError` if the parameters are invalid.
         """
+        # Create the request object.
         request = library_pb2.GetBookFromAnywhereRequest(
             name=name,
             alt_book_name=alt_book_name)
@@ -1032,6 +1069,7 @@ class LibraryServiceClient(object):
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
           :exc:`ValueError` if the parameters are invalid.
         """
+        # Create the request object.
         request = library_pb2.UpdateBookIndexRequest(
             name=name,
             index_name=index_name,
@@ -1093,6 +1131,7 @@ class LibraryServiceClient(object):
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
           :exc:`ValueError` if the parameters are invalid.
         """
+        # Create the request object.
         request = library_pb2.StreamBooksRequest(
             name=name)
         return self._stream_books(request, options)
@@ -1213,6 +1252,7 @@ class LibraryServiceClient(object):
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
           :exc:`ValueError` if the parameters are invalid.
         """
+        # Create the request object.
         request = library_pb2.FindRelatedBooksRequest(
             names=names,
             shelves=shelves,
@@ -1249,6 +1289,7 @@ class LibraryServiceClient(object):
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
           :exc:`ValueError` if the parameters are invalid.
         """
+        # Create the request object.
         request = tagger_pb2.AddTagRequest(
             resource=resource,
             tag=tag)
@@ -1284,6 +1325,7 @@ class LibraryServiceClient(object):
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
           :exc:`ValueError` if the parameters are invalid.
         """
+        # Create the request object.
         request = tagger_pb2.AddLabelRequest(
             resource=resource,
             label=label)
@@ -1323,6 +1365,7 @@ class LibraryServiceClient(object):
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
           :exc:`ValueError` if the parameters are invalid.
         """
+        # Create the request object.
         request = library_pb2.GetBookRequest(
             name=name)
         return google.gax._OperationFuture(
@@ -1366,6 +1409,7 @@ class LibraryServiceClient(object):
           :exc:`google.gax.errors.GaxError` if the RPC is aborted.
           :exc:`ValueError` if the parameters are invalid.
         """
+        # Create the request object.
         request = library_pb2.GetBookRequest(
             name=name)
         return google.gax._OperationFuture(


### PR DESCRIPTION
This commit:

  * Adds a (language-independent) `getOneofs` argument to the `MethodConfig` class which returns each applicable `Oneof` object. Unlike an iteration over the methods themselves, this will provide each `Oneof` once and exactly once, and from there you can get the applicable argument names.
  * Adds snippet code in Python to raise `ValueError` if the user provides more than one of a "one of" argument set.

This PR addresses #1061 for Python, and is dependent on googleapis/gax-python#164.