### PR TITLE
Update PHP gapic header to client library version

### DIFF
--- a/src/main/resources/com/google/api/codegen/php/main.snip
+++ b/src/main/resources/com/google/api/codegen/php/main.snip
@@ -385,10 +385,22 @@
             }
         @end
 
+        if (isset($options['libVersion'])) {
+          $gapicVersion = $options['libVersion'];
+        } elseif (class_exists('\Google\Cloud\ServiceBuilder') &&
+            defined('\Google\Cloud\ServiceBuilder::VERSION'))
+        ) {
+          $gapicVersion = \Google\Cloud\ServiceBuilder::VERSION;
+        } elseif (file_exists(__DIR__ . "../VERSION")) {
+          $gapicVersion = file_get_contents(__DIR__ . "../VERSION");
+        } else {
+          $gapicVersion = null;
+        }
+        
         $headerDescriptor = new AgentHeaderDescriptor([
             'libName' => $options['libName'],
             'libVersion' => $options['libVersion'],
-            'gapicVersion' => self::CODEGEN_VERSION,
+            'gapicVersion' => $gapicVersion,
         ]);
 
         $defaultDescriptors = ['headerDescriptor' => $headerDescriptor];

--- a/src/main/resources/com/google/api/codegen/php/main.snip
+++ b/src/main/resources/com/google/api/codegen/php/main.snip
@@ -134,6 +134,7 @@
     {@pageStreamingDescriptorFunction(xapiClass)}
     {@longRunningDescriptorFunction(xapiClass)}
     {@grpcStreamingDescriptorFunction(xapiClass)}
+    {@gapicVersionFunction()}
 @end
 
 @private formatResourceFunction(function)
@@ -250,6 +251,20 @@
         }
         {@""}
     @end
+@end
+
+@private gapicVersionFunction()
+    private static function getGapicVersion()
+    {
+        if (file_exists(__DIR__ . "../VERSION")) {
+          $gapicVersion = file_get_contents(__DIR__ . "../VERSION");
+        } elseif (class_exists('\Google\Cloud\ServiceBuilder')) {
+          $gapicVersion = \Google\Cloud\ServiceBuilder::VERSION;
+        } else {
+          $gapicVersion = null;
+        }
+    }
+    {@""}
 @end
 
 @private functions(xapiClass)
@@ -387,16 +402,10 @@
 
         if (isset($options['libVersion'])) {
           $gapicVersion = $options['libVersion'];
-        } elseif (class_exists('\Google\Cloud\ServiceBuilder') &&
-            defined('\Google\Cloud\ServiceBuilder::VERSION'))
-        ) {
-          $gapicVersion = \Google\Cloud\ServiceBuilder::VERSION;
-        } elseif (file_exists(__DIR__ . "../VERSION")) {
-          $gapicVersion = file_get_contents(__DIR__ . "../VERSION");
         } else {
-          $gapicVersion = null;
+          $gapicVersion = self::getGapicVersion();
         }
-        
+
         $headerDescriptor = new AgentHeaderDescriptor([
             'libName' => $options['libName'],
             'libVersion' => $options['libVersion'],

--- a/src/test/java/com/google/api/codegen/testdata/php_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php_main_library.baseline
@@ -343,6 +343,17 @@ class LibraryServiceClient
         ];
     }
 
+    private static function getGapicVersion()
+    {
+        if (file_exists(__DIR__ . "../VERSION")) {
+          $gapicVersion = file_get_contents(__DIR__ . "../VERSION");
+        } elseif (class_exists('\Google\Cloud\ServiceBuilder')) {
+          $gapicVersion = \Google\Cloud\ServiceBuilder::VERSION;
+        } else {
+          $gapicVersion = null;
+        }
+    }
+
     /**
      * Return an OperationsClient object with the same endpoint as $this.
      *
@@ -435,10 +446,16 @@ class LibraryServiceClient
             ]);
         }
 
+        if (isset($options['libVersion'])) {
+          $gapicVersion = $options['libVersion'];
+        } else {
+          $gapicVersion = self::getGapicVersion();
+        }
+
         $headerDescriptor = new AgentHeaderDescriptor([
             'libName' => $options['libName'],
             'libVersion' => $options['libVersion'],
-            'gapicVersion' => self::CODEGEN_VERSION,
+            'gapicVersion' => $gapicVersion,
         ]);
 
         $defaultDescriptors = ['headerDescriptor' => $headerDescriptor];


### PR DESCRIPTION
When available, we use the libVersion passed by the client library. When not, we check for VERSION file and ServiceBuilder::VERSION.