### PR TITLE
Rename Bundling to Batching

### DIFF
--- a/src/main/java/com/google/api/codegen/ServiceMessages.java
+++ b/src/main/java/com/google/api/codegen/ServiceMessages.java
@@ -55,18 +55,18 @@ public class ServiceMessages {
     return Iterables.filter(methods, isPageStreaming);
   }
 
-  /** Inputs a list of methods and returns only those which are bundling. */
-  public Iterable<Method> filterBundlingMethods(
+  /** Inputs a list of methods and returns only those which are batching. */
+  public Iterable<Method> filterBatchingMethods(
       final InterfaceConfig config, List<Method> methods) {
-    Predicate<Method> isBundling =
+    Predicate<Method> isBatching =
         new Predicate<Method>() {
           @Override
           public boolean apply(Method method) {
-            return config.getMethodConfig(method).isBundling();
+            return config.getMethodConfig(method).isBatching();
           }
         };
 
-    return Iterables.filter(methods, isBundling);
+    return Iterables.filter(methods, isBatching);
   }
 
   public Iterable<Method> filterLongrunningMethods(

--- a/src/main/java/com/google/api/codegen/clientconfig/ClientConfigGapicContext.java
+++ b/src/main/java/com/google/api/codegen/clientconfig/ClientConfigGapicContext.java
@@ -16,7 +16,7 @@ package com.google.api.codegen.clientconfig;
 
 import com.google.api.codegen.GapicContext;
 import com.google.api.codegen.config.ApiConfig;
-import com.google.api.codegen.config.BundlingConfig;
+import com.google.api.codegen.config.BatchingConfig;
 import com.google.api.tools.framework.model.Interface;
 import com.google.api.tools.framework.model.Method;
 import com.google.api.tools.framework.model.Model;
@@ -31,22 +31,22 @@ public class ClientConfigGapicContext extends GapicContext {
     super(model, config);
   }
 
-  public Map<String, String> bundlingParams(BundlingConfig bundling) {
+  public Map<String, String> batchingParams(BatchingConfig batching) {
     ImmutableMap.Builder<String, String> builder = ImmutableMap.<String, String>builder();
-    if (bundling.getElementCountThreshold() > 0) {
-      builder.put("element_count_threshold", Integer.toString(bundling.getElementCountThreshold()));
+    if (batching.getElementCountThreshold() > 0) {
+      builder.put("element_count_threshold", Integer.toString(batching.getElementCountThreshold()));
     }
-    if (bundling.getElementCountLimit() > 0) {
-      builder.put("element_count_limit", Integer.toString(bundling.getElementCountLimit()));
+    if (batching.getElementCountLimit() > 0) {
+      builder.put("element_count_limit", Integer.toString(batching.getElementCountLimit()));
     }
-    if (bundling.getRequestByteThreshold() > 0) {
-      builder.put("request_byte_threshold", Long.toString(bundling.getRequestByteThreshold()));
+    if (batching.getRequestByteThreshold() > 0) {
+      builder.put("request_byte_threshold", Long.toString(batching.getRequestByteThreshold()));
     }
-    if (bundling.getRequestByteLimit() > 0) {
-      builder.put("request_byte_limit", Long.toString(bundling.getRequestByteLimit()));
+    if (batching.getRequestByteLimit() > 0) {
+      builder.put("request_byte_limit", Long.toString(batching.getRequestByteLimit()));
     }
-    if (bundling.getDelayThresholdMillis() > 0) {
-      builder.put("delay_threshold_millis", Long.toString(bundling.getDelayThresholdMillis()));
+    if (batching.getDelayThresholdMillis() > 0) {
+      builder.put("delay_threshold_millis", Long.toString(batching.getDelayThresholdMillis()));
     }
     return builder.build();
   }

--- a/src/main/java/com/google/api/codegen/config/BatchingConfig.java
+++ b/src/main/java/com/google/api/codegen/config/BatchingConfig.java
@@ -14,9 +14,9 @@
  */
 package com.google.api.codegen.config;
 
-import com.google.api.codegen.BundlingConfigProto;
-import com.google.api.codegen.BundlingDescriptorProto;
-import com.google.api.codegen.BundlingSettingsProto;
+import com.google.api.codegen.BatchingConfigProto;
+import com.google.api.codegen.BatchingDescriptorProto;
+import com.google.api.codegen.BatchingSettingsProto;
 import com.google.api.tools.framework.model.Diag;
 import com.google.api.tools.framework.model.DiagCollector;
 import com.google.api.tools.framework.model.Field;
@@ -27,41 +27,41 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import javax.annotation.Nullable;
 
-/** BundlingConfig represents the bundling configuration for a method. */
+/** BatchingConfig represents the batching configuration for a method. */
 @AutoValue
-public abstract class BundlingConfig {
+public abstract class BatchingConfig {
 
   /**
-   * Creates an instance of BundlingConfig based on BundlingConfigProto, linking it up with the
+   * Creates an instance of BatchingConfig based on BatchingConfigProto, linking it up with the
    * provided method. On errors, null will be returned, and diagnostics are reported to the diag
    * collector.
    */
   @Nullable
-  public static BundlingConfig createBundling(
-      DiagCollector diagCollector, BundlingConfigProto bundlingConfig, Method method) {
+  public static BatchingConfig createBatching(
+      DiagCollector diagCollector, BatchingConfigProto batchingConfig, Method method) {
 
-    BundlingDescriptorProto bundleDescriptor = bundlingConfig.getBundleDescriptor();
-    String bundledFieldName = bundleDescriptor.getBundledField();
-    Field bundledField = method.getInputType().getMessageType().lookupField(bundledFieldName);
-    if (bundledField == null) {
+    BatchingDescriptorProto batchDescriptor = batchingConfig.getBundleDescriptor();
+    String batchedFieldName = batchDescriptor.getBundledField();
+    Field batchedField = method.getInputType().getMessageType().lookupField(batchedFieldName);
+    if (batchedField == null) {
       diagCollector.addDiag(
           Diag.error(
               SimpleLocation.TOPLEVEL,
-              "Bundled field missing for bundle config: method = %s, message type = %s, field = %s",
+              "Batched field missing for batch config: method = %s, message type = %s, field = %s",
               method.getFullName(),
               method.getInputType().getMessageType().getFullName(),
-              bundledFieldName));
+              batchedFieldName));
     }
 
     ImmutableList.Builder<FieldSelector> discriminatorsBuilder = ImmutableList.builder();
-    for (String discriminatorName : bundleDescriptor.getDiscriminatorFieldsList()) {
+    for (String discriminatorName : batchDescriptor.getDiscriminatorFieldsList()) {
       FieldSelector selector =
           FieldSelector.resolve(method.getInputType().getMessageType(), discriminatorName);
       if (selector == null) {
         diagCollector.addDiag(
             Diag.error(
                 SimpleLocation.TOPLEVEL,
-                "Discriminator field missing for bundle config: method = %s, message type = %s, "
+                "Discriminator field missing for batch config: method = %s, message type = %s, "
                     + "field = %s",
                 method.getFullName(),
                 method.getInputType().getMessageType().getFullName(),
@@ -70,7 +70,7 @@ public abstract class BundlingConfig {
       discriminatorsBuilder.add(selector);
     }
 
-    String subresponseFieldName = bundleDescriptor.getSubresponseField();
+    String subresponseFieldName = batchDescriptor.getSubresponseField();
     Field subresponseField;
     if (!subresponseFieldName.isEmpty()) {
       subresponseField = method.getOutputType().getMessageType().lookupField(subresponseFieldName);
@@ -78,36 +78,36 @@ public abstract class BundlingConfig {
       subresponseField = null;
     }
 
-    BundlingSettingsProto bundlingSettings = bundlingConfig.getThresholds();
-    int elementCountThreshold = bundlingSettings.getElementCountThreshold();
-    long requestByteThreshold = bundlingSettings.getRequestByteThreshold();
-    int elementCountLimit = bundlingSettings.getElementCountLimit();
-    long requestByteLimit = bundlingSettings.getRequestByteLimit();
-    long delayThresholdMillis = bundlingConfig.getThresholds().getDelayThresholdMillis();
+    BatchingSettingsProto batchingSettings = batchingConfig.getThresholds();
+    int elementCountThreshold = batchingSettings.getElementCountThreshold();
+    long requestByteThreshold = batchingSettings.getRequestByteThreshold();
+    int elementCountLimit = batchingSettings.getElementCountLimit();
+    long requestByteLimit = batchingSettings.getRequestByteLimit();
+    long delayThresholdMillis = batchingConfig.getThresholds().getDelayThresholdMillis();
     Long flowControlElementLimit =
-        (long) bundlingConfig.getThresholds().getFlowControlElementLimit();
+        (long) batchingConfig.getThresholds().getFlowControlElementLimit();
     if (flowControlElementLimit == 0) {
       flowControlElementLimit = null;
     }
-    Long flowControlByteLimit = (long) bundlingConfig.getThresholds().getFlowControlByteLimit();
+    Long flowControlByteLimit = (long) batchingConfig.getThresholds().getFlowControlByteLimit();
     if (flowControlByteLimit == 0) {
       flowControlByteLimit = null;
     }
     FlowControlLimitConfig flowControlLimitConfig =
         FlowControlLimitConfig.fromProto(
-            bundlingConfig.getThresholds().getFlowControlLimitExceededBehavior());
+            batchingConfig.getThresholds().getFlowControlLimitExceededBehavior());
 
-    if (bundledFieldName == null) {
+    if (batchedFieldName == null) {
       return null;
     }
 
-    return new AutoValue_BundlingConfig(
+    return new AutoValue_BatchingConfig(
         elementCountThreshold,
         requestByteThreshold,
         elementCountLimit,
         requestByteLimit,
         delayThresholdMillis,
-        bundledField,
+        batchedField,
         discriminatorsBuilder.build(),
         subresponseField,
         flowControlElementLimit,
@@ -125,7 +125,7 @@ public abstract class BundlingConfig {
 
   public abstract long getDelayThresholdMillis();
 
-  public abstract Field getBundledField();
+  public abstract Field getBatchedField();
 
   public abstract ImmutableList<FieldSelector> getDiscriminatorFields();
 

--- a/src/main/java/com/google/api/codegen/config/BatchingConfig.java
+++ b/src/main/java/com/google/api/codegen/config/BatchingConfig.java
@@ -40,8 +40,8 @@ public abstract class BatchingConfig {
   public static BatchingConfig createBatching(
       DiagCollector diagCollector, BatchingConfigProto batchingConfig, Method method) {
 
-    BatchingDescriptorProto batchDescriptor = batchingConfig.getBundleDescriptor();
-    String batchedFieldName = batchDescriptor.getBundledField();
+    BatchingDescriptorProto batchDescriptor = batchingConfig.getBatchDescriptor();
+    String batchedFieldName = batchDescriptor.getBatchedField();
     Field batchedField = method.getInputType().getMessageType().lookupField(batchedFieldName);
     if (batchedField == null) {
       diagCollector.addDiag(

--- a/src/main/java/com/google/api/codegen/config/InterfaceConfig.java
+++ b/src/main/java/com/google/api/codegen/config/InterfaceConfig.java
@@ -365,9 +365,9 @@ public abstract class InterfaceConfig {
     return false;
   }
 
-  public boolean hasBundlingMethods() {
+  public boolean hasBatchingMethods() {
     for (MethodConfig methodConfig : getMethodConfigs()) {
-      if (methodConfig.isBundling()) {
+      if (methodConfig.isBatching()) {
         return true;
       }
     }

--- a/src/main/java/com/google/api/codegen/config/MethodConfig.java
+++ b/src/main/java/com/google/api/codegen/config/MethodConfig.java
@@ -145,9 +145,9 @@ public abstract class MethodConfig {
     }
 
     BatchingConfig batching = null;
-    if (!BatchingConfigProto.getDefaultInstance().equals(methodConfigProto.getBundling())) {
+    if (!BatchingConfigProto.getDefaultInstance().equals(methodConfigProto.getBatching())) {
       batching =
-          BatchingConfig.createBatching(diagCollector, methodConfigProto.getBundling(), method);
+          BatchingConfig.createBatching(diagCollector, methodConfigProto.getBatching(), method);
       if (batching == null) {
         error = true;
       }

--- a/src/main/java/com/google/api/codegen/config/MethodConfig.java
+++ b/src/main/java/com/google/api/codegen/config/MethodConfig.java
@@ -14,7 +14,7 @@
  */
 package com.google.api.codegen.config;
 
-import com.google.api.codegen.BundlingConfigProto;
+import com.google.api.codegen.BatchingConfigProto;
 import com.google.api.codegen.FlatteningConfigProto;
 import com.google.api.codegen.FlatteningGroupProto;
 import com.google.api.codegen.LongRunningConfigProto;
@@ -73,7 +73,7 @@ public abstract class MethodConfig {
   public abstract ResourceNameTreatment getDefaultResourceNameTreatment();
 
   @Nullable
-  public abstract BundlingConfig getBundling();
+  public abstract BatchingConfig getBatching();
 
   public abstract boolean hasRequestObjectMethod();
 
@@ -144,11 +144,11 @@ public abstract class MethodConfig {
       }
     }
 
-    BundlingConfig bundling = null;
-    if (!BundlingConfigProto.getDefaultInstance().equals(methodConfigProto.getBundling())) {
-      bundling =
-          BundlingConfig.createBundling(diagCollector, methodConfigProto.getBundling(), method);
-      if (bundling == null) {
+    BatchingConfig batching = null;
+    if (!BatchingConfigProto.getDefaultInstance().equals(methodConfigProto.getBundling())) {
+      batching =
+          BatchingConfig.createBatching(diagCollector, methodConfigProto.getBundling(), method);
+      if (batching == null) {
         error = true;
       }
     }
@@ -260,7 +260,7 @@ public abstract class MethodConfig {
           requiredFieldConfigs,
           optionalFieldConfigs,
           defaultResourceNameTreatment,
-          bundling,
+          batching,
           hasRequestObjectMethod,
           fieldNamePatterns,
           sampleCodeInitFields,
@@ -389,9 +389,9 @@ public abstract class MethodConfig {
     return getFlatteningConfigs() != null;
   }
 
-  /** Returns true if this method has bundling configured. */
-  public boolean isBundling() {
-    return getBundling() != null;
+  /** Returns true if this method has batching configured. */
+  public boolean isBatching() {
+    return getBatching() != null;
   }
 
   public boolean isLongRunningOperation() {

--- a/src/main/java/com/google/api/codegen/nodejs/NodeJSGapicContext.java
+++ b/src/main/java/com/google/api/codegen/nodejs/NodeJSGapicContext.java
@@ -480,7 +480,7 @@ public class NodeJSGapicContext extends GapicContext implements NodeJSContext {
     if (messages().filterPageStreamingMethods(ifaceConfig, methods).iterator().hasNext()) {
       builder.add("PAGE_DESCRIPTORS");
     }
-    if (messages().filterBundlingMethods(ifaceConfig, methods).iterator().hasNext()) {
+    if (messages().filterBatchingMethods(ifaceConfig, methods).iterator().hasNext()) {
       builder.add("bundleDescriptors");
     }
     if (filterStreamingMethods(service).iterator().hasNext()) {

--- a/src/main/java/com/google/api/codegen/transformer/ApiCallableTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ApiCallableTransformer.java
@@ -35,11 +35,11 @@ import java.util.Map;
 import org.joda.time.Duration;
 
 public class ApiCallableTransformer {
-  private final BundlingTransformer bundlingTransformer;
+  private final BatchingTransformer batchingTransformer;
   private final RetryDefinitionsTransformer retryDefinitionsTransformer;
 
   public ApiCallableTransformer() {
-    this.bundlingTransformer = new BundlingTransformer();
+    this.batchingTransformer = new BatchingTransformer();
     this.retryDefinitionsTransformer = new RetryDefinitionsTransformer();
   }
 
@@ -107,8 +107,8 @@ public class ApiCallableTransformer {
     if (methodConfig.isGrpcStreaming()) {
       callableImplType = ApiCallableImplType.StreamingApiCallable;
       apiCallableBuilder.grpcStreamingType(methodConfig.getGrpcStreaming().getType());
-    } else if (methodConfig.isBundling()) {
-      callableImplType = ApiCallableImplType.BundlingApiCallable;
+    } else if (methodConfig.isBatching()) {
+      callableImplType = ApiCallableImplType.BatchingApiCallable;
     } else if (methodConfig.isLongRunningOperation()) {
       callableImplType = ApiCallableImplType.InitialOperationApiCallable;
     }
@@ -223,8 +223,8 @@ public class ApiCallableTransformer {
         namer.getNotImplementedString(notImplementedPrefix + "pageStreamingDescriptorName"));
     settings.pagedListResponseFactoryName(
         namer.getNotImplementedString(notImplementedPrefix + "pagedListResponseFactoryName"));
-    settings.bundlingDescriptorName(
-        namer.getNotImplementedString(notImplementedPrefix + "bundlingDescriptorName"));
+    settings.batchingDescriptorName(
+        namer.getNotImplementedString(notImplementedPrefix + "batchingDescriptorName"));
     settings.operationResultTypeName(
         namer.getNotImplementedString(notImplementedPrefix + "operationResultTypeName"));
 
@@ -247,10 +247,10 @@ public class ApiCallableTransformer {
               methodConfig.getPageStreaming().getResourcesFieldConfig()));
       settings.pageStreamingDescriptorName(namer.getPageStreamingDescriptorConstName(method));
       settings.pagedListResponseFactoryName(namer.getPagedListResponseFactoryConstName(method));
-    } else if (methodConfig.isBundling()) {
-      settings.type(ApiCallableImplType.BundlingApiCallable);
-      settings.bundlingDescriptorName(namer.getBundlingDescriptorConstName(method));
-      settings.bundlingConfig(bundlingTransformer.generateBundlingConfig(context));
+    } else if (methodConfig.isBatching()) {
+      settings.type(ApiCallableImplType.BatchingApiCallable);
+      settings.batchingDescriptorName(namer.getBatchingDescriptorConstName(method));
+      settings.batchingConfig(batchingTransformer.generateBatchingConfig(context));
     } else if (methodConfig.isLongRunningOperation()) {
       settings.type(ApiCallableImplType.OperationApiCallable);
       TypeRef operationResultType = methodConfig.getLongRunningConfig().getReturnType();

--- a/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
@@ -898,8 +898,8 @@ public class SurfaceNamer extends NameFormatterDelegator {
 
   ///////////////////////////////////// Constant & Keyword ////////////////////////////////////////
 
-  /** The name of the constant to hold the bundling descriptor for the given method. */
-  public String getBundlingDescriptorConstName(Method method) {
+  /** The name of the constant to hold the batching descriptor for the given method. */
+  public String getBatchingDescriptorConstName(Method method) {
     return inittedConstantName(Name.upperCamel(method.getSimpleName()).join("bundling_desc"));
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/SurfaceTransformerContext.java
+++ b/src/main/java/com/google/api/codegen/transformer/SurfaceTransformerContext.java
@@ -204,10 +204,10 @@ public abstract class SurfaceTransformerContext {
     return methods;
   }
 
-  public List<Method> getBundlingMethods() {
+  public List<Method> getBatchingMethods() {
     List<Method> methods = new ArrayList<>();
     for (Method method : getSupportedMethods()) {
-      if (getMethodConfig(method).isBundling()) {
+      if (getMethodConfig(method).isBatching()) {
         methods.add(method);
       }
     }

--- a/src/main/java/com/google/api/codegen/transformer/TestCaseTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/TestCaseTransformer.java
@@ -215,9 +215,9 @@ public class TestCaseTransformer {
           InitCodeNode.createWithValue(
               responseTokenName, InitValueConfig.createWithValue(InitValue.createLiteral(""))));
     }
-    if (context.getMethodConfig().isBundling()) {
-      // Initialize one bundling element if it is bundling.
-      BundlingConfig config = context.getMethodConfig().getBundling();
+    if (context.getMethodConfig().isBatching()) {
+      // Initialize one batching element if it is batching.
+      BatchingConfig config = context.getMethodConfig().getBatching();
       if (config.getSubresponseField() != null) {
         String subResponseFieldName = config.getSubresponseField().getSimpleName();
         additionalSubTrees.add(InitCodeNode.createSingletonList(subResponseFieldName));

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicClientTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicClientTransformer.java
@@ -23,7 +23,7 @@ import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.config.ServiceConfig;
 import com.google.api.codegen.gapic.GapicCodePathMapper;
 import com.google.api.codegen.transformer.ApiCallableTransformer;
-import com.google.api.codegen.transformer.BundlingTransformer;
+import com.google.api.codegen.transformer.BatchingTransformer;
 import com.google.api.codegen.transformer.FileHeaderTransformer;
 import com.google.api.codegen.transformer.MethodTransformerContext;
 import com.google.api.codegen.transformer.ModelToViewTransformer;
@@ -76,7 +76,7 @@ public class CSharpGapicClientTransformer implements ModelToViewTransformer {
   private final FileHeaderTransformer fileHeaderTransformer =
       new FileHeaderTransformer(new StandardImportSectionTransformer());
   private final PageStreamingTransformer pageStreamingTransformer = new PageStreamingTransformer();
-  private final BundlingTransformer bundlingTransformer = new BundlingTransformer();
+  private final BatchingTransformer batchingTransformer = new BatchingTransformer();
   private final RetryDefinitionsTransformer retryDefinitionsTransformer =
       new RetryDefinitionsTransformer();
   private final CSharpCommonTransformer csharpCommonTransformer = new CSharpCommonTransformer();
@@ -175,7 +175,7 @@ public class CSharpGapicClientTransformer implements ModelToViewTransformer {
     List<ApiCallableView> callables = new ArrayList<>();
     for (ApiCallableView call : apiCallableTransformer.generateStaticLangApiCallables(context)) {
       if (call.type() == ApiCallableImplType.SimpleApiCallable
-          || call.type() == ApiCallableImplType.BundlingApiCallable
+          || call.type() == ApiCallableImplType.BatchingApiCallable
           || call.type() == ApiCallableImplType.InitialOperationApiCallable
           || (call.type() == ApiCallableImplType.StreamingApiCallable
               && call.grpcStreamingType() == GrpcStreamingType.BidiStreaming)) {
@@ -232,7 +232,7 @@ public class CSharpGapicClientTransformer implements ModelToViewTransformer {
         pageStreamingTransformer.generateDescriptorClasses(context));
     settingsClass.pagedListResponseFactories(
         pageStreamingTransformer.generateFactoryClasses(context));
-    settingsClass.bundlingDescriptors(bundlingTransformer.generateDescriptorClasses(context));
+    settingsClass.batchingDescriptors(batchingTransformer.generateDescriptorClasses(context));
     settingsClass.retryCodesDefinitions(
         retryDefinitionsTransformer.generateRetryCodesDefinitions(context));
     settingsClass.retryParamsDefinitions(

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTransformer.java
@@ -23,7 +23,7 @@ import com.google.api.codegen.config.MethodConfig;
 import com.google.api.codegen.config.ServiceConfig;
 import com.google.api.codegen.gapic.GapicCodePathMapper;
 import com.google.api.codegen.transformer.ApiCallableTransformer;
-import com.google.api.codegen.transformer.BundlingTransformer;
+import com.google.api.codegen.transformer.BatchingTransformer;
 import com.google.api.codegen.transformer.FileHeaderTransformer;
 import com.google.api.codegen.transformer.MethodTransformerContext;
 import com.google.api.codegen.transformer.ModelToViewTransformer;
@@ -71,7 +71,7 @@ public class JavaGapicSurfaceTransformer implements ModelToViewTransformer {
   private final StaticLangApiMethodTransformer apiMethodTransformer =
       new StaticLangApiMethodTransformer();
   private final PageStreamingTransformer pageStreamingTransformer = new PageStreamingTransformer();
-  private final BundlingTransformer bundlingTransformer = new BundlingTransformer();
+  private final BatchingTransformer batchingTransformer = new BatchingTransformer();
   private final StandardImportSectionTransformer importSectionTransformer =
       new StandardImportSectionTransformer();
   private final FileHeaderTransformer fileHeaderTransformer =
@@ -365,7 +365,7 @@ public class JavaGapicSurfaceTransformer implements ModelToViewTransformer {
         pageStreamingTransformer.generateDescriptorClasses(context));
     xsettingsClass.pagedListResponseFactories(
         pageStreamingTransformer.generateFactoryClasses(context));
-    xsettingsClass.bundlingDescriptors(bundlingTransformer.generateDescriptorClasses(context));
+    xsettingsClass.batchingDescriptors(batchingTransformer.generateDescriptorClasses(context));
     xsettingsClass.retryCodesDefinitions(
         retryDefinitionsTransformer.generateRetryCodesDefinitions(context));
     xsettingsClass.retryParamsDefinitions(
@@ -457,7 +457,7 @@ public class JavaGapicSurfaceTransformer implements ModelToViewTransformer {
       typeTable.saveNicknameFor("com.google.api.gax.grpc.PagedListResponseFactory");
       typeTable.saveNicknameFor("com.google.api.gax.grpc.UnaryCallable");
     }
-    if (interfaceConfig.hasBundlingMethods()) {
+    if (interfaceConfig.hasBatchingMethods()) {
       typeTable.saveNicknameFor("com.google.api.gax.batching.BatchingSettings");
       typeTable.saveNicknameFor("com.google.api.gax.batching.RequestBuilder");
       typeTable.saveNicknameFor("com.google.api.gax.core.FlowController");

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTransformer.java
@@ -458,14 +458,14 @@ public class JavaGapicSurfaceTransformer implements ModelToViewTransformer {
       typeTable.saveNicknameFor("com.google.api.gax.grpc.UnaryCallable");
     }
     if (interfaceConfig.hasBundlingMethods()) {
-      typeTable.saveNicknameFor("com.google.api.gax.bundling.BundlingSettings");
-      typeTable.saveNicknameFor("com.google.api.gax.bundling.RequestBuilder");
+      typeTable.saveNicknameFor("com.google.api.gax.batching.BatchingSettings");
+      typeTable.saveNicknameFor("com.google.api.gax.batching.RequestBuilder");
       typeTable.saveNicknameFor("com.google.api.gax.core.FlowController");
       typeTable.saveNicknameFor("com.google.api.gax.core.FlowController.LimitExceededBehavior");
       typeTable.saveNicknameFor("com.google.api.gax.core.FlowControlSettings");
-      typeTable.saveNicknameFor("com.google.api.gax.grpc.BundlingCallSettings");
-      typeTable.saveNicknameFor("com.google.api.gax.grpc.BundledRequestIssuer");
-      typeTable.saveNicknameFor("com.google.api.gax.grpc.BundlingDescriptor");
+      typeTable.saveNicknameFor("com.google.api.gax.grpc.BatchingCallSettings");
+      typeTable.saveNicknameFor("com.google.api.gax.grpc.BatchedRequestIssuer");
+      typeTable.saveNicknameFor("com.google.api.gax.grpc.BatchingDescriptor");
       typeTable.saveNicknameFor("com.google.api.gax.grpc.RequestIssuer");
       typeTable.saveNicknameFor("java.util.ArrayList");
       typeTable.saveNicknameFor("java.util.Collection");

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceNamer.java
@@ -191,4 +191,9 @@ public class JavaSurfaceNamer extends SurfaceNamer {
         return "";
     }
   }
+
+  @Override
+  public String getBundlingDescriptorConstName(Method method) {
+    return inittedConstantName(Name.upperCamel(method.getSimpleName()).join("batching_desc"));
+  }
 }

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceNamer.java
@@ -193,7 +193,7 @@ public class JavaSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getBundlingDescriptorConstName(Method method) {
+  public String getBatchingDescriptorConstName(Method method) {
     return inittedConstantName(Name.upperCamel(method.getSimpleName()).join("batching_desc"));
   }
 }

--- a/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSurfaceTransformer.java
@@ -129,7 +129,7 @@ public class PhpGapicSurfaceTransformer implements ModelToViewTransformer {
         pathTemplateTransformer.generatePathTemplateGetterFunctions(context));
     xapiClass.pageStreamingDescriptors(pageStreamingTransformer.generateDescriptors(context));
     xapiClass.hasPageStreamingMethods(context.getInterfaceConfig().hasPageStreamingMethods());
-    xapiClass.hasBundlingMethods(context.getInterfaceConfig().hasBundlingMethods());
+    xapiClass.hasBatchingMethods(context.getInterfaceConfig().hasBatchingMethods());
     xapiClass.longRunningDescriptors(createLongRunningDescriptors(context));
     xapiClass.hasLongRunningOperations(context.getInterfaceConfig().hasLongRunningOperations());
     xapiClass.grpcStreamingDescriptors(createGrpcStreamingDescriptors(context));

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubyGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubyGapicSurfaceTransformer.java
@@ -21,7 +21,7 @@ import com.google.api.codegen.config.ApiConfig;
 import com.google.api.codegen.config.PackageMetadataConfig;
 import com.google.api.codegen.config.ServiceConfig;
 import com.google.api.codegen.gapic.GapicCodePathMapper;
-import com.google.api.codegen.transformer.BundlingTransformer;
+import com.google.api.codegen.transformer.BatchingTransformer;
 import com.google.api.codegen.transformer.DynamicLangApiMethodTransformer;
 import com.google.api.codegen.transformer.FeatureConfig;
 import com.google.api.codegen.transformer.FileHeaderTransformer;
@@ -59,7 +59,7 @@ public class RubyGapicSurfaceTransformer implements ModelToViewTransformer {
   private final ServiceTransformer serviceTransformer = new ServiceTransformer();
   private final GrpcStubTransformer grpcStubTransformer = new GrpcStubTransformer();
   private final PageStreamingTransformer pageStreamingTransformer = new PageStreamingTransformer();
-  private final BundlingTransformer bundlingTransformer = new BundlingTransformer();
+  private final BatchingTransformer batchingTransformer = new BatchingTransformer();
   private final PathTemplateTransformer pathTemplateTransformer = new PathTemplateTransformer();
 
   public RubyGapicSurfaceTransformer(
@@ -117,11 +117,11 @@ public class RubyGapicSurfaceTransformer implements ModelToViewTransformer {
     xapiClass.hasDefaultServiceScopes(context.getInterfaceConfig().hasDefaultServiceScopes());
 
     xapiClass.pageStreamingDescriptors(pageStreamingTransformer.generateDescriptors(context));
-    xapiClass.bundlingDescriptors(bundlingTransformer.generateDescriptors(context));
+    xapiClass.batchingDescriptors(batchingTransformer.generateDescriptors(context));
     xapiClass.longRunningDescriptors(ImmutableList.<LongRunningOperationDetailView>of());
     xapiClass.grpcStreamingDescriptors(ImmutableList.<GrpcStreamingDetailView>of());
     xapiClass.hasPageStreamingMethods(context.getInterfaceConfig().hasPageStreamingMethods());
-    xapiClass.hasBundlingMethods(context.getInterfaceConfig().hasBundlingMethods());
+    xapiClass.hasBatchingMethods(context.getInterfaceConfig().hasBatchingMethods());
     xapiClass.hasLongRunningOperations(context.getInterfaceConfig().hasLongRunningOperations());
 
     xapiClass.pathTemplates(pathTemplateTransformer.generatePathTemplates(context));

--- a/src/main/java/com/google/api/codegen/viewmodel/ApiCallSettingsView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/ApiCallSettingsView.java
@@ -52,7 +52,7 @@ public abstract class ApiCallSettingsView {
 
   public abstract String pagedListResponseFactoryName();
 
-  public abstract String bundlingDescriptorName();
+  public abstract String batchingDescriptorName();
 
   public abstract String operationResultTypeName();
 
@@ -74,7 +74,7 @@ public abstract class ApiCallSettingsView {
   public abstract RetryParamsDefinitionView retryParamsView();
 
   @Nullable
-  public abstract BundlingConfigView bundlingConfig();
+  public abstract BatchingConfigView batchingConfig();
 
   public abstract Builder toBuilder();
 
@@ -113,9 +113,9 @@ public abstract class ApiCallSettingsView {
 
     public abstract Builder pagedListResponseFactoryName(String val);
 
-    public abstract Builder bundlingDescriptorName(String val);
+    public abstract Builder batchingDescriptorName(String val);
 
-    public abstract Builder bundlingConfig(BundlingConfigView val);
+    public abstract Builder batchingConfig(BatchingConfigView val);
 
     public abstract Builder operationResultTypeName(String val);
 

--- a/src/main/java/com/google/api/codegen/viewmodel/ApiCallableImplType.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/ApiCallableImplType.java
@@ -18,7 +18,7 @@ package com.google.api.codegen.viewmodel;
 public enum ApiCallableImplType {
   SimpleApiCallable(ServiceMethodType.UnaryMethod),
   PagedApiCallable(ServiceMethodType.UnaryMethod),
-  BundlingApiCallable(ServiceMethodType.UnaryMethod),
+  BatchingApiCallable(ServiceMethodType.UnaryMethod),
   StreamingApiCallable(ServiceMethodType.GrpcStreamingMethod),
   InitialOperationApiCallable(ServiceMethodType.UnaryMethod),
   OperationApiCallable(ServiceMethodType.LongRunningMethod);

--- a/src/main/java/com/google/api/codegen/viewmodel/BatchingConfigView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/BatchingConfigView.java
@@ -18,7 +18,7 @@ import com.google.auto.value.AutoValue;
 import javax.annotation.Nullable;
 
 @AutoValue
-public abstract class BundlingConfigView {
+public abstract class BatchingConfigView {
   public abstract int elementCountThreshold();
 
   public abstract long requestByteThreshold();
@@ -46,7 +46,7 @@ public abstract class BundlingConfigView {
   }
 
   public static Builder newBuilder() {
-    return new AutoValue_BundlingConfigView.Builder();
+    return new AutoValue_BatchingConfigView.Builder();
   }
 
   @AutoValue.Builder
@@ -67,6 +67,6 @@ public abstract class BundlingConfigView {
 
     public abstract Builder flowControlLimitExceededBehavior(String val);
 
-    public abstract BundlingConfigView build();
+    public abstract BatchingConfigView build();
   }
 }

--- a/src/main/java/com/google/api/codegen/viewmodel/BatchingDescriptorClassView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/BatchingDescriptorClassView.java
@@ -19,7 +19,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 
 @AutoValue
-public abstract class BundlingDescriptorClassView {
+public abstract class BatchingDescriptorClassView {
 
   public abstract String name();
 
@@ -27,20 +27,20 @@ public abstract class BundlingDescriptorClassView {
 
   public abstract String responseTypeName();
 
-  public abstract String bundledFieldTypeName();
+  public abstract String batchedFieldTypeName();
 
   @Nullable
   public abstract String subresponseTypeName();
 
-  public abstract List<BundlingPartitionKeyView> partitionKeys();
+  public abstract List<BatchingPartitionKeyView> partitionKeys();
 
   public abstract List<FieldCopyView> discriminatorFieldCopies();
 
-  public abstract String bundledFieldGetFunction();
+  public abstract String batchedFieldGetFunction();
 
-  public abstract String bundledFieldSetFunction();
+  public abstract String batchedFieldSetFunction();
 
-  public abstract String bundledFieldCountGetFunction();
+  public abstract String batchedFieldCountGetFunction();
 
   @Nullable
   public abstract String subresponseByIndexGetFunction();
@@ -53,7 +53,7 @@ public abstract class BundlingDescriptorClassView {
   }
 
   public static Builder newBuilder() {
-    return new AutoValue_BundlingDescriptorClassView.Builder();
+    return new AutoValue_BatchingDescriptorClassView.Builder();
   }
 
   @AutoValue.Builder
@@ -65,25 +65,25 @@ public abstract class BundlingDescriptorClassView {
 
     public abstract Builder responseTypeName(String val);
 
-    public abstract Builder bundledFieldTypeName(String val);
+    public abstract Builder batchedFieldTypeName(String val);
 
     public abstract Builder subresponseTypeName(String val);
 
-    public abstract Builder partitionKeys(List<BundlingPartitionKeyView> val);
+    public abstract Builder partitionKeys(List<BatchingPartitionKeyView> val);
 
     public abstract Builder discriminatorFieldCopies(
         List<FieldCopyView> generateDiscriminatorFieldCopies);
 
-    public abstract Builder bundledFieldGetFunction(String val);
+    public abstract Builder batchedFieldGetFunction(String val);
 
-    public abstract Builder bundledFieldSetFunction(String val);
+    public abstract Builder batchedFieldSetFunction(String val);
 
-    public abstract Builder bundledFieldCountGetFunction(String val);
+    public abstract Builder batchedFieldCountGetFunction(String val);
 
     public abstract Builder subresponseByIndexGetFunction(String val);
 
     public abstract Builder subresponseSetFunction(String val);
 
-    public abstract BundlingDescriptorClassView build();
+    public abstract BatchingDescriptorClassView build();
   }
 }

--- a/src/main/java/com/google/api/codegen/viewmodel/BatchingDescriptorView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/BatchingDescriptorView.java
@@ -19,10 +19,10 @@ import java.util.List;
 import javax.annotation.Nullable;
 
 @AutoValue
-public abstract class BundlingDescriptorView {
+public abstract class BatchingDescriptorView {
   public abstract String methodName();
 
-  public abstract String bundledFieldName();
+  public abstract String batchedFieldName();
 
   public abstract List<String> discriminatorFieldNames();
 
@@ -30,7 +30,7 @@ public abstract class BundlingDescriptorView {
   public abstract String subresponseFieldName();
 
   public static Builder newBuilder() {
-    return new AutoValue_BundlingDescriptorView.Builder();
+    return new AutoValue_BatchingDescriptorView.Builder();
   }
 
   public boolean hasSubresponseField() {
@@ -41,12 +41,12 @@ public abstract class BundlingDescriptorView {
   public abstract static class Builder {
     public abstract Builder methodName(String val);
 
-    public abstract Builder bundledFieldName(String val);
+    public abstract Builder batchedFieldName(String val);
 
     public abstract Builder subresponseFieldName(String val);
 
     public abstract Builder discriminatorFieldNames(List<String> val);
 
-    public abstract BundlingDescriptorView build();
+    public abstract BatchingDescriptorView build();
   }
 }

--- a/src/main/java/com/google/api/codegen/viewmodel/BatchingPartitionKeyView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/BatchingPartitionKeyView.java
@@ -14,18 +14,17 @@
  */
 package com.google.api.codegen.viewmodel;
 
-import com.google.api.codegen.viewmodel.BundlingDescriptorClassView.Builder;
 import com.google.auto.value.AutoValue;
 
 @AutoValue
-public abstract class BundlingPartitionKeyView {
+public abstract class BatchingPartitionKeyView {
 
   public abstract String separatorLiteral();
 
   public abstract String fieldGetFunction();
 
   public static Builder newBuilder() {
-    return new AutoValue_BundlingPartitionKeyView.Builder();
+    return new AutoValue_BatchingPartitionKeyView.Builder();
   }
 
   @AutoValue.Builder
@@ -35,6 +34,6 @@ public abstract class BundlingPartitionKeyView {
 
     public abstract Builder fieldGetFunction(String val);
 
-    public abstract BundlingPartitionKeyView build();
+    public abstract BatchingPartitionKeyView build();
   }
 }

--- a/src/main/java/com/google/api/codegen/viewmodel/DynamicLangXApiView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/DynamicLangXApiView.java
@@ -50,7 +50,7 @@ public abstract class DynamicLangXApiView implements ViewModel {
   public abstract List<PageStreamingDescriptorView> pageStreamingDescriptors();
 
   @Nullable
-  public abstract List<BundlingDescriptorView> bundlingDescriptors();
+  public abstract List<BatchingDescriptorView> batchingDescriptors();
 
   public abstract List<LongRunningOperationDetailView> longRunningDescriptors();
 
@@ -72,7 +72,7 @@ public abstract class DynamicLangXApiView implements ViewModel {
 
   public abstract boolean hasPageStreamingMethods();
 
-  public abstract boolean hasBundlingMethods();
+  public abstract boolean hasBatchingMethods();
 
   public abstract boolean hasLongRunningOperations();
 
@@ -140,7 +140,7 @@ public abstract class DynamicLangXApiView implements ViewModel {
 
     public abstract Builder pageStreamingDescriptors(List<PageStreamingDescriptorView> val);
 
-    public abstract Builder bundlingDescriptors(List<BundlingDescriptorView> val);
+    public abstract Builder batchingDescriptors(List<BatchingDescriptorView> val);
 
     public abstract Builder longRunningDescriptors(List<LongRunningOperationDetailView> val);
 
@@ -162,7 +162,7 @@ public abstract class DynamicLangXApiView implements ViewModel {
 
     public abstract Builder hasPageStreamingMethods(boolean val);
 
-    public abstract Builder hasBundlingMethods(boolean val);
+    public abstract Builder hasBatchingMethods(boolean val);
 
     public abstract Builder hasLongRunningOperations(boolean val);
 

--- a/src/main/java/com/google/api/codegen/viewmodel/StaticLangSettingsView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/StaticLangSettingsView.java
@@ -57,7 +57,7 @@ public abstract class StaticLangSettingsView {
 
   public abstract List<PagedListResponseFactoryClassView> pagedListResponseFactories();
 
-  public abstract List<BundlingDescriptorClassView> bundlingDescriptors();
+  public abstract List<BatchingDescriptorClassView> batchingDescriptors();
 
   public abstract List<RetryCodesDefinitionView> retryCodesDefinitions();
 
@@ -93,7 +93,7 @@ public abstract class StaticLangSettingsView {
 
     public abstract Builder pagedListResponseFactories(List<PagedListResponseFactoryClassView> val);
 
-    public abstract Builder bundlingDescriptors(List<BundlingDescriptorClassView> val);
+    public abstract Builder batchingDescriptors(List<BatchingDescriptorClassView> val);
 
     public abstract Builder retryCodesDefinitions(List<RetryCodesDefinitionView> val);
 

--- a/src/main/proto/com/google/api/codegen/config.proto
+++ b/src/main/proto/com/google/api/codegen/config.proto
@@ -49,12 +49,12 @@ option java_package = "com.google.api.codegen";
 //           response:
 //             token_field: next_page_token
 //             resources_field: books
-//         bundling:
+//         batching:
 //           thresholds:
 //             element_count_threshold: 5
 //             request_byte_threshold: 16384
-//           bundle_descriptor:
-//             bundled_field: pictures
+//           batch_descriptor:
+//             batched_field: pictures
 //             request_discriminator_fields:
 //             - album
 //             - labels
@@ -244,7 +244,7 @@ message MethodConfigProto {
   uint64 timeout_millis = 11;
 
   // Specifies the configuration for batching.
-  BatchingConfigProto bundling = 6;
+  BatchingConfigProto batching = 6;
 
   // Turns on or off the generation of a method whose sole parameter is
   // a request object. Not all languages will generate this method.
@@ -378,7 +378,7 @@ message BatchingConfigProto {
   BatchingSettingsProto thresholds = 1;
 
   // The request and response fields used in batching.
-  BatchingDescriptorProto bundle_descriptor = 2;
+  BatchingDescriptorProto batch_descriptor = 2;
 }
 
 // `BatchingSettingsProto` specifies a set of batching thresholds, each of
@@ -423,7 +423,7 @@ enum FlowControlLimitExceededBehaviorProto {
 // used for demultiplexing.
 message BatchingDescriptorProto {
   // The repeated field in the request message to be aggregated by batching.
-  string bundled_field = 1;
+  string batched_field = 1;
 
   // A list of the fields in the request message. Two requests will be batched
   // together only if the values of every field specified in

--- a/src/main/proto/com/google/api/codegen/config.proto
+++ b/src/main/proto/com/google/api/codegen/config.proto
@@ -243,8 +243,8 @@ message MethodConfigProto {
   // retrying, refer to `retry_params_name` instead.
   uint64 timeout_millis = 11;
 
-  // Specifies the configuration for bundling.
-  BundlingConfigProto bundling = 6;
+  // Specifies the configuration for batching.
+  BatchingConfigProto bundling = 6;
 
   // Turns on or off the generation of a method whose sole parameter is
   // a request object. Not all languages will generate this method.
@@ -372,33 +372,33 @@ message RetryParamsDefinitionProto {
   uint64 total_timeout_millis = 8;
 }
 
-// `BundlingConfigProto` defines the bundling configuration for an API method.
-message BundlingConfigProto {
-  // The thresholds which trigger a bundled request to be sent.
-  BundlingSettingsProto thresholds = 1;
+// `BatchingConfigProto` defines the batching configuration for an API method.
+message BatchingConfigProto {
+  // The thresholds which trigger a batched request to be sent.
+  BatchingSettingsProto thresholds = 1;
 
-  // The request and response fields used in bundling.
-  BundlingDescriptorProto bundle_descriptor = 2;
+  // The request and response fields used in batching.
+  BatchingDescriptorProto bundle_descriptor = 2;
 }
 
-// `BundlingSettingsProto` specifies a set of bundling thresholds, each of
-// which acts as a trigger to send a bundle of messages as a request. At least
+// `BatchingSettingsProto` specifies a set of batching thresholds, each of
+// which acts as a trigger to send a batch of messages as a request. At least
 // one threshold must be positive nonzero.
-message BundlingSettingsProto {
-  // The number of elements of a field collected into a bundle which, if
-  // exceeded, causes the bundle to be sent.
+message BatchingSettingsProto {
+  // The number of elements of a field collected into a batch which, if
+  // exceeded, causes the batch to be sent.
   uint32 element_count_threshold = 1;
 
-  // The aggregated size of the bundled field which, if exceeded, causes the
-  // bundle to be sent. This size is computed by aggregating the sizes of the
-  // request field to be bundled, not of the entire request message.
+  // The aggregated size of the batched field which, if exceeded, causes the
+  // batch to be sent. This size is computed by aggregating the sizes of the
+  // request field to be batched, not of the entire request message.
   uint64 request_byte_threshold = 2;
 
-  // The duration, in milliseconds, after which a bundle should be sent,
-  // starting from the addition of the first message to that bundle.
+  // The duration, in milliseconds, after which a batch should be sent,
+  // starting from the addition of the first message to that batch.
   uint64 delay_threshold_millis = 3;
 
-  // The maximum number of elements collected in a bundle that could be accepted by server.
+  // The maximum number of elements collected in a batch that could be accepted by server.
   uint32 element_count_limit = 4;
 
   // The maximum size of the request that could be accepted by server.
@@ -418,21 +418,21 @@ enum FlowControlLimitExceededBehaviorProto {
   IGNORE = 3;
 }
 
-// `BundlingDescriptorProto` specifies the fields of the request message to be
-// used for bundling, and, optionally, the fields of the response message to be
+// `BatchingDescriptorProto` specifies the fields of the request message to be
+// used for batching, and, optionally, the fields of the response message to be
 // used for demultiplexing.
-message BundlingDescriptorProto {
-  // The repeated field in the request message to be aggregated by bundling.
+message BatchingDescriptorProto {
+  // The repeated field in the request message to be aggregated by batching.
   string bundled_field = 1;
 
-  // A list of the fields in the request message. Two requests will be bundled
+  // A list of the fields in the request message. Two requests will be batched
   // together only if the values of every field specified in
   // `request_discriminator_fields` is equal between the two requests.
   repeated string discriminator_fields = 2;
 
   // Optional. When present, indicates the field in the response message to be
   // used to demultiplex the response into multiple response messages, in
-  // correspondence with the multiple request messages originally bundled
+  // correspondence with the multiple request messages originally batched
   // together.
   string subresponse_field = 3;
 }

--- a/src/main/resources/com/google/api/codegen/clientconfig/json.snip
+++ b/src/main/resources/com/google/api/codegen/clientconfig/json.snip
@@ -83,27 +83,27 @@
     @join method : context.getSupportedMethods(service) on ",".add(BREAK)
         @let methodConfig = context.getApiConfig.getInterfaceConfig(service).getMethodConfig(method), \
                 methodName = context.upperCamelToLowerUnderscore(method.getSimpleName), \
-                isBundling = methodConfig.isBundling, \
+                isBatching = methodConfig.isBatching, \
                 timeout = methodConfig.getTimeout.getMillis, \
                 retryCodesName = methodConfig.getRetryCodesConfigName, \
                 retryParamsName = methodConfig.getRetrySettingsConfigName
             "{@method.getSimpleName}": {
-              @if or(and(retryCodesName, retryParamsName), isBundling)
+              @if or(and(retryCodesName, retryParamsName), isBatching)
                 "timeout_millis": {@timeout},
               @else
                 "timeout_millis": {@timeout}
               @end
               @if and(retryCodesName, retryParamsName)
                   "retry_codes_name": "{@retryCodesName}",
-                  @if isBundling
+                  @if isBatching
                       "retry_params_name": "{@retryParamsName}",
                   @else
                       "retry_params_name": "{@retryParamsName}"
                   @end
               @end
-              @if isBundling
+              @if isBatching
                   "bundling": {
-                    @join param : context.entrySet(context.bundlingParams(methodConfig.getBundling)) on ",".add(BREAK)
+                    @join param : context.entrySet(context.batchingParams(methodConfig.getBatching)) on ",".add(BREAK)
                         "{@param.getKey}": {@param.getValue}
                     @end
                   }

--- a/src/main/resources/com/google/api/codegen/java/main.snip
+++ b/src/main/resources/com/google/api/codegen/java/main.snip
@@ -233,7 +233,7 @@
       @case "PagedApiCallable"
         this.{@apiCallable.name} =
             UnaryCallable.createPagedVariant(settings.{@apiCallable.settingsFunctionName}(), this.channel, this.executor);
-      @case "BundlingApiCallable"
+      @case "BatchingApiCallable"
         this.{@apiCallable.name} = UnaryCallable.create(settings.{@apiCallable.settingsFunctionName}(), this.channel, this.executor);
       @case "StreamingApiCallable"
         this.{@apiCallable.name} = StreamingCallable.create(settings.{@apiCallable.settingsFunctionName}(), this.channel);

--- a/src/main/resources/com/google/api/codegen/java/settings.snip
+++ b/src/main/resources/com/google/api/codegen/java/settings.snip
@@ -178,7 +178,7 @@
           {@settings.responseTypeName}, \
           {@settings.pagedListResponseTypeName}> {@settings.memberName};
     @case "BundlingApiCallable"
-      private final BundlingCallSettings<{@settings.requestTypeName}, \
+      private final BatchingCallSettings<{@settings.requestTypeName}, \
           {@settings.responseTypeName}> {@settings.memberName};
     @case "StreamingApiCallable"
       private final StreamingCallSettings<{@settings.requestTypeName}, \
@@ -211,7 +211,7 @@
         return {@settings.memberName};
       }
     @case "BundlingApiCallable"
-      public BundlingCallSettings<{@settings.requestTypeName}, \
+      public BatchingCallSettings<{@settings.requestTypeName}, \
           {@settings.responseTypeName}> {@settings.settingsGetFunction}() {
         return {@settings.memberName};
       }
@@ -247,7 +247,7 @@
 @private descriptors(xsettingsClass)
   {@pageStreamingDescriptors(xsettingsClass)}
   {@pagedListResponseFactories(xsettingsClass)}
-  {@bundlingDescriptors(xsettingsClass)}
+  {@batchingDescriptors(xsettingsClass)}
 @end
 
 @private pageStreamingDescriptors(xsettingsClass)
@@ -313,12 +313,12 @@
   @end
 @end
 
-@private bundlingDescriptors(xsettingsClass)
+@private batchingDescriptors(xsettingsClass)
   @join desc : xsettingsClass.bundlingDescriptors
-    private static final BundlingDescriptor<{@desc.requestTypeName}, {@desc.responseTypeName}> {@desc.name} =
-        new BundlingDescriptor<{@desc.requestTypeName}, {@desc.responseTypeName}>() {
+    private static final BatchingDescriptor<{@desc.requestTypeName}, {@desc.responseTypeName}> {@desc.name} =
+        new BatchingDescriptor<{@desc.requestTypeName}, {@desc.responseTypeName}>() {
           @@Override
-          public String getBundlePartitionKey({@desc.requestTypeName} request) {
+          public String getBatchPartitionKey({@desc.requestTypeName} request) {
             return {@partitionKeyCode(desc)};
           }
 
@@ -343,16 +343,16 @@
 
           @@Override
           public void splitResponse(
-              {@desc.responseTypeName} bundleResponse,
-              Collection<? extends BundledRequestIssuer<{@desc.responseTypeName}>> bundle) {
-            int bundleMessageIndex = 0;
-            for (BundledRequestIssuer<{@desc.responseTypeName}> responder : bundle) {
+              {@desc.responseTypeName} batchResponse,
+              Collection<? extends BatchedRequestIssuer<{@desc.responseTypeName}>> batch) {
+            int batchMessageIndex = 0;
+            for (BatchedRequestIssuer<{@desc.responseTypeName}> responder : batch) {
               @if desc.hasSubresponse
                 {@desc.subresponseTypeName} subresponseElements = new ArrayList<>();
                 long subresponseCount = responder.getMessageCount();
                 for (int i = 0; i < subresponseCount; i++) {
-                  subresponseElements.add(bundleResponse.{@desc.subresponseByIndexGetFunction}(bundleMessageIndex));
-                  bundleMessageIndex += 1;
+                  subresponseElements.add(batchResponse.{@desc.subresponseByIndexGetFunction}(batchMessageIndex));
+                  batchMessageIndex += 1;
                 }
                 {@desc.responseTypeName} response =
                     {@desc.responseTypeName}.newBuilder().{@desc.subresponseSetFunction}(subresponseElements).build();
@@ -367,8 +367,8 @@
           @@Override
           public void splitException(
               Throwable throwable,
-              Collection<? extends BundledRequestIssuer<{@desc.responseTypeName}>> bundle) {
-            for (BundledRequestIssuer<{@desc.responseTypeName}> responder : bundle) {
+              Collection<? extends BatchedRequestIssuer<{@desc.responseTypeName}>> batch) {
+            for (BatchedRequestIssuer<{@desc.responseTypeName}> responder : batch) {
               responder.setException(throwable);
             }
           }
@@ -387,8 +387,8 @@
   @end
 @end
 
-@private partitionKeyCode(bundlingDesc)
-  @join partitionKey : bundlingDesc.partitionKeys on " + "
+@private partitionKeyCode(batchingDesc)
+  @join partitionKey : batchingDesc.partitionKeys on " + "
     request.{@partitionKey.fieldGetFunction}() + {@partitionKey.separatorLiteral}
   @end
 @end
@@ -427,7 +427,7 @@
           {@settings.responseTypeName}, \
           {@settings.pagedListResponseTypeName}> {@settings.memberName};
     @case "BundlingApiCallable"
-      private final BundlingCallSettings.Builder<{@settings.requestTypeName}, \
+      private final BatchingCallSettings.Builder<{@settings.requestTypeName}, \
           {@settings.responseTypeName}> {@settings.memberName};
     @case "StreamingApiCallable"
       private final StreamingCallSettings.Builder<{@settings.requestTypeName}, \
@@ -497,10 +497,10 @@
             {@settings.grpcTypeName}.{@settings.grpcMethodConstant},
             {@settings.pagedListResponseFactoryName});
       @case "BundlingApiCallable"
-        {@settings.memberName} = BundlingCallSettings.newBuilder(
+        {@settings.memberName} = BatchingCallSettings.newBuilder(
             {@settings.grpcTypeName}.{@settings.grpcMethodConstant},
             {@settings.bundlingDescriptorName})
-                .setBundlingSettingsBuilder(BundlingSettings.newBuilder());
+                .setBatchingSettingsBuilder(BatchingSettings.newBuilder());
       @case "StreamingApiCallable"
         {@settings.memberName} = StreamingCallSettings.newBuilder({@settings.grpcTypeName}.{@settings.grpcMethodConstant});
       @case "OperationApiCallable"
@@ -527,10 +527,10 @@
     Builder builder = new Builder();
     @join settings : xsettingsClass.unaryCallSettings
       {@""}
-      # bundling settings
+      # batching settings
       @switch settings.type
       @case "BundlingApiCallable"
-        builder.{@settings.settingsGetFunction}().getBundlingSettingsBuilder()
+        builder.{@settings.settingsGetFunction}().getBatchingSettingsBuilder()
             .setElementCountThreshold({@settings.bundlingConfig.elementCountThreshold})
             .setRequestByteThreshold({@settings.bundlingConfig.requestByteThreshold})
             .setDelayThreshold(Duration.millis({@settings.bundlingConfig.delayThresholdMillis}))
@@ -616,7 +616,7 @@
         return {@settings.memberName};
       }
     @case "BundlingApiCallable"
-      public BundlingCallSettings.Builder<{@settings.requestTypeName}, \
+      public BatchingCallSettings.Builder<{@settings.requestTypeName}, \
           {@settings.responseTypeName}> {@settings.settingsGetFunction}() {
         return {@settings.memberName};
       }

--- a/src/main/resources/com/google/api/codegen/java/settings.snip
+++ b/src/main/resources/com/google/api/codegen/java/settings.snip
@@ -177,7 +177,7 @@
       private final PagedCallSettings<{@settings.requestTypeName}, \
           {@settings.responseTypeName}, \
           {@settings.pagedListResponseTypeName}> {@settings.memberName};
-    @case "BundlingApiCallable"
+    @case "BatchingApiCallable"
       private final BatchingCallSettings<{@settings.requestTypeName}, \
           {@settings.responseTypeName}> {@settings.memberName};
     @case "StreamingApiCallable"
@@ -210,7 +210,7 @@
           {@settings.pagedListResponseTypeName}> {@settings.settingsGetFunction}() {
         return {@settings.memberName};
       }
-    @case "BundlingApiCallable"
+    @case "BatchingApiCallable"
       public BatchingCallSettings<{@settings.requestTypeName}, \
           {@settings.responseTypeName}> {@settings.settingsGetFunction}() {
         return {@settings.memberName};
@@ -314,7 +314,7 @@
 @end
 
 @private batchingDescriptors(xsettingsClass)
-  @join desc : xsettingsClass.bundlingDescriptors
+  @join desc : xsettingsClass.batchingDescriptors
     private static final BatchingDescriptor<{@desc.requestTypeName}, {@desc.responseTypeName}> {@desc.name} =
         new BatchingDescriptor<{@desc.requestTypeName}, {@desc.responseTypeName}>() {
           @@Override
@@ -331,7 +331,7 @@
                 if (builder == null) {
                   builder = request.toBuilder();
                 } else {
-                  builder.{@desc.bundledFieldSetFunction}(request.{@desc.bundledFieldGetFunction}());
+                  builder.{@desc.batchedFieldSetFunction}(request.{@desc.batchedFieldGetFunction}());
                 }
               }
               @@Override
@@ -375,7 +375,7 @@
 
           @@Override
           public long countElements({@desc.requestTypeName} request) {
-            return request.{@desc.bundledFieldCountGetFunction}();
+            return request.{@desc.batchedFieldCountGetFunction}();
           }
 
           @@Override
@@ -426,7 +426,7 @@
       private final PagedCallSettings.Builder<{@settings.requestTypeName}, \
           {@settings.responseTypeName}, \
           {@settings.pagedListResponseTypeName}> {@settings.memberName};
-    @case "BundlingApiCallable"
+    @case "BatchingApiCallable"
       private final BatchingCallSettings.Builder<{@settings.requestTypeName}, \
           {@settings.responseTypeName}> {@settings.memberName};
     @case "StreamingApiCallable"
@@ -496,10 +496,10 @@
         {@settings.memberName} = PagedCallSettings.newBuilder(
             {@settings.grpcTypeName}.{@settings.grpcMethodConstant},
             {@settings.pagedListResponseFactoryName});
-      @case "BundlingApiCallable"
+      @case "BatchingApiCallable"
         {@settings.memberName} = BatchingCallSettings.newBuilder(
             {@settings.grpcTypeName}.{@settings.grpcMethodConstant},
-            {@settings.bundlingDescriptorName})
+            {@settings.batchingDescriptorName})
                 .setBatchingSettingsBuilder(BatchingSettings.newBuilder());
       @case "StreamingApiCallable"
         {@settings.memberName} = StreamingCallSettings.newBuilder({@settings.grpcTypeName}.{@settings.grpcMethodConstant});
@@ -529,20 +529,20 @@
       {@""}
       # batching settings
       @switch settings.type
-      @case "BundlingApiCallable"
+      @case "BatchingApiCallable"
         builder.{@settings.settingsGetFunction}().getBatchingSettingsBuilder()
-            .setElementCountThreshold({@settings.bundlingConfig.elementCountThreshold})
-            .setRequestByteThreshold({@settings.bundlingConfig.requestByteThreshold})
-            .setDelayThreshold(Duration.millis({@settings.bundlingConfig.delayThresholdMillis}))
+            .setElementCountThreshold({@settings.batchingConfig.elementCountThreshold})
+            .setRequestByteThreshold({@settings.batchingConfig.requestByteThreshold})
+            .setDelayThreshold(Duration.millis({@settings.batchingConfig.delayThresholdMillis}))
             .setFlowControlSettings(
               FlowControlSettings.newBuilder()
-                @if settings.bundlingConfig.hasFlowControlElementLimit
-                  .setMaxOutstandingElementCount({@settings.bundlingConfig.flowControlElementLimit})
+                @if settings.batchingConfig.hasFlowControlElementLimit
+                  .setMaxOutstandingElementCount({@settings.batchingConfig.flowControlElementLimit})
                 @end
-                @if settings.bundlingConfig.hasFlowControlByteLimit
-                  .setMaxOutstandingRequestBytes({@settings.bundlingConfig.flowControlByteLimit})
+                @if settings.batchingConfig.hasFlowControlByteLimit
+                  .setMaxOutstandingRequestBytes({@settings.batchingConfig.flowControlByteLimit})
                 @end
-                .setLimitExceededBehavior(LimitExceededBehavior.{@settings.bundlingConfig.flowControlLimitExceededBehavior})
+                .setLimitExceededBehavior(LimitExceededBehavior.{@settings.batchingConfig.flowControlLimitExceededBehavior})
                 .build());
       @default
       @end
@@ -615,7 +615,7 @@
           {@settings.responseTypeName}, {@settings.pagedListResponseTypeName}> {@settings.settingsGetFunction}() {
         return {@settings.memberName};
       }
-    @case "BundlingApiCallable"
+    @case "BatchingApiCallable"
       public BatchingCallSettings.Builder<{@settings.requestTypeName}, \
           {@settings.responseTypeName}> {@settings.settingsGetFunction}() {
         return {@settings.memberName};

--- a/src/main/resources/com/google/api/codegen/nodejs/main.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/main.snip
@@ -261,26 +261,26 @@
         'grpc/' + gaxGrpc.grpcVersion
       );
       @let methods = context.getSupportedMethods(service), \
-           bundlingMethods = context.messages.filterBundlingMethods(ifaceConfig, methods), \
+           batchingMethods = context.messages.filterBatchingMethods(ifaceConfig, methods), \
            longrunningMethods = context.messages.filterLongrunningMethods(ifaceConfig, methods)
-        @if bundlingMethods
+        @if batchingMethods
 
           var bundleDescriptors = {
-            @join method : bundlingMethods on {@", "}.add(BREAK)
-              @let bundling = ifaceConfig.getMethodConfig(method).getBundling()
+            @join method : batchingMethods on {@", "}.add(BREAK)
+              @let batching = ifaceConfig.getMethodConfig(method).getBatching()
                 {@methodName(method)}: new gax.BundleDescriptor(
-                  '{@bundling.getBundledField().getSimpleName()}',
+                  '{@batching.getBatchedField().getSimpleName()}',
                   [
-                    @join fieldSelector : bundling.getDiscriminatorFields() on {@", "}.add(BREAK)
+                    @join fieldSelector : batching.getDiscriminatorFields() on {@", "}.add(BREAK)
                       '{@context.fieldSelectorName(fieldSelector)}'
                     @end
                   ],
-                  @if bundling.hasSubresponseField()
-                    '{@context.propertyName(bundling.getSubresponseField())}',
+                  @if batching.hasSubresponseField()
+                    '{@context.propertyName(batching.getSubresponseField())}',
                   @else
                     null,
                   @end
-                  {@context.getByteLengthFunction(service, method, bundling.getBundledField().getType())})
+                  {@context.getByteLengthFunction(service, method, batching.getBatchedField().getType())})
               @end
             @end
           };

--- a/src/main/resources/com/google/api/codegen/ruby/main.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/main.snip
@@ -95,12 +95,12 @@
 
     private_constant :PAGE_DESCRIPTORS
   @end
-  @if xapiClass.hasBundlingMethods
+  @if xapiClass.hasBatchingMethods
 
     BUNDLE_DESCRIPTORS = {
-      @join descriptor : xapiClass.bundlingDescriptors on {@", "}.add(BREAK)
+      @join descriptor : xapiClass.batchingDescriptors on {@", "}.add(BREAK)
         "{@descriptor.methodName}" => Google::Gax::BundleDescriptor.new(
-          {@bundleDescriptorBody(descriptor)})
+          {@batchDescriptorBody(descriptor)})
       @end
     }.freeze
 
@@ -127,7 +127,7 @@
       client_config,
       Google::Gax::Grpc::STATUS_CODE_NAMES,
       timeout,
-      @if xapiClass.hasBundlingMethods
+      @if xapiClass.hasBatchingMethods
         bundle_descriptors: BUNDLE_DESCRIPTORS,
       @end
       @if xapiClass.hasPageStreamingMethods
@@ -224,8 +224,8 @@
   end
 @end
 
-@private bundleDescriptorBody(descriptor)
-  "{@descriptor.bundledFieldName}",
+@private batchDescriptorBody(descriptor)
+  "{@descriptor.batchedFieldName}",
   [
     @join name : descriptor.discriminatorFieldNames on {@","}.add(BREAK)
       "{@name}"

--- a/src/test/java/com/google/api/codegen/testdata/java_settings_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_settings_library.baseline
@@ -16,17 +16,17 @@
  */
 package com.google.gcloud.pubsub.spi;
 
-import com.google.api.gax.bundling.BundlingSettings;
-import com.google.api.gax.bundling.RequestBuilder;
+import com.google.api.gax.batching.BatchingSettings;
+import com.google.api.gax.batching.RequestBuilder;
 import com.google.api.gax.core.CredentialsProvider;
 import com.google.api.gax.core.FlowControlSettings;
 import com.google.api.gax.core.FlowController;
 import com.google.api.gax.core.FlowController.LimitExceededBehavior;
 import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.RetrySettings;
-import com.google.api.gax.grpc.BundledRequestIssuer;
-import com.google.api.gax.grpc.BundlingCallSettings;
-import com.google.api.gax.grpc.BundlingDescriptor;
+import com.google.api.gax.grpc.BatchedRequestIssuer;
+import com.google.api.gax.grpc.BatchingCallSettings;
+import com.google.api.gax.grpc.BatchingDescriptor;
 import com.google.api.gax.grpc.CallContext;
 import com.google.api.gax.grpc.ChannelProvider;
 import com.google.api.gax.grpc.ClientSettings;
@@ -163,14 +163,14 @@ public class LibrarySettings extends ClientSettings {
   private final SimpleCallSettings<DeleteShelfRequest, Empty> deleteShelfSettings;
   private final SimpleCallSettings<MergeShelvesRequest, Shelf> mergeShelvesSettings;
   private final SimpleCallSettings<CreateBookRequest, Book> createBookSettings;
-  private final BundlingCallSettings<PublishSeriesRequest, PublishSeriesResponse> publishSeriesSettings;
+  private final BatchingCallSettings<PublishSeriesRequest, PublishSeriesResponse> publishSeriesSettings;
   private final SimpleCallSettings<GetBookRequest, Book> getBookSettings;
   private final PagedCallSettings<ListBooksRequest, ListBooksResponse, ListBooksPagedResponse> listBooksSettings;
   private final SimpleCallSettings<DeleteBookRequest, Empty> deleteBookSettings;
   private final SimpleCallSettings<UpdateBookRequest, Book> updateBookSettings;
   private final SimpleCallSettings<MoveBookRequest, Book> moveBookSettings;
   private final PagedCallSettings<ListStringsRequest, ListStringsResponse, ListStringsPagedResponse> listStringsSettings;
-  private final BundlingCallSettings<AddCommentsRequest, Empty> addCommentsSettings;
+  private final BatchingCallSettings<AddCommentsRequest, Empty> addCommentsSettings;
   private final SimpleCallSettings<GetBookFromArchiveRequest, BookFromArchive> getBookFromArchiveSettings;
   private final SimpleCallSettings<GetBookFromAnywhereRequest, BookFromAnywhere> getBookFromAnywhereSettings;
   private final SimpleCallSettings<UpdateBookIndexRequest, Empty> updateBookIndexSettings;
@@ -230,7 +230,7 @@ public class LibrarySettings extends ClientSettings {
   /**
    * Returns the object with the settings used for calls to publishSeries.
    */
-  public BundlingCallSettings<PublishSeriesRequest, PublishSeriesResponse> publishSeriesSettings() {
+  public BatchingCallSettings<PublishSeriesRequest, PublishSeriesResponse> publishSeriesSettings() {
     return publishSeriesSettings;
   }
 
@@ -279,7 +279,7 @@ public class LibrarySettings extends ClientSettings {
   /**
    * Returns the object with the settings used for calls to addComments.
    */
-  public BundlingCallSettings<AddCommentsRequest, Empty> addCommentsSettings() {
+  public BatchingCallSettings<AddCommentsRequest, Empty> addCommentsSettings() {
     return addCommentsSettings;
   }
 
@@ -658,10 +658,10 @@ public class LibrarySettings extends ClientSettings {
         }
       };
 
-  private static final BundlingDescriptor<PublishSeriesRequest, PublishSeriesResponse> PUBLISH_SERIES_BUNDLING_DESC =
-      new BundlingDescriptor<PublishSeriesRequest, PublishSeriesResponse>() {
+  private static final BatchingDescriptor<PublishSeriesRequest, PublishSeriesResponse> PUBLISH_SERIES_BATCHING_DESC =
+      new BatchingDescriptor<PublishSeriesRequest, PublishSeriesResponse>() {
         @Override
-        public String getBundlePartitionKey(PublishSeriesRequest request) {
+        public String getBatchPartitionKey(PublishSeriesRequest request) {
           return request.getEdition() + "|" + request.getName() + "|";
         }
 
@@ -686,15 +686,15 @@ public class LibrarySettings extends ClientSettings {
 
         @Override
         public void splitResponse(
-            PublishSeriesResponse bundleResponse,
-            Collection<? extends BundledRequestIssuer<PublishSeriesResponse>> bundle) {
-          int bundleMessageIndex = 0;
-          for (BundledRequestIssuer<PublishSeriesResponse> responder : bundle) {
+            PublishSeriesResponse batchResponse,
+            Collection<? extends BatchedRequestIssuer<PublishSeriesResponse>> batch) {
+          int batchMessageIndex = 0;
+          for (BatchedRequestIssuer<PublishSeriesResponse> responder : batch) {
             List<String> subresponseElements = new ArrayList<>();
             long subresponseCount = responder.getMessageCount();
             for (int i = 0; i < subresponseCount; i++) {
-              subresponseElements.add(bundleResponse.getBookNames(bundleMessageIndex));
-              bundleMessageIndex += 1;
+              subresponseElements.add(batchResponse.getBookNames(batchMessageIndex));
+              batchMessageIndex += 1;
             }
             PublishSeriesResponse response =
                 PublishSeriesResponse.newBuilder().addAllBookNames(subresponseElements).build();
@@ -705,8 +705,8 @@ public class LibrarySettings extends ClientSettings {
         @Override
         public void splitException(
             Throwable throwable,
-            Collection<? extends BundledRequestIssuer<PublishSeriesResponse>> bundle) {
-          for (BundledRequestIssuer<PublishSeriesResponse> responder : bundle) {
+            Collection<? extends BatchedRequestIssuer<PublishSeriesResponse>> batch) {
+          for (BatchedRequestIssuer<PublishSeriesResponse> responder : batch) {
             responder.setException(throwable);
           }
         }
@@ -722,10 +722,10 @@ public class LibrarySettings extends ClientSettings {
         }
       };
 
-  private static final BundlingDescriptor<AddCommentsRequest, Empty> ADD_COMMENTS_BUNDLING_DESC =
-      new BundlingDescriptor<AddCommentsRequest, Empty>() {
+  private static final BatchingDescriptor<AddCommentsRequest, Empty> ADD_COMMENTS_BATCHING_DESC =
+      new BatchingDescriptor<AddCommentsRequest, Empty>() {
         @Override
-        public String getBundlePartitionKey(AddCommentsRequest request) {
+        public String getBatchPartitionKey(AddCommentsRequest request) {
           return request.getName() + "|";
         }
 
@@ -750,10 +750,10 @@ public class LibrarySettings extends ClientSettings {
 
         @Override
         public void splitResponse(
-            Empty bundleResponse,
-            Collection<? extends BundledRequestIssuer<Empty>> bundle) {
-          int bundleMessageIndex = 0;
-          for (BundledRequestIssuer<Empty> responder : bundle) {
+            Empty batchResponse,
+            Collection<? extends BatchedRequestIssuer<Empty>> batch) {
+          int batchMessageIndex = 0;
+          for (BatchedRequestIssuer<Empty> responder : batch) {
             Empty response =
                 Empty.newBuilder().build();
             responder.setResponse(response);
@@ -763,8 +763,8 @@ public class LibrarySettings extends ClientSettings {
         @Override
         public void splitException(
             Throwable throwable,
-            Collection<? extends BundledRequestIssuer<Empty>> bundle) {
-          for (BundledRequestIssuer<Empty> responder : bundle) {
+            Collection<? extends BatchedRequestIssuer<Empty>> batch) {
+          for (BatchedRequestIssuer<Empty> responder : batch) {
             responder.setException(throwable);
           }
         }
@@ -792,14 +792,14 @@ public class LibrarySettings extends ClientSettings {
     private final SimpleCallSettings.Builder<DeleteShelfRequest, Empty> deleteShelfSettings;
     private final SimpleCallSettings.Builder<MergeShelvesRequest, Shelf> mergeShelvesSettings;
     private final SimpleCallSettings.Builder<CreateBookRequest, Book> createBookSettings;
-    private final BundlingCallSettings.Builder<PublishSeriesRequest, PublishSeriesResponse> publishSeriesSettings;
+    private final BatchingCallSettings.Builder<PublishSeriesRequest, PublishSeriesResponse> publishSeriesSettings;
     private final SimpleCallSettings.Builder<GetBookRequest, Book> getBookSettings;
     private final PagedCallSettings.Builder<ListBooksRequest, ListBooksResponse, ListBooksPagedResponse> listBooksSettings;
     private final SimpleCallSettings.Builder<DeleteBookRequest, Empty> deleteBookSettings;
     private final SimpleCallSettings.Builder<UpdateBookRequest, Book> updateBookSettings;
     private final SimpleCallSettings.Builder<MoveBookRequest, Book> moveBookSettings;
     private final PagedCallSettings.Builder<ListStringsRequest, ListStringsResponse, ListStringsPagedResponse> listStringsSettings;
-    private final BundlingCallSettings.Builder<AddCommentsRequest, Empty> addCommentsSettings;
+    private final BatchingCallSettings.Builder<AddCommentsRequest, Empty> addCommentsSettings;
     private final SimpleCallSettings.Builder<GetBookFromArchiveRequest, BookFromArchive> getBookFromArchiveSettings;
     private final SimpleCallSettings.Builder<GetBookFromAnywhereRequest, BookFromAnywhere> getBookFromAnywhereSettings;
     private final SimpleCallSettings.Builder<UpdateBookIndexRequest, Empty> updateBookIndexSettings;
@@ -861,10 +861,10 @@ public class LibrarySettings extends ClientSettings {
 
       createBookSettings = SimpleCallSettings.newBuilder(LibraryServiceGrpc.METHOD_CREATE_BOOK);
 
-      publishSeriesSettings = BundlingCallSettings.newBuilder(
+      publishSeriesSettings = BatchingCallSettings.newBuilder(
           LibraryServiceGrpc.METHOD_PUBLISH_SERIES,
-          PUBLISH_SERIES_BUNDLING_DESC)
-              .setBundlingSettingsBuilder(BundlingSettings.newBuilder());
+          PUBLISH_SERIES_BATCHING_DESC)
+              .setBatchingSettingsBuilder(BatchingSettings.newBuilder());
 
       getBookSettings = SimpleCallSettings.newBuilder(LibraryServiceGrpc.METHOD_GET_BOOK);
 
@@ -882,10 +882,10 @@ public class LibrarySettings extends ClientSettings {
           LibraryServiceGrpc.METHOD_LIST_STRINGS,
           LIST_STRINGS_PAGE_STR_FACT);
 
-      addCommentsSettings = BundlingCallSettings.newBuilder(
+      addCommentsSettings = BatchingCallSettings.newBuilder(
           LibraryServiceGrpc.METHOD_ADD_COMMENTS,
-          ADD_COMMENTS_BUNDLING_DESC)
-              .setBundlingSettingsBuilder(BundlingSettings.newBuilder());
+          ADD_COMMENTS_BATCHING_DESC)
+              .setBatchingSettingsBuilder(BatchingSettings.newBuilder());
 
       getBookFromArchiveSettings = SimpleCallSettings.newBuilder(LibraryServiceGrpc.METHOD_GET_BOOK_FROM_ARCHIVE);
 
@@ -974,7 +974,7 @@ public class LibrarySettings extends ClientSettings {
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("non_idempotent"))
           .setRetrySettingsBuilder(RETRY_PARAM_DEFINITIONS.get("default"));
 
-      builder.publishSeriesSettings().getBundlingSettingsBuilder()
+      builder.publishSeriesSettings().getBatchingSettingsBuilder()
           .setElementCountThreshold(6)
           .setRequestByteThreshold(100000)
           .setDelayThreshold(Duration.millis(500))
@@ -1010,7 +1010,7 @@ public class LibrarySettings extends ClientSettings {
           .setRetryableCodes(RETRYABLE_CODE_DEFINITIONS.get("idempotent"))
           .setRetrySettingsBuilder(RETRY_PARAM_DEFINITIONS.get("default"));
 
-      builder.addCommentsSettings().getBundlingSettingsBuilder()
+      builder.addCommentsSettings().getBatchingSettingsBuilder()
           .setElementCountThreshold(6)
           .setRequestByteThreshold(100000)
           .setDelayThreshold(Duration.millis(500))
@@ -1184,7 +1184,7 @@ public class LibrarySettings extends ClientSettings {
     /**
      * Returns the builder for the settings used for calls to publishSeries.
      */
-    public BundlingCallSettings.Builder<PublishSeriesRequest, PublishSeriesResponse> publishSeriesSettings() {
+    public BatchingCallSettings.Builder<PublishSeriesRequest, PublishSeriesResponse> publishSeriesSettings() {
       return publishSeriesSettings;
     }
 
@@ -1233,7 +1233,7 @@ public class LibrarySettings extends ClientSettings {
     /**
      * Returns the builder for the settings used for calls to addComments.
      */
-    public BundlingCallSettings.Builder<AddCommentsRequest, Empty> addCommentsSettings() {
+    public BatchingCallSettings.Builder<AddCommentsRequest, Empty> addCommentsSettings() {
       return addCommentsSettings;
     }
 

--- a/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testdata/library_gapic.yaml
@@ -205,15 +205,15 @@ interfaces:
     retry_codes_name: non_idempotent
     retry_params_name: default
     timeout_millis: 7000
-    bundling:
+    batching:
       thresholds:
         element_count_threshold: 6
         element_count_limit: 7
         request_byte_threshold: 100000
         request_byte_limit: 150000
         delay_threshold_millis: 500
-      bundle_descriptor:
-        bundled_field: books
+      batch_descriptor:
+        batched_field: books
         discriminator_fields:
           - edition
           - shelf.name
@@ -345,14 +345,14 @@ interfaces:
     retry_codes_name: non_idempotent
     retry_params_name: default
     timeout_millis: 10000
-    # Test bundling with minimal settings (no flow control)
-    bundling:
+    # Test batching with minimal settings (no flow control)
+    batching:
       thresholds:
         element_count_threshold: 6
         request_byte_threshold: 100000
         delay_threshold_millis: 500
-      bundle_descriptor:
-        bundled_field: comments
+      batch_descriptor:
+        batched_field: comments
         discriminator_fields:
           - name
     request_object_method: true


### PR DESCRIPTION
This PR contains 3 commits, which perform the bundling->batching rename in stages:
- Update the Java surface only, not changing shared code
- Update shared code, but no changes that affect GAPIC yamls
- Update config proto, which changes the bundling/batching settings

Baselines for all other languages are unchanged. The corresponding googleapis PR is here: https://github.com/googleapis/googleapis/pull/294