### PR TITLE
Pretty print responses in C# discovery samplegen

### DIFF
--- a/src/main/java/com/google/api/codegen/discovery/transformer/csharp/CSharpSampleMethodToViewTransformer.java
+++ b/src/main/java/com/google/api/codegen/discovery/transformer/csharp/CSharpSampleMethodToViewTransformer.java
@@ -238,5 +238,6 @@ public class CSharpSampleMethodToViewTransformer implements SampleMethodToViewTr
 
   private void addStaticImports(SampleTransformerContext context) {
     context.getSampleTypeTable().saveNicknameFor("Google.Apis.Services.BaseClientService");
+    context.getSampleTypeTable().saveNicknameFor("Newtonsoft.Json.JsonConvert");
   }
 }

--- a/src/main/resources/com/google/api/codegen/csharp/sample.snip
+++ b/src/main/resources/com/google/api/codegen/csharp/sample.snip
@@ -124,18 +124,18 @@
                         foreach ({@class.pageStreaming.resourceElementTypeName} {@class.pageStreaming.resourceVarName} in response.{@class.pageStreaming.resourceFieldName})
                         {
                             // TODO: Change code below to process each `{@class.pageStreaming.resourceVarName}` element:
-                            Console.WriteLine("[" + {@class.pageStreaming.resourceVarName}.Key + "] = " + {@class.pageStreaming.resourceVarName}.Value);
+                            Console.WriteLine(JsonConvert.SerializeObject({@class.pageStreaming.resourceVarName}));
                         }
                     @else
                         foreach ({@class.pageStreaming.resourceElementTypeName} {@class.pageStreaming.resourceVarName} in response.{@class.pageStreaming.resourceFieldName})
                         {
                             // TODO: Change code below to process each `{@class.pageStreaming.resourceVarName}` resource:
-                            Console.WriteLine({@class.pageStreaming.resourceVarName});
+                            Console.WriteLine(JsonConvert.SerializeObject({@class.pageStreaming.resourceVarName}));
                         }
                     @end
                 @else
                     // TODO: Change code below to process each `response.{@class.pageStreaming.resourceFieldName}` resource:
-                    Console.WriteLine(response.{@class.pageStreaming.resourceFieldName});
+                    Console.WriteLine(JsonConvert.SerializeObject(response.{@class.pageStreaming.resourceFieldName}));
 
                 @end
                 @if class.pageStreaming.isResourceSetterInRequestBody
@@ -151,7 +151,7 @@
                 // {@class.responseTypeName} {@class.responseVarName} = await {@class.requestVarName}.ExecuteAsync();
 
                 // TODO: Change code below to process the `response` object:
-                Console.WriteLine({@class.responseVarName});
+                Console.WriteLine(JsonConvert.SerializeObject({@class.responseVarName}));
             @else
                 // To execute asynchronously in an async method, replace `{@class.requestVarName}.Execute()` as shown:
                 {@class.requestVarName}.Execute();

--- a/src/main/resources/com/google/api/codegen/csharp/sample.snip
+++ b/src/main/resources/com/google/api/codegen/csharp/sample.snip
@@ -124,7 +124,7 @@
                         foreach ({@class.pageStreaming.resourceElementTypeName} {@class.pageStreaming.resourceVarName} in response.{@class.pageStreaming.resourceFieldName})
                         {
                             // TODO: Change code below to process each `{@class.pageStreaming.resourceVarName}` element:
-                            Console.WriteLine(JsonConvert.SerializeObject({@class.pageStreaming.resourceVarName}));
+                            Console.WriteLine("[" + {@class.pageStreaming.resourceVarName}.Key + "] = " + JsonConvert.SerializeObject({@class.pageStreaming.resourceVarName}.Value));
                         }
                     @else
                         foreach ({@class.pageStreaming.resourceElementTypeName} {@class.pageStreaming.resourceVarName} in response.{@class.pageStreaming.resourceFieldName})

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_adexchangebuyer.v1.4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_adexchangebuyer.v1.4.json.baseline
@@ -11,6 +11,7 @@
 using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
@@ -37,7 +38,7 @@ namespace AdExchangeBuyerSample
             // Data.Account response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -63,6 +64,7 @@ namespace AdExchangeBuyerSample
 using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
@@ -86,7 +88,7 @@ namespace AdExchangeBuyerSample
             // Data.AccountsList response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -112,6 +114,7 @@ namespace AdExchangeBuyerSample
 using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
@@ -142,7 +145,7 @@ namespace AdExchangeBuyerSample
             // Data.Account response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -168,6 +171,7 @@ namespace AdExchangeBuyerSample
 using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
@@ -198,7 +202,7 @@ namespace AdExchangeBuyerSample
             // Data.Account response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -224,6 +228,7 @@ namespace AdExchangeBuyerSample
 using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
@@ -250,7 +255,7 @@ namespace AdExchangeBuyerSample
             // Data.BillingInfo response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -276,6 +281,7 @@ namespace AdExchangeBuyerSample
 using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
@@ -299,7 +305,7 @@ namespace AdExchangeBuyerSample
             // Data.BillingInfoList response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -325,6 +331,7 @@ namespace AdExchangeBuyerSample
 using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
@@ -354,7 +361,7 @@ namespace AdExchangeBuyerSample
             // Data.Budget response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -380,6 +387,7 @@ namespace AdExchangeBuyerSample
 using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
@@ -413,7 +421,7 @@ namespace AdExchangeBuyerSample
             // Data.Budget response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -439,6 +447,7 @@ namespace AdExchangeBuyerSample
 using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
@@ -472,7 +481,7 @@ namespace AdExchangeBuyerSample
             // Data.Budget response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -498,6 +507,7 @@ namespace AdExchangeBuyerSample
 using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 
 namespace AdExchangeBuyerSample
 {
@@ -550,6 +560,7 @@ namespace AdExchangeBuyerSample
 using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
@@ -579,7 +590,7 @@ namespace AdExchangeBuyerSample
             // Data.Creative response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -605,6 +616,7 @@ namespace AdExchangeBuyerSample
 using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
@@ -631,7 +643,7 @@ namespace AdExchangeBuyerSample
             // Data.Creative response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -657,6 +669,7 @@ namespace AdExchangeBuyerSample
 using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
@@ -689,7 +702,7 @@ namespace AdExchangeBuyerSample
                 foreach (Data.Creative creative in response.Items)
                 {
                     // TODO: Change code below to process each `creative` resource:
-                    Console.WriteLine(creative);
+                    Console.WriteLine(JsonConvert.SerializeObject(creative));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -718,6 +731,7 @@ namespace AdExchangeBuyerSample
 using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
@@ -747,7 +761,7 @@ namespace AdExchangeBuyerSample
             // Data.CreativeDealIds response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -773,6 +787,7 @@ namespace AdExchangeBuyerSample
 using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 
 namespace AdExchangeBuyerSample
 {
@@ -825,6 +840,7 @@ namespace AdExchangeBuyerSample
 using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
@@ -854,7 +870,7 @@ namespace AdExchangeBuyerSample
             // Data.DeleteOrderDealsResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -880,6 +896,7 @@ namespace AdExchangeBuyerSample
 using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
@@ -909,7 +926,7 @@ namespace AdExchangeBuyerSample
             // Data.AddOrderDealsResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -935,6 +952,7 @@ namespace AdExchangeBuyerSample
 using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
@@ -962,7 +980,7 @@ namespace AdExchangeBuyerSample
             // Data.GetOrderDealsResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -988,6 +1006,7 @@ namespace AdExchangeBuyerSample
 using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
@@ -1017,7 +1036,7 @@ namespace AdExchangeBuyerSample
             // Data.EditAllOrderDealsResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -1043,6 +1062,7 @@ namespace AdExchangeBuyerSample
 using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
@@ -1072,7 +1092,7 @@ namespace AdExchangeBuyerSample
             // Data.AddOrderNotesResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -1098,6 +1118,7 @@ namespace AdExchangeBuyerSample
 using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
@@ -1125,7 +1146,7 @@ namespace AdExchangeBuyerSample
             // Data.GetOrderNotesResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -1151,6 +1172,7 @@ namespace AdExchangeBuyerSample
 using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
 
@@ -1202,6 +1224,7 @@ namespace AdExchangeBuyerSample
 using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
@@ -1234,7 +1257,7 @@ namespace AdExchangeBuyerSample
             // Data.PerformanceReportList response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -1260,6 +1283,7 @@ namespace AdExchangeBuyerSample
 using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 
 namespace AdExchangeBuyerSample
 {
@@ -1309,6 +1333,7 @@ namespace AdExchangeBuyerSample
 using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
@@ -1338,7 +1363,7 @@ namespace AdExchangeBuyerSample
             // Data.PretargetingConfig response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -1364,6 +1389,7 @@ namespace AdExchangeBuyerSample
 using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
@@ -1393,7 +1419,7 @@ namespace AdExchangeBuyerSample
             // Data.PretargetingConfig response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -1419,6 +1445,7 @@ namespace AdExchangeBuyerSample
 using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
@@ -1445,7 +1472,7 @@ namespace AdExchangeBuyerSample
             // Data.PretargetingConfigList response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -1471,6 +1498,7 @@ namespace AdExchangeBuyerSample
 using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
@@ -1504,7 +1532,7 @@ namespace AdExchangeBuyerSample
             // Data.PretargetingConfig response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -1530,6 +1558,7 @@ namespace AdExchangeBuyerSample
 using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
@@ -1563,7 +1592,7 @@ namespace AdExchangeBuyerSample
             // Data.PretargetingConfig response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -1589,6 +1618,7 @@ namespace AdExchangeBuyerSample
 using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
@@ -1615,7 +1645,7 @@ namespace AdExchangeBuyerSample
             // Data.Product response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -1641,6 +1671,7 @@ namespace AdExchangeBuyerSample
 using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
@@ -1664,7 +1695,7 @@ namespace AdExchangeBuyerSample
             // Data.GetOffersResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -1690,6 +1721,7 @@ namespace AdExchangeBuyerSample
 using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
@@ -1716,7 +1748,7 @@ namespace AdExchangeBuyerSample
             // Data.Proposal response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -1742,6 +1774,7 @@ namespace AdExchangeBuyerSample
 using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
@@ -1768,7 +1801,7 @@ namespace AdExchangeBuyerSample
             // Data.CreateOrdersResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -1794,6 +1827,7 @@ namespace AdExchangeBuyerSample
 using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
@@ -1833,7 +1867,7 @@ namespace AdExchangeBuyerSample
             // Data.Proposal response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -1859,6 +1893,7 @@ namespace AdExchangeBuyerSample
 using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
@@ -1882,7 +1917,7 @@ namespace AdExchangeBuyerSample
             // Data.GetOrdersResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -1908,6 +1943,7 @@ namespace AdExchangeBuyerSample
 using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 
 namespace AdExchangeBuyerSample
 {
@@ -1954,6 +1990,7 @@ namespace AdExchangeBuyerSample
 using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
@@ -1993,7 +2030,7 @@ namespace AdExchangeBuyerSample
             // Data.Proposal response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -2019,6 +2056,7 @@ namespace AdExchangeBuyerSample
 using Google.Apis.AdExchangeBuyer.v1_4;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.AdExchangeBuyer.v1_4.Data;
@@ -2045,7 +2083,7 @@ namespace AdExchangeBuyerSample
             // Data.GetPublisherProfilesByAccountIdResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_appengine.v1beta5.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_appengine.v1beta5.json.baseline
@@ -17,6 +17,7 @@
 using Google.Apis.Appengine.v1beta5;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -44,7 +45,7 @@ namespace AppengineSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -76,6 +77,7 @@ namespace AppengineSample
 using Google.Apis.Appengine.v1beta5;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -103,7 +105,7 @@ namespace AppengineSample
             // Data.Application response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -135,6 +137,7 @@ namespace AppengineSample
 using Google.Apis.Appengine.v1beta5;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -165,7 +168,7 @@ namespace AppengineSample
             // Data.Location response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -197,6 +200,7 @@ namespace AppengineSample
 using Google.Apis.Appengine.v1beta5;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -233,7 +237,7 @@ namespace AppengineSample
                 foreach (Data.Location location in response.Locations)
                 {
                     // TODO: Change code below to process each `location` resource:
-                    Console.WriteLine(location);
+                    Console.WriteLine(JsonConvert.SerializeObject(location));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -268,6 +272,7 @@ namespace AppengineSample
 using Google.Apis.Appengine.v1beta5;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -298,7 +303,7 @@ namespace AppengineSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -330,6 +335,7 @@ namespace AppengineSample
 using Google.Apis.Appengine.v1beta5;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -366,7 +372,7 @@ namespace AppengineSample
                 foreach (Data.Operation operation in response.Operations)
                 {
                     // TODO: Change code below to process each `operation` resource:
-                    Console.WriteLine(operation);
+                    Console.WriteLine(JsonConvert.SerializeObject(operation));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -401,6 +407,7 @@ namespace AppengineSample
 using Google.Apis.Appengine.v1beta5;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -432,7 +439,7 @@ namespace AppengineSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -464,6 +471,7 @@ namespace AppengineSample
 using Google.Apis.Appengine.v1beta5;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -494,7 +502,7 @@ namespace AppengineSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -526,6 +534,7 @@ namespace AppengineSample
 using Google.Apis.Appengine.v1beta5;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -556,7 +565,7 @@ namespace AppengineSample
             // Data.Service response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -588,6 +597,7 @@ namespace AppengineSample
 using Google.Apis.Appengine.v1beta5;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -624,7 +634,7 @@ namespace AppengineSample
                 foreach (Data.Service service in response.Services)
                 {
                     // TODO: Change code below to process each `service` resource:
-                    Console.WriteLine(service);
+                    Console.WriteLine(JsonConvert.SerializeObject(service));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -659,6 +669,7 @@ namespace AppengineSample
 using Google.Apis.Appengine.v1beta5;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -693,7 +704,7 @@ namespace AppengineSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -725,6 +736,7 @@ namespace AppengineSample
 using Google.Apis.Appengine.v1beta5;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -758,7 +770,7 @@ namespace AppengineSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -790,6 +802,7 @@ namespace AppengineSample
 using Google.Apis.Appengine.v1beta5;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -823,7 +836,7 @@ namespace AppengineSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -855,6 +868,7 @@ namespace AppengineSample
 using Google.Apis.Appengine.v1beta5;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -888,7 +902,7 @@ namespace AppengineSample
             // Data.Version response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -920,6 +934,7 @@ namespace AppengineSample
 using Google.Apis.Appengine.v1beta5;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -960,7 +975,7 @@ namespace AppengineSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -992,6 +1007,7 @@ namespace AppengineSample
 using Google.Apis.Appengine.v1beta5;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1029,7 +1045,7 @@ namespace AppengineSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1061,6 +1077,7 @@ namespace AppengineSample
 using Google.Apis.Appengine.v1beta5;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1098,7 +1115,7 @@ namespace AppengineSample
             // Data.Instance response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1130,6 +1147,7 @@ namespace AppengineSample
 using Google.Apis.Appengine.v1beta5;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1172,7 +1190,7 @@ namespace AppengineSample
                 foreach (Data.Instance instance in response.Instances)
                 {
                     // TODO: Change code below to process each `instance` resource:
-                    Console.WriteLine(instance);
+                    Console.WriteLine(JsonConvert.SerializeObject(instance));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -1207,6 +1225,7 @@ namespace AppengineSample
 using Google.Apis.Appengine.v1beta5;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1246,7 +1265,7 @@ namespace AppengineSample
                 foreach (Data.Version version in response.Versions)
                 {
                     // TODO: Change code below to process each `version` resource:
-                    Console.WriteLine(version);
+                    Console.WriteLine(JsonConvert.SerializeObject(version));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -1281,6 +1300,7 @@ namespace AppengineSample
 using Google.Apis.Appengine.v1beta5;
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1318,7 +1338,7 @@ namespace AppengineSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_bigquery.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_bigquery.v2.json.baseline
@@ -17,6 +17,7 @@
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Bigquery.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System.Threading.Tasks;
 
 namespace BigquerySample
@@ -73,6 +74,7 @@ namespace BigquerySample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Bigquery.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -103,7 +105,7 @@ namespace BigquerySample
             // Data.Dataset response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -135,6 +137,7 @@ namespace BigquerySample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Bigquery.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -165,7 +168,7 @@ namespace BigquerySample
             // Data.Dataset response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -197,6 +200,7 @@ namespace BigquerySample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Bigquery.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -233,7 +237,7 @@ namespace BigquerySample
                 foreach (Data.DatasetList.DatasetsData datasetsData in response.Datasets)
                 {
                     // TODO: Change code below to process each `datasetsData` resource:
-                    Console.WriteLine(datasetsData);
+                    Console.WriteLine(JsonConvert.SerializeObject(datasetsData));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -268,6 +272,7 @@ namespace BigquerySample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Bigquery.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -302,7 +307,7 @@ namespace BigquerySample
             // Data.Dataset response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -334,6 +339,7 @@ namespace BigquerySample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Bigquery.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -368,7 +374,7 @@ namespace BigquerySample
             // Data.Dataset response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -400,6 +406,7 @@ namespace BigquerySample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Bigquery.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -430,7 +437,7 @@ namespace BigquerySample
             // Data.JobCancelResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -462,6 +469,7 @@ namespace BigquerySample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Bigquery.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -492,7 +500,7 @@ namespace BigquerySample
             // Data.Job response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -524,6 +532,7 @@ namespace BigquerySample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Bigquery.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -563,7 +572,7 @@ namespace BigquerySample
                 foreach (Data.ErrorProto errorProto in response.Errors)
                 {
                     // TODO: Change code below to process each `errorProto` resource:
-                    Console.WriteLine(errorProto);
+                    Console.WriteLine(JsonConvert.SerializeObject(errorProto));
                 }
                 request.PageToken = response.PageToken;
             } while (response.PageToken != null);
@@ -598,6 +607,7 @@ namespace BigquerySample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Bigquery.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -631,7 +641,7 @@ namespace BigquerySample
             // Data.Job response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -663,6 +673,7 @@ namespace BigquerySample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Bigquery.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -699,7 +710,7 @@ namespace BigquerySample
                 foreach (Data.JobList.JobsData jobsData in response.Jobs)
                 {
                     // TODO: Change code below to process each `jobsData` resource:
-                    Console.WriteLine(jobsData);
+                    Console.WriteLine(JsonConvert.SerializeObject(jobsData));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -734,6 +745,7 @@ namespace BigquerySample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Bigquery.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -764,7 +776,7 @@ namespace BigquerySample
             // Data.QueryResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -796,6 +808,7 @@ namespace BigquerySample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Bigquery.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -829,7 +842,7 @@ namespace BigquerySample
                 foreach (Data.ProjectList.ProjectsData projectsData in response.Projects)
                 {
                     // TODO: Change code below to process each `projectsData` resource:
-                    Console.WriteLine(projectsData);
+                    Console.WriteLine(JsonConvert.SerializeObject(projectsData));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -864,6 +877,7 @@ namespace BigquerySample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Bigquery.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -900,7 +914,7 @@ namespace BigquerySample
             // Data.TableDataInsertAllResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -932,6 +946,7 @@ namespace BigquerySample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Bigquery.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -974,7 +989,7 @@ namespace BigquerySample
                 foreach (Data.TableRow tableRow in response.Rows)
                 {
                     // TODO: Change code below to process each `tableRow` resource:
-                    Console.WriteLine(tableRow);
+                    Console.WriteLine(JsonConvert.SerializeObject(tableRow));
                 }
                 request.PageToken = response.PageToken;
             } while (response.PageToken != null);
@@ -1009,6 +1024,7 @@ namespace BigquerySample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Bigquery.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System.Threading.Tasks;
 
 namespace BigquerySample
@@ -1068,6 +1084,7 @@ namespace BigquerySample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Bigquery.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1101,7 +1118,7 @@ namespace BigquerySample
             // Data.Table response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1133,6 +1150,7 @@ namespace BigquerySample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Bigquery.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1166,7 +1184,7 @@ namespace BigquerySample
             // Data.Table response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1198,6 +1216,7 @@ namespace BigquerySample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Bigquery.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1237,7 +1256,7 @@ namespace BigquerySample
                 foreach (Data.TableList.TablesData tablesData in response.Tables)
                 {
                     // TODO: Change code below to process each `tablesData` resource:
-                    Console.WriteLine(tablesData);
+                    Console.WriteLine(JsonConvert.SerializeObject(tablesData));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -1272,6 +1291,7 @@ namespace BigquerySample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Bigquery.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1309,7 +1329,7 @@ namespace BigquerySample
             // Data.Table response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1341,6 +1361,7 @@ namespace BigquerySample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Bigquery.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1378,7 +1399,7 @@ namespace BigquerySample
             // Data.Table response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_cloudbilling.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_cloudbilling.v1.json.baseline
@@ -17,6 +17,7 @@
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Cloudbilling.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -46,7 +47,7 @@ namespace CloudbillingSample
             // Data.BillingAccount response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -78,6 +79,7 @@ namespace CloudbillingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Cloudbilling.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -111,7 +113,7 @@ namespace CloudbillingSample
                 foreach (Data.BillingAccount billingAccount in response.BillingAccounts)
                 {
                     // TODO: Change code below to process each `billingAccount` resource:
-                    Console.WriteLine(billingAccount);
+                    Console.WriteLine(JsonConvert.SerializeObject(billingAccount));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -146,6 +148,7 @@ namespace CloudbillingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Cloudbilling.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -184,7 +187,7 @@ namespace CloudbillingSample
                 foreach (Data.ProjectBillingInfo projectBillingInfo in response.ProjectBillingInfo)
                 {
                     // TODO: Change code below to process each `projectBillingInfo` resource:
-                    Console.WriteLine(projectBillingInfo);
+                    Console.WriteLine(JsonConvert.SerializeObject(projectBillingInfo));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -219,6 +222,7 @@ namespace CloudbillingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Cloudbilling.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -248,7 +252,7 @@ namespace CloudbillingSample
             // Data.ProjectBillingInfo response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -280,6 +284,7 @@ namespace CloudbillingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Cloudbilling.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -313,7 +318,7 @@ namespace CloudbillingSample
             // Data.ProjectBillingInfo response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_clouddebugger.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_clouddebugger.v2.json.baseline
@@ -17,6 +17,7 @@
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudDebugger.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -44,7 +45,7 @@ namespace CloudDebuggerSample
             // Data.ListActiveBreakpointsResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -76,6 +77,7 @@ namespace CloudDebuggerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudDebugger.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -110,7 +112,7 @@ namespace CloudDebuggerSample
             // Data.UpdateActiveBreakpointResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -142,6 +144,7 @@ namespace CloudDebuggerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudDebugger.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -169,7 +172,7 @@ namespace CloudDebuggerSample
             // Data.RegisterDebuggeeResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -201,6 +204,7 @@ namespace CloudDebuggerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudDebugger.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System.Threading.Tasks;
 
 namespace CloudDebuggerSample
@@ -257,6 +261,7 @@ namespace CloudDebuggerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudDebugger.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -287,7 +292,7 @@ namespace CloudDebuggerSample
             // Data.GetBreakpointResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -319,6 +324,7 @@ namespace CloudDebuggerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudDebugger.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -346,7 +352,7 @@ namespace CloudDebuggerSample
             // Data.ListBreakpointsResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -378,6 +384,7 @@ namespace CloudDebuggerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudDebugger.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -408,7 +415,7 @@ namespace CloudDebuggerSample
             // Data.SetBreakpointResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -440,6 +447,7 @@ namespace CloudDebuggerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudDebugger.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -464,7 +472,7 @@ namespace CloudDebuggerSample
             // Data.ListDebuggeesResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_cloudmonitoring.v2beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_cloudmonitoring.v2beta2.json.baseline
@@ -17,6 +17,7 @@
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudMonitoring.v2beta2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -47,7 +48,7 @@ namespace CloudMonitoringSample
             // Data.MetricDescriptor response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -79,6 +80,7 @@ namespace CloudMonitoringSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudMonitoring.v2beta2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -109,7 +111,7 @@ namespace CloudMonitoringSample
             // Data.DeleteMetricDescriptorResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -141,6 +143,7 @@ namespace CloudMonitoringSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudMonitoring.v2beta2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -177,7 +180,7 @@ namespace CloudMonitoringSample
                 foreach (Data.MetricDescriptor metricDescriptor in response.Metrics)
                 {
                     // TODO: Change code below to process each `metricDescriptor` resource:
-                    Console.WriteLine(metricDescriptor);
+                    Console.WriteLine(JsonConvert.SerializeObject(metricDescriptor));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -212,6 +215,7 @@ namespace CloudMonitoringSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudMonitoring.v2beta2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -256,7 +260,7 @@ namespace CloudMonitoringSample
                 foreach (Data.Timeseries timeseries in response.Timeseries)
                 {
                     // TODO: Change code below to process each `timeseries` resource:
-                    Console.WriteLine(timeseries);
+                    Console.WriteLine(JsonConvert.SerializeObject(timeseries));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -291,6 +295,7 @@ namespace CloudMonitoringSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudMonitoring.v2beta2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -321,7 +326,7 @@ namespace CloudMonitoringSample
             // Data.WriteTimeseriesResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -353,6 +358,7 @@ namespace CloudMonitoringSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudMonitoring.v2beta2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -397,7 +403,7 @@ namespace CloudMonitoringSample
                 foreach (Data.TimeseriesDescriptor timeseriesDescriptor in response.Timeseries)
                 {
                     // TODO: Change code below to process each `timeseriesDescriptor` resource:
-                    Console.WriteLine(timeseriesDescriptor);
+                    Console.WriteLine(JsonConvert.SerializeObject(timeseriesDescriptor));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_cloudresourcemanager.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_cloudresourcemanager.v1.json.baseline
@@ -17,6 +17,7 @@
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudResourceManager.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -44,7 +45,7 @@ namespace CloudResourceManagerSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -76,6 +77,7 @@ namespace CloudResourceManagerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudResourceManager.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -103,7 +105,7 @@ namespace CloudResourceManagerSample
             // Data.Organization response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -135,6 +137,7 @@ namespace CloudResourceManagerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudResourceManager.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -167,7 +170,7 @@ namespace CloudResourceManagerSample
             // Data.Policy response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -199,6 +202,7 @@ namespace CloudResourceManagerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudResourceManager.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -235,7 +239,7 @@ namespace CloudResourceManagerSample
                 foreach (Data.Organization organization in response.Organizations)
                 {
                     // TODO: Change code below to process each `organization` resource:
-                    Console.WriteLine(organization);
+                    Console.WriteLine(JsonConvert.SerializeObject(organization));
                 }
                 requestBody.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -270,6 +274,7 @@ namespace CloudResourceManagerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudResourceManager.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -302,7 +307,7 @@ namespace CloudResourceManagerSample
             // Data.Policy response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -334,6 +339,7 @@ namespace CloudResourceManagerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudResourceManager.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -366,7 +372,7 @@ namespace CloudResourceManagerSample
             // Data.TestIamPermissionsResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -398,6 +404,7 @@ namespace CloudResourceManagerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudResourceManager.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -425,7 +432,7 @@ namespace CloudResourceManagerSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -457,6 +464,7 @@ namespace CloudResourceManagerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudResourceManager.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System.Threading.Tasks;
 
 namespace CloudResourceManagerSample
@@ -511,6 +519,7 @@ namespace CloudResourceManagerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudResourceManager.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -539,7 +548,7 @@ namespace CloudResourceManagerSample
             // Data.Project response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -571,6 +580,7 @@ namespace CloudResourceManagerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudResourceManager.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -602,7 +612,7 @@ namespace CloudResourceManagerSample
             // Data.GetAncestryResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -634,6 +644,7 @@ namespace CloudResourceManagerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudResourceManager.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -666,7 +677,7 @@ namespace CloudResourceManagerSample
             // Data.Policy response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -698,6 +709,7 @@ namespace CloudResourceManagerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudResourceManager.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -731,7 +743,7 @@ namespace CloudResourceManagerSample
                 foreach (Data.Project project in response.Projects)
                 {
                     // TODO: Change code below to process each `project` resource:
-                    Console.WriteLine(project);
+                    Console.WriteLine(JsonConvert.SerializeObject(project));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -766,6 +778,7 @@ namespace CloudResourceManagerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudResourceManager.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -798,7 +811,7 @@ namespace CloudResourceManagerSample
             // Data.Policy response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -830,6 +843,7 @@ namespace CloudResourceManagerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudResourceManager.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -862,7 +876,7 @@ namespace CloudResourceManagerSample
             // Data.TestIamPermissionsResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -894,6 +908,7 @@ namespace CloudResourceManagerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudResourceManager.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System.Threading.Tasks;
 
 using Data = Google.Apis.CloudResourceManager.v1.Data;
@@ -953,6 +968,7 @@ namespace CloudResourceManagerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudResourceManager.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -985,7 +1001,7 @@ namespace CloudResourceManagerSample
             // Data.Project response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_cloudtrace.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_cloudtrace.v1.json.baseline
@@ -17,6 +17,7 @@
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudTrace.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System.Threading.Tasks;
 
 using Data = Google.Apis.CloudTrace.v1.Data;
@@ -76,6 +77,7 @@ namespace CloudTraceSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudTrace.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -106,7 +108,7 @@ namespace CloudTraceSample
             // Data.Trace response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -138,6 +140,7 @@ namespace CloudTraceSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudTrace.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -174,7 +177,7 @@ namespace CloudTraceSample
                 foreach (Data.Trace trace in response.Traces)
                 {
                     // TODO: Change code below to process each `trace` resource:
-                    Console.WriteLine(trace);
+                    Console.WriteLine(JsonConvert.SerializeObject(trace));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_clouduseraccounts.beta.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_clouduseraccounts.beta.json.baseline
@@ -17,6 +17,7 @@
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudUserAccounts.beta;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System.Threading.Tasks;
 
 namespace CloudUserAccountsSample
@@ -73,6 +74,7 @@ namespace CloudUserAccountsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudUserAccounts.beta;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -103,7 +105,7 @@ namespace CloudUserAccountsSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -135,6 +137,7 @@ namespace CloudUserAccountsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudUserAccounts.beta;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -171,7 +174,7 @@ namespace CloudUserAccountsSample
                 foreach (Data.Operation operation in response.Items)
                 {
                     // TODO: Change code below to process each `operation` resource:
-                    Console.WriteLine(operation);
+                    Console.WriteLine(JsonConvert.SerializeObject(operation));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -206,6 +209,7 @@ namespace CloudUserAccountsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudUserAccounts.beta;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -239,7 +243,7 @@ namespace CloudUserAccountsSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -271,6 +275,7 @@ namespace CloudUserAccountsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudUserAccounts.beta;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -301,7 +306,7 @@ namespace CloudUserAccountsSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -333,6 +338,7 @@ namespace CloudUserAccountsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudUserAccounts.beta;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -363,7 +369,7 @@ namespace CloudUserAccountsSample
             // Data.Group response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -395,6 +401,7 @@ namespace CloudUserAccountsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudUserAccounts.beta;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -425,7 +432,7 @@ namespace CloudUserAccountsSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -457,6 +464,7 @@ namespace CloudUserAccountsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudUserAccounts.beta;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -493,7 +501,7 @@ namespace CloudUserAccountsSample
                 foreach (Data.Group group in response.Items)
                 {
                     // TODO: Change code below to process each `group` resource:
-                    Console.WriteLine(group);
+                    Console.WriteLine(JsonConvert.SerializeObject(group));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -528,6 +536,7 @@ namespace CloudUserAccountsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudUserAccounts.beta;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -561,7 +570,7 @@ namespace CloudUserAccountsSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -593,6 +602,7 @@ namespace CloudUserAccountsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudUserAccounts.beta;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -629,7 +639,7 @@ namespace CloudUserAccountsSample
             // Data.LinuxGetAuthorizedKeysViewResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -661,6 +671,7 @@ namespace CloudUserAccountsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudUserAccounts.beta;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -694,7 +705,7 @@ namespace CloudUserAccountsSample
             // Data.LinuxGetLinuxAccountViewsResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -726,6 +737,7 @@ namespace CloudUserAccountsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudUserAccounts.beta;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -759,7 +771,7 @@ namespace CloudUserAccountsSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -791,6 +803,7 @@ namespace CloudUserAccountsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudUserAccounts.beta;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -821,7 +834,7 @@ namespace CloudUserAccountsSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -853,6 +866,7 @@ namespace CloudUserAccountsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudUserAccounts.beta;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -883,7 +897,7 @@ namespace CloudUserAccountsSample
             // Data.User response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -915,6 +929,7 @@ namespace CloudUserAccountsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudUserAccounts.beta;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -945,7 +960,7 @@ namespace CloudUserAccountsSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -977,6 +992,7 @@ namespace CloudUserAccountsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudUserAccounts.beta;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1013,7 +1029,7 @@ namespace CloudUserAccountsSample
                 foreach (Data.User user in response.Items)
                 {
                     // TODO: Change code below to process each `user` resource:
-                    Console.WriteLine(user);
+                    Console.WriteLine(JsonConvert.SerializeObject(user));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -1048,6 +1064,7 @@ namespace CloudUserAccountsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.CloudUserAccounts.beta;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1082,7 +1099,7 @@ namespace CloudUserAccountsSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_compute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_compute.v1.json.baseline
@@ -55,7 +55,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.AddressesScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine(JsonConvert.SerializeObject(item));
+                    Console.WriteLine("[" + item.Key + "] = " + JsonConvert.SerializeObject(item.Value));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -401,7 +401,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.AutoscalersScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine(JsonConvert.SerializeObject(item));
+                    Console.WriteLine("[" + item.Key + "] = " + JsonConvert.SerializeObject(item.Value));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -884,7 +884,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.BackendServicesScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine(JsonConvert.SerializeObject(item));
+                    Console.WriteLine("[" + item.Key + "] = " + JsonConvert.SerializeObject(item.Value));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -1417,7 +1417,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.DiskTypesScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine(JsonConvert.SerializeObject(item));
+                    Console.WriteLine("[" + item.Key + "] = " + JsonConvert.SerializeObject(item.Value));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -1631,7 +1631,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.DisksScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine(JsonConvert.SerializeObject(item));
+                    Console.WriteLine("[" + item.Key + "] = " + JsonConvert.SerializeObject(item.Value));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -2510,7 +2510,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.ForwardingRulesScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine(JsonConvert.SerializeObject(item));
+                    Console.WriteLine("[" + item.Key + "] = " + JsonConvert.SerializeObject(item.Value));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -3513,7 +3513,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.OperationsScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine(JsonConvert.SerializeObject(item));
+                    Console.WriteLine("[" + item.Key + "] = " + JsonConvert.SerializeObject(item.Value));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -5422,7 +5422,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.InstanceGroupManagersScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine(JsonConvert.SerializeObject(item));
+                    Console.WriteLine("[" + item.Key + "] = " + JsonConvert.SerializeObject(item.Value));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -6250,7 +6250,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.InstanceGroupsScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine(JsonConvert.SerializeObject(item));
+                    Console.WriteLine("[" + item.Key + "] = " + JsonConvert.SerializeObject(item.Value));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -7148,7 +7148,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.InstancesScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine(JsonConvert.SerializeObject(item));
+                    Console.WriteLine("[" + item.Key + "] = " + JsonConvert.SerializeObject(item.Value));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -8517,7 +8517,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.MachineTypesScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine(JsonConvert.SerializeObject(item));
+                    Console.WriteLine("[" + item.Key + "] = " + JsonConvert.SerializeObject(item.Value));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -11638,7 +11638,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.RoutersScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine(JsonConvert.SerializeObject(item));
+                    Console.WriteLine("[" + item.Key + "] = " + JsonConvert.SerializeObject(item.Value));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -12979,7 +12979,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.SubnetworksScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine(JsonConvert.SerializeObject(item));
+                    Console.WriteLine("[" + item.Key + "] = " + JsonConvert.SerializeObject(item.Value));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -14114,7 +14114,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.TargetInstancesScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine(JsonConvert.SerializeObject(item));
+                    Console.WriteLine("[" + item.Key + "] = " + JsonConvert.SerializeObject(item.Value));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -14598,7 +14598,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.TargetPoolsScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine(JsonConvert.SerializeObject(item));
+                    Console.WriteLine("[" + item.Key + "] = " + JsonConvert.SerializeObject(item.Value));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -15679,7 +15679,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.TargetVpnGatewaysScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine(JsonConvert.SerializeObject(item));
+                    Console.WriteLine("[" + item.Key + "] = " + JsonConvert.SerializeObject(item.Value));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -16552,7 +16552,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.VpnTunnelsScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine(JsonConvert.SerializeObject(item));
+                    Console.WriteLine("[" + item.Key + "] = " + JsonConvert.SerializeObject(item.Value));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_compute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_compute.v1.json.baseline
@@ -17,6 +17,7 @@
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -54,7 +55,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.AddressesScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine("[" + item.Key + "] = " + item.Value);
+                    Console.WriteLine(JsonConvert.SerializeObject(item));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -89,6 +90,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -122,7 +124,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -154,6 +156,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -187,7 +190,7 @@ namespace ComputeSample
             // Data.Address response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -219,6 +222,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -252,7 +256,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -284,6 +288,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -323,7 +328,7 @@ namespace ComputeSample
                 foreach (Data.Address address in response.Items)
                 {
                     // TODO: Change code below to process each `address` resource:
-                    Console.WriteLine(address);
+                    Console.WriteLine(JsonConvert.SerializeObject(address));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -358,6 +363,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -395,7 +401,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.AutoscalersScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine("[" + item.Key + "] = " + item.Value);
+                    Console.WriteLine(JsonConvert.SerializeObject(item));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -430,6 +436,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -463,7 +470,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -495,6 +502,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -528,7 +536,7 @@ namespace ComputeSample
             // Data.Autoscaler response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -560,6 +568,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -593,7 +602,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -625,6 +634,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -664,7 +674,7 @@ namespace ComputeSample
                 foreach (Data.Autoscaler autoscaler in response.Items)
                 {
                     // TODO: Change code below to process each `autoscaler` resource:
-                    Console.WriteLine(autoscaler);
+                    Console.WriteLine(JsonConvert.SerializeObject(autoscaler));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -699,6 +709,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -736,7 +747,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -768,6 +779,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -802,7 +814,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -834,6 +846,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -871,7 +884,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.BackendServicesScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine("[" + item.Key + "] = " + item.Value);
+                    Console.WriteLine(JsonConvert.SerializeObject(item));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -906,6 +919,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -936,7 +950,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -968,6 +982,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -998,7 +1013,7 @@ namespace ComputeSample
             // Data.BackendService response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1030,6 +1045,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1062,7 +1078,7 @@ namespace ComputeSample
             // Data.BackendServiceGroupHealth response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1094,6 +1110,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1124,7 +1141,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1156,6 +1173,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1192,7 +1210,7 @@ namespace ComputeSample
                 foreach (Data.BackendService backendService in response.Items)
                 {
                     // TODO: Change code below to process each `backendService` resource:
-                    Console.WriteLine(backendService);
+                    Console.WriteLine(JsonConvert.SerializeObject(backendService));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -1227,6 +1245,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1261,7 +1280,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1293,6 +1312,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1327,7 +1347,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1359,6 +1379,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -1396,7 +1417,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.DiskTypesScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine("[" + item.Key + "] = " + item.Value);
+                    Console.WriteLine(JsonConvert.SerializeObject(item));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -1431,6 +1452,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1464,7 +1486,7 @@ namespace ComputeSample
             // Data.DiskType response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1496,6 +1518,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1535,7 +1558,7 @@ namespace ComputeSample
                 foreach (Data.DiskType diskType in response.Items)
                 {
                     // TODO: Change code below to process each `diskType` resource:
-                    Console.WriteLine(diskType);
+                    Console.WriteLine(JsonConvert.SerializeObject(diskType));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -1570,6 +1593,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -1607,7 +1631,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.DisksScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine("[" + item.Key + "] = " + item.Value);
+                    Console.WriteLine(JsonConvert.SerializeObject(item));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -1642,6 +1666,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1678,7 +1703,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1710,6 +1735,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1743,7 +1769,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1775,6 +1801,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1808,7 +1835,7 @@ namespace ComputeSample
             // Data.Disk response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1840,6 +1867,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1873,7 +1901,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1905,6 +1933,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1944,7 +1973,7 @@ namespace ComputeSample
                 foreach (Data.Disk disk in response.Items)
                 {
                     // TODO: Change code below to process each `disk` resource:
-                    Console.WriteLine(disk);
+                    Console.WriteLine(JsonConvert.SerializeObject(disk));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -1979,6 +2008,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -2015,7 +2045,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -2047,6 +2077,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -2077,7 +2108,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -2109,6 +2140,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -2139,7 +2171,7 @@ namespace ComputeSample
             // Data.Firewall response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -2171,6 +2203,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -2201,7 +2234,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -2233,6 +2266,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -2269,7 +2303,7 @@ namespace ComputeSample
                 foreach (Data.Firewall firewall in response.Items)
                 {
                     // TODO: Change code below to process each `firewall` resource:
-                    Console.WriteLine(firewall);
+                    Console.WriteLine(JsonConvert.SerializeObject(firewall));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -2304,6 +2338,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -2338,7 +2373,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -2370,6 +2405,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -2404,7 +2440,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -2436,6 +2472,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -2473,7 +2510,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.ForwardingRulesScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine("[" + item.Key + "] = " + item.Value);
+                    Console.WriteLine(JsonConvert.SerializeObject(item));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -2508,6 +2545,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -2541,7 +2579,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -2573,6 +2611,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -2606,7 +2645,7 @@ namespace ComputeSample
             // Data.ForwardingRule response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -2638,6 +2677,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -2671,7 +2711,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -2703,6 +2743,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -2742,7 +2783,7 @@ namespace ComputeSample
                 foreach (Data.ForwardingRule forwardingRule in response.Items)
                 {
                     // TODO: Change code below to process each `forwardingRule` resource:
-                    Console.WriteLine(forwardingRule);
+                    Console.WriteLine(JsonConvert.SerializeObject(forwardingRule));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -2777,6 +2818,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -2813,7 +2855,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -2845,6 +2887,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -2875,7 +2918,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -2907,6 +2950,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -2937,7 +2981,7 @@ namespace ComputeSample
             // Data.Address response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -2969,6 +3013,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -2999,7 +3044,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -3031,6 +3076,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -3067,7 +3113,7 @@ namespace ComputeSample
                 foreach (Data.Address address in response.Items)
                 {
                     // TODO: Change code below to process each `address` resource:
-                    Console.WriteLine(address);
+                    Console.WriteLine(JsonConvert.SerializeObject(address));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -3102,6 +3148,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -3132,7 +3179,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -3164,6 +3211,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -3194,7 +3242,7 @@ namespace ComputeSample
             // Data.ForwardingRule response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -3226,6 +3274,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -3256,7 +3305,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -3288,6 +3337,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -3324,7 +3374,7 @@ namespace ComputeSample
                 foreach (Data.ForwardingRule forwardingRule in response.Items)
                 {
                     // TODO: Change code below to process each `forwardingRule` resource:
-                    Console.WriteLine(forwardingRule);
+                    Console.WriteLine(JsonConvert.SerializeObject(forwardingRule));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -3359,6 +3409,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -3392,7 +3443,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -3424,6 +3475,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -3461,7 +3513,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.OperationsScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine("[" + item.Key + "] = " + item.Value);
+                    Console.WriteLine(JsonConvert.SerializeObject(item));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -3496,6 +3548,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System.Threading.Tasks;
 
 namespace ComputeSample
@@ -3552,6 +3605,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -3582,7 +3636,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -3614,6 +3668,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -3650,7 +3705,7 @@ namespace ComputeSample
                 foreach (Data.Operation operation in response.Items)
                 {
                     // TODO: Change code below to process each `operation` resource:
-                    Console.WriteLine(operation);
+                    Console.WriteLine(JsonConvert.SerializeObject(operation));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -3685,6 +3740,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -3715,7 +3771,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -3747,6 +3803,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -3777,7 +3834,7 @@ namespace ComputeSample
             // Data.HealthCheck response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -3809,6 +3866,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -3839,7 +3897,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -3871,6 +3929,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -3907,7 +3966,7 @@ namespace ComputeSample
                 foreach (Data.HealthCheck healthCheck in response.Items)
                 {
                     // TODO: Change code below to process each `healthCheck` resource:
-                    Console.WriteLine(healthCheck);
+                    Console.WriteLine(JsonConvert.SerializeObject(healthCheck));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -3942,6 +4001,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -3976,7 +4036,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -4008,6 +4068,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -4042,7 +4103,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -4074,6 +4135,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -4104,7 +4166,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -4136,6 +4198,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -4166,7 +4229,7 @@ namespace ComputeSample
             // Data.HttpHealthCheck response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -4198,6 +4261,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -4228,7 +4292,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -4260,6 +4324,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -4296,7 +4361,7 @@ namespace ComputeSample
                 foreach (Data.HttpHealthCheck httpHealthCheck in response.Items)
                 {
                     // TODO: Change code below to process each `httpHealthCheck` resource:
-                    Console.WriteLine(httpHealthCheck);
+                    Console.WriteLine(JsonConvert.SerializeObject(httpHealthCheck));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -4331,6 +4396,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -4365,7 +4431,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -4397,6 +4463,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -4431,7 +4498,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -4463,6 +4530,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -4493,7 +4561,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -4525,6 +4593,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -4555,7 +4624,7 @@ namespace ComputeSample
             // Data.HttpsHealthCheck response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -4587,6 +4656,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -4617,7 +4687,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -4649,6 +4719,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -4685,7 +4756,7 @@ namespace ComputeSample
                 foreach (Data.HttpsHealthCheck httpsHealthCheck in response.Items)
                 {
                     // TODO: Change code below to process each `httpsHealthCheck` resource:
-                    Console.WriteLine(httpsHealthCheck);
+                    Console.WriteLine(JsonConvert.SerializeObject(httpsHealthCheck));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -4720,6 +4791,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -4754,7 +4826,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -4786,6 +4858,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -4820,7 +4893,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -4852,6 +4925,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -4882,7 +4956,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -4914,6 +4988,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -4947,7 +5022,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -4979,6 +5054,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -5009,7 +5085,7 @@ namespace ComputeSample
             // Data.Image response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -5041,6 +5117,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -5071,7 +5148,7 @@ namespace ComputeSample
             // Data.Image response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -5103,6 +5180,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -5133,7 +5211,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -5165,6 +5243,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -5201,7 +5280,7 @@ namespace ComputeSample
                 foreach (Data.Image image in response.Items)
                 {
                     // TODO: Change code below to process each `image` resource:
-                    Console.WriteLine(image);
+                    Console.WriteLine(JsonConvert.SerializeObject(image));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -5236,6 +5315,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -5272,7 +5352,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -5304,6 +5384,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -5341,7 +5422,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.InstanceGroupManagersScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine("[" + item.Key + "] = " + item.Value);
+                    Console.WriteLine(JsonConvert.SerializeObject(item));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -5376,6 +5457,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -5409,7 +5491,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -5441,6 +5523,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -5477,7 +5560,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -5509,6 +5592,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -5542,7 +5626,7 @@ namespace ComputeSample
             // Data.InstanceGroupManager response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -5574,6 +5658,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -5607,7 +5692,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -5639,6 +5724,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -5678,7 +5764,7 @@ namespace ComputeSample
                 foreach (Data.InstanceGroupManager instanceGroupManager in response.Items)
                 {
                     // TODO: Change code below to process each `instanceGroupManager` resource:
-                    Console.WriteLine(instanceGroupManager);
+                    Console.WriteLine(JsonConvert.SerializeObject(instanceGroupManager));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -5713,6 +5799,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -5746,7 +5833,7 @@ namespace ComputeSample
             // Data.InstanceGroupManagersListManagedInstancesResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -5778,6 +5865,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -5814,7 +5902,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -5846,6 +5934,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -5884,7 +5973,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -5916,6 +6005,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -5952,7 +6042,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -5984,6 +6074,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -6020,7 +6111,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -6052,6 +6143,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -6088,7 +6180,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -6120,6 +6212,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -6157,7 +6250,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.InstanceGroupsScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine("[" + item.Key + "] = " + item.Value);
+                    Console.WriteLine(JsonConvert.SerializeObject(item));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -6192,6 +6285,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -6225,7 +6319,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -6257,6 +6351,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -6290,7 +6385,7 @@ namespace ComputeSample
             // Data.InstanceGroup response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -6322,6 +6417,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -6355,7 +6451,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -6387,6 +6483,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -6426,7 +6523,7 @@ namespace ComputeSample
                 foreach (Data.InstanceGroup instanceGroup in response.Items)
                 {
                     // TODO: Change code below to process each `instanceGroup` resource:
-                    Console.WriteLine(instanceGroup);
+                    Console.WriteLine(JsonConvert.SerializeObject(instanceGroup));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -6461,6 +6558,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -6506,7 +6604,7 @@ namespace ComputeSample
                 foreach (Data.InstanceWithNamedPorts instanceWithNamedPorts in response.Items)
                 {
                     // TODO: Change code below to process each `instanceWithNamedPorts` resource:
-                    Console.WriteLine(instanceWithNamedPorts);
+                    Console.WriteLine(JsonConvert.SerializeObject(instanceWithNamedPorts));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -6541,6 +6639,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -6577,7 +6676,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -6609,6 +6708,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -6645,7 +6745,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -6677,6 +6777,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -6707,7 +6808,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -6739,6 +6840,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -6769,7 +6871,7 @@ namespace ComputeSample
             // Data.InstanceTemplate response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -6801,6 +6903,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -6831,7 +6934,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -6863,6 +6966,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -6899,7 +7003,7 @@ namespace ComputeSample
                 foreach (Data.InstanceTemplate instanceTemplate in response.Items)
                 {
                     // TODO: Change code below to process each `instanceTemplate` resource:
-                    Console.WriteLine(instanceTemplate);
+                    Console.WriteLine(JsonConvert.SerializeObject(instanceTemplate));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -6934,6 +7038,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -6973,7 +7078,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -7005,6 +7110,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -7042,7 +7148,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.InstancesScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine("[" + item.Key + "] = " + item.Value);
+                    Console.WriteLine(JsonConvert.SerializeObject(item));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -7077,6 +7183,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -7113,7 +7220,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -7145,6 +7252,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -7178,7 +7286,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -7210,6 +7318,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -7249,7 +7358,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -7281,6 +7390,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -7317,7 +7427,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -7349,6 +7459,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -7382,7 +7493,7 @@ namespace ComputeSample
             // Data.Instance response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -7414,6 +7525,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -7447,7 +7559,7 @@ namespace ComputeSample
             // Data.SerialPortOutput response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -7479,6 +7591,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -7512,7 +7625,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -7544,6 +7657,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -7583,7 +7697,7 @@ namespace ComputeSample
                 foreach (Data.Instance instance in response.Items)
                 {
                     // TODO: Change code below to process each `instance` resource:
-                    Console.WriteLine(instance);
+                    Console.WriteLine(JsonConvert.SerializeObject(instance));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -7618,6 +7732,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -7651,7 +7766,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -7683,6 +7798,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -7722,7 +7838,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -7754,6 +7870,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -7790,7 +7907,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -7822,6 +7939,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -7858,7 +7976,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -7890,6 +8008,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -7926,7 +8045,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -7958,6 +8077,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -7994,7 +8114,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -8026,6 +8146,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -8062,7 +8183,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -8094,6 +8215,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -8127,7 +8249,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -8159,6 +8281,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -8195,7 +8318,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -8227,6 +8350,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -8260,7 +8384,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -8292,6 +8416,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -8322,7 +8447,7 @@ namespace ComputeSample
             // Data.License response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -8354,6 +8479,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -8391,7 +8517,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.MachineTypesScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine("[" + item.Key + "] = " + item.Value);
+                    Console.WriteLine(JsonConvert.SerializeObject(item));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -8426,6 +8552,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -8459,7 +8586,7 @@ namespace ComputeSample
             // Data.MachineType response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -8491,6 +8618,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -8530,7 +8658,7 @@ namespace ComputeSample
                 foreach (Data.MachineType machineType in response.Items)
                 {
                     // TODO: Change code below to process each `machineType` resource:
-                    Console.WriteLine(machineType);
+                    Console.WriteLine(JsonConvert.SerializeObject(machineType));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -8565,6 +8693,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -8595,7 +8724,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -8627,6 +8756,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -8657,7 +8787,7 @@ namespace ComputeSample
             // Data.Network response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -8689,6 +8819,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -8719,7 +8850,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -8751,6 +8882,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -8787,7 +8919,7 @@ namespace ComputeSample
                 foreach (Data.Network network in response.Items)
                 {
                     // TODO: Change code below to process each `network` resource:
-                    Console.WriteLine(network);
+                    Console.WriteLine(JsonConvert.SerializeObject(network));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -8822,6 +8954,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -8852,7 +8985,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -8884,6 +9017,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -8911,7 +9045,7 @@ namespace ComputeSample
             // Data.Project response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -8943,6 +9077,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -8973,7 +9108,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -9005,6 +9140,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -9035,7 +9171,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -9067,6 +9203,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -9097,7 +9234,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -9129,6 +9266,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -9159,7 +9297,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -9191,6 +9329,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -9224,7 +9363,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -9256,6 +9395,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -9289,7 +9429,7 @@ namespace ComputeSample
             // Data.Autoscaler response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -9321,6 +9461,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -9354,7 +9495,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -9386,6 +9527,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -9425,7 +9567,7 @@ namespace ComputeSample
                 foreach (Data.Autoscaler autoscaler in response.Items)
                 {
                     // TODO: Change code below to process each `autoscaler` resource:
-                    Console.WriteLine(autoscaler);
+                    Console.WriteLine(JsonConvert.SerializeObject(autoscaler));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -9460,6 +9602,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -9497,7 +9640,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -9529,6 +9672,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -9563,7 +9707,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -9595,6 +9739,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -9628,7 +9773,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -9660,6 +9805,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -9693,7 +9839,7 @@ namespace ComputeSample
             // Data.BackendService response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -9725,6 +9871,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -9760,7 +9907,7 @@ namespace ComputeSample
             // Data.BackendServiceGroupHealth response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -9792,6 +9939,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -9825,7 +9973,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -9857,6 +10005,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -9896,7 +10045,7 @@ namespace ComputeSample
                 foreach (Data.BackendService backendService in response.Items)
                 {
                     // TODO: Change code below to process each `backendService` resource:
-                    Console.WriteLine(backendService);
+                    Console.WriteLine(JsonConvert.SerializeObject(backendService));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -9931,6 +10080,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -9968,7 +10118,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -10000,6 +10150,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -10037,7 +10188,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -10069,6 +10220,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -10105,7 +10257,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -10137,6 +10289,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -10170,7 +10323,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -10202,6 +10355,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -10238,7 +10392,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -10270,6 +10424,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -10303,7 +10458,7 @@ namespace ComputeSample
             // Data.InstanceGroupManager response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -10335,6 +10490,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -10368,7 +10524,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -10400,6 +10556,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -10439,7 +10596,7 @@ namespace ComputeSample
                 foreach (Data.InstanceGroupManager instanceGroupManager in response.Items)
                 {
                     // TODO: Change code below to process each `instanceGroupManager` resource:
-                    Console.WriteLine(instanceGroupManager);
+                    Console.WriteLine(JsonConvert.SerializeObject(instanceGroupManager));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -10474,6 +10631,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -10507,7 +10665,7 @@ namespace ComputeSample
             // Data.RegionInstanceGroupManagersListInstancesResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -10539,6 +10697,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -10575,7 +10734,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -10607,6 +10766,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -10643,7 +10803,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -10675,6 +10835,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -10711,7 +10872,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -10743,6 +10904,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -10779,7 +10941,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -10811,6 +10973,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -10844,7 +11007,7 @@ namespace ComputeSample
             // Data.InstanceGroup response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -10876,6 +11039,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -10915,7 +11079,7 @@ namespace ComputeSample
                 foreach (Data.InstanceGroup instanceGroup in response.Items)
                 {
                     // TODO: Change code below to process each `instanceGroup` resource:
-                    Console.WriteLine(instanceGroup);
+                    Console.WriteLine(JsonConvert.SerializeObject(instanceGroup));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -10950,6 +11114,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -10995,7 +11160,7 @@ namespace ComputeSample
                 foreach (Data.InstanceWithNamedPorts instanceWithNamedPorts in response.Items)
                 {
                     // TODO: Change code below to process each `instanceWithNamedPorts` resource:
-                    Console.WriteLine(instanceWithNamedPorts);
+                    Console.WriteLine(JsonConvert.SerializeObject(instanceWithNamedPorts));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -11030,6 +11195,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -11066,7 +11232,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -11098,6 +11264,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System.Threading.Tasks;
 
 namespace ComputeSample
@@ -11157,6 +11324,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -11190,7 +11358,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -11222,6 +11390,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -11261,7 +11430,7 @@ namespace ComputeSample
                 foreach (Data.Operation operation in response.Items)
                 {
                     // TODO: Change code below to process each `operation` resource:
-                    Console.WriteLine(operation);
+                    Console.WriteLine(JsonConvert.SerializeObject(operation));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -11296,6 +11465,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -11326,7 +11496,7 @@ namespace ComputeSample
             // Data.Region response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -11358,6 +11528,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -11394,7 +11565,7 @@ namespace ComputeSample
                 foreach (Data.Region region in response.Items)
                 {
                     // TODO: Change code below to process each `region` resource:
-                    Console.WriteLine(region);
+                    Console.WriteLine(JsonConvert.SerializeObject(region));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -11429,6 +11600,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -11466,7 +11638,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.RoutersScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine("[" + item.Key + "] = " + item.Value);
+                    Console.WriteLine(JsonConvert.SerializeObject(item));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -11501,6 +11673,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -11534,7 +11707,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -11566,6 +11739,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -11599,7 +11773,7 @@ namespace ComputeSample
             // Data.Router response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -11631,6 +11805,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -11664,7 +11839,7 @@ namespace ComputeSample
             // Data.RouterStatusResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -11696,6 +11871,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -11729,7 +11905,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -11761,6 +11937,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -11800,7 +11977,7 @@ namespace ComputeSample
                 foreach (Data.Router router in response.Items)
                 {
                     // TODO: Change code below to process each `router` resource:
-                    Console.WriteLine(router);
+                    Console.WriteLine(JsonConvert.SerializeObject(router));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -11835,6 +12012,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -11872,7 +12050,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -11904,6 +12082,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -11940,7 +12119,7 @@ namespace ComputeSample
             // Data.RoutersPreviewResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -11972,6 +12151,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -12009,7 +12189,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -12041,6 +12221,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -12071,7 +12252,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -12103,6 +12284,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -12133,7 +12315,7 @@ namespace ComputeSample
             // Data.Route response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -12165,6 +12347,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -12195,7 +12378,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -12227,6 +12410,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -12263,7 +12447,7 @@ namespace ComputeSample
                 foreach (Data.Route route in response.Items)
                 {
                     // TODO: Change code below to process each `route` resource:
-                    Console.WriteLine(route);
+                    Console.WriteLine(JsonConvert.SerializeObject(route));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -12298,6 +12482,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -12328,7 +12513,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -12360,6 +12545,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -12390,7 +12576,7 @@ namespace ComputeSample
             // Data.Snapshot response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -12422,6 +12608,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -12458,7 +12645,7 @@ namespace ComputeSample
                 foreach (Data.Snapshot snapshot in response.Items)
                 {
                     // TODO: Change code below to process each `snapshot` resource:
-                    Console.WriteLine(snapshot);
+                    Console.WriteLine(JsonConvert.SerializeObject(snapshot));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -12493,6 +12680,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -12523,7 +12711,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -12555,6 +12743,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -12585,7 +12774,7 @@ namespace ComputeSample
             // Data.SslCertificate response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -12617,6 +12806,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -12647,7 +12837,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -12679,6 +12869,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -12715,7 +12906,7 @@ namespace ComputeSample
                 foreach (Data.SslCertificate sslCertificate in response.Items)
                 {
                     // TODO: Change code below to process each `sslCertificate` resource:
-                    Console.WriteLine(sslCertificate);
+                    Console.WriteLine(JsonConvert.SerializeObject(sslCertificate));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -12750,6 +12941,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -12787,7 +12979,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.SubnetworksScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine("[" + item.Key + "] = " + item.Value);
+                    Console.WriteLine(JsonConvert.SerializeObject(item));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -12822,6 +13014,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -12855,7 +13048,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -12887,6 +13080,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -12923,7 +13117,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -12955,6 +13149,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -12988,7 +13183,7 @@ namespace ComputeSample
             // Data.Subnetwork response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -13020,6 +13215,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -13053,7 +13249,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -13085,6 +13281,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -13124,7 +13321,7 @@ namespace ComputeSample
                 foreach (Data.Subnetwork subnetwork in response.Items)
                 {
                     // TODO: Change code below to process each `subnetwork` resource:
-                    Console.WriteLine(subnetwork);
+                    Console.WriteLine(JsonConvert.SerializeObject(subnetwork));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -13159,6 +13356,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -13189,7 +13387,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -13221,6 +13419,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -13251,7 +13450,7 @@ namespace ComputeSample
             // Data.TargetHttpProxy response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -13283,6 +13482,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -13313,7 +13513,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -13345,6 +13545,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -13381,7 +13582,7 @@ namespace ComputeSample
                 foreach (Data.TargetHttpProxy targetHttpProxy in response.Items)
                 {
                     // TODO: Change code below to process each `targetHttpProxy` resource:
-                    Console.WriteLine(targetHttpProxy);
+                    Console.WriteLine(JsonConvert.SerializeObject(targetHttpProxy));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -13416,6 +13617,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -13449,7 +13651,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -13481,6 +13683,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -13511,7 +13714,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -13543,6 +13746,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -13573,7 +13777,7 @@ namespace ComputeSample
             // Data.TargetHttpsProxy response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -13605,6 +13809,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -13635,7 +13840,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -13667,6 +13872,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -13703,7 +13909,7 @@ namespace ComputeSample
                 foreach (Data.TargetHttpsProxy targetHttpsProxy in response.Items)
                 {
                     // TODO: Change code below to process each `targetHttpsProxy` resource:
-                    Console.WriteLine(targetHttpsProxy);
+                    Console.WriteLine(JsonConvert.SerializeObject(targetHttpsProxy));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -13738,6 +13944,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -13771,7 +13978,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -13803,6 +14010,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -13836,7 +14044,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -13868,6 +14076,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -13905,7 +14114,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.TargetInstancesScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine("[" + item.Key + "] = " + item.Value);
+                    Console.WriteLine(JsonConvert.SerializeObject(item));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -13940,6 +14149,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -13973,7 +14183,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -14005,6 +14215,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -14038,7 +14249,7 @@ namespace ComputeSample
             // Data.TargetInstance response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -14070,6 +14281,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -14103,7 +14315,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -14135,6 +14347,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -14174,7 +14387,7 @@ namespace ComputeSample
                 foreach (Data.TargetInstance targetInstance in response.Items)
                 {
                     // TODO: Change code below to process each `targetInstance` resource:
-                    Console.WriteLine(targetInstance);
+                    Console.WriteLine(JsonConvert.SerializeObject(targetInstance));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -14209,6 +14422,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -14245,7 +14459,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -14277,6 +14491,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -14313,7 +14528,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -14345,6 +14560,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -14382,7 +14598,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.TargetPoolsScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine("[" + item.Key + "] = " + item.Value);
+                    Console.WriteLine(JsonConvert.SerializeObject(item));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -14417,6 +14633,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -14450,7 +14667,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -14482,6 +14699,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -14515,7 +14733,7 @@ namespace ComputeSample
             // Data.TargetPool response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -14547,6 +14765,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -14583,7 +14802,7 @@ namespace ComputeSample
             // Data.TargetPoolInstanceHealth response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -14615,6 +14834,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -14648,7 +14868,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -14680,6 +14900,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -14719,7 +14940,7 @@ namespace ComputeSample
                 foreach (Data.TargetPool targetPool in response.Items)
                 {
                     // TODO: Change code below to process each `targetPool` resource:
-                    Console.WriteLine(targetPool);
+                    Console.WriteLine(JsonConvert.SerializeObject(targetPool));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -14754,6 +14975,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -14790,7 +15012,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -14822,6 +15044,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -14858,7 +15081,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -14890,6 +15113,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -14926,7 +15150,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -14958,6 +15182,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -14988,7 +15213,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -15020,6 +15245,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -15050,7 +15276,7 @@ namespace ComputeSample
             // Data.TargetSslProxy response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -15082,6 +15308,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -15112,7 +15339,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -15144,6 +15371,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -15180,7 +15408,7 @@ namespace ComputeSample
                 foreach (Data.TargetSslProxy targetSslProxy in response.Items)
                 {
                     // TODO: Change code below to process each `targetSslProxy` resource:
-                    Console.WriteLine(targetSslProxy);
+                    Console.WriteLine(JsonConvert.SerializeObject(targetSslProxy));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -15215,6 +15443,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -15248,7 +15477,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -15280,6 +15509,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -15313,7 +15543,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -15345,6 +15575,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -15378,7 +15609,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -15410,6 +15641,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -15447,7 +15679,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.TargetVpnGatewaysScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine("[" + item.Key + "] = " + item.Value);
+                    Console.WriteLine(JsonConvert.SerializeObject(item));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -15482,6 +15714,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -15515,7 +15748,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -15547,6 +15780,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -15580,7 +15814,7 @@ namespace ComputeSample
             // Data.TargetVpnGateway response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -15612,6 +15846,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -15645,7 +15880,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -15677,6 +15912,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -15716,7 +15952,7 @@ namespace ComputeSample
                 foreach (Data.TargetVpnGateway targetVpnGateway in response.Items)
                 {
                     // TODO: Change code below to process each `targetVpnGateway` resource:
-                    Console.WriteLine(targetVpnGateway);
+                    Console.WriteLine(JsonConvert.SerializeObject(targetVpnGateway));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -15751,6 +15987,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -15781,7 +16018,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -15813,6 +16050,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -15843,7 +16081,7 @@ namespace ComputeSample
             // Data.UrlMap response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -15875,6 +16113,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -15905,7 +16144,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -15937,6 +16176,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -15970,7 +16210,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -16002,6 +16242,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -16038,7 +16279,7 @@ namespace ComputeSample
                 foreach (Data.UrlMap urlMap in response.Items)
                 {
                     // TODO: Change code below to process each `urlMap` resource:
-                    Console.WriteLine(urlMap);
+                    Console.WriteLine(JsonConvert.SerializeObject(urlMap));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -16073,6 +16314,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -16107,7 +16349,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -16139,6 +16381,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -16173,7 +16416,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -16205,6 +16448,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -16238,7 +16482,7 @@ namespace ComputeSample
             // Data.UrlMapsValidateResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -16270,6 +16514,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -16307,7 +16552,7 @@ namespace ComputeSample
                 foreach (KeyValuePair<string, Data.VpnTunnelsScopedList> item in response.Items)
                 {
                     // TODO: Change code below to process each `item` element:
-                    Console.WriteLine("[" + item.Key + "] = " + item.Value);
+                    Console.WriteLine(JsonConvert.SerializeObject(item));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -16342,6 +16587,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -16375,7 +16621,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -16407,6 +16653,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -16440,7 +16687,7 @@ namespace ComputeSample
             // Data.VpnTunnel response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -16472,6 +16719,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -16505,7 +16753,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -16537,6 +16785,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -16576,7 +16825,7 @@ namespace ComputeSample
                 foreach (Data.VpnTunnel vpnTunnel in response.Items)
                 {
                     // TODO: Change code below to process each `vpnTunnel` resource:
-                    Console.WriteLine(vpnTunnel);
+                    Console.WriteLine(JsonConvert.SerializeObject(vpnTunnel));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -16611,6 +16860,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System.Threading.Tasks;
 
 namespace ComputeSample
@@ -16670,6 +16920,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -16703,7 +16954,7 @@ namespace ComputeSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -16735,6 +16986,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -16774,7 +17026,7 @@ namespace ComputeSample
                 foreach (Data.Operation operation in response.Items)
                 {
                     // TODO: Change code below to process each `operation` resource:
-                    Console.WriteLine(operation);
+                    Console.WriteLine(JsonConvert.SerializeObject(operation));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -16809,6 +17061,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -16839,7 +17092,7 @@ namespace ComputeSample
             // Data.Zone response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -16871,6 +17124,7 @@ namespace ComputeSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Compute.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -16907,7 +17161,7 @@ namespace ComputeSample
                 foreach (Data.Zone zone in response.Items)
                 {
                     // TODO: Change code below to process each `zone` resource:
-                    Console.WriteLine(zone);
+                    Console.WriteLine(JsonConvert.SerializeObject(zone));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_container.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_container.v1.json.baseline
@@ -17,6 +17,7 @@
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Container.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -52,7 +53,7 @@ namespace ContainerSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -84,6 +85,7 @@ namespace ContainerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Container.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -119,7 +121,7 @@ namespace ContainerSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -151,6 +153,7 @@ namespace ContainerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Container.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -186,7 +189,7 @@ namespace ContainerSample
             // Data.Cluster response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -218,6 +221,7 @@ namespace ContainerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Container.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -250,7 +254,7 @@ namespace ContainerSample
             // Data.ListClustersResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -282,6 +286,7 @@ namespace ContainerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Container.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -320,7 +325,7 @@ namespace ContainerSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -352,6 +357,7 @@ namespace ContainerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Container.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -390,7 +396,7 @@ namespace ContainerSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -422,6 +428,7 @@ namespace ContainerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Container.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -460,7 +467,7 @@ namespace ContainerSample
             // Data.NodePool response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -492,6 +499,7 @@ namespace ContainerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Container.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -527,7 +535,7 @@ namespace ContainerSample
             // Data.ListNodePoolsResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -559,6 +567,7 @@ namespace ContainerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Container.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -598,7 +607,7 @@ namespace ContainerSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -630,6 +639,7 @@ namespace ContainerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Container.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -662,7 +672,7 @@ namespace ContainerSample
             // Data.ServerConfig response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -694,6 +704,7 @@ namespace ContainerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Container.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -729,7 +740,7 @@ namespace ContainerSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -761,6 +772,7 @@ namespace ContainerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Container.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -793,7 +805,7 @@ namespace ContainerSample
             // Data.ListOperationsResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_dataflow.v1b3.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_dataflow.v1b3.json.baseline
@@ -17,6 +17,7 @@
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataflow.v1b3;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -47,7 +48,7 @@ namespace DataflowSample
             // Data.Job response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -79,6 +80,7 @@ namespace DataflowSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataflow.v1b3;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -112,7 +114,7 @@ namespace DataflowSample
             // Data.GetDebugConfigResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -144,6 +146,7 @@ namespace DataflowSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataflow.v1b3;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -177,7 +180,7 @@ namespace DataflowSample
             // Data.SendDebugCaptureResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -209,6 +212,7 @@ namespace DataflowSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataflow.v1b3;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -239,7 +243,7 @@ namespace DataflowSample
             // Data.Job response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -271,6 +275,7 @@ namespace DataflowSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataflow.v1b3;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -301,7 +306,7 @@ namespace DataflowSample
             // Data.JobMetrics response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -333,6 +338,7 @@ namespace DataflowSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataflow.v1b3;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -369,7 +375,7 @@ namespace DataflowSample
                 foreach (Data.Job job in response.Jobs)
                 {
                     // TODO: Change code below to process each `job` resource:
-                    Console.WriteLine(job);
+                    Console.WriteLine(JsonConvert.SerializeObject(job));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -404,6 +410,7 @@ namespace DataflowSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataflow.v1b3;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -443,7 +450,7 @@ namespace DataflowSample
                 foreach (Data.JobMessage jobMessage in response.JobMessages)
                 {
                     // TODO: Change code below to process each `jobMessage` resource:
-                    Console.WriteLine(jobMessage);
+                    Console.WriteLine(JsonConvert.SerializeObject(jobMessage));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -478,6 +485,7 @@ namespace DataflowSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataflow.v1b3;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -512,7 +520,7 @@ namespace DataflowSample
             // Data.Job response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -544,6 +552,7 @@ namespace DataflowSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataflow.v1b3;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -577,7 +586,7 @@ namespace DataflowSample
             // Data.LeaseWorkItemResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -609,6 +618,7 @@ namespace DataflowSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataflow.v1b3;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -642,7 +652,7 @@ namespace DataflowSample
             // Data.ReportWorkItemStatusResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -674,6 +684,7 @@ namespace DataflowSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataflow.v1b3;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -707,7 +718,7 @@ namespace DataflowSample
             // Data.Job response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -739,6 +750,7 @@ namespace DataflowSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataflow.v1b3;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -772,7 +784,7 @@ namespace DataflowSample
             // Data.Job response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -804,6 +816,7 @@ namespace DataflowSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataflow.v1b3;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -837,7 +850,7 @@ namespace DataflowSample
             // Data.JobMetrics response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -869,6 +882,7 @@ namespace DataflowSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataflow.v1b3;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -908,7 +922,7 @@ namespace DataflowSample
                 foreach (Data.Job job in response.Jobs)
                 {
                     // TODO: Change code below to process each `job` resource:
-                    Console.WriteLine(job);
+                    Console.WriteLine(JsonConvert.SerializeObject(job));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -943,6 +957,7 @@ namespace DataflowSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataflow.v1b3;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -985,7 +1000,7 @@ namespace DataflowSample
                 foreach (Data.JobMessage jobMessage in response.JobMessages)
                 {
                     // TODO: Change code below to process each `jobMessage` resource:
-                    Console.WriteLine(jobMessage);
+                    Console.WriteLine(JsonConvert.SerializeObject(jobMessage));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -1020,6 +1035,7 @@ namespace DataflowSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataflow.v1b3;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1057,7 +1073,7 @@ namespace DataflowSample
             // Data.Job response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1089,6 +1105,7 @@ namespace DataflowSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataflow.v1b3;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1125,7 +1142,7 @@ namespace DataflowSample
             // Data.LeaseWorkItemResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1157,6 +1174,7 @@ namespace DataflowSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataflow.v1b3;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1193,7 +1211,7 @@ namespace DataflowSample
             // Data.ReportWorkItemStatusResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1225,6 +1243,7 @@ namespace DataflowSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataflow.v1b3;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1255,7 +1274,7 @@ namespace DataflowSample
             // Data.Job response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1287,6 +1306,7 @@ namespace DataflowSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dataflow.v1b3;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1317,7 +1337,7 @@ namespace DataflowSample
             // Data.SendWorkerMessagesResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_datastore.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_datastore.v1.json.baseline
@@ -17,6 +17,7 @@
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Datastore.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -47,7 +48,7 @@ namespace DatastoreSample
             // Data.AllocateIdsResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -79,6 +80,7 @@ namespace DatastoreSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Datastore.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -109,7 +111,7 @@ namespace DatastoreSample
             // Data.BeginTransactionResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -141,6 +143,7 @@ namespace DatastoreSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Datastore.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -171,7 +174,7 @@ namespace DatastoreSample
             // Data.CommitResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -203,6 +206,7 @@ namespace DatastoreSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Datastore.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -233,7 +237,7 @@ namespace DatastoreSample
             // Data.LookupResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -265,6 +269,7 @@ namespace DatastoreSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Datastore.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -295,7 +300,7 @@ namespace DatastoreSample
             // Data.RollbackResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -327,6 +332,7 @@ namespace DatastoreSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Datastore.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -357,7 +363,7 @@ namespace DatastoreSample
             // Data.RunQueryResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_deploymentmanager.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_deploymentmanager.v2.json.baseline
@@ -17,6 +17,7 @@
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.DeploymentManager.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -50,7 +51,7 @@ namespace DeploymentManagerSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -82,6 +83,7 @@ namespace DeploymentManagerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.DeploymentManager.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -112,7 +114,7 @@ namespace DeploymentManagerSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -144,6 +146,7 @@ namespace DeploymentManagerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.DeploymentManager.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -174,7 +177,7 @@ namespace DeploymentManagerSample
             // Data.Deployment response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -206,6 +209,7 @@ namespace DeploymentManagerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.DeploymentManager.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -236,7 +240,7 @@ namespace DeploymentManagerSample
             // Data.Policy response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -268,6 +272,7 @@ namespace DeploymentManagerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.DeploymentManager.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -298,7 +303,7 @@ namespace DeploymentManagerSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -330,6 +335,7 @@ namespace DeploymentManagerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.DeploymentManager.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -366,7 +372,7 @@ namespace DeploymentManagerSample
                 foreach (Data.Deployment deployment in response.Deployments)
                 {
                     // TODO: Change code below to process each `deployment` resource:
-                    Console.WriteLine(deployment);
+                    Console.WriteLine(JsonConvert.SerializeObject(deployment));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -401,6 +407,7 @@ namespace DeploymentManagerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.DeploymentManager.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -435,7 +442,7 @@ namespace DeploymentManagerSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -467,6 +474,7 @@ namespace DeploymentManagerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.DeploymentManager.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -500,7 +508,7 @@ namespace DeploymentManagerSample
             // Data.Policy response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -532,6 +540,7 @@ namespace DeploymentManagerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.DeploymentManager.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -565,7 +574,7 @@ namespace DeploymentManagerSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -597,6 +606,7 @@ namespace DeploymentManagerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.DeploymentManager.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -630,7 +640,7 @@ namespace DeploymentManagerSample
             // Data.TestPermissionsResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -662,6 +672,7 @@ namespace DeploymentManagerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.DeploymentManager.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -696,7 +707,7 @@ namespace DeploymentManagerSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -728,6 +739,7 @@ namespace DeploymentManagerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.DeploymentManager.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -761,7 +773,7 @@ namespace DeploymentManagerSample
             // Data.Manifest response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -793,6 +805,7 @@ namespace DeploymentManagerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.DeploymentManager.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -832,7 +845,7 @@ namespace DeploymentManagerSample
                 foreach (Data.Manifest manifest in response.Manifests)
                 {
                     // TODO: Change code below to process each `manifest` resource:
-                    Console.WriteLine(manifest);
+                    Console.WriteLine(JsonConvert.SerializeObject(manifest));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -867,6 +880,7 @@ namespace DeploymentManagerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.DeploymentManager.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -897,7 +911,7 @@ namespace DeploymentManagerSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -929,6 +943,7 @@ namespace DeploymentManagerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.DeploymentManager.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -965,7 +980,7 @@ namespace DeploymentManagerSample
                 foreach (Data.Operation operation in response.Operations)
                 {
                     // TODO: Change code below to process each `operation` resource:
-                    Console.WriteLine(operation);
+                    Console.WriteLine(JsonConvert.SerializeObject(operation));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -1000,6 +1015,7 @@ namespace DeploymentManagerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.DeploymentManager.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1033,7 +1049,7 @@ namespace DeploymentManagerSample
             // Data.Resource response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1065,6 +1081,7 @@ namespace DeploymentManagerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.DeploymentManager.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1104,7 +1121,7 @@ namespace DeploymentManagerSample
                 foreach (Data.Resource resource in response.Resources)
                 {
                     // TODO: Change code below to process each `resource` resource:
-                    Console.WriteLine(resource);
+                    Console.WriteLine(JsonConvert.SerializeObject(resource));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -1139,6 +1156,7 @@ namespace DeploymentManagerSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.DeploymentManager.v2;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1175,7 +1193,7 @@ namespace DeploymentManagerSample
                 foreach (Data.Type type in response.Types)
                 {
                     // TODO: Change code below to process each `type` resource:
-                    Console.WriteLine(type);
+                    Console.WriteLine(JsonConvert.SerializeObject(type));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_dfareporting.v2.6.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_dfareporting.v2.6.json.baseline
@@ -11,6 +11,7 @@
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -40,7 +41,7 @@ namespace DfareportingSample
             // Data.AccountActiveAdSummary response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -66,6 +67,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -95,7 +97,7 @@ namespace DfareportingSample
             // Data.AccountPermissionGroup response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -121,6 +123,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -147,7 +150,7 @@ namespace DfareportingSample
             // Data.AccountPermissionGroupsListResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -173,6 +176,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -202,7 +206,7 @@ namespace DfareportingSample
             // Data.AccountPermission response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -228,6 +232,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -254,7 +259,7 @@ namespace DfareportingSample
             // Data.AccountPermissionsListResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -280,6 +285,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -309,7 +315,7 @@ namespace DfareportingSample
             // Data.AccountUserProfile response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -335,6 +341,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -364,7 +371,7 @@ namespace DfareportingSample
             // Data.AccountUserProfile response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -390,6 +397,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -425,7 +433,7 @@ namespace DfareportingSample
                 foreach (Data.AccountUserProfile accountUserProfile in response.AccountUserProfiles)
                 {
                     // TODO: Change code below to process each `accountUserProfile` resource:
-                    Console.WriteLine(accountUserProfile);
+                    Console.WriteLine(JsonConvert.SerializeObject(accountUserProfile));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -454,6 +462,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -487,7 +496,7 @@ namespace DfareportingSample
             // Data.AccountUserProfile response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -513,6 +522,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -543,7 +553,7 @@ namespace DfareportingSample
             // Data.AccountUserProfile response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -569,6 +579,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -598,7 +609,7 @@ namespace DfareportingSample
             // Data.Account response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -624,6 +635,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -659,7 +671,7 @@ namespace DfareportingSample
                 foreach (Data.Account account in response.Accounts)
                 {
                     // TODO: Change code below to process each `account` resource:
-                    Console.WriteLine(account);
+                    Console.WriteLine(JsonConvert.SerializeObject(account));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -688,6 +700,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -721,7 +734,7 @@ namespace DfareportingSample
             // Data.Account response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -747,6 +760,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -777,7 +791,7 @@ namespace DfareportingSample
             // Data.Account response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -803,6 +817,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -832,7 +847,7 @@ namespace DfareportingSample
             // Data.Ad response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -858,6 +873,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -887,7 +903,7 @@ namespace DfareportingSample
             // Data.Ad response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -913,6 +929,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -948,7 +965,7 @@ namespace DfareportingSample
                 foreach (Data.Ad ad in response.Ads)
                 {
                     // TODO: Change code below to process each `ad` resource:
-                    Console.WriteLine(ad);
+                    Console.WriteLine(JsonConvert.SerializeObject(ad));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -977,6 +994,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -1010,7 +1028,7 @@ namespace DfareportingSample
             // Data.Ad response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -1036,6 +1054,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -1066,7 +1085,7 @@ namespace DfareportingSample
             // Data.Ad response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -1092,6 +1111,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 
 namespace DfareportingSample
 {
@@ -1141,6 +1161,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -1170,7 +1191,7 @@ namespace DfareportingSample
             // Data.AdvertiserGroup response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -1196,6 +1217,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -1225,7 +1247,7 @@ namespace DfareportingSample
             // Data.AdvertiserGroup response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -1251,6 +1273,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -1286,7 +1309,7 @@ namespace DfareportingSample
                 foreach (Data.AdvertiserGroup advertiserGroup in response.AdvertiserGroups)
                 {
                     // TODO: Change code below to process each `advertiserGroup` resource:
-                    Console.WriteLine(advertiserGroup);
+                    Console.WriteLine(JsonConvert.SerializeObject(advertiserGroup));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -1315,6 +1338,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -1348,7 +1372,7 @@ namespace DfareportingSample
             // Data.AdvertiserGroup response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -1374,6 +1398,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -1404,7 +1429,7 @@ namespace DfareportingSample
             // Data.AdvertiserGroup response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -1430,6 +1455,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -1459,7 +1485,7 @@ namespace DfareportingSample
             // Data.Advertiser response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -1485,6 +1511,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -1514,7 +1541,7 @@ namespace DfareportingSample
             // Data.Advertiser response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -1540,6 +1567,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -1575,7 +1603,7 @@ namespace DfareportingSample
                 foreach (Data.Advertiser advertiser in response.Advertisers)
                 {
                     // TODO: Change code below to process each `advertiser` resource:
-                    Console.WriteLine(advertiser);
+                    Console.WriteLine(JsonConvert.SerializeObject(advertiser));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -1604,6 +1632,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -1637,7 +1666,7 @@ namespace DfareportingSample
             // Data.Advertiser response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -1663,6 +1692,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -1693,7 +1723,7 @@ namespace DfareportingSample
             // Data.Advertiser response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -1719,6 +1749,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -1745,7 +1776,7 @@ namespace DfareportingSample
             // Data.BrowsersListResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -1771,6 +1802,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -1803,7 +1835,7 @@ namespace DfareportingSample
             // Data.CampaignCreativeAssociation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -1829,6 +1861,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -1867,7 +1900,7 @@ namespace DfareportingSample
                 foreach (Data.CampaignCreativeAssociation campaignCreativeAssociation in response.CampaignCreativeAssociations)
                 {
                     // TODO: Change code below to process each `campaignCreativeAssociation` resource:
-                    Console.WriteLine(campaignCreativeAssociation);
+                    Console.WriteLine(JsonConvert.SerializeObject(campaignCreativeAssociation));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -1896,6 +1929,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -1925,7 +1959,7 @@ namespace DfareportingSample
             // Data.Campaign response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -1951,6 +1985,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -1986,7 +2021,7 @@ namespace DfareportingSample
             // Data.Campaign response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -2012,6 +2047,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -2047,7 +2083,7 @@ namespace DfareportingSample
                 foreach (Data.Campaign campaign in response.Campaigns)
                 {
                     // TODO: Change code below to process each `campaign` resource:
-                    Console.WriteLine(campaign);
+                    Console.WriteLine(JsonConvert.SerializeObject(campaign));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -2076,6 +2112,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -2109,7 +2146,7 @@ namespace DfareportingSample
             // Data.Campaign response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -2135,6 +2172,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -2165,7 +2203,7 @@ namespace DfareportingSample
             // Data.Campaign response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -2191,6 +2229,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -2220,7 +2259,7 @@ namespace DfareportingSample
             // Data.ChangeLog response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -2246,6 +2285,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -2281,7 +2321,7 @@ namespace DfareportingSample
                 foreach (Data.ChangeLog changeLog in response.ChangeLogs)
                 {
                     // TODO: Change code below to process each `changeLog` resource:
-                    Console.WriteLine(changeLog);
+                    Console.WriteLine(JsonConvert.SerializeObject(changeLog));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -2310,6 +2350,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -2336,7 +2377,7 @@ namespace DfareportingSample
             // Data.CitiesListResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -2362,6 +2403,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -2391,7 +2433,7 @@ namespace DfareportingSample
             // Data.ConnectionType response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -2417,6 +2459,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -2443,7 +2486,7 @@ namespace DfareportingSample
             // Data.ConnectionTypesListResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -2469,6 +2512,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 
 namespace DfareportingSample
 {
@@ -2518,6 +2562,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -2547,7 +2592,7 @@ namespace DfareportingSample
             // Data.ContentCategory response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -2573,6 +2618,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -2602,7 +2648,7 @@ namespace DfareportingSample
             // Data.ContentCategory response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -2628,6 +2674,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -2663,7 +2710,7 @@ namespace DfareportingSample
                 foreach (Data.ContentCategory contentCategory in response.ContentCategories)
                 {
                     // TODO: Change code below to process each `contentCategory` resource:
-                    Console.WriteLine(contentCategory);
+                    Console.WriteLine(JsonConvert.SerializeObject(contentCategory));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -2692,6 +2739,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -2725,7 +2773,7 @@ namespace DfareportingSample
             // Data.ContentCategory response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -2751,6 +2799,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -2781,7 +2830,7 @@ namespace DfareportingSample
             // Data.ContentCategory response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -2807,6 +2856,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -2836,7 +2886,7 @@ namespace DfareportingSample
             // Data.ConversionsBatchInsertResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -2862,6 +2912,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -2891,7 +2942,7 @@ namespace DfareportingSample
             // Data.Country response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -2917,6 +2968,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -2943,7 +2995,7 @@ namespace DfareportingSample
             // Data.CountriesListResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -2969,6 +3021,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -3004,7 +3057,7 @@ namespace DfareportingSample
             // Data.CreativeAssetMetadata response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -3030,6 +3083,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 
 namespace DfareportingSample
 {
@@ -3082,6 +3136,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -3114,7 +3169,7 @@ namespace DfareportingSample
             // Data.CreativeFieldValue response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -3140,6 +3195,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -3172,7 +3228,7 @@ namespace DfareportingSample
             // Data.CreativeFieldValue response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -3198,6 +3254,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -3236,7 +3293,7 @@ namespace DfareportingSample
                 foreach (Data.CreativeFieldValue creativeFieldValue in response.CreativeFieldValues)
                 {
                     // TODO: Change code below to process each `creativeFieldValue` resource:
-                    Console.WriteLine(creativeFieldValue);
+                    Console.WriteLine(JsonConvert.SerializeObject(creativeFieldValue));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -3265,6 +3322,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -3301,7 +3359,7 @@ namespace DfareportingSample
             // Data.CreativeFieldValue response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -3327,6 +3385,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -3360,7 +3419,7 @@ namespace DfareportingSample
             // Data.CreativeFieldValue response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -3386,6 +3445,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 
 namespace DfareportingSample
 {
@@ -3435,6 +3495,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -3464,7 +3525,7 @@ namespace DfareportingSample
             // Data.CreativeField response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -3490,6 +3551,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -3519,7 +3581,7 @@ namespace DfareportingSample
             // Data.CreativeField response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -3545,6 +3607,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -3580,7 +3643,7 @@ namespace DfareportingSample
                 foreach (Data.CreativeField creativeField in response.CreativeFields)
                 {
                     // TODO: Change code below to process each `creativeField` resource:
-                    Console.WriteLine(creativeField);
+                    Console.WriteLine(JsonConvert.SerializeObject(creativeField));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -3609,6 +3672,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -3642,7 +3706,7 @@ namespace DfareportingSample
             // Data.CreativeField response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -3668,6 +3732,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -3698,7 +3763,7 @@ namespace DfareportingSample
             // Data.CreativeField response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -3724,6 +3789,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -3753,7 +3819,7 @@ namespace DfareportingSample
             // Data.CreativeGroup response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -3779,6 +3845,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -3808,7 +3875,7 @@ namespace DfareportingSample
             // Data.CreativeGroup response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -3834,6 +3901,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -3869,7 +3937,7 @@ namespace DfareportingSample
                 foreach (Data.CreativeGroup creativeGroup in response.CreativeGroups)
                 {
                     // TODO: Change code below to process each `creativeGroup` resource:
-                    Console.WriteLine(creativeGroup);
+                    Console.WriteLine(JsonConvert.SerializeObject(creativeGroup));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -3898,6 +3966,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -3931,7 +4000,7 @@ namespace DfareportingSample
             // Data.CreativeGroup response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -3957,6 +4026,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -3987,7 +4057,7 @@ namespace DfareportingSample
             // Data.CreativeGroup response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -4013,6 +4083,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -4042,7 +4113,7 @@ namespace DfareportingSample
             // Data.Creative response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -4068,6 +4139,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -4097,7 +4169,7 @@ namespace DfareportingSample
             // Data.Creative response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -4123,6 +4195,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -4158,7 +4231,7 @@ namespace DfareportingSample
                 foreach (Data.Creative creative in response.Creatives)
                 {
                     // TODO: Change code below to process each `creative` resource:
-                    Console.WriteLine(creative);
+                    Console.WriteLine(JsonConvert.SerializeObject(creative));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -4187,6 +4260,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -4220,7 +4294,7 @@ namespace DfareportingSample
             // Data.Creative response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -4246,6 +4320,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -4276,7 +4351,7 @@ namespace DfareportingSample
             // Data.Creative response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -4302,6 +4377,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -4340,7 +4416,7 @@ namespace DfareportingSample
                 foreach (Data.DimensionValue dimensionValue in response.Items)
                 {
                     // TODO: Change code below to process each `dimensionValue` resource:
-                    Console.WriteLine(dimensionValue);
+                    Console.WriteLine(JsonConvert.SerializeObject(dimensionValue));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -4369,6 +4445,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -4398,7 +4475,7 @@ namespace DfareportingSample
             // Data.DirectorySiteContact response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -4424,6 +4501,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -4459,7 +4537,7 @@ namespace DfareportingSample
                 foreach (Data.DirectorySiteContact directorySiteContact in response.DirectorySiteContacts)
                 {
                     // TODO: Change code below to process each `directorySiteContact` resource:
-                    Console.WriteLine(directorySiteContact);
+                    Console.WriteLine(JsonConvert.SerializeObject(directorySiteContact));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -4488,6 +4566,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -4517,7 +4596,7 @@ namespace DfareportingSample
             // Data.DirectorySite response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -4543,6 +4622,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -4572,7 +4652,7 @@ namespace DfareportingSample
             // Data.DirectorySite response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -4598,6 +4678,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -4633,7 +4714,7 @@ namespace DfareportingSample
                 foreach (Data.DirectorySite directorySite in response.DirectorySites)
                 {
                     // TODO: Change code below to process each `directorySite` resource:
-                    Console.WriteLine(directorySite);
+                    Console.WriteLine(JsonConvert.SerializeObject(directorySite));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -4662,6 +4743,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 
 namespace DfareportingSample
 {
@@ -4718,6 +4800,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -4747,7 +4830,7 @@ namespace DfareportingSample
             // Data.DynamicTargetingKey response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -4773,6 +4856,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -4799,7 +4883,7 @@ namespace DfareportingSample
             // Data.DynamicTargetingKeysListResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -4825,6 +4909,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 
 namespace DfareportingSample
 {
@@ -4874,6 +4959,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -4903,7 +4989,7 @@ namespace DfareportingSample
             // Data.EventTag response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -4929,6 +5015,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -4958,7 +5045,7 @@ namespace DfareportingSample
             // Data.EventTag response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -4984,6 +5071,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -5010,7 +5098,7 @@ namespace DfareportingSample
             // Data.EventTagsListResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -5036,6 +5124,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -5069,7 +5158,7 @@ namespace DfareportingSample
             // Data.EventTag response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -5095,6 +5184,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -5125,7 +5215,7 @@ namespace DfareportingSample
             // Data.EventTag response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -5151,6 +5241,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -5183,7 +5274,7 @@ namespace DfareportingSample
             // Data.File response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -5209,6 +5300,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -5244,7 +5336,7 @@ namespace DfareportingSample
                 foreach (Data.File file in response.Items)
                 {
                     // TODO: Change code below to process each `file` resource:
-                    Console.WriteLine(file);
+                    Console.WriteLine(JsonConvert.SerializeObject(file));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -5273,6 +5365,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 
 namespace DfareportingSample
 {
@@ -5322,6 +5415,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -5348,7 +5442,7 @@ namespace DfareportingSample
             // Data.FloodlightActivitiesGenerateTagResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -5374,6 +5468,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -5403,7 +5498,7 @@ namespace DfareportingSample
             // Data.FloodlightActivity response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -5429,6 +5524,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -5458,7 +5554,7 @@ namespace DfareportingSample
             // Data.FloodlightActivity response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -5484,6 +5580,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -5519,7 +5616,7 @@ namespace DfareportingSample
                 foreach (Data.FloodlightActivity floodlightActivity in response.FloodlightActivities)
                 {
                     // TODO: Change code below to process each `floodlightActivity` resource:
-                    Console.WriteLine(floodlightActivity);
+                    Console.WriteLine(JsonConvert.SerializeObject(floodlightActivity));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -5548,6 +5645,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -5581,7 +5679,7 @@ namespace DfareportingSample
             // Data.FloodlightActivity response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -5607,6 +5705,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -5637,7 +5736,7 @@ namespace DfareportingSample
             // Data.FloodlightActivity response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -5663,6 +5762,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -5692,7 +5792,7 @@ namespace DfareportingSample
             // Data.FloodlightActivityGroup response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -5718,6 +5818,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -5747,7 +5848,7 @@ namespace DfareportingSample
             // Data.FloodlightActivityGroup response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -5773,6 +5874,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -5808,7 +5910,7 @@ namespace DfareportingSample
                 foreach (Data.FloodlightActivityGroup floodlightActivityGroup in response.FloodlightActivityGroups)
                 {
                     // TODO: Change code below to process each `floodlightActivityGroup` resource:
-                    Console.WriteLine(floodlightActivityGroup);
+                    Console.WriteLine(JsonConvert.SerializeObject(floodlightActivityGroup));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -5837,6 +5939,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -5870,7 +5973,7 @@ namespace DfareportingSample
             // Data.FloodlightActivityGroup response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -5896,6 +5999,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -5926,7 +6030,7 @@ namespace DfareportingSample
             // Data.FloodlightActivityGroup response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -5952,6 +6056,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -5981,7 +6086,7 @@ namespace DfareportingSample
             // Data.FloodlightConfiguration response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -6007,6 +6112,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -6033,7 +6139,7 @@ namespace DfareportingSample
             // Data.FloodlightConfigurationsListResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -6059,6 +6165,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -6092,7 +6199,7 @@ namespace DfareportingSample
             // Data.FloodlightConfiguration response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -6118,6 +6225,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -6148,7 +6256,7 @@ namespace DfareportingSample
             // Data.FloodlightConfiguration response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -6174,6 +6282,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -6206,7 +6315,7 @@ namespace DfareportingSample
             // Data.InventoryItem response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -6232,6 +6341,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -6270,7 +6380,7 @@ namespace DfareportingSample
                 foreach (Data.InventoryItem inventoryItem in response.InventoryItems)
                 {
                     // TODO: Change code below to process each `inventoryItem` resource:
-                    Console.WriteLine(inventoryItem);
+                    Console.WriteLine(JsonConvert.SerializeObject(inventoryItem));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -6299,6 +6409,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 
 namespace DfareportingSample
 {
@@ -6351,6 +6462,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -6383,7 +6495,7 @@ namespace DfareportingSample
             // Data.LandingPage response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -6409,6 +6521,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -6441,7 +6554,7 @@ namespace DfareportingSample
             // Data.LandingPage response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -6467,6 +6580,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -6496,7 +6610,7 @@ namespace DfareportingSample
             // Data.LandingPagesListResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -6522,6 +6636,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -6558,7 +6673,7 @@ namespace DfareportingSample
             // Data.LandingPage response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -6584,6 +6699,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -6617,7 +6733,7 @@ namespace DfareportingSample
             // Data.LandingPage response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -6643,6 +6759,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -6669,7 +6786,7 @@ namespace DfareportingSample
             // Data.LanguagesListResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -6695,6 +6812,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -6721,7 +6839,7 @@ namespace DfareportingSample
             // Data.MetrosListResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -6747,6 +6865,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -6776,7 +6895,7 @@ namespace DfareportingSample
             // Data.MobileCarrier response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -6802,6 +6921,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -6828,7 +6948,7 @@ namespace DfareportingSample
             // Data.MobileCarriersListResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -6854,6 +6974,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -6883,7 +7004,7 @@ namespace DfareportingSample
             // Data.OperatingSystemVersion response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -6909,6 +7030,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -6935,7 +7057,7 @@ namespace DfareportingSample
             // Data.OperatingSystemVersionsListResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -6961,6 +7083,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -6990,7 +7113,7 @@ namespace DfareportingSample
             // Data.OperatingSystem response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -7016,6 +7139,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -7042,7 +7166,7 @@ namespace DfareportingSample
             // Data.OperatingSystemsListResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -7068,6 +7192,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -7100,7 +7225,7 @@ namespace DfareportingSample
             // Data.OrderDocument response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -7126,6 +7251,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -7164,7 +7290,7 @@ namespace DfareportingSample
                 foreach (Data.OrderDocument orderDocument in response.OrderDocuments)
                 {
                     // TODO: Change code below to process each `orderDocument` resource:
-                    Console.WriteLine(orderDocument);
+                    Console.WriteLine(JsonConvert.SerializeObject(orderDocument));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -7193,6 +7319,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -7225,7 +7352,7 @@ namespace DfareportingSample
             // Data.Order response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -7251,6 +7378,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -7289,7 +7417,7 @@ namespace DfareportingSample
                 foreach (Data.Order order in response.Orders)
                 {
                     // TODO: Change code below to process each `order` resource:
-                    Console.WriteLine(order);
+                    Console.WriteLine(JsonConvert.SerializeObject(order));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -7318,6 +7446,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -7347,7 +7476,7 @@ namespace DfareportingSample
             // Data.PlacementGroup response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -7373,6 +7502,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -7402,7 +7532,7 @@ namespace DfareportingSample
             // Data.PlacementGroup response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -7428,6 +7558,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -7463,7 +7594,7 @@ namespace DfareportingSample
                 foreach (Data.PlacementGroup placementGroup in response.PlacementGroups)
                 {
                     // TODO: Change code below to process each `placementGroup` resource:
-                    Console.WriteLine(placementGroup);
+                    Console.WriteLine(JsonConvert.SerializeObject(placementGroup));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -7492,6 +7623,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -7525,7 +7657,7 @@ namespace DfareportingSample
             // Data.PlacementGroup response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -7551,6 +7683,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -7581,7 +7714,7 @@ namespace DfareportingSample
             // Data.PlacementGroup response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -7607,6 +7740,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 
 namespace DfareportingSample
 {
@@ -7656,6 +7790,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -7685,7 +7820,7 @@ namespace DfareportingSample
             // Data.PlacementStrategy response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -7711,6 +7846,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -7740,7 +7876,7 @@ namespace DfareportingSample
             // Data.PlacementStrategy response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -7766,6 +7902,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -7801,7 +7938,7 @@ namespace DfareportingSample
                 foreach (Data.PlacementStrategy placementStrategy in response.PlacementStrategies)
                 {
                     // TODO: Change code below to process each `placementStrategy` resource:
-                    Console.WriteLine(placementStrategy);
+                    Console.WriteLine(JsonConvert.SerializeObject(placementStrategy));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -7830,6 +7967,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -7863,7 +8001,7 @@ namespace DfareportingSample
             // Data.PlacementStrategy response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -7889,6 +8027,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -7919,7 +8058,7 @@ namespace DfareportingSample
             // Data.PlacementStrategy response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -7945,6 +8084,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -7971,7 +8111,7 @@ namespace DfareportingSample
             // Data.PlacementsGenerateTagsResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -7997,6 +8137,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -8026,7 +8167,7 @@ namespace DfareportingSample
             // Data.Placement response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -8052,6 +8193,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -8081,7 +8223,7 @@ namespace DfareportingSample
             // Data.Placement response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -8107,6 +8249,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -8142,7 +8285,7 @@ namespace DfareportingSample
                 foreach (Data.Placement placement in response.Placements)
                 {
                     // TODO: Change code below to process each `placement` resource:
-                    Console.WriteLine(placement);
+                    Console.WriteLine(JsonConvert.SerializeObject(placement));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -8171,6 +8314,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -8204,7 +8348,7 @@ namespace DfareportingSample
             // Data.Placement response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -8230,6 +8374,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -8260,7 +8405,7 @@ namespace DfareportingSample
             // Data.Placement response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -8286,6 +8431,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -8315,7 +8461,7 @@ namespace DfareportingSample
             // Data.PlatformType response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -8341,6 +8487,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -8367,7 +8514,7 @@ namespace DfareportingSample
             // Data.PlatformTypesListResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -8393,6 +8540,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -8422,7 +8570,7 @@ namespace DfareportingSample
             // Data.PostalCode response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -8448,6 +8596,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -8474,7 +8623,7 @@ namespace DfareportingSample
             // Data.PostalCodesListResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -8500,6 +8649,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -8529,7 +8679,7 @@ namespace DfareportingSample
             // Data.Project response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -8555,6 +8705,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -8590,7 +8741,7 @@ namespace DfareportingSample
                 foreach (Data.Project project in response.Projects)
                 {
                     // TODO: Change code below to process each `project` resource:
-                    Console.WriteLine(project);
+                    Console.WriteLine(JsonConvert.SerializeObject(project));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -8619,6 +8770,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -8645,7 +8797,7 @@ namespace DfareportingSample
             // Data.RegionsListResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -8671,6 +8823,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -8700,7 +8853,7 @@ namespace DfareportingSample
             // Data.RemarketingListShare response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -8726,6 +8879,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -8759,7 +8913,7 @@ namespace DfareportingSample
             // Data.RemarketingListShare response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -8785,6 +8939,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -8815,7 +8970,7 @@ namespace DfareportingSample
             // Data.RemarketingListShare response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -8841,6 +8996,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -8870,7 +9026,7 @@ namespace DfareportingSample
             // Data.RemarketingList response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -8896,6 +9052,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -8925,7 +9082,7 @@ namespace DfareportingSample
             // Data.RemarketingList response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -8951,6 +9108,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -8989,7 +9147,7 @@ namespace DfareportingSample
                 foreach (Data.RemarketingList remarketingList in response.RemarketingLists)
                 {
                     // TODO: Change code below to process each `remarketingList` resource:
-                    Console.WriteLine(remarketingList);
+                    Console.WriteLine(JsonConvert.SerializeObject(remarketingList));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -9018,6 +9176,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -9051,7 +9210,7 @@ namespace DfareportingSample
             // Data.RemarketingList response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -9077,6 +9236,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -9107,7 +9267,7 @@ namespace DfareportingSample
             // Data.RemarketingList response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -9133,6 +9293,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -9162,7 +9323,7 @@ namespace DfareportingSample
             // Data.CompatibleFields response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -9188,6 +9349,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 
 namespace DfareportingSample
 {
@@ -9237,6 +9399,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -9272,7 +9435,7 @@ namespace DfareportingSample
             // Data.File response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -9298,6 +9461,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -9336,7 +9500,7 @@ namespace DfareportingSample
                 foreach (Data.File file in response.Items)
                 {
                     // TODO: Change code below to process each `file` resource:
-                    Console.WriteLine(file);
+                    Console.WriteLine(JsonConvert.SerializeObject(file));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -9365,6 +9529,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -9394,7 +9559,7 @@ namespace DfareportingSample
             // Data.Report response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -9420,6 +9585,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -9449,7 +9615,7 @@ namespace DfareportingSample
             // Data.Report response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -9475,6 +9641,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -9510,7 +9677,7 @@ namespace DfareportingSample
                 foreach (Data.Report report in response.Items)
                 {
                     // TODO: Change code below to process each `report` resource:
-                    Console.WriteLine(report);
+                    Console.WriteLine(JsonConvert.SerializeObject(report));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -9539,6 +9706,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -9572,7 +9740,7 @@ namespace DfareportingSample
             // Data.Report response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -9598,6 +9766,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -9627,7 +9796,7 @@ namespace DfareportingSample
             // Data.File response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -9653,6 +9822,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -9686,7 +9856,7 @@ namespace DfareportingSample
             // Data.Report response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -9712,6 +9882,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -9741,7 +9912,7 @@ namespace DfareportingSample
             // Data.Site response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -9767,6 +9938,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -9796,7 +9968,7 @@ namespace DfareportingSample
             // Data.Site response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -9822,6 +9994,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -9857,7 +10030,7 @@ namespace DfareportingSample
                 foreach (Data.Site site in response.Sites)
                 {
                     // TODO: Change code below to process each `site` resource:
-                    Console.WriteLine(site);
+                    Console.WriteLine(JsonConvert.SerializeObject(site));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -9886,6 +10059,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -9919,7 +10093,7 @@ namespace DfareportingSample
             // Data.Site response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -9945,6 +10119,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -9975,7 +10150,7 @@ namespace DfareportingSample
             // Data.Site response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -10001,6 +10176,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -10030,7 +10206,7 @@ namespace DfareportingSample
             // Data.Size response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -10056,6 +10232,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -10085,7 +10262,7 @@ namespace DfareportingSample
             // Data.Size response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -10111,6 +10288,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -10137,7 +10315,7 @@ namespace DfareportingSample
             // Data.SizesListResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -10163,6 +10341,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -10192,7 +10371,7 @@ namespace DfareportingSample
             // Data.Subaccount response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -10218,6 +10397,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -10247,7 +10427,7 @@ namespace DfareportingSample
             // Data.Subaccount response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -10273,6 +10453,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -10308,7 +10489,7 @@ namespace DfareportingSample
                 foreach (Data.Subaccount subaccount in response.Subaccounts)
                 {
                     // TODO: Change code below to process each `subaccount` resource:
-                    Console.WriteLine(subaccount);
+                    Console.WriteLine(JsonConvert.SerializeObject(subaccount));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -10337,6 +10518,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -10370,7 +10552,7 @@ namespace DfareportingSample
             // Data.Subaccount response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -10396,6 +10578,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -10426,7 +10609,7 @@ namespace DfareportingSample
             // Data.Subaccount response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -10452,6 +10635,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -10481,7 +10665,7 @@ namespace DfareportingSample
             // Data.TargetableRemarketingList response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -10507,6 +10691,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -10545,7 +10730,7 @@ namespace DfareportingSample
                 foreach (Data.TargetableRemarketingList targetableRemarketingList in response.TargetableRemarketingLists)
                 {
                     // TODO: Change code below to process each `targetableRemarketingList` resource:
-                    Console.WriteLine(targetableRemarketingList);
+                    Console.WriteLine(JsonConvert.SerializeObject(targetableRemarketingList));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -10574,6 +10759,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -10603,7 +10789,7 @@ namespace DfareportingSample
             // Data.TargetingTemplate response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -10629,6 +10815,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -10658,7 +10845,7 @@ namespace DfareportingSample
             // Data.TargetingTemplate response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -10684,6 +10871,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -10719,7 +10907,7 @@ namespace DfareportingSample
                 foreach (Data.TargetingTemplate targetingTemplate in response.TargetingTemplates)
                 {
                     // TODO: Change code below to process each `targetingTemplate` resource:
-                    Console.WriteLine(targetingTemplate);
+                    Console.WriteLine(JsonConvert.SerializeObject(targetingTemplate));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -10748,6 +10936,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -10781,7 +10970,7 @@ namespace DfareportingSample
             // Data.TargetingTemplate response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -10807,6 +10996,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -10837,7 +11027,7 @@ namespace DfareportingSample
             // Data.TargetingTemplate response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -10863,6 +11053,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -10889,7 +11080,7 @@ namespace DfareportingSample
             // Data.UserProfile response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -10916,6 +11107,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -10939,7 +11131,7 @@ namespace DfareportingSample
             // Data.UserProfileList response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -10966,6 +11158,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -10995,7 +11188,7 @@ namespace DfareportingSample
             // Data.UserRolePermissionGroup response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -11021,6 +11214,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -11047,7 +11241,7 @@ namespace DfareportingSample
             // Data.UserRolePermissionGroupsListResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -11073,6 +11267,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -11102,7 +11297,7 @@ namespace DfareportingSample
             // Data.UserRolePermission response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -11128,6 +11323,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -11154,7 +11350,7 @@ namespace DfareportingSample
             // Data.UserRolePermissionsListResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -11180,6 +11376,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 
 namespace DfareportingSample
 {
@@ -11229,6 +11426,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -11258,7 +11456,7 @@ namespace DfareportingSample
             // Data.UserRole response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -11284,6 +11482,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -11313,7 +11512,7 @@ namespace DfareportingSample
             // Data.UserRole response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -11339,6 +11538,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -11374,7 +11574,7 @@ namespace DfareportingSample
                 foreach (Data.UserRole userRole in response.UserRoles)
                 {
                     // TODO: Change code below to process each `userRole` resource:
-                    Console.WriteLine(userRole);
+                    Console.WriteLine(JsonConvert.SerializeObject(userRole));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -11403,6 +11603,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -11436,7 +11637,7 @@ namespace DfareportingSample
             // Data.UserRole response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -11462,6 +11663,7 @@ namespace DfareportingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dfareporting.v2_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Dfareporting.v2_6.Data;
@@ -11492,7 +11694,7 @@ namespace DfareportingSample
             // Data.UserRole response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_dns.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_dns.v1.json.baseline
@@ -17,6 +17,7 @@
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dns.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -50,7 +51,7 @@ namespace DnsSample
             // Data.Change response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -82,6 +83,7 @@ namespace DnsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dns.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -115,7 +117,7 @@ namespace DnsSample
             // Data.Change response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -147,6 +149,7 @@ namespace DnsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dns.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -186,7 +189,7 @@ namespace DnsSample
                 foreach (Data.Change change in response.Changes)
                 {
                     // TODO: Change code below to process each `change` resource:
-                    Console.WriteLine(change);
+                    Console.WriteLine(JsonConvert.SerializeObject(change));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -221,6 +224,7 @@ namespace DnsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dns.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -251,7 +255,7 @@ namespace DnsSample
             // Data.ManagedZone response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -283,6 +287,7 @@ namespace DnsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dns.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System.Threading.Tasks;
 
 namespace DnsSample
@@ -339,6 +344,7 @@ namespace DnsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dns.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -369,7 +375,7 @@ namespace DnsSample
             // Data.ManagedZone response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -401,6 +407,7 @@ namespace DnsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dns.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -437,7 +444,7 @@ namespace DnsSample
                 foreach (Data.ManagedZone managedZone in response.ManagedZones)
                 {
                     // TODO: Change code below to process each `managedZone` resource:
-                    Console.WriteLine(managedZone);
+                    Console.WriteLine(JsonConvert.SerializeObject(managedZone));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -472,6 +479,7 @@ namespace DnsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dns.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -499,7 +507,7 @@ namespace DnsSample
             // Data.Project response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -531,6 +539,7 @@ namespace DnsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Dns.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -570,7 +579,7 @@ namespace DnsSample
                 foreach (Data.ResourceRecordSet resourceRecordSet in response.Rrsets)
                 {
                     // TODO: Change code below to process each `resourceRecordSet` resource:
-                    Console.WriteLine(resourceRecordSet);
+                    Console.WriteLine(JsonConvert.SerializeObject(resourceRecordSet));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_foo.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_foo.v1.json.baseline
@@ -10,6 +10,7 @@
 
 using Google.Apis.Foo.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Foo.v1.Data;
@@ -29,7 +30,7 @@ namespace FooSample
             // Data.Baz response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
     }
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_genomics.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_genomics.v1.json.baseline
@@ -17,6 +17,7 @@
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -44,7 +45,7 @@ namespace GenomicsSample
             // Data.BatchCreateAnnotationsResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -76,6 +77,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -103,7 +105,7 @@ namespace GenomicsSample
             // Data.Annotation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -135,6 +137,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System.Threading.Tasks;
 
 namespace GenomicsSample
@@ -188,6 +191,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -215,7 +219,7 @@ namespace GenomicsSample
             // Data.Annotation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -247,6 +251,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -283,7 +288,7 @@ namespace GenomicsSample
                 foreach (Data.Annotation annotation in response.Annotations)
                 {
                     // TODO: Change code below to process each `annotation` resource:
-                    Console.WriteLine(annotation);
+                    Console.WriteLine(JsonConvert.SerializeObject(annotation));
                 }
                 requestBody.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -318,6 +323,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -349,7 +355,7 @@ namespace GenomicsSample
             // Data.Annotation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -381,6 +387,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -408,7 +415,7 @@ namespace GenomicsSample
             // Data.AnnotationSet response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -440,6 +447,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System.Threading.Tasks;
 
 namespace GenomicsSample
@@ -493,6 +501,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -520,7 +529,7 @@ namespace GenomicsSample
             // Data.AnnotationSet response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -552,6 +561,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -588,7 +598,7 @@ namespace GenomicsSample
                 foreach (Data.AnnotationSet annotationSet in response.AnnotationSets)
                 {
                     // TODO: Change code below to process each `annotationSet` resource:
-                    Console.WriteLine(annotationSet);
+                    Console.WriteLine(JsonConvert.SerializeObject(annotationSet));
                 }
                 requestBody.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -623,6 +633,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -654,7 +665,7 @@ namespace GenomicsSample
             // Data.AnnotationSet response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -686,6 +697,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -713,7 +725,7 @@ namespace GenomicsSample
             // Data.CallSet response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -745,6 +757,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System.Threading.Tasks;
 
 namespace GenomicsSample
@@ -798,6 +811,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -825,7 +839,7 @@ namespace GenomicsSample
             // Data.CallSet response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -857,6 +871,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -888,7 +903,7 @@ namespace GenomicsSample
             // Data.CallSet response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -920,6 +935,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -956,7 +972,7 @@ namespace GenomicsSample
                 foreach (Data.CallSet callSet in response.CallSets)
                 {
                     // TODO: Change code below to process each `callSet` resource:
-                    Console.WriteLine(callSet);
+                    Console.WriteLine(JsonConvert.SerializeObject(callSet));
                 }
                 requestBody.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -991,6 +1007,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1018,7 +1035,7 @@ namespace GenomicsSample
             // Data.Dataset response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1050,6 +1067,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System.Threading.Tasks;
 
 namespace GenomicsSample
@@ -1103,6 +1121,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1130,7 +1149,7 @@ namespace GenomicsSample
             // Data.Dataset response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1162,6 +1181,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1192,7 +1212,7 @@ namespace GenomicsSample
             // Data.Policy response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1224,6 +1244,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1257,7 +1278,7 @@ namespace GenomicsSample
                 foreach (Data.Dataset dataset in response.Datasets)
                 {
                     // TODO: Change code below to process each `dataset` resource:
-                    Console.WriteLine(dataset);
+                    Console.WriteLine(JsonConvert.SerializeObject(dataset));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -1292,6 +1313,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1323,7 +1345,7 @@ namespace GenomicsSample
             // Data.Dataset response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1355,6 +1377,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1385,7 +1408,7 @@ namespace GenomicsSample
             // Data.Policy response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1417,6 +1440,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1447,7 +1471,7 @@ namespace GenomicsSample
             // Data.TestIamPermissionsResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1479,6 +1503,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1509,7 +1534,7 @@ namespace GenomicsSample
             // Data.Dataset response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1541,6 +1566,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System.Threading.Tasks;
 
 using Data = Google.Apis.Genomics.v1.Data;
@@ -1599,6 +1625,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1626,7 +1653,7 @@ namespace GenomicsSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1658,6 +1685,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1694,7 +1722,7 @@ namespace GenomicsSample
                 foreach (Data.Operation operation in response.Operations)
                 {
                     // TODO: Change code below to process each `operation` resource:
-                    Console.WriteLine(operation);
+                    Console.WriteLine(JsonConvert.SerializeObject(operation));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -1729,6 +1757,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1765,7 +1794,7 @@ namespace GenomicsSample
                 foreach (Data.CoverageBucket coverageBucket in response.CoverageBuckets)
                 {
                     // TODO: Change code below to process each `coverageBucket` resource:
-                    Console.WriteLine(coverageBucket);
+                    Console.WriteLine(JsonConvert.SerializeObject(coverageBucket));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -1800,6 +1829,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System.Threading.Tasks;
 
 namespace GenomicsSample
@@ -1854,6 +1884,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1885,7 +1916,7 @@ namespace GenomicsSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1917,6 +1948,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1944,7 +1976,7 @@ namespace GenomicsSample
             // Data.ReadGroupSet response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1976,6 +2008,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -2003,7 +2036,7 @@ namespace GenomicsSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -2035,6 +2068,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -2067,7 +2101,7 @@ namespace GenomicsSample
             // Data.ReadGroupSet response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -2099,6 +2133,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -2135,7 +2170,7 @@ namespace GenomicsSample
                 foreach (Data.ReadGroupSet readGroupSet in response.ReadGroupSets)
                 {
                     // TODO: Change code below to process each `readGroupSet` resource:
-                    Console.WriteLine(readGroupSet);
+                    Console.WriteLine(JsonConvert.SerializeObject(readGroupSet));
                 }
                 requestBody.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -2170,6 +2205,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -2206,7 +2242,7 @@ namespace GenomicsSample
                 foreach (Data.Read read in response.Alignments)
                 {
                     // TODO: Change code below to process each `read` resource:
-                    Console.WriteLine(read);
+                    Console.WriteLine(JsonConvert.SerializeObject(read));
                 }
                 requestBody.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -2241,6 +2277,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -2268,7 +2305,7 @@ namespace GenomicsSample
             // Data.StreamReadsResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -2300,6 +2337,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -2334,7 +2372,7 @@ namespace GenomicsSample
                     continue;
                 }
                 // TODO: Change code below to process each `response.Sequence` resource:
-                Console.WriteLine(response.Sequence);
+                Console.WriteLine(JsonConvert.SerializeObject(response.Sequence));
 
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -2369,6 +2407,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -2396,7 +2435,7 @@ namespace GenomicsSample
             // Data.Reference response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -2428,6 +2467,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -2464,7 +2504,7 @@ namespace GenomicsSample
                 foreach (Data.Reference reference in response.References)
                 {
                     // TODO: Change code below to process each `reference` resource:
-                    Console.WriteLine(reference);
+                    Console.WriteLine(JsonConvert.SerializeObject(reference));
                 }
                 requestBody.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -2499,6 +2539,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -2526,7 +2567,7 @@ namespace GenomicsSample
             // Data.ReferenceSet response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -2558,6 +2599,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -2594,7 +2636,7 @@ namespace GenomicsSample
                 foreach (Data.ReferenceSet referenceSet in response.ReferenceSets)
                 {
                     // TODO: Change code below to process each `referenceSet` resource:
-                    Console.WriteLine(referenceSet);
+                    Console.WriteLine(JsonConvert.SerializeObject(referenceSet));
                 }
                 requestBody.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -2629,6 +2671,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -2656,7 +2699,7 @@ namespace GenomicsSample
             // Data.Variant response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -2688,6 +2731,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System.Threading.Tasks;
 
 namespace GenomicsSample
@@ -2741,6 +2785,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -2768,7 +2813,7 @@ namespace GenomicsSample
             // Data.Variant response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -2800,6 +2845,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -2827,7 +2873,7 @@ namespace GenomicsSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -2859,6 +2905,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System.Threading.Tasks;
 
 using Data = Google.Apis.Genomics.v1.Data;
@@ -2914,6 +2961,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -2945,7 +2993,7 @@ namespace GenomicsSample
             // Data.Variant response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -2977,6 +3025,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -3013,7 +3062,7 @@ namespace GenomicsSample
                 foreach (Data.Variant variant in response.Variants)
                 {
                     // TODO: Change code below to process each `variant` resource:
-                    Console.WriteLine(variant);
+                    Console.WriteLine(JsonConvert.SerializeObject(variant));
                 }
                 requestBody.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -3048,6 +3097,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -3075,7 +3125,7 @@ namespace GenomicsSample
             // Data.StreamVariantsResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -3107,6 +3157,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -3134,7 +3185,7 @@ namespace GenomicsSample
             // Data.VariantSet response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -3166,6 +3217,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System.Threading.Tasks;
 
 namespace GenomicsSample
@@ -3219,6 +3271,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -3250,7 +3303,7 @@ namespace GenomicsSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -3282,6 +3335,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -3309,7 +3363,7 @@ namespace GenomicsSample
             // Data.VariantSet response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -3341,6 +3395,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -3372,7 +3427,7 @@ namespace GenomicsSample
             // Data.VariantSet response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -3404,6 +3459,7 @@ namespace GenomicsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Genomics.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -3440,7 +3496,7 @@ namespace GenomicsSample
                 foreach (Data.VariantSet variantSet in response.VariantSets)
                 {
                     // TODO: Change code below to process each `variantSet` resource:
-                    Console.WriteLine(variantSet);
+                    Console.WriteLine(JsonConvert.SerializeObject(variantSet));
                 }
                 requestBody.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_logging.v2beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_logging.v2beta1.json.baseline
@@ -17,6 +17,7 @@
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Logging.v2beta1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System.Threading.Tasks;
 
 namespace LoggingSample
@@ -75,6 +76,7 @@ namespace LoggingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Logging.v2beta1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -113,7 +115,7 @@ namespace LoggingSample
                 foreach (string item in response.LogNames)
                 {
                     // TODO: Change code below to process each `item` resource:
-                    Console.WriteLine(item);
+                    Console.WriteLine(JsonConvert.SerializeObject(item));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -148,6 +150,7 @@ namespace LoggingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Logging.v2beta1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -184,7 +187,7 @@ namespace LoggingSample
                 foreach (Data.LogEntry logEntry in response.Entries)
                 {
                     // TODO: Change code below to process each `logEntry` resource:
-                    Console.WriteLine(logEntry);
+                    Console.WriteLine(JsonConvert.SerializeObject(logEntry));
                 }
                 requestBody.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -219,6 +222,7 @@ namespace LoggingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Logging.v2beta1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -246,7 +250,7 @@ namespace LoggingSample
             // Data.WriteLogEntriesResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -278,6 +282,7 @@ namespace LoggingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Logging.v2beta1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -311,7 +316,7 @@ namespace LoggingSample
                 foreach (Data.MonitoredResourceDescriptor monitoredResourceDescriptor in response.ResourceDescriptors)
                 {
                     // TODO: Change code below to process each `monitoredResourceDescriptor` resource:
-                    Console.WriteLine(monitoredResourceDescriptor);
+                    Console.WriteLine(JsonConvert.SerializeObject(monitoredResourceDescriptor));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -346,6 +351,7 @@ namespace LoggingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Logging.v2beta1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System.Threading.Tasks;
 
 namespace LoggingSample
@@ -404,6 +410,7 @@ namespace LoggingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Logging.v2beta1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -442,7 +449,7 @@ namespace LoggingSample
                 foreach (string item in response.LogNames)
                 {
                     // TODO: Change code below to process each `item` resource:
-                    Console.WriteLine(item);
+                    Console.WriteLine(JsonConvert.SerializeObject(item));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -477,6 +484,7 @@ namespace LoggingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Logging.v2beta1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System.Threading.Tasks;
 
 namespace LoggingSample
@@ -535,6 +543,7 @@ namespace LoggingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Logging.v2beta1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -573,7 +582,7 @@ namespace LoggingSample
                 foreach (string item in response.LogNames)
                 {
                     // TODO: Change code below to process each `item` resource:
-                    Console.WriteLine(item);
+                    Console.WriteLine(JsonConvert.SerializeObject(item));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -608,6 +617,7 @@ namespace LoggingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Logging.v2beta1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -640,7 +650,7 @@ namespace LoggingSample
             // Data.LogMetric response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -672,6 +682,7 @@ namespace LoggingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Logging.v2beta1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System.Threading.Tasks;
 
 namespace LoggingSample
@@ -726,6 +737,7 @@ namespace LoggingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Logging.v2beta1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -754,7 +766,7 @@ namespace LoggingSample
             // Data.LogMetric response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -786,6 +798,7 @@ namespace LoggingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Logging.v2beta1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -823,7 +836,7 @@ namespace LoggingSample
                 foreach (Data.LogMetric logMetric in response.Metrics)
                 {
                     // TODO: Change code below to process each `logMetric` resource:
-                    Console.WriteLine(logMetric);
+                    Console.WriteLine(JsonConvert.SerializeObject(logMetric));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -858,6 +871,7 @@ namespace LoggingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Logging.v2beta1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -892,7 +906,7 @@ namespace LoggingSample
             // Data.LogMetric response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -924,6 +938,7 @@ namespace LoggingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Logging.v2beta1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -957,7 +972,7 @@ namespace LoggingSample
             // Data.LogSink response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -989,6 +1004,7 @@ namespace LoggingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Logging.v2beta1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System.Threading.Tasks;
 
 namespace LoggingSample
@@ -1047,6 +1063,7 @@ namespace LoggingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Logging.v2beta1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1077,7 +1094,7 @@ namespace LoggingSample
             // Data.LogSink response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1109,6 +1126,7 @@ namespace LoggingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Logging.v2beta1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1146,7 +1164,7 @@ namespace LoggingSample
                 foreach (Data.LogSink logSink in response.Sinks)
                 {
                     // TODO: Change code below to process each `logSink` resource:
-                    Console.WriteLine(logSink);
+                    Console.WriteLine(JsonConvert.SerializeObject(logSink));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -1181,6 +1199,7 @@ namespace LoggingSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Logging.v2beta1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1216,7 +1235,7 @@ namespace LoggingSample
             // Data.LogSink response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_prediction.v1.6.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_prediction.v1.6.json.baseline
@@ -17,6 +17,7 @@
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Prediction.v1_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -50,7 +51,7 @@ namespace PredictionSample
             // Data.Output response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -82,6 +83,7 @@ namespace PredictionSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Prediction.v1_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -112,7 +114,7 @@ namespace PredictionSample
             // Data.Analyze response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -144,6 +146,7 @@ namespace PredictionSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Prediction.v1_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System.Threading.Tasks;
 
 namespace PredictionSample
@@ -200,6 +203,7 @@ namespace PredictionSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Prediction.v1_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -230,7 +234,7 @@ namespace PredictionSample
             // Data.Insert2 response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -262,6 +266,7 @@ namespace PredictionSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Prediction.v1_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -292,7 +297,7 @@ namespace PredictionSample
             // Data.Insert2 response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -324,6 +329,7 @@ namespace PredictionSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Prediction.v1_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -360,7 +366,7 @@ namespace PredictionSample
                 foreach (Data.Insert2 insert2 in response.Items)
                 {
                     // TODO: Change code below to process each `insert2` resource:
-                    Console.WriteLine(insert2);
+                    Console.WriteLine(JsonConvert.SerializeObject(insert2));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -395,6 +401,7 @@ namespace PredictionSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Prediction.v1_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -428,7 +435,7 @@ namespace PredictionSample
             // Data.Output response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -460,6 +467,7 @@ namespace PredictionSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Prediction.v1_6;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -494,7 +502,7 @@ namespace PredictionSample
             // Data.Insert2 response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_pubsub.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_pubsub.v1.json.baseline
@@ -17,6 +17,7 @@
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Pubsub.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -46,7 +47,7 @@ namespace PubsubSample
             // Data.Policy response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -78,6 +79,7 @@ namespace PubsubSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Pubsub.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -110,7 +112,7 @@ namespace PubsubSample
             // Data.Policy response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -142,6 +144,7 @@ namespace PubsubSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Pubsub.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -174,7 +177,7 @@ namespace PubsubSample
             // Data.TestIamPermissionsResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -206,6 +209,7 @@ namespace PubsubSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Pubsub.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System.Threading.Tasks;
 
 using Data = Google.Apis.Pubsub.v1.Data;
@@ -265,6 +269,7 @@ namespace PubsubSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Pubsub.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -301,7 +306,7 @@ namespace PubsubSample
             // Data.Subscription response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -333,6 +338,7 @@ namespace PubsubSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Pubsub.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System.Threading.Tasks;
 
 namespace PubsubSample
@@ -387,6 +393,7 @@ namespace PubsubSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Pubsub.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -415,7 +422,7 @@ namespace PubsubSample
             // Data.Subscription response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -447,6 +454,7 @@ namespace PubsubSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Pubsub.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -476,7 +484,7 @@ namespace PubsubSample
             // Data.Policy response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -508,6 +516,7 @@ namespace PubsubSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Pubsub.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -545,7 +554,7 @@ namespace PubsubSample
                 foreach (Data.Subscription subscription in response.Subscriptions)
                 {
                     // TODO: Change code below to process each `subscription` resource:
-                    Console.WriteLine(subscription);
+                    Console.WriteLine(JsonConvert.SerializeObject(subscription));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -580,6 +589,7 @@ namespace PubsubSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Pubsub.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System.Threading.Tasks;
 
 using Data = Google.Apis.Pubsub.v1.Data;
@@ -639,6 +649,7 @@ namespace PubsubSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Pubsub.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System.Threading.Tasks;
 
 using Data = Google.Apis.Pubsub.v1.Data;
@@ -698,6 +709,7 @@ namespace PubsubSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Pubsub.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -729,7 +741,7 @@ namespace PubsubSample
             // Data.PullResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -761,6 +773,7 @@ namespace PubsubSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Pubsub.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -793,7 +806,7 @@ namespace PubsubSample
             // Data.Policy response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -825,6 +838,7 @@ namespace PubsubSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Pubsub.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -857,7 +871,7 @@ namespace PubsubSample
             // Data.TestIamPermissionsResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -889,6 +903,7 @@ namespace PubsubSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Pubsub.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -925,7 +940,7 @@ namespace PubsubSample
             // Data.Topic response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -957,6 +972,7 @@ namespace PubsubSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Pubsub.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System.Threading.Tasks;
 
 namespace PubsubSample
@@ -1011,6 +1027,7 @@ namespace PubsubSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Pubsub.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1039,7 +1056,7 @@ namespace PubsubSample
             // Data.Topic response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1071,6 +1088,7 @@ namespace PubsubSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Pubsub.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1100,7 +1118,7 @@ namespace PubsubSample
             // Data.Policy response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1132,6 +1150,7 @@ namespace PubsubSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Pubsub.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1169,7 +1188,7 @@ namespace PubsubSample
                 foreach (Data.Topic topic in response.Topics)
                 {
                     // TODO: Change code below to process each `topic` resource:
-                    Console.WriteLine(topic);
+                    Console.WriteLine(JsonConvert.SerializeObject(topic));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -1204,6 +1223,7 @@ namespace PubsubSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Pubsub.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1235,7 +1255,7 @@ namespace PubsubSample
             // Data.PublishResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1267,6 +1287,7 @@ namespace PubsubSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Pubsub.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1299,7 +1320,7 @@ namespace PubsubSample
             // Data.Policy response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1331,6 +1352,7 @@ namespace PubsubSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Pubsub.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1368,7 +1390,7 @@ namespace PubsubSample
                 foreach (string item in response.Subscriptions)
                 {
                     // TODO: Change code below to process each `item` resource:
-                    Console.WriteLine(item);
+                    Console.WriteLine(JsonConvert.SerializeObject(item));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -1403,6 +1425,7 @@ namespace PubsubSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Pubsub.v1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1435,7 +1458,7 @@ namespace PubsubSample
             // Data.TestIamPermissionsResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_replicapoolupdater.v1beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_replicapoolupdater.v1beta1.json.baseline
@@ -17,6 +17,7 @@
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Replicapoolupdater.v1beta1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -50,7 +51,7 @@ namespace ReplicapoolupdaterSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -82,6 +83,7 @@ namespace ReplicapoolupdaterSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Replicapoolupdater.v1beta1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -115,7 +117,7 @@ namespace ReplicapoolupdaterSample
             // Data.RollingUpdate response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -147,6 +149,7 @@ namespace ReplicapoolupdaterSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Replicapoolupdater.v1beta1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -180,7 +183,7 @@ namespace ReplicapoolupdaterSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -212,6 +215,7 @@ namespace ReplicapoolupdaterSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Replicapoolupdater.v1beta1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -251,7 +255,7 @@ namespace ReplicapoolupdaterSample
                 foreach (Data.RollingUpdate rollingUpdate in response.Items)
                 {
                     // TODO: Change code below to process each `rollingUpdate` resource:
-                    Console.WriteLine(rollingUpdate);
+                    Console.WriteLine(JsonConvert.SerializeObject(rollingUpdate));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -286,6 +290,7 @@ namespace ReplicapoolupdaterSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Replicapoolupdater.v1beta1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -328,7 +333,7 @@ namespace ReplicapoolupdaterSample
                 foreach (Data.InstanceUpdate instanceUpdate in response.Items)
                 {
                     // TODO: Change code below to process each `instanceUpdate` resource:
-                    Console.WriteLine(instanceUpdate);
+                    Console.WriteLine(JsonConvert.SerializeObject(instanceUpdate));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -363,6 +368,7 @@ namespace ReplicapoolupdaterSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Replicapoolupdater.v1beta1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -396,7 +402,7 @@ namespace ReplicapoolupdaterSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -428,6 +434,7 @@ namespace ReplicapoolupdaterSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Replicapoolupdater.v1beta1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -461,7 +468,7 @@ namespace ReplicapoolupdaterSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -493,6 +500,7 @@ namespace ReplicapoolupdaterSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Replicapoolupdater.v1beta1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -526,7 +534,7 @@ namespace ReplicapoolupdaterSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -558,6 +566,7 @@ namespace ReplicapoolupdaterSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Replicapoolupdater.v1beta1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -591,7 +600,7 @@ namespace ReplicapoolupdaterSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -623,6 +632,7 @@ namespace ReplicapoolupdaterSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Replicapoolupdater.v1beta1;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -662,7 +672,7 @@ namespace ReplicapoolupdaterSample
                 foreach (Data.Operation operation in response.Items)
                 {
                     // TODO: Change code below to process each `operation` resource:
-                    Console.WriteLine(operation);
+                    Console.WriteLine(JsonConvert.SerializeObject(operation));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_sheets.v4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_sheets.v4.json.baseline
@@ -11,6 +11,7 @@
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Sheets.v4;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 
@@ -45,7 +46,7 @@ namespace SheetsSample
             // Data.BatchUpdateSpreadsheetResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -72,6 +73,7 @@ namespace SheetsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Sheets.v4;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Sheets.v4.Data;
@@ -98,7 +100,7 @@ namespace SheetsSample
             // Data.Spreadsheet response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -125,6 +127,7 @@ namespace SheetsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Sheets.v4;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 
@@ -161,7 +164,7 @@ namespace SheetsSample
             // Data.Spreadsheet response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -190,6 +193,7 @@ namespace SheetsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Sheets.v4;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Sheets.v4.Data;
@@ -226,7 +230,7 @@ namespace SheetsSample
             // Data.SheetProperties response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -253,6 +257,7 @@ namespace SheetsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Sheets.v4;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Sheets.v4.Data;
@@ -294,7 +299,7 @@ namespace SheetsSample
             // Data.AppendValuesResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -321,6 +326,7 @@ namespace SheetsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Sheets.v4;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 
@@ -355,7 +361,7 @@ namespace SheetsSample
             // Data.BatchClearValuesResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -382,6 +388,7 @@ namespace SheetsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Sheets.v4;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 
@@ -425,7 +432,7 @@ namespace SheetsSample
             // Data.BatchGetValuesResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -454,6 +461,7 @@ namespace SheetsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Sheets.v4;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 
@@ -492,7 +500,7 @@ namespace SheetsSample
             // Data.BatchUpdateValuesResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -519,6 +527,7 @@ namespace SheetsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Sheets.v4;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Sheets.v4.Data;
@@ -551,7 +560,7 @@ namespace SheetsSample
             // Data.ClearValuesResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -578,6 +587,7 @@ namespace SheetsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Sheets.v4;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Sheets.v4.Data;
@@ -619,7 +629,7 @@ namespace SheetsSample
             // Data.ValueRange response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -648,6 +658,7 @@ namespace SheetsSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Sheets.v4;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Sheets.v4.Data;
@@ -685,7 +696,7 @@ namespace SheetsSample
             // Data.UpdateValuesResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_sqladmin.v1beta4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_sqladmin.v1beta4.json.baseline
@@ -17,6 +17,7 @@
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -50,7 +51,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -82,6 +83,7 @@ namespace SQLAdminSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -115,7 +117,7 @@ namespace SQLAdminSample
             // Data.BackupRun response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -147,6 +149,7 @@ namespace SQLAdminSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -180,7 +183,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -212,6 +215,7 @@ namespace SQLAdminSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -251,7 +255,7 @@ namespace SQLAdminSample
                 foreach (Data.BackupRun backupRun in response.Items)
                 {
                     // TODO: Change code below to process each `backupRun` resource:
-                    Console.WriteLine(backupRun);
+                    Console.WriteLine(JsonConvert.SerializeObject(backupRun));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -286,6 +290,7 @@ namespace SQLAdminSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -319,7 +324,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -351,6 +356,7 @@ namespace SQLAdminSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -384,7 +390,7 @@ namespace SQLAdminSample
             // Data.Database response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -416,6 +422,7 @@ namespace SQLAdminSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -449,7 +456,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -481,6 +488,7 @@ namespace SQLAdminSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -511,7 +519,7 @@ namespace SQLAdminSample
             // Data.DatabasesListResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -543,6 +551,7 @@ namespace SQLAdminSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -580,7 +589,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -612,6 +621,7 @@ namespace SQLAdminSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -649,7 +659,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -681,6 +691,7 @@ namespace SQLAdminSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -705,7 +716,7 @@ namespace SQLAdminSample
             // Data.FlagsListResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -737,6 +748,7 @@ namespace SQLAdminSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -770,7 +782,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -802,6 +814,7 @@ namespace SQLAdminSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -832,7 +845,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -864,6 +877,7 @@ namespace SQLAdminSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -897,7 +911,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -929,6 +943,7 @@ namespace SQLAdminSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -962,7 +977,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -994,6 +1009,7 @@ namespace SQLAdminSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1024,7 +1040,7 @@ namespace SQLAdminSample
             // Data.DatabaseInstance response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1056,6 +1072,7 @@ namespace SQLAdminSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1089,7 +1106,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1121,6 +1138,7 @@ namespace SQLAdminSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1151,7 +1169,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1183,6 +1201,7 @@ namespace SQLAdminSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1219,7 +1238,7 @@ namespace SQLAdminSample
                 foreach (Data.DatabaseInstance databaseInstance in response.Items)
                 {
                     // TODO: Change code below to process each `databaseInstance` resource:
-                    Console.WriteLine(databaseInstance);
+                    Console.WriteLine(JsonConvert.SerializeObject(databaseInstance));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -1254,6 +1273,7 @@ namespace SQLAdminSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1288,7 +1308,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1320,6 +1340,7 @@ namespace SQLAdminSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1350,7 +1371,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1382,6 +1403,7 @@ namespace SQLAdminSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1412,7 +1434,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1444,6 +1466,7 @@ namespace SQLAdminSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1474,7 +1497,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1506,6 +1529,7 @@ namespace SQLAdminSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1539,7 +1563,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1571,6 +1595,7 @@ namespace SQLAdminSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1601,7 +1626,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1633,6 +1658,7 @@ namespace SQLAdminSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1663,7 +1689,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1695,6 +1721,7 @@ namespace SQLAdminSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1728,7 +1755,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1760,6 +1787,7 @@ namespace SQLAdminSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1794,7 +1822,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1826,6 +1854,7 @@ namespace SQLAdminSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1856,7 +1885,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1888,6 +1917,7 @@ namespace SQLAdminSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1927,7 +1957,7 @@ namespace SQLAdminSample
                 foreach (Data.Operation operation in response.Items)
                 {
                     // TODO: Change code below to process each `operation` resource:
-                    Console.WriteLine(operation);
+                    Console.WriteLine(JsonConvert.SerializeObject(operation));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -1962,6 +1992,7 @@ namespace SQLAdminSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1995,7 +2026,7 @@ namespace SQLAdminSample
             // Data.SslCert response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -2027,6 +2058,7 @@ namespace SQLAdminSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -2060,7 +2092,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -2092,6 +2124,7 @@ namespace SQLAdminSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -2125,7 +2158,7 @@ namespace SQLAdminSample
             // Data.SslCert response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -2157,6 +2190,7 @@ namespace SQLAdminSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -2190,7 +2224,7 @@ namespace SQLAdminSample
             // Data.SslCertsInsertResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -2222,6 +2256,7 @@ namespace SQLAdminSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -2252,7 +2287,7 @@ namespace SQLAdminSample
             // Data.SslCertsListResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -2284,6 +2319,7 @@ namespace SQLAdminSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -2311,7 +2347,7 @@ namespace SQLAdminSample
             // Data.TiersListResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -2343,6 +2379,7 @@ namespace SQLAdminSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -2379,7 +2416,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -2411,6 +2448,7 @@ namespace SQLAdminSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -2444,7 +2482,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -2476,6 +2514,7 @@ namespace SQLAdminSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -2506,7 +2545,7 @@ namespace SQLAdminSample
             // Data.UsersListResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -2538,6 +2577,7 @@ namespace SQLAdminSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.SQLAdmin.v1beta4;
 using Google.Apis.Services;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -2578,7 +2618,7 @@ namespace SQLAdminSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_storage.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_storage.v1.json.baseline
@@ -17,6 +17,7 @@
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
+using Newtonsoft.Json;
 using System.Threading.Tasks;
 
 namespace StorageSample
@@ -74,6 +75,7 @@ namespace StorageSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -105,7 +107,7 @@ namespace StorageSample
             // Data.BucketAccessControl response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -137,6 +139,7 @@ namespace StorageSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -167,7 +170,7 @@ namespace StorageSample
             // Data.BucketAccessControl response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -199,6 +202,7 @@ namespace StorageSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -226,7 +230,7 @@ namespace StorageSample
             // Data.BucketAccessControls response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -258,6 +262,7 @@ namespace StorageSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -293,7 +298,7 @@ namespace StorageSample
             // Data.BucketAccessControl response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -325,6 +330,7 @@ namespace StorageSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -360,7 +366,7 @@ namespace StorageSample
             // Data.BucketAccessControl response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -392,6 +398,7 @@ namespace StorageSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
+using Newtonsoft.Json;
 using System.Threading.Tasks;
 
 namespace StorageSample
@@ -445,6 +452,7 @@ namespace StorageSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -472,7 +480,7 @@ namespace StorageSample
             // Data.Bucket response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -504,6 +512,7 @@ namespace StorageSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -534,7 +543,7 @@ namespace StorageSample
             // Data.Bucket response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -566,6 +575,7 @@ namespace StorageSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -602,7 +612,7 @@ namespace StorageSample
                 foreach (Data.Bucket bucket in response.Items)
                 {
                     // TODO: Change code below to process each `bucket` resource:
-                    Console.WriteLine(bucket);
+                    Console.WriteLine(JsonConvert.SerializeObject(bucket));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -637,6 +647,7 @@ namespace StorageSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -668,7 +679,7 @@ namespace StorageSample
             // Data.Bucket response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -700,6 +711,7 @@ namespace StorageSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -731,7 +743,7 @@ namespace StorageSample
             // Data.Bucket response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -763,6 +775,7 @@ namespace StorageSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
+using Newtonsoft.Json;
 using System.Threading.Tasks;
 
 using Data = Google.Apis.Storage.v1.Data;
@@ -818,6 +831,7 @@ namespace StorageSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
+using Newtonsoft.Json;
 using System.Threading.Tasks;
 
 namespace StorageSample
@@ -875,6 +889,7 @@ namespace StorageSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -906,7 +921,7 @@ namespace StorageSample
             // Data.ObjectAccessControl response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -938,6 +953,7 @@ namespace StorageSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -968,7 +984,7 @@ namespace StorageSample
             // Data.ObjectAccessControl response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1000,6 +1016,7 @@ namespace StorageSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1027,7 +1044,7 @@ namespace StorageSample
             // Data.ObjectAccessControls response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1059,6 +1076,7 @@ namespace StorageSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1094,7 +1112,7 @@ namespace StorageSample
             // Data.ObjectAccessControl response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1126,6 +1144,7 @@ namespace StorageSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1161,7 +1180,7 @@ namespace StorageSample
             // Data.ObjectAccessControl response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1193,6 +1212,7 @@ namespace StorageSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
+using Newtonsoft.Json;
 using System.Threading.Tasks;
 
 namespace StorageSample
@@ -1254,6 +1274,7 @@ namespace StorageSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1289,7 +1310,7 @@ namespace StorageSample
             // Data.ObjectAccessControl response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1321,6 +1342,7 @@ namespace StorageSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1355,7 +1377,7 @@ namespace StorageSample
             // Data.ObjectAccessControl response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1387,6 +1409,7 @@ namespace StorageSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1418,7 +1441,7 @@ namespace StorageSample
             // Data.ObjectAccessControls response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1450,6 +1473,7 @@ namespace StorageSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1489,7 +1513,7 @@ namespace StorageSample
             // Data.ObjectAccessControl response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1521,6 +1545,7 @@ namespace StorageSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1560,7 +1585,7 @@ namespace StorageSample
             // Data.ObjectAccessControl response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1592,6 +1617,7 @@ namespace StorageSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1629,7 +1655,7 @@ namespace StorageSample
             // Data.Object response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1661,6 +1687,7 @@ namespace StorageSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1707,7 +1734,7 @@ namespace StorageSample
             // Data.Object response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1739,6 +1766,7 @@ namespace StorageSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
+using Newtonsoft.Json;
 using System.Threading.Tasks;
 
 namespace StorageSample
@@ -1796,6 +1824,7 @@ namespace StorageSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1830,7 +1859,7 @@ namespace StorageSample
             // Data.Object response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1862,6 +1891,7 @@ namespace StorageSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1896,7 +1926,7 @@ namespace StorageSample
             // Data.Object response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -1928,6 +1958,7 @@ namespace StorageSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -1964,7 +1995,7 @@ namespace StorageSample
                 foreach (Data.Object object2 in response.Items)
                 {
                     // TODO: Change code below to process each `object2` resource:
-                    Console.WriteLine(object2);
+                    Console.WriteLine(JsonConvert.SerializeObject(object2));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -1999,6 +2030,7 @@ namespace StorageSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -2034,7 +2066,7 @@ namespace StorageSample
             // Data.Object response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -2066,6 +2098,7 @@ namespace StorageSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -2109,7 +2142,7 @@ namespace StorageSample
             // Data.RewriteResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -2141,6 +2174,7 @@ namespace StorageSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -2179,7 +2213,7 @@ namespace StorageSample
             // Data.Object response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -2211,6 +2245,7 @@ namespace StorageSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storage.v1;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -2241,7 +2276,7 @@ namespace StorageSample
             // Data.Channel response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_storagetransfer.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_storagetransfer.v1.json.baseline
@@ -17,6 +17,7 @@
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storagetransfer.v1;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -41,7 +42,7 @@ namespace StoragetransferSample
             // Data.GoogleServiceAccount response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -73,6 +74,7 @@ namespace StoragetransferSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storagetransfer.v1;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -101,7 +103,7 @@ namespace StoragetransferSample
             // Data.GoogleServiceAccount response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -133,6 +135,7 @@ namespace StoragetransferSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storagetransfer.v1;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -160,7 +163,7 @@ namespace StoragetransferSample
             // Data.TransferJob response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -192,6 +195,7 @@ namespace StoragetransferSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storagetransfer.v1;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -219,7 +223,7 @@ namespace StoragetransferSample
             // Data.TransferJob response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -251,6 +255,7 @@ namespace StoragetransferSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storagetransfer.v1;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -284,7 +289,7 @@ namespace StoragetransferSample
                 foreach (Data.TransferJob transferJob in response.TransferJobs)
                 {
                     // TODO: Change code below to process each `transferJob` resource:
-                    Console.WriteLine(transferJob);
+                    Console.WriteLine(JsonConvert.SerializeObject(transferJob));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -319,6 +324,7 @@ namespace StoragetransferSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storagetransfer.v1;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -350,7 +356,7 @@ namespace StoragetransferSample
             // Data.TransferJob response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -382,6 +388,7 @@ namespace StoragetransferSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storagetransfer.v1;
+using Newtonsoft.Json;
 using System.Threading.Tasks;
 
 namespace StoragetransferSample
@@ -435,6 +442,7 @@ namespace StoragetransferSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storagetransfer.v1;
+using Newtonsoft.Json;
 using System.Threading.Tasks;
 
 namespace StoragetransferSample
@@ -488,6 +496,7 @@ namespace StoragetransferSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storagetransfer.v1;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -515,7 +524,7 @@ namespace StoragetransferSample
             // Data.Operation response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()
@@ -547,6 +556,7 @@ namespace StoragetransferSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storagetransfer.v1;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -583,7 +593,7 @@ namespace StoragetransferSample
                 foreach (Data.Operation operation in response.Operations)
                 {
                     // TODO: Change code below to process each `operation` resource:
-                    Console.WriteLine(operation);
+                    Console.WriteLine(JsonConvert.SerializeObject(operation));
                 }
                 request.PageToken = response.NextPageToken;
             } while (response.NextPageToken != null);
@@ -618,6 +628,7 @@ namespace StoragetransferSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storagetransfer.v1;
+using Newtonsoft.Json;
 using System.Threading.Tasks;
 
 using Data = Google.Apis.Storagetransfer.v1.Data;
@@ -676,6 +687,7 @@ namespace StoragetransferSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Storagetransfer.v1;
+using Newtonsoft.Json;
 using System.Threading.Tasks;
 
 using Data = Google.Apis.Storagetransfer.v1.Data;

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_taskqueue.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_taskqueue.v1beta2.json.baseline
@@ -11,6 +11,7 @@
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Taskqueue.v1beta2;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Taskqueue.v1beta2.Data;
@@ -40,7 +41,7 @@ namespace TaskqueueSample
             // Data.TaskQueue response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -67,6 +68,7 @@ namespace TaskqueueSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Taskqueue.v1beta2;
+using Newtonsoft.Json;
 
 namespace TaskqueueSample
 {
@@ -120,6 +122,7 @@ namespace TaskqueueSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Taskqueue.v1beta2;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Taskqueue.v1beta2.Data;
@@ -152,7 +155,7 @@ namespace TaskqueueSample
             // Data.Task response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -179,6 +182,7 @@ namespace TaskqueueSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Taskqueue.v1beta2;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Taskqueue.v1beta2.Data;
@@ -211,7 +215,7 @@ namespace TaskqueueSample
             // Data.Task response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -238,6 +242,7 @@ namespace TaskqueueSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Taskqueue.v1beta2;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Taskqueue.v1beta2.Data;
@@ -273,7 +278,7 @@ namespace TaskqueueSample
             // Data.Tasks response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -300,6 +305,7 @@ namespace TaskqueueSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Taskqueue.v1beta2;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Taskqueue.v1beta2.Data;
@@ -329,7 +335,7 @@ namespace TaskqueueSample
             // Data.Tasks2 response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -356,6 +362,7 @@ namespace TaskqueueSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Taskqueue.v1beta2;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Taskqueue.v1beta2.Data;
@@ -393,7 +400,7 @@ namespace TaskqueueSample
             // Data.Task response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()
@@ -420,6 +427,7 @@ namespace TaskqueueSample
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Taskqueue.v1beta2;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Taskqueue.v1beta2.Data;
@@ -456,7 +464,7 @@ namespace TaskqueueSample
             // Data.Task response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static UserCredential GetCredential()

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_translate.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_translate.v2.json.baseline
@@ -10,6 +10,7 @@
 
 using Google.Apis.Services;
 using Google.Apis.Translate.v2;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 
@@ -37,7 +38,7 @@ namespace TranslateSample
             // Data.DetectionsListResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
     }
 }
@@ -52,6 +53,7 @@ namespace TranslateSample
 
 using Google.Apis.Services;
 using Google.Apis.Translate.v2;
+using Newtonsoft.Json;
 using System;
 
 using Data = Google.Apis.Translate.v2.Data;
@@ -75,7 +77,7 @@ namespace TranslateSample
             // Data.LanguagesListResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
     }
 }
@@ -90,6 +92,7 @@ namespace TranslateSample
 
 using Google.Apis.Services;
 using Google.Apis.Translate.v2;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 
@@ -120,7 +123,7 @@ namespace TranslateSample
             // Data.TranslationsListResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
     }
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_vision.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_vision.v1.json.baseline
@@ -17,6 +17,7 @@
 using Google.Apis.Auth.OAuth2;
 using Google.Apis.Services;
 using Google.Apis.Vision.v1;
+using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
 
@@ -44,7 +45,7 @@ namespace VisionSample
             // Data.BatchAnnotateImagesResponse response = await request.ExecuteAsync();
 
             // TODO: Change code below to process the `response` object:
-            Console.WriteLine(response);
+            Console.WriteLine(JsonConvert.SerializeObject(response));
         }
 
         public static GoogleCredential GetCredential()


### PR DESCRIPTION
It turns out that on success, the C# samples are just printing the fully
qualified name of the response object.

For example, for `language.detections.list` in `translate/v2`:

    Console.WriteLine(response);

prints

    Google.Apis.Translate.v2.Data.DetectionsListResponse

This change converts `response` to a formatted JSON string before printing.