### PR TITLE
Ruby: Add updater-proc as a constructor param.

### DIFF
--- a/src/main/resources/com/google/api/codegen/ruby/main.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/main.snip
@@ -148,6 +148,12 @@
   @#   A Channel object through which to make calls.
   @# @@param chan_creds [Grpc::ChannelCredentials]
   @#   A ChannelCredentials for the setting up the RPC client.
+  @# @@param updater_proc [Proc]
+  @#   A function that transforms the metadata for requests, e.g., to give
+  @#   OAuth credentials.
+  @# @@param scopes [Array<String>]
+  @#   The OAuth scopes for this service. This parameter is ignored if
+  @#   an updater_proc is supplied.
   @# @@param client_config[Hash]
   @#   A Hash for call options for each method. See
   @#   Google::Gax#construct_settings for the structure of
@@ -160,6 +166,7 @@
       port: DEFAULT_SERVICE_PORT,
       channel: nil,
       chan_creds: nil,
+      updater_proc: nil,
       scopes: ALL_SCOPES,
       client_config: {},
       timeout: DEFAULT_TIMEOUT,
@@ -180,6 +187,7 @@
         port: port,
         channel: channel,
         chan_creds: chan_creds,
+        updater_proc: updater_proc,
         scopes: scopes,
         client_config: client_config,
         timeout: timeout,
@@ -208,6 +216,7 @@
         port,
         chan_creds: chan_creds,
         channel: channel,
+        updater_proc: updater_proc,
         scopes: scopes,
         &{@stub.fullyQualifiedType}.method(:new)
       )

--- a/src/test/java/com/google/api/codegen/testdata/ruby_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_doc_main_library.baseline
@@ -211,6 +211,12 @@ module Library
       #   A Channel object through which to make calls.
       # @param chan_creds [Grpc::ChannelCredentials]
       #   A ChannelCredentials for the setting up the RPC client.
+      # @param updater_proc [Proc]
+      #   A function that transforms the metadata for requests, e.g., to give
+      #   OAuth credentials.
+      # @param scopes [Array<String>]
+      #   The OAuth scopes for this service. This parameter is ignored if
+      #   an updater_proc is supplied.
       # @param client_config[Hash]
       #   A Hash for call options for each method. See
       #   Google::Gax#construct_settings for the structure of
@@ -223,6 +229,7 @@ module Library
           port: DEFAULT_SERVICE_PORT,
           channel: nil,
           chan_creds: nil,
+          updater_proc: nil,
           scopes: ALL_SCOPES,
           client_config: {},
           timeout: DEFAULT_TIMEOUT,
@@ -242,6 +249,7 @@ module Library
           port: port,
           channel: channel,
           chan_creds: chan_creds,
+          updater_proc: updater_proc,
           scopes: scopes,
           client_config: client_config,
           timeout: timeout,
@@ -283,6 +291,7 @@ module Library
           port,
           chan_creds: chan_creds,
           channel: channel,
+          updater_proc: updater_proc,
           scopes: scopes,
           &Google::Example::Library::V1::LibraryService::Stub.method(:new)
         )
@@ -291,6 +300,7 @@ module Library
           port,
           chan_creds: chan_creds,
           channel: channel,
+          updater_proc: updater_proc,
           scopes: scopes,
           &Google::Tagger::V1::Labeler::Stub.method(:new)
         )

--- a/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
@@ -211,6 +211,12 @@ module Library
       #   A Channel object through which to make calls.
       # @param chan_creds [Grpc::ChannelCredentials]
       #   A ChannelCredentials for the setting up the RPC client.
+      # @param updater_proc [Proc]
+      #   A function that transforms the metadata for requests, e.g., to give
+      #   OAuth credentials.
+      # @param scopes [Array<String>]
+      #   The OAuth scopes for this service. This parameter is ignored if
+      #   an updater_proc is supplied.
       # @param client_config[Hash]
       #   A Hash for call options for each method. See
       #   Google::Gax#construct_settings for the structure of
@@ -223,6 +229,7 @@ module Library
           port: DEFAULT_SERVICE_PORT,
           channel: nil,
           chan_creds: nil,
+          updater_proc: nil,
           scopes: ALL_SCOPES,
           client_config: {},
           timeout: DEFAULT_TIMEOUT,
@@ -242,6 +249,7 @@ module Library
           port: port,
           channel: channel,
           chan_creds: chan_creds,
+          updater_proc: updater_proc,
           scopes: scopes,
           client_config: client_config,
           timeout: timeout,
@@ -283,6 +291,7 @@ module Library
           port,
           chan_creds: chan_creds,
           channel: channel,
+          updater_proc: updater_proc,
           scopes: scopes,
           &Google::Example::Library::V1::LibraryService::Stub.method(:new)
         )
@@ -291,6 +300,7 @@ module Library
           port,
           chan_creds: chan_creds,
           channel: channel,
+          updater_proc: updater_proc,
           scopes: scopes,
           &Google::Tagger::V1::Labeler::Stub.method(:new)
         )


### PR DESCRIPTION
This will allow users to specify an updater proc to transform metadata for requests. There has been requests for this in order to allow users to add authentication parameters to their requests.