### PR TITLE
Add a GAPIC_VERSION variable in Node.js GAPICs.

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTransformer.java
@@ -276,6 +276,8 @@ public class NodeJSGapicSurfaceTransformer implements ModelToViewTransformer {
             .outputPath(indexOutputPath)
             .requireViews(requireViews)
             .primaryService(requireViews.get(0))
+            .packageVersion(
+                packageConfig.generatedPackageVersionBound(TargetLanguage.NODEJS).lower())
             .fileHeader(
                 fileHeaderTransformer.generateFileHeader(
                     apiConfig, ImportSectionView.newBuilder().build(), namer));
@@ -292,6 +294,8 @@ public class NodeJSGapicSurfaceTransformer implements ModelToViewTransformer {
               .outputPath(versionIndexOutputPath)
               .requireViews(new ArrayList<VersionIndexRequireView>())
               .apiVersion(version)
+              .packageVersion(
+                  packageConfig.generatedPackageVersionBound(TargetLanguage.NODEJS).lower())
               .fileHeader(
                   fileHeaderTransformer.generateFileHeader(
                       apiConfig, ImportSectionView.newBuilder().build(), namer));

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubyGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubyGapicSurfaceTransformer.java
@@ -184,6 +184,7 @@ public class RubyGapicSurfaceTransformer implements ModelToViewTransformer {
         .outputPath(pathMapper.getOutputPath(interfaces.iterator().next(), apiConfig) + ".rb")
         .requireViews(requireViews.build())
         .templateFileName(VERSION_INDEX_TEMPLATE_FILE)
+        .packageVersion(packageConfig.generatedPackageVersionBound(TargetLanguage.RUBY).lower())
         .fileHeader(
             fileHeaderTransformer.generateFileHeader(
                 apiConfig, ImportSectionView.newBuilder().build(), namer))

--- a/src/main/java/com/google/api/codegen/viewmodel/metadata/VersionIndexView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/metadata/VersionIndexView.java
@@ -40,6 +40,8 @@ public abstract class VersionIndexView implements ViewModel {
 
   public abstract String apiVersion();
 
+  public abstract String packageVersion();
+
   public abstract List<VersionIndexRequireView> requireViews();
 
   public abstract FileHeaderView fileHeader();
@@ -62,6 +64,8 @@ public abstract class VersionIndexView implements ViewModel {
     public abstract Builder primaryService(VersionIndexRequireView val);
 
     public abstract Builder apiVersion(String val);
+
+    public abstract Builder packageVersion(String val);
 
     public abstract Builder requireViews(List<VersionIndexRequireView> val);
 

--- a/src/main/resources/com/google/api/codegen/nodejs/index.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/index.snip
@@ -31,6 +31,7 @@
     @end
   }
 
+  {@index.apiVersion}.GAPIC_VERSION = '{@index.packageVersion}';
   {@index.apiVersion}.SERVICE_ADDRESS = {@index.primaryService.clientName}.SERVICE_ADDRESS;
   @if index.hasMultipleServices
     {@index.apiVersion}.ALL_SCOPES = union(
@@ -45,4 +46,3 @@
   module.exports = {@index.apiVersion};
 
 @end
-

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_doc_index_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_doc_index_library.baseline
@@ -28,8 +28,8 @@ function v1(options) {
   return libraryServiceClient(gaxGrpc);
 }
 
+v1.GAPIC_VERSION = '0.7.1';
 v1.SERVICE_ADDRESS = libraryServiceClient.SERVICE_ADDRESS;
 v1.ALL_SCOPES = libraryServiceClient.ALL_SCOPES;
 
 module.exports = v1;
-

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_index_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_index_library.baseline
@@ -28,8 +28,8 @@ function v1(options) {
   return libraryServiceClient(gaxGrpc);
 }
 
+v1.GAPIC_VERSION = '0.7.1';
 v1.SERVICE_ADDRESS = libraryServiceClient.SERVICE_ADDRESS;
 v1.ALL_SCOPES = libraryServiceClient.ALL_SCOPES;
 
 module.exports = v1;
-

--- a/src/test/java/com/google/api/codegen/testdata/nodejs_index_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/nodejs_index_no_path_templates.baseline
@@ -28,8 +28,8 @@ function v1(options) {
   return noTemplatesApiServiceClient(gaxGrpc);
 }
 
+v1.GAPIC_VERSION = '0.7.1';
 v1.SERVICE_ADDRESS = noTemplatesApiServiceClient.SERVICE_ADDRESS;
 v1.ALL_SCOPES = noTemplatesApiServiceClient.ALL_SCOPES;
 
 module.exports = v1;
-


### PR DESCRIPTION
This is a prerequisite to having headers report them properly, since their `package.json` files are stripped away before delivery.