### PR TITLE
Use trailing commas

### DIFF
--- a/src/main/resources/com/google/api/codegen/nodejs/sample.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/sample.snip
@@ -83,7 +83,7 @@
         // TODO: Add desired media content for upload. See
         // https://github.com/google/google-api-nodejs-client#media-uploads
         mimeType: '',  // See https://www.w3.org/Protocols/rfc1341/4_Content-Type.html
-        body: {}
+        body: {},
       },
 
     @end
@@ -94,7 +94,7 @@
 
     @end
     @if class.auth.type != "NONE"
-      auth: {@class.auth.authVarName}
+      auth: {@class.auth.authVarName},
     @end
   };
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_adexchangebuyer.v1.4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_adexchangebuyer.v1.4.json.baseline
@@ -15,7 +15,7 @@ authorize(function(authClient) {
     // The account id
     id: 0,  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   adExchangeBuyer.accounts.get(request, function(err, response) {
@@ -56,7 +56,7 @@ var adExchangeBuyer = google.adexchangebuyer('v1.4');
 
 authorize(function(authClient) {
   var request = {
-    auth: authClient
+    auth: authClient,
   };
 
   adExchangeBuyer.accounts.list(request, function(err, response) {
@@ -105,7 +105,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   adExchangeBuyer.accounts.patch(request, function(err, response) {
@@ -154,7 +154,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   adExchangeBuyer.accounts.update(request, function(err, response) {
@@ -198,7 +198,7 @@ authorize(function(authClient) {
     // The account id.
     accountId: 0,  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   adExchangeBuyer.billingInfo.get(request, function(err, response) {
@@ -239,7 +239,7 @@ var adExchangeBuyer = google.adexchangebuyer('v1.4');
 
 authorize(function(authClient) {
   var request = {
-    auth: authClient
+    auth: authClient,
   };
 
   adExchangeBuyer.billingInfo.list(request, function(err, response) {
@@ -286,7 +286,7 @@ authorize(function(authClient) {
     // The billing id to get the budget information for.
     billingId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   adExchangeBuyer.budget.get(request, function(err, response) {
@@ -338,7 +338,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   adExchangeBuyer.budget.patch(request, function(err, response) {
@@ -390,7 +390,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   adExchangeBuyer.budget.update(request, function(err, response) {
@@ -440,7 +440,7 @@ authorize(function(authClient) {
     // The id of the deal id to associate with this creative.
     dealId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   adExchangeBuyer.creatives.addDeal(request, function(err) {
@@ -484,7 +484,7 @@ authorize(function(authClient) {
     // The buyer-specific id for this creative.
     buyerCreativeId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   adExchangeBuyer.creatives.get(request, function(err, response) {
@@ -529,7 +529,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   adExchangeBuyer.creatives.insert(request, function(err, response) {
@@ -570,7 +570,7 @@ var adExchangeBuyer = google.adexchangebuyer('v1.4');
 
 authorize(function(authClient) {
   var request = {
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -630,7 +630,7 @@ authorize(function(authClient) {
     // The buyer-specific id for this creative.
     buyerCreativeId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   adExchangeBuyer.creatives.listDeals(request, function(err, response) {
@@ -680,7 +680,7 @@ authorize(function(authClient) {
     // The id of the deal id to disassociate with this creative.
     dealId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   adExchangeBuyer.creatives.removeDeal(request, function(err) {
@@ -725,7 +725,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   adExchangeBuyer.marketplacedeals.delete(request, function(err, response) {
@@ -773,7 +773,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   adExchangeBuyer.marketplacedeals.insert(request, function(err, response) {
@@ -818,7 +818,7 @@ authorize(function(authClient) {
     // the URL.
     proposalId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   adExchangeBuyer.marketplacedeals.list(request, function(err, response) {
@@ -866,7 +866,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   adExchangeBuyer.marketplacedeals.update(request, function(err, response) {
@@ -914,7 +914,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   adExchangeBuyer.marketplacenotes.insert(request, function(err, response) {
@@ -959,7 +959,7 @@ authorize(function(authClient) {
     // the URL.
     proposalId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   adExchangeBuyer.marketplacenotes.list(request, function(err, response) {
@@ -1007,7 +1007,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   adExchangeBuyer.marketplaceprivateauction.updateproposal(request, function(err) {
@@ -1054,7 +1054,7 @@ authorize(function(authClient) {
     // The start time of the report in ISO 8601 timestamp format using UTC.
     startDateTime: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   adExchangeBuyer.performanceReport.list(request, function(err, response) {
@@ -1101,7 +1101,7 @@ authorize(function(authClient) {
     // The specific id of the configuration to delete.
     configId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   adExchangeBuyer.pretargetingConfig.delete(request, function(err) {
@@ -1145,7 +1145,7 @@ authorize(function(authClient) {
     // The specific id of the configuration to retrieve.
     configId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   adExchangeBuyer.pretargetingConfig.get(request, function(err, response) {
@@ -1193,7 +1193,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   adExchangeBuyer.pretargetingConfig.insert(request, function(err, response) {
@@ -1237,7 +1237,7 @@ authorize(function(authClient) {
     // The account id to get the pretargeting configs for.
     accountId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   adExchangeBuyer.pretargetingConfig.list(request, function(err, response) {
@@ -1289,7 +1289,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   adExchangeBuyer.pretargetingConfig.patch(request, function(err, response) {
@@ -1341,7 +1341,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   adExchangeBuyer.pretargetingConfig.update(request, function(err, response) {
@@ -1385,7 +1385,7 @@ authorize(function(authClient) {
     // The id for the product to get the head revision for.
     productId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   adExchangeBuyer.products.get(request, function(err, response) {
@@ -1426,7 +1426,7 @@ var adExchangeBuyer = google.adexchangebuyer('v1.4');
 
 authorize(function(authClient) {
   var request = {
-    auth: authClient
+    auth: authClient,
   };
 
   adExchangeBuyer.products.search(request, function(err, response) {
@@ -1470,7 +1470,7 @@ authorize(function(authClient) {
     // Id of the proposal to retrieve.
     proposalId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   adExchangeBuyer.proposals.get(request, function(err, response) {
@@ -1515,7 +1515,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   adExchangeBuyer.proposals.insert(request, function(err, response) {
@@ -1573,7 +1573,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   adExchangeBuyer.proposals.patch(request, function(err, response) {
@@ -1614,7 +1614,7 @@ var adExchangeBuyer = google.adexchangebuyer('v1.4');
 
 authorize(function(authClient) {
   var request = {
-    auth: authClient
+    auth: authClient,
   };
 
   adExchangeBuyer.proposals.search(request, function(err, response) {
@@ -1658,7 +1658,7 @@ authorize(function(authClient) {
     // The proposal id for which the setup is complete
     proposalId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   adExchangeBuyer.proposals.setupcomplete(request, function(err) {
@@ -1713,7 +1713,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   adExchangeBuyer.proposals.update(request, function(err, response) {
@@ -1757,7 +1757,7 @@ authorize(function(authClient) {
     // The accountId of the publisher to get profiles for.
     accountId: 0,  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   adExchangeBuyer.pubprofiles.list(request, function(err, response) {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_appengine.v1beta5.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_appengine.v1beta5.json.baseline
@@ -22,7 +22,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   appengine.apps.create(request, function(err, response) {
@@ -71,7 +71,7 @@ authorize(function(authClient) {
     // Part of `name`. Name of the application to get. Example: apps/myapp.
     appsId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   appengine.apps.get(request, function(err, response) {
@@ -123,7 +123,7 @@ authorize(function(authClient) {
     // Part of `name`. See documentation of `appsId`.
     locationsId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   appengine.apps.locations.get(request, function(err, response) {
@@ -172,7 +172,7 @@ authorize(function(authClient) {
     // Part of `name`. The resource that owns the locations collection, if applicable.
     appsId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -237,7 +237,7 @@ authorize(function(authClient) {
     // Part of `name`. See documentation of `appsId`.
     operationsId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   appengine.apps.operations.get(request, function(err, response) {
@@ -286,7 +286,7 @@ authorize(function(authClient) {
     // Part of `name`. The name of the operation collection.
     appsId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -353,7 +353,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   appengine.apps.patch(request, function(err, response) {
@@ -405,7 +405,7 @@ authorize(function(authClient) {
     // Part of `name`. See documentation of `appsId`.
     servicesId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   appengine.apps.services.delete(request, function(err, response) {
@@ -457,7 +457,7 @@ authorize(function(authClient) {
     // Part of `name`. See documentation of `appsId`.
     servicesId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   appengine.apps.services.get(request, function(err, response) {
@@ -506,7 +506,7 @@ authorize(function(authClient) {
     // Part of `name`. Name of the resource requested. Example: apps/myapp.
     appsId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -576,7 +576,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   appengine.apps.services.patch(request, function(err, response) {
@@ -632,7 +632,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   appengine.apps.services.versions.create(request, function(err, response) {
@@ -687,7 +687,7 @@ authorize(function(authClient) {
     // Part of `name`. See documentation of `appsId`.
     versionsId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   appengine.apps.services.versions.delete(request, function(err, response) {
@@ -742,7 +742,7 @@ authorize(function(authClient) {
     // Part of `name`. See documentation of `appsId`.
     versionsId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   appengine.apps.services.versions.get(request, function(err, response) {
@@ -805,7 +805,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   appengine.apps.services.versions.instances.debug(request, function(err, response) {
@@ -864,7 +864,7 @@ authorize(function(authClient) {
     // Part of `name`. See documentation of `appsId`.
     instancesId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   appengine.apps.services.versions.instances.delete(request, function(err, response) {
@@ -923,7 +923,7 @@ authorize(function(authClient) {
     // Part of `name`. See documentation of `appsId`.
     instancesId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   appengine.apps.services.versions.instances.get(request, function(err, response) {
@@ -978,7 +978,7 @@ authorize(function(authClient) {
     // Part of `name`. See documentation of `appsId`.
     versionsId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -1043,7 +1043,7 @@ authorize(function(authClient) {
     // Part of `name`. See documentation of `appsId`.
     servicesId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -1116,7 +1116,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   appengine.apps.services.versions.patch(request, function(err, response) {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_bigquery.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_bigquery.v2.json.baseline
@@ -24,7 +24,7 @@ authorize(function(authClient) {
     // Dataset ID of dataset being deleted
     datasetId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   bigquery.datasets.delete(request, function(err) {
@@ -73,7 +73,7 @@ authorize(function(authClient) {
     // Dataset ID of the requested dataset
     datasetId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   bigquery.datasets.get(request, function(err, response) {
@@ -126,7 +126,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   bigquery.datasets.insert(request, function(err, response) {
@@ -175,7 +175,7 @@ authorize(function(authClient) {
     // Project ID of the datasets to be listed
     projectId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -245,7 +245,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   bigquery.datasets.patch(request, function(err, response) {
@@ -302,7 +302,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   bigquery.datasets.update(request, function(err, response) {
@@ -354,7 +354,7 @@ authorize(function(authClient) {
     // [Required] Job ID of the job to cancel
     jobId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   bigquery.jobs.cancel(request, function(err, response) {
@@ -406,7 +406,7 @@ authorize(function(authClient) {
     // [Required] Job ID of the requested job
     jobId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   bigquery.jobs.get(request, function(err, response) {
@@ -458,7 +458,7 @@ authorize(function(authClient) {
     // [Required] Job ID of the query job
     jobId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -528,10 +528,10 @@ authorize(function(authClient) {
       // TODO: Add desired media content for upload. See
       // https://github.com/google/google-api-nodejs-client#media-uploads
       mimeType: '',  // See https://www.w3.org/Protocols/rfc1341/4_Content-Type.html
-      body: {}
+      body: {},
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   bigquery.jobs.insert(request, function(err, response) {
@@ -580,7 +580,7 @@ authorize(function(authClient) {
     // Project ID of the jobs to list
     projectId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -646,7 +646,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   bigquery.jobs.query(request, function(err, response) {
@@ -692,7 +692,7 @@ var bigquery = google.bigquery('v2');
 
 authorize(function(authClient) {
   var request = {
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -764,7 +764,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   bigquery.tabledata.insertAll(request, function(err, response) {
@@ -819,7 +819,7 @@ authorize(function(authClient) {
     // Table ID of the table to read
     tableId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -887,7 +887,7 @@ authorize(function(authClient) {
     // Table ID of the table to delete
     tableId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   bigquery.tables.delete(request, function(err) {
@@ -939,7 +939,7 @@ authorize(function(authClient) {
     // Table ID of the requested table
     tableId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   bigquery.tables.get(request, function(err, response) {
@@ -995,7 +995,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   bigquery.tables.insert(request, function(err, response) {
@@ -1047,7 +1047,7 @@ authorize(function(authClient) {
     // Dataset ID of the tables to list
     datasetId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -1120,7 +1120,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   bigquery.tables.patch(request, function(err, response) {
@@ -1180,7 +1180,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   bigquery.tables.update(request, function(err, response) {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_cloudbilling.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_cloudbilling.v1.json.baseline
@@ -23,7 +23,7 @@ authorize(function(authClient) {
     name: '',  // TODO: Update placeholder value.
     // ex: 'billingAccounts/my-billingAccount'
 
-    auth: authClient
+    auth: authClient,
   };
 
   cloudbilling.billingAccounts.get(request, function(err, response) {
@@ -69,7 +69,7 @@ var cloudbilling = google.cloudbilling('v1');
 
 authorize(function(authClient) {
   var request = {
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -133,7 +133,7 @@ authorize(function(authClient) {
     name: '',  // TODO: Update placeholder value.
     // ex: 'billingAccounts/my-billingAccount'
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -197,7 +197,7 @@ authorize(function(authClient) {
     name: '',  // TODO: Update placeholder value.
     // ex: 'projects/my-project'
 
-    auth: authClient
+    auth: authClient,
   };
 
   cloudbilling.projects.getBillingInfo(request, function(err, response) {
@@ -253,7 +253,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   cloudbilling.projects.updateBillingInfo(request, function(err, response) {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_clouddebugger.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_clouddebugger.v2.json.baseline
@@ -21,7 +21,7 @@ authorize(function(authClient) {
     // Identifies the debuggee.
     debuggeeId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   cloudDebugger.controller.debuggees.breakpoints.list(request, function(err, response) {
@@ -78,7 +78,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   cloudDebugger.controller.debuggees.breakpoints.update(request, function(err, response) {
@@ -128,7 +128,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   cloudDebugger.controller.debuggees.register(request, function(err, response) {
@@ -180,7 +180,7 @@ authorize(function(authClient) {
     // ID of the breakpoint to delete.
     breakpointId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   cloudDebugger.debugger.debuggees.breakpoints.delete(request, function(err) {
@@ -229,7 +229,7 @@ authorize(function(authClient) {
     // ID of the breakpoint to get.
     breakpointId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   cloudDebugger.debugger.debuggees.breakpoints.get(request, function(err, response) {
@@ -278,7 +278,7 @@ authorize(function(authClient) {
     // ID of the debuggee whose breakpoints to list.
     debuggeeId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   cloudDebugger.debugger.debuggees.breakpoints.list(request, function(err, response) {
@@ -331,7 +331,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   cloudDebugger.debugger.debuggees.breakpoints.set(request, function(err, response) {
@@ -377,7 +377,7 @@ var cloudDebugger = google.clouddebugger('v2');
 
 authorize(function(authClient) {
   var request = {
-    auth: authClient
+    auth: authClient,
   };
 
   cloudDebugger.debugger.debuggees.list(request, function(err, response) {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_cloudmonitoring.v2beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_cloudmonitoring.v2beta2.json.baseline
@@ -25,7 +25,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   cloudMonitoring.metricDescriptors.create(request, function(err, response) {
@@ -77,7 +77,7 @@ authorize(function(authClient) {
     // Name of the metric.
     metric: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   cloudMonitoring.metricDescriptors.delete(request, function(err, response) {
@@ -130,7 +130,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -204,7 +204,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -270,7 +270,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   cloudMonitoring.timeseries.write(request, function(err, response) {
@@ -331,7 +331,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_cloudresourcemanager.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_cloudresourcemanager.v1.json.baseline
@@ -21,7 +21,7 @@ authorize(function(authClient) {
     // The name of the operation resource.
     name: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   cloudResourceManager.operations.get(request, function(err, response) {
@@ -70,7 +70,7 @@ authorize(function(authClient) {
     // The resource name of the Organization to fetch, e.g. "organizations/1234".
     name: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   cloudResourceManager.organizations.get(request, function(err, response) {
@@ -125,7 +125,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   cloudResourceManager.organizations.getIamPolicy(request, function(err, response) {
@@ -175,7 +175,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -243,7 +243,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   cloudResourceManager.organizations.setIamPolicy(request, function(err, response) {
@@ -298,7 +298,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   cloudResourceManager.organizations.testIamPermissions(request, function(err, response) {
@@ -348,7 +348,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   cloudResourceManager.projects.create(request, function(err, response) {
@@ -398,7 +398,7 @@ authorize(function(authClient) {
     // Required.
     projectId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   cloudResourceManager.projects.delete(request, function(err) {
@@ -445,7 +445,7 @@ authorize(function(authClient) {
     // Required.
     projectId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   cloudResourceManager.projects.get(request, function(err, response) {
@@ -499,7 +499,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   cloudResourceManager.projects.getAncestry(request, function(err, response) {
@@ -554,7 +554,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   cloudResourceManager.projects.getIamPolicy(request, function(err, response) {
@@ -600,7 +600,7 @@ var cloudResourceManager = google.cloudresourcemanager('v1');
 
 authorize(function(authClient) {
   var request = {
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -668,7 +668,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   cloudResourceManager.projects.setIamPolicy(request, function(err, response) {
@@ -723,7 +723,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   cloudResourceManager.projects.testIamPermissions(request, function(err, response) {
@@ -777,7 +777,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   cloudResourceManager.projects.undelete(request, function(err) {
@@ -829,7 +829,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   cloudResourceManager.projects.update(request, function(err, response) {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_cloudtrace.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_cloudtrace.v1.json.baseline
@@ -26,7 +26,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   cloudTrace.projects.patchTraces(request, function(err) {
@@ -75,7 +75,7 @@ authorize(function(authClient) {
     // ID of the trace to return.
     traceId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   cloudTrace.projects.traces.get(request, function(err, response) {
@@ -124,7 +124,7 @@ authorize(function(authClient) {
     // ID of the Cloud project where the trace data is stored.
     projectId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_clouduseraccounts.beta.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_clouduseraccounts.beta.json.baseline
@@ -24,7 +24,7 @@ authorize(function(authClient) {
     // Name of the Operations resource to delete.
     operation: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   cloudUserAccounts.globalAccountsOperations.delete(request, function(err) {
@@ -73,7 +73,7 @@ authorize(function(authClient) {
     // Name of the Operations resource to return.
     operation: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   cloudUserAccounts.globalAccountsOperations.get(request, function(err, response) {
@@ -122,7 +122,7 @@ authorize(function(authClient) {
     // Project ID for this request.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -191,7 +191,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   cloudUserAccounts.groups.addMember(request, function(err, response) {
@@ -243,7 +243,7 @@ authorize(function(authClient) {
     // Name of the Group resource to delete.
     groupName: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   cloudUserAccounts.groups.delete(request, function(err, response) {
@@ -295,7 +295,7 @@ authorize(function(authClient) {
     // Name of the Group resource to return.
     groupName: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   cloudUserAccounts.groups.get(request, function(err, response) {
@@ -348,7 +348,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   cloudUserAccounts.groups.insert(request, function(err, response) {
@@ -397,7 +397,7 @@ authorize(function(authClient) {
     // Project ID for this request.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -466,7 +466,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   cloudUserAccounts.groups.removeMember(request, function(err, response) {
@@ -524,7 +524,7 @@ authorize(function(authClient) {
     // The fully-qualified URL of the virtual machine requesting the view.
     instance: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   cloudUserAccounts.linux.getAuthorizedKeysView(request, function(err, response) {
@@ -579,7 +579,7 @@ authorize(function(authClient) {
     // The fully-qualified URL of the virtual machine requesting the views.
     instance: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   cloudUserAccounts.linux.getLinuxAccountViews(request, function(err, response) {
@@ -635,7 +635,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   cloudUserAccounts.users.addPublicKey(request, function(err, response) {
@@ -687,7 +687,7 @@ authorize(function(authClient) {
     // Name of the user resource to delete.
     user: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   cloudUserAccounts.users.delete(request, function(err, response) {
@@ -739,7 +739,7 @@ authorize(function(authClient) {
     // Name of the user resource to return.
     user: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   cloudUserAccounts.users.get(request, function(err, response) {
@@ -792,7 +792,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   cloudUserAccounts.users.insert(request, function(err, response) {
@@ -841,7 +841,7 @@ authorize(function(authClient) {
     // Project ID for this request.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -910,7 +910,7 @@ authorize(function(authClient) {
     // is defined by RFC4716 to be the MD5 digest of the public key.
     fingerprint: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   cloudUserAccounts.users.removePublicKey(request, function(err, response) {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_compute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_compute.v1.json.baseline
@@ -21,7 +21,7 @@ authorize(function(authClient) {
     // Project ID for this request.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -89,7 +89,7 @@ authorize(function(authClient) {
     // Name of the address resource to delete.
     address: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.addresses.delete(request, function(err, response) {
@@ -144,7 +144,7 @@ authorize(function(authClient) {
     // Name of the address resource to return.
     address: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.addresses.get(request, function(err, response) {
@@ -200,7 +200,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.addresses.insert(request, function(err, response) {
@@ -252,7 +252,7 @@ authorize(function(authClient) {
     // Name of the region for this request.
     region: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -314,7 +314,7 @@ authorize(function(authClient) {
     // Project ID for this request.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -382,7 +382,7 @@ authorize(function(authClient) {
     // Name of the autoscaler to delete.
     autoscaler: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.autoscalers.delete(request, function(err, response) {
@@ -437,7 +437,7 @@ authorize(function(authClient) {
     // Name of the autoscaler to return.
     autoscaler: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.autoscalers.get(request, function(err, response) {
@@ -493,7 +493,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.autoscalers.insert(request, function(err, response) {
@@ -545,7 +545,7 @@ authorize(function(authClient) {
     // Name of the zone for this request.
     zone: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -618,7 +618,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.autoscalers.patch(request, function(err, response) {
@@ -675,7 +675,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.autoscalers.update(request, function(err, response) {
@@ -724,7 +724,7 @@ authorize(function(authClient) {
     // Name of the project scoping this request.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -789,7 +789,7 @@ authorize(function(authClient) {
     // Name of the BackendService resource to delete.
     backendService: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.backendServices.delete(request, function(err, response) {
@@ -841,7 +841,7 @@ authorize(function(authClient) {
     // Name of the BackendService resource to return.
     backendService: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.backendServices.get(request, function(err, response) {
@@ -896,7 +896,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.backendServices.getHealth(request, function(err, response) {
@@ -949,7 +949,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.backendServices.insert(request, function(err, response) {
@@ -998,7 +998,7 @@ authorize(function(authClient) {
     // Project ID for this request.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -1068,7 +1068,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.backendServices.patch(request, function(err, response) {
@@ -1125,7 +1125,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.backendServices.update(request, function(err, response) {
@@ -1174,7 +1174,7 @@ authorize(function(authClient) {
     // Project ID for this request.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -1242,7 +1242,7 @@ authorize(function(authClient) {
     // Name of the disk type to return.
     diskType: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.diskTypes.get(request, function(err, response) {
@@ -1294,7 +1294,7 @@ authorize(function(authClient) {
     // The name of the zone for this request.
     zone: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -1356,7 +1356,7 @@ authorize(function(authClient) {
     // Project ID for this request.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -1428,7 +1428,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.disks.createSnapshot(request, function(err, response) {
@@ -1483,7 +1483,7 @@ authorize(function(authClient) {
     // Name of the persistent disk to delete.
     disk: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.disks.delete(request, function(err, response) {
@@ -1538,7 +1538,7 @@ authorize(function(authClient) {
     // Name of the persistent disk to return.
     disk: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.disks.get(request, function(err, response) {
@@ -1594,7 +1594,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.disks.insert(request, function(err, response) {
@@ -1646,7 +1646,7 @@ authorize(function(authClient) {
     // The name of the zone for this request.
     zone: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -1718,7 +1718,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.disks.resize(request, function(err, response) {
@@ -1770,7 +1770,7 @@ authorize(function(authClient) {
     // Name of the firewall rule to delete.
     firewall: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.firewalls.delete(request, function(err, response) {
@@ -1822,7 +1822,7 @@ authorize(function(authClient) {
     // Name of the firewall rule to return.
     firewall: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.firewalls.get(request, function(err, response) {
@@ -1875,7 +1875,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.firewalls.insert(request, function(err, response) {
@@ -1924,7 +1924,7 @@ authorize(function(authClient) {
     // Project ID for this request.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -1994,7 +1994,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.firewalls.patch(request, function(err, response) {
@@ -2051,7 +2051,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.firewalls.update(request, function(err, response) {
@@ -2100,7 +2100,7 @@ authorize(function(authClient) {
     // Project ID for this request.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -2168,7 +2168,7 @@ authorize(function(authClient) {
     // Name of the ForwardingRule resource to delete.
     forwardingRule: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.forwardingRules.delete(request, function(err, response) {
@@ -2223,7 +2223,7 @@ authorize(function(authClient) {
     // Name of the ForwardingRule resource to return.
     forwardingRule: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.forwardingRules.get(request, function(err, response) {
@@ -2279,7 +2279,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.forwardingRules.insert(request, function(err, response) {
@@ -2331,7 +2331,7 @@ authorize(function(authClient) {
     // Name of the region scoping this request.
     region: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -2403,7 +2403,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.forwardingRules.setTarget(request, function(err, response) {
@@ -2455,7 +2455,7 @@ authorize(function(authClient) {
     // Name of the address resource to delete.
     address: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.globalAddresses.delete(request, function(err, response) {
@@ -2507,7 +2507,7 @@ authorize(function(authClient) {
     // Name of the address resource to return.
     address: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.globalAddresses.get(request, function(err, response) {
@@ -2560,7 +2560,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.globalAddresses.insert(request, function(err, response) {
@@ -2609,7 +2609,7 @@ authorize(function(authClient) {
     // Project ID for this request.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -2674,7 +2674,7 @@ authorize(function(authClient) {
     // Name of the ForwardingRule resource to delete.
     forwardingRule: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.globalForwardingRules.delete(request, function(err, response) {
@@ -2726,7 +2726,7 @@ authorize(function(authClient) {
     // Name of the ForwardingRule resource to return.
     forwardingRule: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.globalForwardingRules.get(request, function(err, response) {
@@ -2779,7 +2779,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.globalForwardingRules.insert(request, function(err, response) {
@@ -2828,7 +2828,7 @@ authorize(function(authClient) {
     // Project ID for this request.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -2897,7 +2897,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.globalForwardingRules.setTarget(request, function(err, response) {
@@ -2946,7 +2946,7 @@ authorize(function(authClient) {
     // Project ID for this request.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -3011,7 +3011,7 @@ authorize(function(authClient) {
     // Name of the Operations resource to delete.
     operation: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.globalOperations.delete(request, function(err) {
@@ -3060,7 +3060,7 @@ authorize(function(authClient) {
     // Name of the Operations resource to return.
     operation: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.globalOperations.get(request, function(err, response) {
@@ -3109,7 +3109,7 @@ authorize(function(authClient) {
     // Project ID for this request.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -3174,7 +3174,7 @@ authorize(function(authClient) {
     // Name of the HealthCheck resource to delete.
     healthCheck: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.healthChecks.delete(request, function(err, response) {
@@ -3226,7 +3226,7 @@ authorize(function(authClient) {
     // Name of the HealthCheck resource to return.
     healthCheck: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.healthChecks.get(request, function(err, response) {
@@ -3279,7 +3279,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.healthChecks.insert(request, function(err, response) {
@@ -3328,7 +3328,7 @@ authorize(function(authClient) {
     // Project ID for this request.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -3398,7 +3398,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.healthChecks.patch(request, function(err, response) {
@@ -3455,7 +3455,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.healthChecks.update(request, function(err, response) {
@@ -3507,7 +3507,7 @@ authorize(function(authClient) {
     // Name of the HttpHealthCheck resource to delete.
     httpHealthCheck: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.httpHealthChecks.delete(request, function(err, response) {
@@ -3559,7 +3559,7 @@ authorize(function(authClient) {
     // Name of the HttpHealthCheck resource to return.
     httpHealthCheck: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.httpHealthChecks.get(request, function(err, response) {
@@ -3612,7 +3612,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.httpHealthChecks.insert(request, function(err, response) {
@@ -3661,7 +3661,7 @@ authorize(function(authClient) {
     // Project ID for this request.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -3731,7 +3731,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.httpHealthChecks.patch(request, function(err, response) {
@@ -3788,7 +3788,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.httpHealthChecks.update(request, function(err, response) {
@@ -3840,7 +3840,7 @@ authorize(function(authClient) {
     // Name of the HttpsHealthCheck resource to delete.
     httpsHealthCheck: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.httpsHealthChecks.delete(request, function(err, response) {
@@ -3892,7 +3892,7 @@ authorize(function(authClient) {
     // Name of the HttpsHealthCheck resource to return.
     httpsHealthCheck: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.httpsHealthChecks.get(request, function(err, response) {
@@ -3945,7 +3945,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.httpsHealthChecks.insert(request, function(err, response) {
@@ -3994,7 +3994,7 @@ authorize(function(authClient) {
     // Project ID for this request.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -4064,7 +4064,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.httpsHealthChecks.patch(request, function(err, response) {
@@ -4121,7 +4121,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.httpsHealthChecks.update(request, function(err, response) {
@@ -4173,7 +4173,7 @@ authorize(function(authClient) {
     // Name of the image resource to delete.
     image: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.images.delete(request, function(err, response) {
@@ -4229,7 +4229,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.images.deprecate(request, function(err, response) {
@@ -4281,7 +4281,7 @@ authorize(function(authClient) {
     // Name of the image resource to return.
     image: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.images.get(request, function(err, response) {
@@ -4333,7 +4333,7 @@ authorize(function(authClient) {
     // Name of the image family to search for.
     family: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.images.getFromFamily(request, function(err, response) {
@@ -4386,7 +4386,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.images.insert(request, function(err, response) {
@@ -4435,7 +4435,7 @@ authorize(function(authClient) {
     // Project ID for this request.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -4507,7 +4507,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.instanceGroupManagers.abandonInstances(request, function(err, response) {
@@ -4556,7 +4556,7 @@ authorize(function(authClient) {
     // Project ID for this request.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -4624,7 +4624,7 @@ authorize(function(authClient) {
     // The name of the managed instance group to delete.
     instanceGroupManager: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.instanceGroupManagers.delete(request, function(err, response) {
@@ -4683,7 +4683,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.instanceGroupManagers.deleteInstances(request, function(err, response) {
@@ -4738,7 +4738,7 @@ authorize(function(authClient) {
     // The name of the managed instance group.
     instanceGroupManager: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.instanceGroupManagers.get(request, function(err, response) {
@@ -4794,7 +4794,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.instanceGroupManagers.insert(request, function(err, response) {
@@ -4846,7 +4846,7 @@ authorize(function(authClient) {
     // The name of the zone where the managed instance group is located.
     zone: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -4914,7 +4914,7 @@ authorize(function(authClient) {
     // The name of the managed instance group.
     instanceGroupManager: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.instanceGroupManagers.listManagedInstances(request, function(err, response) {
@@ -4973,7 +4973,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.instanceGroupManagers.recreateInstances(request, function(err, response) {
@@ -5033,7 +5033,7 @@ authorize(function(authClient) {
     // this parameter.
     size: 0,  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.instanceGroupManagers.resize(request, function(err, response) {
@@ -5092,7 +5092,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.instanceGroupManagers.setInstanceTemplate(request, function(err, response) {
@@ -5151,7 +5151,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.instanceGroupManagers.setTargetPools(request, function(err, response) {
@@ -5210,7 +5210,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.instanceGroups.addInstances(request, function(err, response) {
@@ -5259,7 +5259,7 @@ authorize(function(authClient) {
     // Project ID for this request.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -5327,7 +5327,7 @@ authorize(function(authClient) {
     // The name of the instance group to delete.
     instanceGroup: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.instanceGroups.delete(request, function(err, response) {
@@ -5382,7 +5382,7 @@ authorize(function(authClient) {
     // The name of the instance group.
     instanceGroup: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.instanceGroups.get(request, function(err, response) {
@@ -5438,7 +5438,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.instanceGroups.insert(request, function(err, response) {
@@ -5490,7 +5490,7 @@ authorize(function(authClient) {
     // The name of the zone where the instance group is located.
     zone: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -5562,7 +5562,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -5634,7 +5634,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.instanceGroups.removeInstances(request, function(err, response) {
@@ -5693,7 +5693,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.instanceGroups.setNamedPorts(request, function(err, response) {
@@ -5745,7 +5745,7 @@ authorize(function(authClient) {
     // The name of the instance template to delete.
     instanceTemplate: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.instanceTemplates.delete(request, function(err, response) {
@@ -5797,7 +5797,7 @@ authorize(function(authClient) {
     // The name of the instance template.
     instanceTemplate: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.instanceTemplates.get(request, function(err, response) {
@@ -5850,7 +5850,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.instanceTemplates.insert(request, function(err, response) {
@@ -5899,7 +5899,7 @@ authorize(function(authClient) {
     // Project ID for this request.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -5974,7 +5974,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.instances.addAccessConfig(request, function(err, response) {
@@ -6023,7 +6023,7 @@ authorize(function(authClient) {
     // Project ID for this request.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -6095,7 +6095,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.instances.attachDisk(request, function(err, response) {
@@ -6150,7 +6150,7 @@ authorize(function(authClient) {
     // Name of the instance resource to delete.
     instance: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.instances.delete(request, function(err, response) {
@@ -6211,7 +6211,7 @@ authorize(function(authClient) {
     // The name of the network interface.
     networkInterface: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.instances.deleteAccessConfig(request, function(err, response) {
@@ -6269,7 +6269,7 @@ authorize(function(authClient) {
     // Disk device name to detach.
     deviceName: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.instances.detachDisk(request, function(err, response) {
@@ -6324,7 +6324,7 @@ authorize(function(authClient) {
     // Name of the instance resource to return.
     instance: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.instances.get(request, function(err, response) {
@@ -6379,7 +6379,7 @@ authorize(function(authClient) {
     // Name of the instance scoping this request.
     instance: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.instances.getSerialPortOutput(request, function(err, response) {
@@ -6435,7 +6435,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.instances.insert(request, function(err, response) {
@@ -6487,7 +6487,7 @@ authorize(function(authClient) {
     // The name of the zone for this request.
     zone: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -6555,7 +6555,7 @@ authorize(function(authClient) {
     // Name of the instance scoping this request.
     instance: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.instances.reset(request, function(err, response) {
@@ -6616,7 +6616,7 @@ authorize(function(authClient) {
     // The device name of the disk to modify.
     deviceName: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.instances.setDiskAutoDelete(request, function(err, response) {
@@ -6675,7 +6675,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.instances.setMachineType(request, function(err, response) {
@@ -6734,7 +6734,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.instances.setMetadata(request, function(err, response) {
@@ -6793,7 +6793,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.instances.setScheduling(request, function(err, response) {
@@ -6852,7 +6852,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.instances.setServiceAccount(request, function(err, response) {
@@ -6911,7 +6911,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.instances.setTags(request, function(err, response) {
@@ -6966,7 +6966,7 @@ authorize(function(authClient) {
     // Name of the instance resource to start.
     instance: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.instances.start(request, function(err, response) {
@@ -7025,7 +7025,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.instances.startWithEncryptionKey(request, function(err, response) {
@@ -7080,7 +7080,7 @@ authorize(function(authClient) {
     // Name of the instance resource to stop.
     instance: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.instances.stop(request, function(err, response) {
@@ -7132,7 +7132,7 @@ authorize(function(authClient) {
     // Name of the License resource to return.
     license: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.licenses.get(request, function(err, response) {
@@ -7181,7 +7181,7 @@ authorize(function(authClient) {
     // Project ID for this request.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -7249,7 +7249,7 @@ authorize(function(authClient) {
     // Name of the machine type to return.
     machineType: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.machineTypes.get(request, function(err, response) {
@@ -7301,7 +7301,7 @@ authorize(function(authClient) {
     // The name of the zone for this request.
     zone: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -7366,7 +7366,7 @@ authorize(function(authClient) {
     // Name of the network to delete.
     network: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.networks.delete(request, function(err, response) {
@@ -7418,7 +7418,7 @@ authorize(function(authClient) {
     // Name of the network to return.
     network: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.networks.get(request, function(err, response) {
@@ -7471,7 +7471,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.networks.insert(request, function(err, response) {
@@ -7520,7 +7520,7 @@ authorize(function(authClient) {
     // Project ID for this request.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -7585,7 +7585,7 @@ authorize(function(authClient) {
     // Name of the network to be updated.
     network: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.networks.switchToCustomMode(request, function(err, response) {
@@ -7634,7 +7634,7 @@ authorize(function(authClient) {
     // Project ID for this request.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.projects.get(request, function(err, response) {
@@ -7687,7 +7687,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.projects.moveDisk(request, function(err, response) {
@@ -7740,7 +7740,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.projects.moveInstance(request, function(err, response) {
@@ -7793,7 +7793,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.projects.setCommonInstanceMetadata(request, function(err, response) {
@@ -7846,7 +7846,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.projects.setUsageExportBucket(request, function(err, response) {
@@ -7901,7 +7901,7 @@ authorize(function(authClient) {
     // Name of the autoscaler to delete.
     autoscaler: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.regionAutoscalers.delete(request, function(err, response) {
@@ -7956,7 +7956,7 @@ authorize(function(authClient) {
     // Name of the autoscaler to return.
     autoscaler: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.regionAutoscalers.get(request, function(err, response) {
@@ -8012,7 +8012,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.regionAutoscalers.insert(request, function(err, response) {
@@ -8064,7 +8064,7 @@ authorize(function(authClient) {
     // Name of the region scoping this request.
     region: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -8137,7 +8137,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.regionAutoscalers.patch(request, function(err, response) {
@@ -8194,7 +8194,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.regionAutoscalers.update(request, function(err, response) {
@@ -8249,7 +8249,7 @@ authorize(function(authClient) {
     // Name of the BackendService resource to delete.
     backendService: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.regionBackendServices.delete(request, function(err, response) {
@@ -8304,7 +8304,7 @@ authorize(function(authClient) {
     // Name of the BackendService resource to return.
     backendService: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.regionBackendServices.get(request, function(err, response) {
@@ -8362,7 +8362,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.regionBackendServices.getHealth(request, function(err, response) {
@@ -8418,7 +8418,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.regionBackendServices.insert(request, function(err, response) {
@@ -8470,7 +8470,7 @@ authorize(function(authClient) {
     // Name of the region scoping this request.
     region: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -8543,7 +8543,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.regionBackendServices.patch(request, function(err, response) {
@@ -8603,7 +8603,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.regionBackendServices.update(request, function(err, response) {
@@ -8662,7 +8662,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.regionInstanceGroupManagers.abandonInstances(request, function(err, response) {
@@ -8717,7 +8717,7 @@ authorize(function(authClient) {
     // Name of the managed instance group to delete.
     instanceGroupManager: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.regionInstanceGroupManagers.delete(request, function(err, response) {
@@ -8776,7 +8776,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.regionInstanceGroupManagers.deleteInstances(request, function(err, response) {
@@ -8831,7 +8831,7 @@ authorize(function(authClient) {
     // Name of the managed instance group to return.
     instanceGroupManager: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.regionInstanceGroupManagers.get(request, function(err, response) {
@@ -8887,7 +8887,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.regionInstanceGroupManagers.insert(request, function(err, response) {
@@ -8939,7 +8939,7 @@ authorize(function(authClient) {
     // Name of the region scoping this request.
     region: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -9007,7 +9007,7 @@ authorize(function(authClient) {
     // The name of the managed instance group.
     instanceGroupManager: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.regionInstanceGroupManagers.listManagedInstances(request, function(err, response) {
@@ -9066,7 +9066,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.regionInstanceGroupManagers.recreateInstances(request, function(err, response) {
@@ -9124,7 +9124,7 @@ authorize(function(authClient) {
     // Number of instances that should exist in this instance group manager.
     size: 0,  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.regionInstanceGroupManagers.resize(request, function(err, response) {
@@ -9183,7 +9183,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.regionInstanceGroupManagers.setInstanceTemplate(request, function(err, response) {
@@ -9242,7 +9242,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.regionInstanceGroupManagers.setTargetPools(request, function(err, response) {
@@ -9297,7 +9297,7 @@ authorize(function(authClient) {
     // Name of the instance group resource to return.
     instanceGroup: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.regionInstanceGroups.get(request, function(err, response) {
@@ -9349,7 +9349,7 @@ authorize(function(authClient) {
     // Name of the region scoping this request.
     region: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -9421,7 +9421,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -9493,7 +9493,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.regionInstanceGroups.setNamedPorts(request, function(err, response) {
@@ -9548,7 +9548,7 @@ authorize(function(authClient) {
     // Name of the Operations resource to delete.
     operation: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.regionOperations.delete(request, function(err) {
@@ -9600,7 +9600,7 @@ authorize(function(authClient) {
     // Name of the Operations resource to return.
     operation: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.regionOperations.get(request, function(err, response) {
@@ -9652,7 +9652,7 @@ authorize(function(authClient) {
     // Name of the region for this request.
     region: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -9717,7 +9717,7 @@ authorize(function(authClient) {
     // Name of the region resource to return.
     region: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.regions.get(request, function(err, response) {
@@ -9766,7 +9766,7 @@ authorize(function(authClient) {
     // Project ID for this request.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -9828,7 +9828,7 @@ authorize(function(authClient) {
     // Project ID for this request.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -9896,7 +9896,7 @@ authorize(function(authClient) {
     // Name of the Router resource to delete.
     router: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.routers.delete(request, function(err, response) {
@@ -9951,7 +9951,7 @@ authorize(function(authClient) {
     // Name of the Router resource to return.
     router: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.routers.get(request, function(err, response) {
@@ -10006,7 +10006,7 @@ authorize(function(authClient) {
     // Name of the Router resource to query.
     router: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.routers.getRouterStatus(request, function(err, response) {
@@ -10062,7 +10062,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.routers.insert(request, function(err, response) {
@@ -10114,7 +10114,7 @@ authorize(function(authClient) {
     // Name of the region for this request.
     region: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -10187,7 +10187,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.routers.patch(request, function(err, response) {
@@ -10246,7 +10246,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.routers.preview(request, function(err, response) {
@@ -10306,7 +10306,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.routers.update(request, function(err, response) {
@@ -10358,7 +10358,7 @@ authorize(function(authClient) {
     // Name of the Route resource to delete.
     route: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.routes.delete(request, function(err, response) {
@@ -10410,7 +10410,7 @@ authorize(function(authClient) {
     // Name of the Route resource to return.
     route: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.routes.get(request, function(err, response) {
@@ -10463,7 +10463,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.routes.insert(request, function(err, response) {
@@ -10512,7 +10512,7 @@ authorize(function(authClient) {
     // Project ID for this request.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -10577,7 +10577,7 @@ authorize(function(authClient) {
     // Name of the Snapshot resource to delete.
     snapshot: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.snapshots.delete(request, function(err, response) {
@@ -10629,7 +10629,7 @@ authorize(function(authClient) {
     // Name of the Snapshot resource to return.
     snapshot: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.snapshots.get(request, function(err, response) {
@@ -10678,7 +10678,7 @@ authorize(function(authClient) {
     // Project ID for this request.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -10743,7 +10743,7 @@ authorize(function(authClient) {
     // Name of the SslCertificate resource to delete.
     sslCertificate: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.sslCertificates.delete(request, function(err, response) {
@@ -10795,7 +10795,7 @@ authorize(function(authClient) {
     // Name of the SslCertificate resource to return.
     sslCertificate: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.sslCertificates.get(request, function(err, response) {
@@ -10848,7 +10848,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.sslCertificates.insert(request, function(err, response) {
@@ -10897,7 +10897,7 @@ authorize(function(authClient) {
     // Project ID for this request.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -10959,7 +10959,7 @@ authorize(function(authClient) {
     // Project ID for this request.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -11027,7 +11027,7 @@ authorize(function(authClient) {
     // Name of the Subnetwork resource to delete.
     subnetwork: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.subnetworks.delete(request, function(err, response) {
@@ -11086,7 +11086,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.subnetworks.expandIpCidrRange(request, function(err, response) {
@@ -11141,7 +11141,7 @@ authorize(function(authClient) {
     // Name of the Subnetwork resource to return.
     subnetwork: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.subnetworks.get(request, function(err, response) {
@@ -11197,7 +11197,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.subnetworks.insert(request, function(err, response) {
@@ -11249,7 +11249,7 @@ authorize(function(authClient) {
     // Name of the region scoping this request.
     region: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -11314,7 +11314,7 @@ authorize(function(authClient) {
     // Name of the TargetHttpProxy resource to delete.
     targetHttpProxy: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.targetHttpProxies.delete(request, function(err, response) {
@@ -11366,7 +11366,7 @@ authorize(function(authClient) {
     // Name of the TargetHttpProxy resource to return.
     targetHttpProxy: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.targetHttpProxies.get(request, function(err, response) {
@@ -11419,7 +11419,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.targetHttpProxies.insert(request, function(err, response) {
@@ -11468,7 +11468,7 @@ authorize(function(authClient) {
     // Project ID for this request.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -11537,7 +11537,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.targetHttpProxies.setUrlMap(request, function(err, response) {
@@ -11589,7 +11589,7 @@ authorize(function(authClient) {
     // Name of the TargetHttpsProxy resource to delete.
     targetHttpsProxy: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.targetHttpsProxies.delete(request, function(err, response) {
@@ -11641,7 +11641,7 @@ authorize(function(authClient) {
     // Name of the TargetHttpsProxy resource to return.
     targetHttpsProxy: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.targetHttpsProxies.get(request, function(err, response) {
@@ -11694,7 +11694,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.targetHttpsProxies.insert(request, function(err, response) {
@@ -11743,7 +11743,7 @@ authorize(function(authClient) {
     // Project ID for this request.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -11812,7 +11812,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.targetHttpsProxies.setSslCertificates(request, function(err, response) {
@@ -11868,7 +11868,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.targetHttpsProxies.setUrlMap(request, function(err, response) {
@@ -11917,7 +11917,7 @@ authorize(function(authClient) {
     // Project ID for this request.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -11985,7 +11985,7 @@ authorize(function(authClient) {
     // Name of the TargetInstance resource to delete.
     targetInstance: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.targetInstances.delete(request, function(err, response) {
@@ -12040,7 +12040,7 @@ authorize(function(authClient) {
     // Name of the TargetInstance resource to return.
     targetInstance: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.targetInstances.get(request, function(err, response) {
@@ -12096,7 +12096,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.targetInstances.insert(request, function(err, response) {
@@ -12148,7 +12148,7 @@ authorize(function(authClient) {
     // Name of the zone scoping this request.
     zone: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -12220,7 +12220,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.targetPools.addHealthCheck(request, function(err, response) {
@@ -12279,7 +12279,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.targetPools.addInstance(request, function(err, response) {
@@ -12328,7 +12328,7 @@ authorize(function(authClient) {
     // Project ID for this request.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -12396,7 +12396,7 @@ authorize(function(authClient) {
     // Name of the TargetPool resource to delete.
     targetPool: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.targetPools.delete(request, function(err, response) {
@@ -12451,7 +12451,7 @@ authorize(function(authClient) {
     // Name of the TargetPool resource to return.
     targetPool: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.targetPools.get(request, function(err, response) {
@@ -12510,7 +12510,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.targetPools.getHealth(request, function(err, response) {
@@ -12566,7 +12566,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.targetPools.insert(request, function(err, response) {
@@ -12618,7 +12618,7 @@ authorize(function(authClient) {
     // Name of the region scoping this request.
     region: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -12690,7 +12690,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.targetPools.removeHealthCheck(request, function(err, response) {
@@ -12749,7 +12749,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.targetPools.removeInstance(request, function(err, response) {
@@ -12808,7 +12808,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.targetPools.setBackup(request, function(err, response) {
@@ -12860,7 +12860,7 @@ authorize(function(authClient) {
     // Name of the TargetSslProxy resource to delete.
     targetSslProxy: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.targetSslProxies.delete(request, function(err, response) {
@@ -12912,7 +12912,7 @@ authorize(function(authClient) {
     // Name of the TargetSslProxy resource to return.
     targetSslProxy: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.targetSslProxies.get(request, function(err, response) {
@@ -12965,7 +12965,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.targetSslProxies.insert(request, function(err, response) {
@@ -13014,7 +13014,7 @@ authorize(function(authClient) {
     // Project ID for this request.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -13083,7 +13083,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.targetSslProxies.setBackendService(request, function(err, response) {
@@ -13139,7 +13139,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.targetSslProxies.setProxyHeader(request, function(err, response) {
@@ -13195,7 +13195,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.targetSslProxies.setSslCertificates(request, function(err, response) {
@@ -13244,7 +13244,7 @@ authorize(function(authClient) {
     // Project ID for this request.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -13312,7 +13312,7 @@ authorize(function(authClient) {
     // Name of the target VPN gateway to delete.
     targetVpnGateway: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.targetVpnGateways.delete(request, function(err, response) {
@@ -13367,7 +13367,7 @@ authorize(function(authClient) {
     // Name of the target VPN gateway to return.
     targetVpnGateway: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.targetVpnGateways.get(request, function(err, response) {
@@ -13423,7 +13423,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.targetVpnGateways.insert(request, function(err, response) {
@@ -13475,7 +13475,7 @@ authorize(function(authClient) {
     // Name of the region for this request.
     region: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -13540,7 +13540,7 @@ authorize(function(authClient) {
     // Name of the UrlMap resource to delete.
     urlMap: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.urlMaps.delete(request, function(err, response) {
@@ -13592,7 +13592,7 @@ authorize(function(authClient) {
     // Name of the UrlMap resource to return.
     urlMap: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.urlMaps.get(request, function(err, response) {
@@ -13645,7 +13645,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.urlMaps.insert(request, function(err, response) {
@@ -13701,7 +13701,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.urlMaps.invalidateCache(request, function(err, response) {
@@ -13750,7 +13750,7 @@ authorize(function(authClient) {
     // Project ID for this request.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -13820,7 +13820,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.urlMaps.patch(request, function(err, response) {
@@ -13877,7 +13877,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.urlMaps.update(request, function(err, response) {
@@ -13933,7 +13933,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.urlMaps.validate(request, function(err, response) {
@@ -13982,7 +13982,7 @@ authorize(function(authClient) {
     // Project ID for this request.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -14050,7 +14050,7 @@ authorize(function(authClient) {
     // Name of the VpnTunnel resource to delete.
     vpnTunnel: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.vpnTunnels.delete(request, function(err, response) {
@@ -14105,7 +14105,7 @@ authorize(function(authClient) {
     // Name of the VpnTunnel resource to return.
     vpnTunnel: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.vpnTunnels.get(request, function(err, response) {
@@ -14161,7 +14161,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.vpnTunnels.insert(request, function(err, response) {
@@ -14213,7 +14213,7 @@ authorize(function(authClient) {
     // Name of the region for this request.
     region: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -14281,7 +14281,7 @@ authorize(function(authClient) {
     // Name of the Operations resource to delete.
     operation: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.zoneOperations.delete(request, function(err) {
@@ -14333,7 +14333,7 @@ authorize(function(authClient) {
     // Name of the Operations resource to return.
     operation: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.zoneOperations.get(request, function(err, response) {
@@ -14385,7 +14385,7 @@ authorize(function(authClient) {
     // Name of the zone for request.
     zone: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -14450,7 +14450,7 @@ authorize(function(authClient) {
     // Name of the zone resource to return.
     zone: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   compute.zones.get(request, function(err, response) {
@@ -14499,7 +14499,7 @@ authorize(function(authClient) {
     // Project ID for this request.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_container.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_container.v1.json.baseline
@@ -30,7 +30,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   container.projects.zones.clusters.create(request, function(err, response) {
@@ -87,7 +87,7 @@ authorize(function(authClient) {
     // The name of the cluster to delete.
     clusterId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   container.projects.zones.clusters.delete(request, function(err, response) {
@@ -144,7 +144,7 @@ authorize(function(authClient) {
     // The name of the cluster to retrieve.
     clusterId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   container.projects.zones.clusters.get(request, function(err, response) {
@@ -198,7 +198,7 @@ authorize(function(authClient) {
     // resides, or "-" for all zones.
     zone: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   container.projects.zones.clusters.list(request, function(err, response) {
@@ -259,7 +259,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   container.projects.zones.clusters.nodePools.create(request, function(err, response) {
@@ -319,7 +319,7 @@ authorize(function(authClient) {
     // The name of the node pool to delete.
     nodePoolId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   container.projects.zones.clusters.nodePools.delete(request, function(err, response) {
@@ -379,7 +379,7 @@ authorize(function(authClient) {
     // The name of the node pool.
     nodePoolId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   container.projects.zones.clusters.nodePools.get(request, function(err, response) {
@@ -436,7 +436,7 @@ authorize(function(authClient) {
     // The name of the cluster.
     clusterId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   container.projects.zones.clusters.nodePools.list(request, function(err, response) {
@@ -498,7 +498,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   container.projects.zones.clusters.update(request, function(err, response) {
@@ -552,7 +552,7 @@ authorize(function(authClient) {
     // for.
     zone: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   container.projects.zones.getServerconfig(request, function(err, response) {
@@ -609,7 +609,7 @@ authorize(function(authClient) {
     // The server-assigned `name` of the operation.
     operationId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   container.projects.zones.operations.get(request, function(err, response) {
@@ -663,7 +663,7 @@ authorize(function(authClient) {
     // for, or `-` for all zones.
     zone: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   container.projects.zones.operations.list(request, function(err, response) {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_dataflow.v1b3.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_dataflow.v1b3.json.baseline
@@ -25,7 +25,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dataflow.projects.jobs.create(request, function(err, response) {
@@ -81,7 +81,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dataflow.projects.jobs.debug.getConfig(request, function(err, response) {
@@ -137,7 +137,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dataflow.projects.jobs.debug.sendCapture(request, function(err, response) {
@@ -189,7 +189,7 @@ authorize(function(authClient) {
     // The job ID.
     jobId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dataflow.projects.jobs.get(request, function(err, response) {
@@ -241,7 +241,7 @@ authorize(function(authClient) {
     // The job to get messages for.
     jobId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dataflow.projects.jobs.getMetrics(request, function(err, response) {
@@ -290,7 +290,7 @@ authorize(function(authClient) {
     // The project which owns the jobs.
     projectId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -355,7 +355,7 @@ authorize(function(authClient) {
     // The job to get messages about.
     jobId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -425,7 +425,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dataflow.projects.jobs.update(request, function(err, response) {
@@ -481,7 +481,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dataflow.projects.jobs.workItems.lease(request, function(err, response) {
@@ -537,7 +537,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dataflow.projects.jobs.workItems.reportStatus(request, function(err, response) {
@@ -593,7 +593,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dataflow.projects.locations.jobs.create(request, function(err, response) {
@@ -648,7 +648,7 @@ authorize(function(authClient) {
     // The job ID.
     jobId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dataflow.projects.locations.jobs.get(request, function(err, response) {
@@ -703,7 +703,7 @@ authorize(function(authClient) {
     // The job to get messages for.
     jobId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dataflow.projects.locations.jobs.getMetrics(request, function(err, response) {
@@ -755,7 +755,7 @@ authorize(function(authClient) {
     // The location that contains this job.
     location: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -823,7 +823,7 @@ authorize(function(authClient) {
     // The job to get messages about.
     jobId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -896,7 +896,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dataflow.projects.locations.jobs.update(request, function(err, response) {
@@ -955,7 +955,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dataflow.projects.locations.jobs.workItems.lease(request, function(err, response) {
@@ -1014,7 +1014,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dataflow.projects.locations.jobs.workItems.reportStatus(request, function(err, response) {
@@ -1067,7 +1067,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dataflow.projects.templates.create(request, function(err, response) {
@@ -1120,7 +1120,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dataflow.projects.workerMessages(request, function(err, response) {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_datastore.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_datastore.v1.json.baseline
@@ -25,7 +25,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   datastore.projects.allocateIds(request, function(err, response) {
@@ -78,7 +78,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   datastore.projects.beginTransaction(request, function(err, response) {
@@ -131,7 +131,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   datastore.projects.commit(request, function(err, response) {
@@ -184,7 +184,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   datastore.projects.lookup(request, function(err, response) {
@@ -237,7 +237,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   datastore.projects.rollback(request, function(err, response) {
@@ -290,7 +290,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   datastore.projects.runQuery(request, function(err, response) {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_deploymentmanager.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_deploymentmanager.v2.json.baseline
@@ -28,7 +28,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   deploymentManager.deployments.cancelPreview(request, function(err, response) {
@@ -80,7 +80,7 @@ authorize(function(authClient) {
     // The name of the deployment for this request.
     deployment: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   deploymentManager.deployments.delete(request, function(err, response) {
@@ -132,7 +132,7 @@ authorize(function(authClient) {
     // The name of the deployment for this request.
     deployment: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   deploymentManager.deployments.get(request, function(err, response) {
@@ -184,7 +184,7 @@ authorize(function(authClient) {
     // Name of the resource for this request.
     resource_: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   deploymentManager.deployments.getIamPolicy(request, function(err, response) {
@@ -237,7 +237,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   deploymentManager.deployments.insert(request, function(err, response) {
@@ -286,7 +286,7 @@ authorize(function(authClient) {
     // The project ID for this request.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -356,7 +356,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   deploymentManager.deployments.patch(request, function(err, response) {
@@ -412,7 +412,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   deploymentManager.deployments.setIamPolicy(request, function(err, response) {
@@ -468,7 +468,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   deploymentManager.deployments.stop(request, function(err, response) {
@@ -524,7 +524,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   deploymentManager.deployments.testIamPermissions(request, function(err, response) {
@@ -581,7 +581,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   deploymentManager.deployments.update(request, function(err, response) {
@@ -636,7 +636,7 @@ authorize(function(authClient) {
     // The name of the manifest for this request.
     manifest: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   deploymentManager.manifests.get(request, function(err, response) {
@@ -688,7 +688,7 @@ authorize(function(authClient) {
     // The name of the deployment for this request.
     deployment: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -753,7 +753,7 @@ authorize(function(authClient) {
     // The name of the operation for this request.
     operation: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   deploymentManager.operations.get(request, function(err, response) {
@@ -802,7 +802,7 @@ authorize(function(authClient) {
     // The project ID for this request.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -870,7 +870,7 @@ authorize(function(authClient) {
     // The name of the resource for this request.
     resource_: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   deploymentManager.resources.get(request, function(err, response) {
@@ -922,7 +922,7 @@ authorize(function(authClient) {
     // The name of the deployment for this request.
     deployment: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -984,7 +984,7 @@ authorize(function(authClient) {
     // The project ID for this request.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_dfareporting.v2.6.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_dfareporting.v2.6.json.baseline
@@ -18,7 +18,7 @@ authorize(function(authClient) {
     // Account ID.
     summaryAccountId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.accountActiveAdSummaries.get(request, function(err, response) {
@@ -65,7 +65,7 @@ authorize(function(authClient) {
     // Account permission group ID.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.accountPermissionGroups.get(request, function(err, response) {
@@ -109,7 +109,7 @@ authorize(function(authClient) {
     // User profile ID associated with this request.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.accountPermissionGroups.list(request, function(err, response) {
@@ -156,7 +156,7 @@ authorize(function(authClient) {
     // Account permission ID.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.accountPermissions.get(request, function(err, response) {
@@ -200,7 +200,7 @@ authorize(function(authClient) {
     // User profile ID associated with this request.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.accountPermissions.list(request, function(err, response) {
@@ -247,7 +247,7 @@ authorize(function(authClient) {
     // User profile ID.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.accountUserProfiles.get(request, function(err, response) {
@@ -295,7 +295,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.accountUserProfiles.insert(request, function(err, response) {
@@ -339,7 +339,7 @@ authorize(function(authClient) {
     // User profile ID associated with this request.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -404,7 +404,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.accountUserProfiles.patch(request, function(err, response) {
@@ -453,7 +453,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.accountUserProfiles.update(request, function(err, response) {
@@ -500,7 +500,7 @@ authorize(function(authClient) {
     // Account ID.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.accounts.get(request, function(err, response) {
@@ -544,7 +544,7 @@ authorize(function(authClient) {
     // User profile ID associated with this request.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -609,7 +609,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.accounts.patch(request, function(err, response) {
@@ -658,7 +658,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.accounts.update(request, function(err, response) {
@@ -705,7 +705,7 @@ authorize(function(authClient) {
     // Ad ID.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.ads.get(request, function(err, response) {
@@ -753,7 +753,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.ads.insert(request, function(err, response) {
@@ -797,7 +797,7 @@ authorize(function(authClient) {
     // User profile ID associated with this request.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -862,7 +862,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.ads.patch(request, function(err, response) {
@@ -911,7 +911,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.ads.update(request, function(err, response) {
@@ -958,7 +958,7 @@ authorize(function(authClient) {
     // Advertiser group ID.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.advertiserGroups.delete(request, function(err) {
@@ -1002,7 +1002,7 @@ authorize(function(authClient) {
     // Advertiser group ID.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.advertiserGroups.get(request, function(err, response) {
@@ -1050,7 +1050,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.advertiserGroups.insert(request, function(err, response) {
@@ -1094,7 +1094,7 @@ authorize(function(authClient) {
     // User profile ID associated with this request.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -1159,7 +1159,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.advertiserGroups.patch(request, function(err, response) {
@@ -1208,7 +1208,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.advertiserGroups.update(request, function(err, response) {
@@ -1255,7 +1255,7 @@ authorize(function(authClient) {
     // Advertiser ID.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.advertisers.get(request, function(err, response) {
@@ -1303,7 +1303,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.advertisers.insert(request, function(err, response) {
@@ -1347,7 +1347,7 @@ authorize(function(authClient) {
     // User profile ID associated with this request.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -1412,7 +1412,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.advertisers.patch(request, function(err, response) {
@@ -1461,7 +1461,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.advertisers.update(request, function(err, response) {
@@ -1505,7 +1505,7 @@ authorize(function(authClient) {
     // User profile ID associated with this request.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.browsers.list(request, function(err, response) {
@@ -1556,7 +1556,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.campaignCreativeAssociations.insert(request, function(err, response) {
@@ -1603,7 +1603,7 @@ authorize(function(authClient) {
     // Campaign ID in this association.
     campaignId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -1663,7 +1663,7 @@ authorize(function(authClient) {
     // Campaign ID.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.campaigns.get(request, function(err, response) {
@@ -1717,7 +1717,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.campaigns.insert(request, function(err, response) {
@@ -1761,7 +1761,7 @@ authorize(function(authClient) {
     // User profile ID associated with this request.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -1826,7 +1826,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.campaigns.patch(request, function(err, response) {
@@ -1875,7 +1875,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.campaigns.update(request, function(err, response) {
@@ -1922,7 +1922,7 @@ authorize(function(authClient) {
     // Change log ID.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.changeLogs.get(request, function(err, response) {
@@ -1966,7 +1966,7 @@ authorize(function(authClient) {
     // User profile ID associated with this request.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -2023,7 +2023,7 @@ authorize(function(authClient) {
     // User profile ID associated with this request.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.cities.list(request, function(err, response) {
@@ -2070,7 +2070,7 @@ authorize(function(authClient) {
     // Connection type ID.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.connectionTypes.get(request, function(err, response) {
@@ -2114,7 +2114,7 @@ authorize(function(authClient) {
     // User profile ID associated with this request.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.connectionTypes.list(request, function(err, response) {
@@ -2161,7 +2161,7 @@ authorize(function(authClient) {
     // Content category ID.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.contentCategories.delete(request, function(err) {
@@ -2205,7 +2205,7 @@ authorize(function(authClient) {
     // Content category ID.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.contentCategories.get(request, function(err, response) {
@@ -2253,7 +2253,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.contentCategories.insert(request, function(err, response) {
@@ -2297,7 +2297,7 @@ authorize(function(authClient) {
     // User profile ID associated with this request.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -2362,7 +2362,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.contentCategories.patch(request, function(err, response) {
@@ -2411,7 +2411,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.contentCategories.update(request, function(err, response) {
@@ -2459,7 +2459,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.conversions.batchinsert(request, function(err, response) {
@@ -2506,7 +2506,7 @@ authorize(function(authClient) {
     // Country DART ID.
     dartId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.countries.get(request, function(err, response) {
@@ -2550,7 +2550,7 @@ authorize(function(authClient) {
     // User profile ID associated with this request.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.countries.list(request, function(err, response) {
@@ -2605,10 +2605,10 @@ authorize(function(authClient) {
       // TODO: Add desired media content for upload. See
       // https://github.com/google/google-api-nodejs-client#media-uploads
       mimeType: '',  // See https://www.w3.org/Protocols/rfc1341/4_Content-Type.html
-      body: {}
+      body: {},
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.creativeAssets.insert(request, function(err, response) {
@@ -2658,7 +2658,7 @@ authorize(function(authClient) {
     // Creative Field Value ID
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.creativeFieldValues.delete(request, function(err) {
@@ -2705,7 +2705,7 @@ authorize(function(authClient) {
     // Creative Field Value ID
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.creativeFieldValues.get(request, function(err, response) {
@@ -2756,7 +2756,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.creativeFieldValues.insert(request, function(err, response) {
@@ -2803,7 +2803,7 @@ authorize(function(authClient) {
     // Creative field ID for this creative field value.
     creativeFieldId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -2871,7 +2871,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.creativeFieldValues.patch(request, function(err, response) {
@@ -2923,7 +2923,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.creativeFieldValues.update(request, function(err, response) {
@@ -2970,7 +2970,7 @@ authorize(function(authClient) {
     // Creative Field ID
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.creativeFields.delete(request, function(err) {
@@ -3014,7 +3014,7 @@ authorize(function(authClient) {
     // Creative Field ID
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.creativeFields.get(request, function(err, response) {
@@ -3062,7 +3062,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.creativeFields.insert(request, function(err, response) {
@@ -3106,7 +3106,7 @@ authorize(function(authClient) {
     // User profile ID associated with this request.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -3171,7 +3171,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.creativeFields.patch(request, function(err, response) {
@@ -3220,7 +3220,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.creativeFields.update(request, function(err, response) {
@@ -3267,7 +3267,7 @@ authorize(function(authClient) {
     // Creative group ID.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.creativeGroups.get(request, function(err, response) {
@@ -3315,7 +3315,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.creativeGroups.insert(request, function(err, response) {
@@ -3359,7 +3359,7 @@ authorize(function(authClient) {
     // User profile ID associated with this request.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -3424,7 +3424,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.creativeGroups.patch(request, function(err, response) {
@@ -3473,7 +3473,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.creativeGroups.update(request, function(err, response) {
@@ -3520,7 +3520,7 @@ authorize(function(authClient) {
     // Creative ID.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.creatives.get(request, function(err, response) {
@@ -3568,7 +3568,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.creatives.insert(request, function(err, response) {
@@ -3612,7 +3612,7 @@ authorize(function(authClient) {
     // User profile ID associated with this request.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -3677,7 +3677,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.creatives.patch(request, function(err, response) {
@@ -3726,7 +3726,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.creatives.update(request, function(err, response) {
@@ -3774,7 +3774,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -3834,7 +3834,7 @@ authorize(function(authClient) {
     // Directory site contact ID.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.directorySiteContacts.get(request, function(err, response) {
@@ -3878,7 +3878,7 @@ authorize(function(authClient) {
     // User profile ID associated with this request.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -3938,7 +3938,7 @@ authorize(function(authClient) {
     // Directory site ID.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.directorySites.get(request, function(err, response) {
@@ -3986,7 +3986,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.directorySites.insert(request, function(err, response) {
@@ -4030,7 +4030,7 @@ authorize(function(authClient) {
     // User profile ID associated with this request.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -4097,7 +4097,7 @@ authorize(function(authClient) {
     // Type of the object of this dynamic targeting key. This is a required field.
     objectType: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.dynamicTargetingKeys.delete(request, function(err) {
@@ -4142,7 +4142,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.dynamicTargetingKeys.insert(request, function(err, response) {
@@ -4186,7 +4186,7 @@ authorize(function(authClient) {
     // User profile ID associated with this request.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.dynamicTargetingKeys.list(request, function(err, response) {
@@ -4233,7 +4233,7 @@ authorize(function(authClient) {
     // Event tag ID.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.eventTags.delete(request, function(err) {
@@ -4277,7 +4277,7 @@ authorize(function(authClient) {
     // Event tag ID.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.eventTags.get(request, function(err, response) {
@@ -4325,7 +4325,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.eventTags.insert(request, function(err, response) {
@@ -4369,7 +4369,7 @@ authorize(function(authClient) {
     // User profile ID associated with this request.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.eventTags.list(request, function(err, response) {
@@ -4421,7 +4421,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.eventTags.patch(request, function(err, response) {
@@ -4470,7 +4470,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.eventTags.update(request, function(err, response) {
@@ -4521,7 +4521,7 @@ authorize(function(authClient) {
     //
     // alt: 'media',
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.files.get(request, function(err, response) {
@@ -4565,7 +4565,7 @@ authorize(function(authClient) {
     // The DFA profile ID.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -4625,7 +4625,7 @@ authorize(function(authClient) {
     // Floodlight activity ID.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.floodlightActivities.delete(request, function(err) {
@@ -4666,7 +4666,7 @@ authorize(function(authClient) {
     // User profile ID associated with this request.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.floodlightActivities.generatetag(request, function(err, response) {
@@ -4713,7 +4713,7 @@ authorize(function(authClient) {
     // Floodlight activity ID.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.floodlightActivities.get(request, function(err, response) {
@@ -4761,7 +4761,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.floodlightActivities.insert(request, function(err, response) {
@@ -4805,7 +4805,7 @@ authorize(function(authClient) {
     // User profile ID associated with this request.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -4870,7 +4870,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.floodlightActivities.patch(request, function(err, response) {
@@ -4919,7 +4919,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.floodlightActivities.update(request, function(err, response) {
@@ -4966,7 +4966,7 @@ authorize(function(authClient) {
     // Floodlight activity Group ID.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.floodlightActivityGroups.get(request, function(err, response) {
@@ -5014,7 +5014,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.floodlightActivityGroups.insert(request, function(err, response) {
@@ -5058,7 +5058,7 @@ authorize(function(authClient) {
     // User profile ID associated with this request.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -5123,7 +5123,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.floodlightActivityGroups.patch(request, function(err, response) {
@@ -5172,7 +5172,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.floodlightActivityGroups.update(request, function(err, response) {
@@ -5219,7 +5219,7 @@ authorize(function(authClient) {
     // Floodlight configuration ID.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.floodlightConfigurations.get(request, function(err, response) {
@@ -5263,7 +5263,7 @@ authorize(function(authClient) {
     // User profile ID associated with this request.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.floodlightConfigurations.list(request, function(err, response) {
@@ -5315,7 +5315,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.floodlightConfigurations.patch(request, function(err, response) {
@@ -5364,7 +5364,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.floodlightConfigurations.update(request, function(err, response) {
@@ -5414,7 +5414,7 @@ authorize(function(authClient) {
     // Inventory item ID.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.inventoryItems.get(request, function(err, response) {
@@ -5461,7 +5461,7 @@ authorize(function(authClient) {
     // Project ID for order documents.
     projectId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -5524,7 +5524,7 @@ authorize(function(authClient) {
     // Landing page ID.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.landingPages.delete(request, function(err) {
@@ -5571,7 +5571,7 @@ authorize(function(authClient) {
     // Landing page ID.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.landingPages.get(request, function(err, response) {
@@ -5622,7 +5622,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.landingPages.insert(request, function(err, response) {
@@ -5669,7 +5669,7 @@ authorize(function(authClient) {
     // Landing page campaign ID.
     campaignId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.landingPages.list(request, function(err, response) {
@@ -5724,7 +5724,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.landingPages.patch(request, function(err, response) {
@@ -5776,7 +5776,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.landingPages.update(request, function(err, response) {
@@ -5820,7 +5820,7 @@ authorize(function(authClient) {
     // User profile ID associated with this request.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.languages.list(request, function(err, response) {
@@ -5864,7 +5864,7 @@ authorize(function(authClient) {
     // User profile ID associated with this request.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.metros.list(request, function(err, response) {
@@ -5911,7 +5911,7 @@ authorize(function(authClient) {
     // Mobile carrier ID.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.mobileCarriers.get(request, function(err, response) {
@@ -5955,7 +5955,7 @@ authorize(function(authClient) {
     // User profile ID associated with this request.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.mobileCarriers.list(request, function(err, response) {
@@ -6002,7 +6002,7 @@ authorize(function(authClient) {
     // Operating system version ID.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.operatingSystemVersions.get(request, function(err, response) {
@@ -6046,7 +6046,7 @@ authorize(function(authClient) {
     // User profile ID associated with this request.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.operatingSystemVersions.list(request, function(err, response) {
@@ -6093,7 +6093,7 @@ authorize(function(authClient) {
     // Operating system DART ID.
     dartId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.operatingSystems.get(request, function(err, response) {
@@ -6137,7 +6137,7 @@ authorize(function(authClient) {
     // User profile ID associated with this request.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.operatingSystems.list(request, function(err, response) {
@@ -6187,7 +6187,7 @@ authorize(function(authClient) {
     // Order document ID.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.orderDocuments.get(request, function(err, response) {
@@ -6234,7 +6234,7 @@ authorize(function(authClient) {
     // Project ID for order documents.
     projectId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -6297,7 +6297,7 @@ authorize(function(authClient) {
     // Order ID.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.orders.get(request, function(err, response) {
@@ -6344,7 +6344,7 @@ authorize(function(authClient) {
     // Project ID for orders.
     projectId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -6404,7 +6404,7 @@ authorize(function(authClient) {
     // Placement group ID.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.placementGroups.get(request, function(err, response) {
@@ -6452,7 +6452,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.placementGroups.insert(request, function(err, response) {
@@ -6496,7 +6496,7 @@ authorize(function(authClient) {
     // User profile ID associated with this request.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -6561,7 +6561,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.placementGroups.patch(request, function(err, response) {
@@ -6610,7 +6610,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.placementGroups.update(request, function(err, response) {
@@ -6657,7 +6657,7 @@ authorize(function(authClient) {
     // Placement strategy ID.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.placementStrategies.delete(request, function(err) {
@@ -6701,7 +6701,7 @@ authorize(function(authClient) {
     // Placement strategy ID.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.placementStrategies.get(request, function(err, response) {
@@ -6749,7 +6749,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.placementStrategies.insert(request, function(err, response) {
@@ -6793,7 +6793,7 @@ authorize(function(authClient) {
     // User profile ID associated with this request.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -6858,7 +6858,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.placementStrategies.patch(request, function(err, response) {
@@ -6907,7 +6907,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.placementStrategies.update(request, function(err, response) {
@@ -6951,7 +6951,7 @@ authorize(function(authClient) {
     // User profile ID associated with this request.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.placements.generatetags(request, function(err, response) {
@@ -6998,7 +6998,7 @@ authorize(function(authClient) {
     // Placement ID.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.placements.get(request, function(err, response) {
@@ -7046,7 +7046,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.placements.insert(request, function(err, response) {
@@ -7090,7 +7090,7 @@ authorize(function(authClient) {
     // User profile ID associated with this request.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -7155,7 +7155,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.placements.patch(request, function(err, response) {
@@ -7204,7 +7204,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.placements.update(request, function(err, response) {
@@ -7251,7 +7251,7 @@ authorize(function(authClient) {
     // Platform type ID.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.platformTypes.get(request, function(err, response) {
@@ -7295,7 +7295,7 @@ authorize(function(authClient) {
     // User profile ID associated with this request.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.platformTypes.list(request, function(err, response) {
@@ -7342,7 +7342,7 @@ authorize(function(authClient) {
     // Postal code ID.
     code: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.postalCodes.get(request, function(err, response) {
@@ -7386,7 +7386,7 @@ authorize(function(authClient) {
     // User profile ID associated with this request.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.postalCodes.list(request, function(err, response) {
@@ -7433,7 +7433,7 @@ authorize(function(authClient) {
     // Project ID.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.projects.get(request, function(err, response) {
@@ -7477,7 +7477,7 @@ authorize(function(authClient) {
     // User profile ID associated with this request.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -7534,7 +7534,7 @@ authorize(function(authClient) {
     // User profile ID associated with this request.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.regions.list(request, function(err, response) {
@@ -7581,7 +7581,7 @@ authorize(function(authClient) {
     // Remarketing list ID.
     remarketingListId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.remarketingListShares.get(request, function(err, response) {
@@ -7633,7 +7633,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.remarketingListShares.patch(request, function(err, response) {
@@ -7682,7 +7682,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.remarketingListShares.update(request, function(err, response) {
@@ -7729,7 +7729,7 @@ authorize(function(authClient) {
     // Remarketing list ID.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.remarketingLists.get(request, function(err, response) {
@@ -7777,7 +7777,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.remarketingLists.insert(request, function(err, response) {
@@ -7824,7 +7824,7 @@ authorize(function(authClient) {
     // Select only remarketing lists owned by this advertiser.
     advertiserId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -7889,7 +7889,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.remarketingLists.patch(request, function(err, response) {
@@ -7938,7 +7938,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.remarketingLists.update(request, function(err, response) {
@@ -7986,7 +7986,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.reports.compatibleFields.query(request, function(err, response) {
@@ -8033,7 +8033,7 @@ authorize(function(authClient) {
     // The ID of the report.
     reportId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.reports.delete(request, function(err) {
@@ -8084,7 +8084,7 @@ authorize(function(authClient) {
     //
     // alt: 'media',
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.reports.files.get(request, function(err, response) {
@@ -8131,7 +8131,7 @@ authorize(function(authClient) {
     // The ID of the parent report.
     reportId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -8191,7 +8191,7 @@ authorize(function(authClient) {
     // The ID of the report.
     reportId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.reports.get(request, function(err, response) {
@@ -8239,7 +8239,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.reports.insert(request, function(err, response) {
@@ -8283,7 +8283,7 @@ authorize(function(authClient) {
     // The DFA user profile ID.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -8348,7 +8348,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.reports.patch(request, function(err, response) {
@@ -8395,7 +8395,7 @@ authorize(function(authClient) {
     // The ID of the report.
     reportId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.reports.run(request, function(err, response) {
@@ -8447,7 +8447,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.reports.update(request, function(err, response) {
@@ -8494,7 +8494,7 @@ authorize(function(authClient) {
     // Site ID.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.sites.get(request, function(err, response) {
@@ -8542,7 +8542,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.sites.insert(request, function(err, response) {
@@ -8586,7 +8586,7 @@ authorize(function(authClient) {
     // User profile ID associated with this request.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -8651,7 +8651,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.sites.patch(request, function(err, response) {
@@ -8700,7 +8700,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.sites.update(request, function(err, response) {
@@ -8747,7 +8747,7 @@ authorize(function(authClient) {
     // Size ID.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.sizes.get(request, function(err, response) {
@@ -8795,7 +8795,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.sizes.insert(request, function(err, response) {
@@ -8839,7 +8839,7 @@ authorize(function(authClient) {
     // User profile ID associated with this request.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.sizes.list(request, function(err, response) {
@@ -8886,7 +8886,7 @@ authorize(function(authClient) {
     // Subaccount ID.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.subaccounts.get(request, function(err, response) {
@@ -8934,7 +8934,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.subaccounts.insert(request, function(err, response) {
@@ -8978,7 +8978,7 @@ authorize(function(authClient) {
     // User profile ID associated with this request.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -9043,7 +9043,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.subaccounts.patch(request, function(err, response) {
@@ -9092,7 +9092,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.subaccounts.update(request, function(err, response) {
@@ -9139,7 +9139,7 @@ authorize(function(authClient) {
     // Remarketing list ID.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.targetableRemarketingLists.get(request, function(err, response) {
@@ -9186,7 +9186,7 @@ authorize(function(authClient) {
     // Select only targetable remarketing lists targetable by these advertisers.
     advertiserId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -9246,7 +9246,7 @@ authorize(function(authClient) {
     // Targeting template ID.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.targetingTemplates.get(request, function(err, response) {
@@ -9294,7 +9294,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.targetingTemplates.insert(request, function(err, response) {
@@ -9338,7 +9338,7 @@ authorize(function(authClient) {
     // User profile ID associated with this request.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -9403,7 +9403,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.targetingTemplates.patch(request, function(err, response) {
@@ -9452,7 +9452,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.targetingTemplates.update(request, function(err, response) {
@@ -9496,7 +9496,7 @@ authorize(function(authClient) {
     // The user profile ID.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.userProfiles.get(request, function(err, response) {
@@ -9538,7 +9538,7 @@ var dfareporting = google.dfareporting('v2.6');
 
 authorize(function(authClient) {
   var request = {
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.userProfiles.list(request, function(err, response) {
@@ -9586,7 +9586,7 @@ authorize(function(authClient) {
     // User role permission group ID.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.userRolePermissionGroups.get(request, function(err, response) {
@@ -9630,7 +9630,7 @@ authorize(function(authClient) {
     // User profile ID associated with this request.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.userRolePermissionGroups.list(request, function(err, response) {
@@ -9677,7 +9677,7 @@ authorize(function(authClient) {
     // User role permission ID.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.userRolePermissions.get(request, function(err, response) {
@@ -9721,7 +9721,7 @@ authorize(function(authClient) {
     // User profile ID associated with this request.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.userRolePermissions.list(request, function(err, response) {
@@ -9768,7 +9768,7 @@ authorize(function(authClient) {
     // User role ID.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.userRoles.delete(request, function(err) {
@@ -9812,7 +9812,7 @@ authorize(function(authClient) {
     // User role ID.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.userRoles.get(request, function(err, response) {
@@ -9860,7 +9860,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.userRoles.insert(request, function(err, response) {
@@ -9904,7 +9904,7 @@ authorize(function(authClient) {
     // User profile ID associated with this request.
     profileId: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -9969,7 +9969,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.userRoles.patch(request, function(err, response) {
@@ -10018,7 +10018,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dfareporting.userRoles.update(request, function(err, response) {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_dns.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_dns.v1.json.baseline
@@ -28,7 +28,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dns.changes.create(request, function(err, response) {
@@ -83,7 +83,7 @@ authorize(function(authClient) {
     // The identifier of the requested change, from a previous ResourceRecordSetsChangeResponse.
     changeId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dns.changes.get(request, function(err, response) {
@@ -135,7 +135,7 @@ authorize(function(authClient) {
     // Identifies the managed zone addressed by this request. Can be the managed zone name or id.
     managedZone: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -201,7 +201,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   dns.managedZones.create(request, function(err, response) {
@@ -253,7 +253,7 @@ authorize(function(authClient) {
     // Identifies the managed zone addressed by this request. Can be the managed zone name or id.
     managedZone: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dns.managedZones.delete(request, function(err) {
@@ -302,7 +302,7 @@ authorize(function(authClient) {
     // Identifies the managed zone addressed by this request. Can be the managed zone name or id.
     managedZone: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dns.managedZones.get(request, function(err, response) {
@@ -351,7 +351,7 @@ authorize(function(authClient) {
     // Identifies the project addressed by this request.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -413,7 +413,7 @@ authorize(function(authClient) {
     // Identifies the project addressed by this request.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   dns.projects.get(request, function(err, response) {
@@ -465,7 +465,7 @@ authorize(function(authClient) {
     // Identifies the managed zone addressed by this request. Can be the managed zone name or id.
     managedZone: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_genomics.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_genomics.v1.json.baseline
@@ -22,7 +22,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   genomics.annotations.batchCreate(request, function(err, response) {
@@ -72,7 +72,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   genomics.annotations.create(request, function(err, response) {
@@ -121,7 +121,7 @@ authorize(function(authClient) {
     // The ID of the annotation to be deleted.
     annotationId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   genomics.annotations.delete(request, function(err) {
@@ -167,7 +167,7 @@ authorize(function(authClient) {
     // The ID of the annotation to be retrieved.
     annotationId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   genomics.annotations.get(request, function(err, response) {
@@ -217,7 +217,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -284,7 +284,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   genomics.annotations.update(request, function(err, response) {
@@ -334,7 +334,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   genomics.annotationsets.create(request, function(err, response) {
@@ -383,7 +383,7 @@ authorize(function(authClient) {
     // The ID of the annotation set to be deleted.
     annotationSetId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   genomics.annotationsets.delete(request, function(err) {
@@ -429,7 +429,7 @@ authorize(function(authClient) {
     // The ID of the annotation set to be retrieved.
     annotationSetId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   genomics.annotationsets.get(request, function(err, response) {
@@ -479,7 +479,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -546,7 +546,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   genomics.annotationsets.update(request, function(err, response) {
@@ -596,7 +596,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   genomics.callsets.create(request, function(err, response) {
@@ -645,7 +645,7 @@ authorize(function(authClient) {
     // The ID of the call set to be deleted.
     callSetId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   genomics.callsets.delete(request, function(err) {
@@ -691,7 +691,7 @@ authorize(function(authClient) {
     // The ID of the call set.
     callSetId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   genomics.callsets.get(request, function(err, response) {
@@ -745,7 +745,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   genomics.callsets.patch(request, function(err, response) {
@@ -795,7 +795,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -858,7 +858,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   genomics.datasets.create(request, function(err, response) {
@@ -907,7 +907,7 @@ authorize(function(authClient) {
     // The ID of the dataset to be deleted.
     datasetId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   genomics.datasets.delete(request, function(err) {
@@ -953,7 +953,7 @@ authorize(function(authClient) {
     // The ID of the dataset.
     datasetId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   genomics.datasets.get(request, function(err, response) {
@@ -1006,7 +1006,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   genomics.datasets.getIamPolicy(request, function(err, response) {
@@ -1052,7 +1052,7 @@ var genomics = google.genomics('v1');
 
 authorize(function(authClient) {
   var request = {
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -1119,7 +1119,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   genomics.datasets.patch(request, function(err, response) {
@@ -1172,7 +1172,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   genomics.datasets.setIamPolicy(request, function(err, response) {
@@ -1225,7 +1225,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   genomics.datasets.testIamPermissions(request, function(err, response) {
@@ -1278,7 +1278,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   genomics.datasets.undelete(request, function(err, response) {
@@ -1331,7 +1331,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   genomics.operations.cancel(request, function(err) {
@@ -1377,7 +1377,7 @@ authorize(function(authClient) {
     // The name of the operation resource.
     name: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   genomics.operations.get(request, function(err, response) {
@@ -1426,7 +1426,7 @@ authorize(function(authClient) {
     // The name of the operation collection.
     name: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -1488,7 +1488,7 @@ authorize(function(authClient) {
     // Required. The ID of the read group set over which coverage is requested.
     readGroupSetId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -1551,7 +1551,7 @@ authorize(function(authClient) {
     // associated with this read group set.
     readGroupSetId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   genomics.readgroupsets.delete(request, function(err) {
@@ -1602,7 +1602,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   genomics.readgroupsets.export(request, function(err, response) {
@@ -1651,7 +1651,7 @@ authorize(function(authClient) {
     // The ID of the read group set.
     readGroupSetId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   genomics.readgroupsets.get(request, function(err, response) {
@@ -1701,7 +1701,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   genomics.readgroupsets.import(request, function(err, response) {
@@ -1756,7 +1756,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   genomics.readgroupsets.patch(request, function(err, response) {
@@ -1806,7 +1806,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -1869,7 +1869,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -1932,7 +1932,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   genomics.reads.stream(request, function(err, response) {
@@ -1981,7 +1981,7 @@ authorize(function(authClient) {
     // The ID of the reference.
     referenceId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -2041,7 +2041,7 @@ authorize(function(authClient) {
     // The ID of the reference.
     referenceId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   genomics.references.get(request, function(err, response) {
@@ -2091,7 +2091,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -2153,7 +2153,7 @@ authorize(function(authClient) {
     // The ID of the reference set.
     referenceSetId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   genomics.referencesets.get(request, function(err, response) {
@@ -2203,7 +2203,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -2266,7 +2266,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   genomics.variants.create(request, function(err, response) {
@@ -2315,7 +2315,7 @@ authorize(function(authClient) {
     // The ID of the variant to be deleted.
     variantId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   genomics.variants.delete(request, function(err) {
@@ -2361,7 +2361,7 @@ authorize(function(authClient) {
     // The ID of the variant.
     variantId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   genomics.variants.get(request, function(err, response) {
@@ -2411,7 +2411,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   genomics.variants.import(request, function(err, response) {
@@ -2461,7 +2461,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   genomics.variants.merge(request, function(err) {
@@ -2512,7 +2512,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   genomics.variants.patch(request, function(err, response) {
@@ -2562,7 +2562,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -2625,7 +2625,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   genomics.variants.stream(request, function(err, response) {
@@ -2675,7 +2675,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   genomics.variantsets.create(request, function(err, response) {
@@ -2724,7 +2724,7 @@ authorize(function(authClient) {
     // The ID of the variant set to be deleted.
     variantSetId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   genomics.variantsets.delete(request, function(err) {
@@ -2775,7 +2775,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   genomics.variantsets.export(request, function(err, response) {
@@ -2824,7 +2824,7 @@ authorize(function(authClient) {
     // Required. The ID of the variant set.
     variantSetId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   genomics.variantsets.get(request, function(err, response) {
@@ -2878,7 +2878,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   genomics.variantsets.patch(request, function(err, response) {
@@ -2928,7 +2928,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_logging.v2beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_logging.v2beta1.json.baseline
@@ -26,7 +26,7 @@ authorize(function(authClient) {
     // information about log names, see LogEntry.
     logName: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   logging.billingAccounts.logs.delete(request, function(err) {
@@ -74,7 +74,7 @@ authorize(function(authClient) {
     // "organizations/[ORGANIZATION_ID]"
     parent: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -137,7 +137,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -200,7 +200,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   logging.entries.write(request, function(err, response) {
@@ -246,7 +246,7 @@ var logging = google.logging('v2beta1');
 
 authorize(function(authClient) {
   var request = {
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -313,7 +313,7 @@ authorize(function(authClient) {
     // information about log names, see LogEntry.
     logName: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   logging.organizations.logs.delete(request, function(err) {
@@ -361,7 +361,7 @@ authorize(function(authClient) {
     // "organizations/[ORGANIZATION_ID]"
     parent: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -428,7 +428,7 @@ authorize(function(authClient) {
     // information about log names, see LogEntry.
     logName: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   logging.projects.logs.delete(request, function(err) {
@@ -476,7 +476,7 @@ authorize(function(authClient) {
     // "organizations/[ORGANIZATION_ID]"
     parent: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -544,7 +544,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   logging.projects.metrics.create(request, function(err, response) {
@@ -594,7 +594,7 @@ authorize(function(authClient) {
     // "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
     metricName: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   logging.projects.metrics.delete(request, function(err) {
@@ -641,7 +641,7 @@ authorize(function(authClient) {
     // "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
     metricName: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   logging.projects.metrics.get(request, function(err, response) {
@@ -691,7 +691,7 @@ authorize(function(authClient) {
     // "projects/[PROJECT_ID]"
     parent: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -761,7 +761,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   logging.projects.metrics.update(request, function(err, response) {
@@ -817,7 +817,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   logging.projects.sinks.create(request, function(err, response) {
@@ -871,7 +871,7 @@ authorize(function(authClient) {
     // is an error if the sink does not exist.
     sinkName: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   logging.projects.sinks.delete(request, function(err) {
@@ -920,7 +920,7 @@ authorize(function(authClient) {
     // Example: "projects/my-project-id/sinks/my-sink-id".
     sinkName: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   logging.projects.sinks.get(request, function(err, response) {
@@ -970,7 +970,7 @@ authorize(function(authClient) {
     // "projects/my-logging-project", "organizations/123456789".
     parent: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -1041,7 +1041,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   logging.projects.sinks.update(request, function(err, response) {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_prediction.v1.6.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_prediction.v1.6.json.baseline
@@ -28,7 +28,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   prediction.hostedmodels.predict(request, function(err, response) {
@@ -80,7 +80,7 @@ authorize(function(authClient) {
     // The unique name for the predictive model.
     id: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   prediction.trainedmodels.analyze(request, function(err, response) {
@@ -132,7 +132,7 @@ authorize(function(authClient) {
     // The unique name for the predictive model.
     id: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   prediction.trainedmodels.delete(request, function(err) {
@@ -181,7 +181,7 @@ authorize(function(authClient) {
     // The unique name for the predictive model.
     id: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   prediction.trainedmodels.get(request, function(err, response) {
@@ -234,7 +234,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   prediction.trainedmodels.insert(request, function(err, response) {
@@ -283,7 +283,7 @@ authorize(function(authClient) {
     // The project associated with the model.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -352,7 +352,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   prediction.trainedmodels.predict(request, function(err, response) {
@@ -409,7 +409,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   prediction.trainedmodels.update(request, function(err, response) {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_pubsub.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_pubsub.v1.json.baseline
@@ -23,7 +23,7 @@ authorize(function(authClient) {
     // resource is specified as `projects/{project}`.
     resource_: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   pubsub.projects.snapshots.getIamPolicy(request, function(err, response) {
@@ -78,7 +78,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   pubsub.projects.snapshots.setIamPolicy(request, function(err, response) {
@@ -133,7 +133,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   pubsub.projects.snapshots.testIamPermissions(request, function(err, response) {
@@ -187,7 +187,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   pubsub.projects.subscriptions.acknowledge(request, function(err) {
@@ -243,7 +243,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   pubsub.projects.subscriptions.create(request, function(err, response) {
@@ -293,7 +293,7 @@ authorize(function(authClient) {
     // Format is `projects/{project}/subscriptions/{sub}`.
     subscription: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   pubsub.projects.subscriptions.delete(request, function(err) {
@@ -340,7 +340,7 @@ authorize(function(authClient) {
     // Format is `projects/{project}/subscriptions/{sub}`.
     subscription: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   pubsub.projects.subscriptions.get(request, function(err, response) {
@@ -391,7 +391,7 @@ authorize(function(authClient) {
     // resource is specified as `projects/{project}`.
     resource_: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   pubsub.projects.subscriptions.getIamPolicy(request, function(err, response) {
@@ -441,7 +441,7 @@ authorize(function(authClient) {
     // Format is `projects/{project}`.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -508,7 +508,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   pubsub.projects.subscriptions.modifyAckDeadline(request, function(err) {
@@ -559,7 +559,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   pubsub.projects.subscriptions.modifyPushConfig(request, function(err) {
@@ -610,7 +610,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   pubsub.projects.subscriptions.pull(request, function(err, response) {
@@ -665,7 +665,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   pubsub.projects.subscriptions.setIamPolicy(request, function(err, response) {
@@ -720,7 +720,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   pubsub.projects.subscriptions.testIamPermissions(request, function(err, response) {
@@ -779,7 +779,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   pubsub.projects.topics.create(request, function(err, response) {
@@ -829,7 +829,7 @@ authorize(function(authClient) {
     // Format is `projects/{project}/topics/{topic}`.
     topic: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   pubsub.projects.topics.delete(request, function(err) {
@@ -876,7 +876,7 @@ authorize(function(authClient) {
     // Format is `projects/{project}/topics/{topic}`.
     topic: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   pubsub.projects.topics.get(request, function(err, response) {
@@ -927,7 +927,7 @@ authorize(function(authClient) {
     // resource is specified as `projects/{project}`.
     resource_: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   pubsub.projects.topics.getIamPolicy(request, function(err, response) {
@@ -977,7 +977,7 @@ authorize(function(authClient) {
     // Format is `projects/{project}`.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -1044,7 +1044,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   pubsub.projects.topics.publish(request, function(err, response) {
@@ -1099,7 +1099,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   pubsub.projects.topics.setIamPolicy(request, function(err, response) {
@@ -1149,7 +1149,7 @@ authorize(function(authClient) {
     // Format is `projects/{project}/topics/{topic}`.
     topic: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -1217,7 +1217,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   pubsub.projects.topics.testIamPermissions(request, function(err, response) {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_replicapoolupdater.v1beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_replicapoolupdater.v1beta1.json.baseline
@@ -27,7 +27,7 @@ authorize(function(authClient) {
     // The name of the update.
     rollingUpdate: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   replicapoolupdater.rollingUpdates.cancel(request, function(err, response) {
@@ -82,7 +82,7 @@ authorize(function(authClient) {
     // The name of the update.
     rollingUpdate: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   replicapoolupdater.rollingUpdates.get(request, function(err, response) {
@@ -138,7 +138,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   replicapoolupdater.rollingUpdates.insert(request, function(err, response) {
@@ -190,7 +190,7 @@ authorize(function(authClient) {
     // The name of the zone in which the update's target resides.
     zone: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -258,7 +258,7 @@ authorize(function(authClient) {
     // The name of the update.
     rollingUpdate: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -326,7 +326,7 @@ authorize(function(authClient) {
     // The name of the update.
     rollingUpdate: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   replicapoolupdater.rollingUpdates.pause(request, function(err, response) {
@@ -381,7 +381,7 @@ authorize(function(authClient) {
     // The name of the update.
     rollingUpdate: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   replicapoolupdater.rollingUpdates.resume(request, function(err, response) {
@@ -436,7 +436,7 @@ authorize(function(authClient) {
     // The name of the update.
     rollingUpdate: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   replicapoolupdater.rollingUpdates.rollback(request, function(err, response) {
@@ -491,7 +491,7 @@ authorize(function(authClient) {
     // Name of the operation resource to return.
     operation: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   replicapoolupdater.zoneOperations.get(request, function(err, response) {
@@ -543,7 +543,7 @@ authorize(function(authClient) {
     // Name of the zone scoping this request.
     zone: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_sheets.v4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_sheets.v4.json.baseline
@@ -22,7 +22,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   sheets.spreadsheets.batchUpdate(request, function(err, response) {
@@ -68,7 +68,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   sheets.spreadsheets.create(request, function(err, response) {
@@ -120,7 +120,7 @@ authorize(function(authClient) {
     // This parameter is ignored if a field mask was set in the request.
     includeGridData: false,  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   sheets.spreadsheets.get(request, function(err, response) {
@@ -177,7 +177,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   sheets.spreadsheets.sheets.copyTo(request, function(err, response) {
@@ -236,7 +236,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   sheets.spreadsheets.values.append(request, function(err, response) {
@@ -288,7 +288,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   sheets.spreadsheets.values.batchClear(request, function(err, response) {
@@ -346,7 +346,7 @@ authorize(function(authClient) {
     // The default dateTime render option is [DateTimeRenderOption.SERIAL_NUMBER].
     dateTimeRenderOption: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   sheets.spreadsheets.values.batchGet(request, function(err, response) {
@@ -403,7 +403,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   sheets.spreadsheets.values.batchUpdate(request, function(err, response) {
@@ -455,7 +455,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   sheets.spreadsheets.values.clear(request, function(err, response) {
@@ -513,7 +513,7 @@ authorize(function(authClient) {
     // The default dateTime render option is [DateTimeRenderOption.SERIAL_NUMBER].
     dateTimeRenderOption: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   sheets.spreadsheets.values.get(request, function(err, response) {
@@ -571,7 +571,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   sheets.spreadsheets.values.update(request, function(err, response) {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_sqladmin.v1beta4.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_sqladmin.v1beta4.json.baseline
@@ -27,7 +27,7 @@ authorize(function(authClient) {
     // The ID of the Backup Run to delete. To find a Backup Run ID, use the list method.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   sqlAdmin.backupRuns.delete(request, function(err, response) {
@@ -82,7 +82,7 @@ authorize(function(authClient) {
     // The ID of this Backup Run.
     id: '0',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   sqlAdmin.backupRuns.get(request, function(err, response) {
@@ -138,7 +138,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   sqlAdmin.backupRuns.insert(request, function(err, response) {
@@ -190,7 +190,7 @@ authorize(function(authClient) {
     // Cloud SQL instance ID. This does not include the project ID.
     instance: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -258,7 +258,7 @@ authorize(function(authClient) {
     // Name of the database to be deleted in the instance.
     database: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   sqlAdmin.databases.delete(request, function(err, response) {
@@ -313,7 +313,7 @@ authorize(function(authClient) {
     // Name of the database in the instance.
     database: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   sqlAdmin.databases.get(request, function(err, response) {
@@ -369,7 +369,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   sqlAdmin.databases.insert(request, function(err, response) {
@@ -421,7 +421,7 @@ authorize(function(authClient) {
     // Cloud SQL instance ID. This does not include the project ID.
     instance: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   sqlAdmin.databases.list(request, function(err, response) {
@@ -481,7 +481,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   sqlAdmin.databases.patch(request, function(err, response) {
@@ -541,7 +541,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   sqlAdmin.databases.update(request, function(err, response) {
@@ -587,7 +587,7 @@ var sqlAdmin = google.sqladmin('v1beta4');
 
 authorize(function(authClient) {
   var request = {
-    auth: authClient
+    auth: authClient,
   };
 
   sqlAdmin.flags.list(request, function(err, response) {
@@ -643,7 +643,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   sqlAdmin.instances.clone(request, function(err, response) {
@@ -695,7 +695,7 @@ authorize(function(authClient) {
     // Cloud SQL instance ID. This does not include the project ID.
     instance: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   sqlAdmin.instances.delete(request, function(err, response) {
@@ -751,7 +751,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   sqlAdmin.instances.export(request, function(err, response) {
@@ -807,7 +807,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   sqlAdmin.instances.failover(request, function(err, response) {
@@ -859,7 +859,7 @@ authorize(function(authClient) {
     // Database instance ID. This does not include the project ID.
     instance: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   sqlAdmin.instances.get(request, function(err, response) {
@@ -915,7 +915,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   sqlAdmin.instances.import(request, function(err, response) {
@@ -968,7 +968,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   sqlAdmin.instances.insert(request, function(err, response) {
@@ -1017,7 +1017,7 @@ authorize(function(authClient) {
     // Project ID of the project for which to list Cloud SQL instances.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -1087,7 +1087,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   sqlAdmin.instances.patch(request, function(err, response) {
@@ -1139,7 +1139,7 @@ authorize(function(authClient) {
     // Cloud SQL read replica instance name.
     instance: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   sqlAdmin.instances.promoteReplica(request, function(err, response) {
@@ -1191,7 +1191,7 @@ authorize(function(authClient) {
     // Cloud SQL instance ID. This does not include the project ID.
     instance: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   sqlAdmin.instances.resetSslConfig(request, function(err, response) {
@@ -1243,7 +1243,7 @@ authorize(function(authClient) {
     // Cloud SQL instance ID. This does not include the project ID.
     instance: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   sqlAdmin.instances.restart(request, function(err, response) {
@@ -1299,7 +1299,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   sqlAdmin.instances.restoreBackup(request, function(err, response) {
@@ -1351,7 +1351,7 @@ authorize(function(authClient) {
     // Cloud SQL read replica instance name.
     instance: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   sqlAdmin.instances.startReplica(request, function(err, response) {
@@ -1403,7 +1403,7 @@ authorize(function(authClient) {
     // Cloud SQL read replica instance name.
     instance: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   sqlAdmin.instances.stopReplica(request, function(err, response) {
@@ -1459,7 +1459,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   sqlAdmin.instances.truncateLog(request, function(err, response) {
@@ -1516,7 +1516,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   sqlAdmin.instances.update(request, function(err, response) {
@@ -1568,7 +1568,7 @@ authorize(function(authClient) {
     // Instance operation ID.
     operation: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   sqlAdmin.operations.get(request, function(err, response) {
@@ -1620,7 +1620,7 @@ authorize(function(authClient) {
     // Cloud SQL instance ID. This does not include the project ID.
     instance: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -1689,7 +1689,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   sqlAdmin.sslCerts.createEphemeral(request, function(err, response) {
@@ -1744,7 +1744,7 @@ authorize(function(authClient) {
     // Sha1 FingerPrint.
     sha1Fingerprint: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   sqlAdmin.sslCerts.delete(request, function(err, response) {
@@ -1799,7 +1799,7 @@ authorize(function(authClient) {
     // Sha1 FingerPrint.
     sha1Fingerprint: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   sqlAdmin.sslCerts.get(request, function(err, response) {
@@ -1855,7 +1855,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   sqlAdmin.sslCerts.insert(request, function(err, response) {
@@ -1907,7 +1907,7 @@ authorize(function(authClient) {
     // Cloud SQL instance ID. This does not include the project ID.
     instance: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   sqlAdmin.sslCerts.list(request, function(err, response) {
@@ -1956,7 +1956,7 @@ authorize(function(authClient) {
     // Project ID of the project for which to list tiers.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   sqlAdmin.tiers.list(request, function(err, response) {
@@ -2014,7 +2014,7 @@ authorize(function(authClient) {
     // Name of the user in the instance.
     name: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   sqlAdmin.users.delete(request, function(err, response) {
@@ -2070,7 +2070,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   sqlAdmin.users.insert(request, function(err, response) {
@@ -2122,7 +2122,7 @@ authorize(function(authClient) {
     // Database instance ID. This does not include the project ID.
     instance: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   sqlAdmin.users.list(request, function(err, response) {
@@ -2185,7 +2185,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   sqlAdmin.users.update(request, function(err, response) {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_storage.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_storage.v1.json.baseline
@@ -25,7 +25,7 @@ authorize(function(authClient) {
     // group-emailAddress, allUsers, or allAuthenticatedUsers.
     entity: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   storage.bucketAccessControls.delete(request, function(err) {
@@ -75,7 +75,7 @@ authorize(function(authClient) {
     // group-emailAddress, allUsers, or allAuthenticatedUsers.
     entity: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   storage.bucketAccessControls.get(request, function(err, response) {
@@ -128,7 +128,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   storage.bucketAccessControls.insert(request, function(err, response) {
@@ -177,7 +177,7 @@ authorize(function(authClient) {
     // Name of a bucket.
     bucket: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   storage.bucketAccessControls.list(request, function(err, response) {
@@ -235,7 +235,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   storage.bucketAccessControls.patch(request, function(err, response) {
@@ -293,7 +293,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   storage.bucketAccessControls.update(request, function(err, response) {
@@ -342,7 +342,7 @@ authorize(function(authClient) {
     // Name of a bucket.
     bucket: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   storage.buckets.delete(request, function(err) {
@@ -388,7 +388,7 @@ authorize(function(authClient) {
     // Name of a bucket.
     bucket: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   storage.buckets.get(request, function(err, response) {
@@ -441,7 +441,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   storage.buckets.insert(request, function(err, response) {
@@ -490,7 +490,7 @@ authorize(function(authClient) {
     // A valid API project identifier.
     project: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -557,7 +557,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   storage.buckets.patch(request, function(err, response) {
@@ -611,7 +611,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   storage.buckets.update(request, function(err, response) {
@@ -661,7 +661,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   storage.channels.stop(request, function(err) {
@@ -711,7 +711,7 @@ authorize(function(authClient) {
     // group-emailAddress, allUsers, or allAuthenticatedUsers.
     entity: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   storage.defaultObjectAccessControls.delete(request, function(err) {
@@ -761,7 +761,7 @@ authorize(function(authClient) {
     // group-emailAddress, allUsers, or allAuthenticatedUsers.
     entity: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   storage.defaultObjectAccessControls.get(request, function(err, response) {
@@ -814,7 +814,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   storage.defaultObjectAccessControls.insert(request, function(err, response) {
@@ -863,7 +863,7 @@ authorize(function(authClient) {
     // Name of a bucket.
     bucket: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   storage.defaultObjectAccessControls.list(request, function(err, response) {
@@ -921,7 +921,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   storage.defaultObjectAccessControls.patch(request, function(err, response) {
@@ -979,7 +979,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   storage.defaultObjectAccessControls.update(request, function(err, response) {
@@ -1036,7 +1036,7 @@ authorize(function(authClient) {
     // group-emailAddress, allUsers, or allAuthenticatedUsers.
     entity: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   storage.objectAccessControls.delete(request, function(err) {
@@ -1090,7 +1090,7 @@ authorize(function(authClient) {
     // group-emailAddress, allUsers, or allAuthenticatedUsers.
     entity: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   storage.objectAccessControls.get(request, function(err, response) {
@@ -1147,7 +1147,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   storage.objectAccessControls.insert(request, function(err, response) {
@@ -1200,7 +1200,7 @@ authorize(function(authClient) {
     // Encoding URI Path Parts.
     object: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   storage.objectAccessControls.list(request, function(err, response) {
@@ -1262,7 +1262,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   storage.objectAccessControls.patch(request, function(err, response) {
@@ -1324,7 +1324,7 @@ authorize(function(authClient) {
       // will be replaced.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   storage.objectAccessControls.update(request, function(err, response) {
@@ -1385,7 +1385,7 @@ authorize(function(authClient) {
     //
     // alt: 'media',
 
-    auth: authClient
+    auth: authClient,
   };
 
   storage.objects.compose(request, function(err, response) {
@@ -1455,7 +1455,7 @@ authorize(function(authClient) {
     //
     // alt: 'media',
 
-    auth: authClient
+    auth: authClient,
   };
 
   storage.objects.copy(request, function(err, response) {
@@ -1508,7 +1508,7 @@ authorize(function(authClient) {
     // Encoding URI Path Parts.
     object: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   storage.objects.delete(request, function(err) {
@@ -1562,7 +1562,7 @@ authorize(function(authClient) {
     //
     // alt: 'media',
 
-    auth: authClient
+    auth: authClient,
   };
 
   storage.objects.get(request, function(err, response) {
@@ -1620,10 +1620,10 @@ authorize(function(authClient) {
       // TODO: Add desired media content for upload. See
       // https://github.com/google/google-api-nodejs-client#media-uploads
       mimeType: '',  // See https://www.w3.org/Protocols/rfc1341/4_Content-Type.html
-      body: {}
+      body: {},
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   storage.objects.insert(request, function(err, response) {
@@ -1672,7 +1672,7 @@ authorize(function(authClient) {
     // Name of the bucket in which to look for objects.
     bucket: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -1743,7 +1743,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   storage.objects.patch(request, function(err, response) {
@@ -1809,7 +1809,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   storage.objects.rewrite(request, function(err, response) {
@@ -1871,7 +1871,7 @@ authorize(function(authClient) {
     //
     // alt: 'media',
 
-    auth: authClient
+    auth: authClient,
   };
 
   storage.objects.update(request, function(err, response) {
@@ -1924,7 +1924,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   storage.objects.watchAll(request, function(err, response) {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_storagetransfer.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_storagetransfer.v1.json.baseline
@@ -18,7 +18,7 @@ var storagetransfer = google.storagetransfer('v1');
 
 authorize(function(authClient) {
   var request = {
-    auth: authClient
+    auth: authClient,
   };
 
   storagetransfer.getGoogleServiceAccount(request, function(err, response) {
@@ -68,7 +68,7 @@ authorize(function(authClient) {
     // Required.
     projectId: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   storagetransfer.googleServiceAccounts.get(request, function(err, response) {
@@ -118,7 +118,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   storagetransfer.transferJobs.create(request, function(err, response) {
@@ -167,7 +167,7 @@ authorize(function(authClient) {
     // The job to get. Required.
     jobName: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   storagetransfer.transferJobs.get(request, function(err, response) {
@@ -213,7 +213,7 @@ var storagetransfer = google.storagetransfer('v1');
 
 authorize(function(authClient) {
   var request = {
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -280,7 +280,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   storagetransfer.transferJobs.patch(request, function(err, response) {
@@ -329,7 +329,7 @@ authorize(function(authClient) {
     // The name of the operation resource to be cancelled.
     name: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   storagetransfer.transferOperations.cancel(request, function(err) {
@@ -375,7 +375,7 @@ authorize(function(authClient) {
     // The name of the operation resource to be deleted.
     name: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   storagetransfer.transferOperations.delete(request, function(err) {
@@ -421,7 +421,7 @@ authorize(function(authClient) {
     // The name of the operation resource.
     name: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   storagetransfer.transferOperations.get(request, function(err, response) {
@@ -470,7 +470,7 @@ authorize(function(authClient) {
     // The value `transferOperations`.
     name: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   var handlePage = function(err, response) {
@@ -536,7 +536,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   storagetransfer.transferOperations.pause(request, function(err) {
@@ -586,7 +586,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   storagetransfer.transferOperations.resume(request, function(err) {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_taskqueue.v1beta2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_taskqueue.v1beta2.json.baseline
@@ -18,7 +18,7 @@ authorize(function(authClient) {
     // The id of the taskqueue to get the properties of.
     taskqueue: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   taskqueue.taskqueues.get(request, function(err, response) {
@@ -69,7 +69,7 @@ authorize(function(authClient) {
     // The id of the task to delete.
     task: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   taskqueue.tasks.delete(request, function(err) {
@@ -117,7 +117,7 @@ authorize(function(authClient) {
     // The task to get properties of.
     task: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   taskqueue.tasks.get(request, function(err, response) {
@@ -169,7 +169,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   taskqueue.tasks.insert(request, function(err, response) {
@@ -223,7 +223,7 @@ authorize(function(authClient) {
     // The lease in seconds.
     leaseSecs: 0,  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   taskqueue.tasks.lease(request, function(err, response) {
@@ -271,7 +271,7 @@ authorize(function(authClient) {
     // The id of the taskqueue to list tasks from.
     taskqueue: '',  // TODO: Update placeholder value.
 
-    auth: authClient
+    auth: authClient,
   };
 
   taskqueue.tasks.list(request, function(err, response) {
@@ -328,7 +328,7 @@ authorize(function(authClient) {
       // will be changed.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   taskqueue.tasks.patch(request, function(err, response) {
@@ -384,7 +384,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   taskqueue.tasks.update(request, function(err, response) {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_translate.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_translate.v2.json.baseline
@@ -16,7 +16,7 @@ var request = {
   // The text to detect
   q: '',  // TODO: Update placeholder value.
 
-  auth: apiKey
+  auth: apiKey,
 };
 
 translate.detections.list(request, function(err, response) {
@@ -42,7 +42,7 @@ var translate = google.translate('v2');
 var apiKey = '';  // TODO: Update placeholder with desired API key.
 
 var request = {
-  auth: apiKey
+  auth: apiKey,
 };
 
 translate.languages.list(request, function(err, response) {
@@ -74,7 +74,7 @@ var request = {
   // The target language into which the text should be translated
   target: '',  // TODO: Update placeholder value.
 
-  auth: apiKey
+  auth: apiKey,
 };
 
 translate.translations.list(request, function(err, response) {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_vision.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_vision.v1.json.baseline
@@ -22,7 +22,7 @@ authorize(function(authClient) {
       // TODO: Add desired properties to the request body.
     },
 
-    auth: authClient
+    auth: authClient,
   };
 
   vision.images.annotate(request, function(err, response) {


### PR DESCRIPTION
This commit adds a trailing comma to the last item of each object. Due
to our limitations in snippet language, and the fact that this code is
autogenerated, it's easier to use this style than try to ensure that the
last item in an object has no comma following it.

This commit also achieves consistency, as the samples are currently
inconsistent because all optional request body fields are generated with
trailing commas.