### PR TITLE
Reordering of x-goog-api-client info for Node.JS

### DIFF
--- a/src/main/resources/com/google/api/codegen/nodejs/main.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/main.snip
@@ -242,13 +242,13 @@
       }, opts);
 
       var googleApiClient = [
-        'gl-node/' + process.versions.node,
-        CODE_GEN_NAME_VERSION
+        'gl-node/' + process.versions.node
       ];
       if (opts.libName && opts.libVersion) {
         googleApiClient.push(opts.libName + '/' + opts.libVersion);
       }
       googleApiClient.push(
+        CODE_GEN_NAME_VERSION,
         'gax/' + gax.version,
         'grpc/' + gaxGrpc.grpcVersion
       );

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_doc_main_library.baseline
@@ -110,13 +110,13 @@ function LibraryServiceClient(gaxGrpc, grpcClients, opts) {
   }, opts);
 
   var googleApiClient = [
-    'gl-node/' + process.versions.node,
-    CODE_GEN_NAME_VERSION
+    'gl-node/' + process.versions.node
   ];
   if (opts.libName && opts.libVersion) {
     googleApiClient.push(opts.libName + '/' + opts.libVersion);
   }
   googleApiClient.push(
+    CODE_GEN_NAME_VERSION,
     'gax/' + gax.version,
     'grpc/' + gaxGrpc.grpcVersion
   );

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_main_library.baseline
@@ -110,13 +110,13 @@ function LibraryServiceClient(gaxGrpc, grpcClients, opts) {
   }, opts);
 
   var googleApiClient = [
-    'gl-node/' + process.versions.node,
-    CODE_GEN_NAME_VERSION
+    'gl-node/' + process.versions.node
   ];
   if (opts.libName && opts.libVersion) {
     googleApiClient.push(opts.libName + '/' + opts.libVersion);
   }
   googleApiClient.push(
+    CODE_GEN_NAME_VERSION,
     'gax/' + gax.version,
     'grpc/' + gaxGrpc.grpcVersion
   );

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_main_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_main_no_path_templates.baseline
@@ -66,13 +66,13 @@ function NoTemplatesAPIServiceClient(gaxGrpc, grpcClients, opts) {
   }, opts);
 
   var googleApiClient = [
-    'gl-node/' + process.versions.node,
-    CODE_GEN_NAME_VERSION
+    'gl-node/' + process.versions.node
   ];
   if (opts.libName && opts.libVersion) {
     googleApiClient.push(opts.libName + '/' + opts.libVersion);
   }
   googleApiClient.push(
+    CODE_GEN_NAME_VERSION,
     'gax/' + gax.version,
     'grpc/' + gaxGrpc.grpcVersion
   );


### PR DESCRIPTION
gapic/ position should be after gccl/.