### PR TITLE
bump protoc to 3.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ sourceCompatibility = 1.7
 group = "com.google.api"
 project.version = file("version.txt").text.trim()
 
-def protoVersion = "3.0.0-beta-3"
+def protoVersion = "3.2.0"
 
 // Dependencies
 // ------------

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_doc_message_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_doc_message_library.baseline
@@ -231,6 +231,12 @@ var FieldMask = {
  *       end.nanos -= 1000000000;
  *     }
  *
+ * Example 3: Compute Duration from datetime.timedelta in Python.
+ *
+ *     td = datetime.timedelta(days=3, minutes=10)
+ *     duration = Duration()
+ *     duration.FromTimedelta(td)
+ *
  * @external "google.protobuf.Duration"
  * @property {number} seconds
  *   Signed seconds of the span of time. Must be from -315,576,000,000
@@ -312,7 +318,7 @@ var FieldMask = {
  *     }
  *
  * A repeated field is not allowed except at the last position of a
- * field mask.
+ * paths string.
  *
  * If a FieldMask object is not present in a get operation, the
  * operation applies to all fields (as if a FieldMask of all fields
@@ -339,8 +345,8 @@ var FieldMask = {
  *
  * If a repeated field is specified for an update operation, the existing
  * repeated values in the target resource will be overwritten by the new values.
- * Note that a repeated field is only allowed in the last position of a field
- * mask.
+ * Note that a repeated field is only allowed in the last position of a `paths`
+ * string.
  *
  * If a sub-message is specified in the last position of the field mask for an
  * update operation, then the existing sub-message in the target resource is
@@ -637,15 +643,13 @@ var FieldMask = {
  *
  * Example 5: Compute Timestamp from current time in Python.
  *
- *     now = time.time()
- *     seconds = int(now)
- *     nanos = int((now - seconds) * 10**9)
- *     timestamp = Timestamp(seconds=seconds, nanos=nanos)
+ *     timestamp = Timestamp()
+ *     timestamp.GetCurrentTime()
  *
  * @external "google.protobuf.Timestamp"
  * @property {number} seconds
  *   Represents seconds of UTC time since Unix epoch
- *   1970-01-01T00:00:00Z. Must be from from 0001-01-01T00:00:00Z to
+ *   1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
  *   9999-12-31T23:59:59Z inclusive.
  *
  * @property {number} nanos

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_message_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_message_library.baseline
@@ -210,6 +210,14 @@ class Duration(object):
           end.nanos -= 1000000000;
         }
 
+    Example 3: Compute Duration from datetime.timedelta in Python.
+
+    ::
+
+        td = datetime.timedelta(days=3, minutes=10)
+        duration = Duration()
+        duration.FromTimedelta(td)
+
     Attributes:
       seconds (long): Signed seconds of the span of time. Must be from -315,576,000,000
         to +315,576,000,000 inclusive.
@@ -290,7 +298,7 @@ class FieldMask(object):
         }
 
     A repeated field is not allowed except at the last position of a
-    field mask.
+    paths string.
 
     If a FieldMask object is not present in a get operation, the
     operation applies to all fields (as if a FieldMask of all fields
@@ -317,8 +325,8 @@ class FieldMask(object):
 
     If a repeated field is specified for an update operation, the existing
     repeated values in the target resource will be overwritten by the new values.
-    Note that a repeated field is only allowed in the last position of a field
-    mask.
+    Note that a repeated field is only allowed in the last position of a ``paths``
+    string.
 
     If a sub-message is specified in the last position of the field mask for an
     update operation, then the existing sub-message in the target resource is
@@ -619,14 +627,12 @@ class Timestamp(object):
 
     ::
 
-        now = time.time()
-        seconds = int(now)
-        nanos = int((now - seconds) * 10**9)
-        timestamp = Timestamp(seconds=seconds, nanos=nanos)
+        timestamp = Timestamp()
+        timestamp.GetCurrentTime()
 
     Attributes:
       seconds (long): Represents seconds of UTC time since Unix epoch
-        1970-01-01T00:00:00Z. Must be from from 0001-01-01T00:00:00Z to
+        1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
         9999-12-31T23:59:59Z inclusive.
       nanos (int): Non-negative fractions of a second at nanosecond resolution. Negative
         second values with fractions must still have non-negative nanos values

--- a/src/test/java/com/google/api/codegen/testdata/ruby_doc_message_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_doc_message_library.baseline
@@ -208,6 +208,12 @@ module Google
     #       end.seconds += 1;
     #       end.nanos -= 1000000000;
     #     }
+    #
+    # Example 3: Compute Duration from datetime.timedelta in Python.
+    #
+    #     td = datetime.timedelta(days=3, minutes=10)
+    #     duration = Duration()
+    #     duration.FromTimedelta(td)
     # @!attribute [rw] seconds
     #   @return [Integer]
     #     Signed seconds of the span of time. Must be from -315,576,000,000
@@ -283,7 +289,7 @@ module Google
     #     }
     #
     # A repeated field is not allowed except at the last position of a
-    # field mask.
+    # paths string.
     #
     # If a FieldMask object is not present in a get operation, the
     # operation applies to all fields (as if a FieldMask of all fields
@@ -310,8 +316,8 @@ module Google
     #
     # If a repeated field is specified for an update operation, the existing
     # repeated values in the target resource will be overwritten by the new values.
-    # Note that a repeated field is only allowed in the last position of a field
-    # mask.
+    # Note that a repeated field is only allowed in the last position of a +paths+
+    # string.
     #
     # If a sub-message is specified in the last position of the field mask for an
     # update operation, then the existing sub-message in the target resource is
@@ -587,14 +593,12 @@ module Google
     #
     # Example 5: Compute Timestamp from current time in Python.
     #
-    #     now = time.time()
-    #     seconds = int(now)
-    #     nanos = int((now - seconds) * 10**9)
-    #     timestamp = Timestamp(seconds=seconds, nanos=nanos)
+    #     timestamp = Timestamp()
+    #     timestamp.GetCurrentTime()
     # @!attribute [rw] seconds
     #   @return [Integer]
     #     Represents seconds of UTC time since Unix epoch
-    #     1970-01-01T00:00:00Z. Must be from from 0001-01-01T00:00:00Z to
+    #     1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to
     #     9999-12-31T23:59:59Z inclusive.
     # @!attribute [rw] nanos
     #   @return [Integer]


### PR DESCRIPTION
For Go specifically, this lets us write correct import paths for proto files under the google.api package.

I'm tagging all language leads, since this might have cross-language ramifications, even though I do not foresee any specific problems.