### PR TITLE
go: accept CallOption

### DIFF
--- a/src/main/resources/com/google/api/codegen/go/main.snip
+++ b/src/main/resources/com/google/api/codegen/go/main.snip
@@ -182,14 +182,15 @@
 @end
 
 @private simpleMethod(view, method)
-    func (c *{@view.clientTypeName}) {@method.name}(ctx context.Context, req {@method.serviceRequestTypeName}) ({@method.responseTypeName}, error) {
+    func (c *{@view.clientTypeName}) {@method.name}(ctx context.Context, req {@method.serviceRequestTypeName}, opts ...gax.CallOption) ({@method.responseTypeName}, error) {
         {@mergeMetadata()}
+        opts = {@mergeOptions(method.settingsGetterName)}
         var resp {@method.serviceResponseTypeName}
         err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
             var err error
             resp, err = c.{@method.stubName}.{@method.callableName}(ctx, req, settings.GRPC...)
             return err
-        }, c.CallOptions.{@method.settingsGetterName}...)
+        }, opts...)
         if err != nil {
             return nil, err
         }
@@ -198,14 +199,15 @@
 @end
 
 @private lroMethod(view, method)
-    func (c *{@view.clientTypeName}) {@method.name}(ctx context.Context, req {@method.serviceRequestTypeName}) (*{@method.operationMethod.clientReturnTypeName}, error) {
+    func (c *{@view.clientTypeName}) {@method.name}(ctx context.Context, req {@method.serviceRequestTypeName}, opts ...gax.CallOption) (*{@method.operationMethod.clientReturnTypeName}, error) {
         {@mergeMetadata()}
+        opts = {@mergeOptions(method.settingsGetterName)}
         var resp {@method.serviceResponseTypeName}
         err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
             var err error
             resp, err = c.{@method.stubName}.{@method.callableName}(ctx, req, settings.GRPC...)
             return err
-        }, c.CallOptions.{@method.settingsGetterName}...)
+        }, opts...)
         if err != nil {
             return nil, err
         }
@@ -219,14 +221,15 @@
 # Used for bidi and request GRPC streaming.
 # The function is not accept a request, but otherwise the same with simpleMethod.
 @private noRequestStreamMethod(view, method)
-    func (c *{@view.clientTypeName}) {@method.name}(ctx context.Context) ({@method.responseTypeName}, error) {
+    func (c *{@view.clientTypeName}) {@method.name}(ctx context.Context, opts ...gax.CallOption) ({@method.responseTypeName}, error) {
         {@mergeMetadata()}
+        opts = {@mergeOptions(method.settingsGetterName)}
         var resp {@method.serviceResponseTypeName}
         err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
             var err error
             resp, err = c.{@method.stubName}.{@method.name}(ctx, settings.GRPC...)
             return err
-        }, c.CallOptions.{@method.settingsGetterName}...)
+        }, opts...)
         if err != nil {
             return nil, err
         }
@@ -235,20 +238,22 @@
 @end
 
 @private emptyReturnMethod(view, method)
-    func (c *{@view.clientTypeName}) {@method.name}(ctx context.Context, req {@method.serviceRequestTypeName}) error {
+    func (c *{@view.clientTypeName}) {@method.name}(ctx context.Context, req {@method.serviceRequestTypeName}, opts ...gax.CallOption) error {
         {@mergeMetadata()}
+        opts = {@mergeOptions(method.settingsGetterName)}
         err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
             var err error
             _, err = c.{@method.stubName}.{@method.callableName}(ctx, req, settings.GRPC...)
             return err
-        }, c.CallOptions.{@method.settingsGetterName}...)
+        }, opts...)
         return err
     }
 @end
 
 @private pageStreamingMethod(view, method)
-    func (c *{@view.clientTypeName}) {@method.name}(ctx context.Context, req {@method.serviceRequestTypeName}) *{@method.responseTypeName} {
+    func (c *{@view.clientTypeName}) {@method.name}(ctx context.Context, req {@method.serviceRequestTypeName}, opts ...gax.CallOption) *{@method.responseTypeName} {
         {@mergeMetadata()}
+        opts = {@mergeOptions(method.settingsGetterName)}
         it := &{@method.responseTypeName}{}
         it.InternalFetch = func(pageSize int, pageToken string) ([]{@method.listMethod.resourceTypeName}, string, error) {
             var resp {@method.serviceResponseTypeName}
@@ -262,7 +267,7 @@
                 var err error
                 resp, err = c.{@method.stubName}.{@method.callableName}(ctx, req, settings.GRPC...)
                 return err
-            }, c.CallOptions.{@method.settingsGetterName}...)
+            }, opts...)
             if err != nil {
                 return nil, "", err
             }
@@ -460,4 +465,8 @@
 
 @private mergeMetadata()
     ctx = insertXGoog(ctx, c.xGoogHeader)
+@end
+
+@private mergeOptions(getterName)
+    append(c.CallOptions.{@getterName}[0:len(c.CallOptions.{@getterName}):len(c.CallOptions.{@getterName})], opts...)
 @end

--- a/src/test/java/com/google/api/codegen/testdata/go_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_main_library.baseline
@@ -241,14 +241,15 @@ func (c *Client) BookIAM(book *librarypb.Book) *iam.Handle {
 
 // CreateShelf creates a shelf, and returns the new Shelf.
 // RPC method comment may include special characters: <>&"`'@.
-func (c *Client) CreateShelf(ctx context.Context, req *librarypb.CreateShelfRequest) (*librarypb.Shelf, error) {
+func (c *Client) CreateShelf(ctx context.Context, req *librarypb.CreateShelfRequest, opts ...gax.CallOption) (*librarypb.Shelf, error) {
     ctx = insertXGoog(ctx, c.xGoogHeader)
+    opts = append(c.CallOptions.CreateShelf[0:len(c.CallOptions.CreateShelf):len(c.CallOptions.CreateShelf)], opts...)
     var resp *librarypb.Shelf
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
         var err error
         resp, err = c.client.CreateShelf(ctx, req, settings.GRPC...)
         return err
-    }, c.CallOptions.CreateShelf...)
+    }, opts...)
     if err != nil {
         return nil, err
     }
@@ -256,14 +257,15 @@ func (c *Client) CreateShelf(ctx context.Context, req *librarypb.CreateShelfRequ
 }
 
 // GetShelf gets a shelf.
-func (c *Client) GetShelf(ctx context.Context, req *librarypb.GetShelfRequest) (*librarypb.Shelf, error) {
+func (c *Client) GetShelf(ctx context.Context, req *librarypb.GetShelfRequest, opts ...gax.CallOption) (*librarypb.Shelf, error) {
     ctx = insertXGoog(ctx, c.xGoogHeader)
+    opts = append(c.CallOptions.GetShelf[0:len(c.CallOptions.GetShelf):len(c.CallOptions.GetShelf)], opts...)
     var resp *librarypb.Shelf
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
         var err error
         resp, err = c.client.GetShelf(ctx, req, settings.GRPC...)
         return err
-    }, c.CallOptions.GetShelf...)
+    }, opts...)
     if err != nil {
         return nil, err
     }
@@ -271,8 +273,9 @@ func (c *Client) GetShelf(ctx context.Context, req *librarypb.GetShelfRequest) (
 }
 
 // ListShelves lists shelves.
-func (c *Client) ListShelves(ctx context.Context, req *librarypb.ListShelvesRequest) *ShelfIterator {
+func (c *Client) ListShelves(ctx context.Context, req *librarypb.ListShelvesRequest, opts ...gax.CallOption) *ShelfIterator {
     ctx = insertXGoog(ctx, c.xGoogHeader)
+    opts = append(c.CallOptions.ListShelves[0:len(c.CallOptions.ListShelves):len(c.CallOptions.ListShelves)], opts...)
     it := &ShelfIterator{}
     it.InternalFetch = func(pageSize int, pageToken string) ([]*librarypb.Shelf, string, error) {
         var resp *librarypb.ListShelvesResponse
@@ -286,7 +289,7 @@ func (c *Client) ListShelves(ctx context.Context, req *librarypb.ListShelvesRequ
             var err error
             resp, err = c.client.ListShelves(ctx, req, settings.GRPC...)
             return err
-        }, c.CallOptions.ListShelves...)
+        }, opts...)
         if err != nil {
             return nil, "", err
         }
@@ -305,27 +308,29 @@ func (c *Client) ListShelves(ctx context.Context, req *librarypb.ListShelvesRequ
 }
 
 // DeleteShelf deletes a shelf.
-func (c *Client) DeleteShelf(ctx context.Context, req *librarypb.DeleteShelfRequest) error {
+func (c *Client) DeleteShelf(ctx context.Context, req *librarypb.DeleteShelfRequest, opts ...gax.CallOption) error {
     ctx = insertXGoog(ctx, c.xGoogHeader)
+    opts = append(c.CallOptions.DeleteShelf[0:len(c.CallOptions.DeleteShelf):len(c.CallOptions.DeleteShelf)], opts...)
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
         var err error
         _, err = c.client.DeleteShelf(ctx, req, settings.GRPC...)
         return err
-    }, c.CallOptions.DeleteShelf...)
+    }, opts...)
     return err
 }
 
 // MergeShelves merges two shelves by adding all books from the shelf named
 // `other_shelf_name` to shelf `name`, and deletes
 // `other_shelf_name`. Returns the updated shelf.
-func (c *Client) MergeShelves(ctx context.Context, req *librarypb.MergeShelvesRequest) (*librarypb.Shelf, error) {
+func (c *Client) MergeShelves(ctx context.Context, req *librarypb.MergeShelvesRequest, opts ...gax.CallOption) (*librarypb.Shelf, error) {
     ctx = insertXGoog(ctx, c.xGoogHeader)
+    opts = append(c.CallOptions.MergeShelves[0:len(c.CallOptions.MergeShelves):len(c.CallOptions.MergeShelves)], opts...)
     var resp *librarypb.Shelf
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
         var err error
         resp, err = c.client.MergeShelves(ctx, req, settings.GRPC...)
         return err
-    }, c.CallOptions.MergeShelves...)
+    }, opts...)
     if err != nil {
         return nil, err
     }
@@ -333,14 +338,15 @@ func (c *Client) MergeShelves(ctx context.Context, req *librarypb.MergeShelvesRe
 }
 
 // CreateBook creates a book.
-func (c *Client) CreateBook(ctx context.Context, req *librarypb.CreateBookRequest) (*librarypb.Book, error) {
+func (c *Client) CreateBook(ctx context.Context, req *librarypb.CreateBookRequest, opts ...gax.CallOption) (*librarypb.Book, error) {
     ctx = insertXGoog(ctx, c.xGoogHeader)
+    opts = append(c.CallOptions.CreateBook[0:len(c.CallOptions.CreateBook):len(c.CallOptions.CreateBook)], opts...)
     var resp *librarypb.Book
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
         var err error
         resp, err = c.client.CreateBook(ctx, req, settings.GRPC...)
         return err
-    }, c.CallOptions.CreateBook...)
+    }, opts...)
     if err != nil {
         return nil, err
     }
@@ -348,14 +354,15 @@ func (c *Client) CreateBook(ctx context.Context, req *librarypb.CreateBookReques
 }
 
 // PublishSeries creates a series of books.
-func (c *Client) PublishSeries(ctx context.Context, req *librarypb.PublishSeriesRequest) (*librarypb.PublishSeriesResponse, error) {
+func (c *Client) PublishSeries(ctx context.Context, req *librarypb.PublishSeriesRequest, opts ...gax.CallOption) (*librarypb.PublishSeriesResponse, error) {
     ctx = insertXGoog(ctx, c.xGoogHeader)
+    opts = append(c.CallOptions.PublishSeries[0:len(c.CallOptions.PublishSeries):len(c.CallOptions.PublishSeries)], opts...)
     var resp *librarypb.PublishSeriesResponse
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
         var err error
         resp, err = c.client.PublishSeries(ctx, req, settings.GRPC...)
         return err
-    }, c.CallOptions.PublishSeries...)
+    }, opts...)
     if err != nil {
         return nil, err
     }
@@ -363,14 +370,15 @@ func (c *Client) PublishSeries(ctx context.Context, req *librarypb.PublishSeries
 }
 
 // GetBook gets a book.
-func (c *Client) GetBook(ctx context.Context, req *librarypb.GetBookRequest) (*librarypb.Book, error) {
+func (c *Client) GetBook(ctx context.Context, req *librarypb.GetBookRequest, opts ...gax.CallOption) (*librarypb.Book, error) {
     ctx = insertXGoog(ctx, c.xGoogHeader)
+    opts = append(c.CallOptions.GetBook[0:len(c.CallOptions.GetBook):len(c.CallOptions.GetBook)], opts...)
     var resp *librarypb.Book
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
         var err error
         resp, err = c.client.GetBook(ctx, req, settings.GRPC...)
         return err
-    }, c.CallOptions.GetBook...)
+    }, opts...)
     if err != nil {
         return nil, err
     }
@@ -378,8 +386,9 @@ func (c *Client) GetBook(ctx context.Context, req *librarypb.GetBookRequest) (*l
 }
 
 // ListBooks lists books in a shelf.
-func (c *Client) ListBooks(ctx context.Context, req *librarypb.ListBooksRequest) *BookIterator {
+func (c *Client) ListBooks(ctx context.Context, req *librarypb.ListBooksRequest, opts ...gax.CallOption) *BookIterator {
     ctx = insertXGoog(ctx, c.xGoogHeader)
+    opts = append(c.CallOptions.ListBooks[0:len(c.CallOptions.ListBooks):len(c.CallOptions.ListBooks)], opts...)
     it := &BookIterator{}
     it.InternalFetch = func(pageSize int, pageToken string) ([]*librarypb.Book, string, error) {
         var resp *librarypb.ListBooksResponse
@@ -393,7 +402,7 @@ func (c *Client) ListBooks(ctx context.Context, req *librarypb.ListBooksRequest)
             var err error
             resp, err = c.client.ListBooks(ctx, req, settings.GRPC...)
             return err
-        }, c.CallOptions.ListBooks...)
+        }, opts...)
         if err != nil {
             return nil, "", err
         }
@@ -412,25 +421,27 @@ func (c *Client) ListBooks(ctx context.Context, req *librarypb.ListBooksRequest)
 }
 
 // DeleteBook deletes a book.
-func (c *Client) DeleteBook(ctx context.Context, req *librarypb.DeleteBookRequest) error {
+func (c *Client) DeleteBook(ctx context.Context, req *librarypb.DeleteBookRequest, opts ...gax.CallOption) error {
     ctx = insertXGoog(ctx, c.xGoogHeader)
+    opts = append(c.CallOptions.DeleteBook[0:len(c.CallOptions.DeleteBook):len(c.CallOptions.DeleteBook)], opts...)
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
         var err error
         _, err = c.client.DeleteBook(ctx, req, settings.GRPC...)
         return err
-    }, c.CallOptions.DeleteBook...)
+    }, opts...)
     return err
 }
 
 // UpdateBook updates a book.
-func (c *Client) UpdateBook(ctx context.Context, req *librarypb.UpdateBookRequest) (*librarypb.Book, error) {
+func (c *Client) UpdateBook(ctx context.Context, req *librarypb.UpdateBookRequest, opts ...gax.CallOption) (*librarypb.Book, error) {
     ctx = insertXGoog(ctx, c.xGoogHeader)
+    opts = append(c.CallOptions.UpdateBook[0:len(c.CallOptions.UpdateBook):len(c.CallOptions.UpdateBook)], opts...)
     var resp *librarypb.Book
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
         var err error
         resp, err = c.client.UpdateBook(ctx, req, settings.GRPC...)
         return err
-    }, c.CallOptions.UpdateBook...)
+    }, opts...)
     if err != nil {
         return nil, err
     }
@@ -438,14 +449,15 @@ func (c *Client) UpdateBook(ctx context.Context, req *librarypb.UpdateBookReques
 }
 
 // MoveBook moves a book to another shelf, and returns the new book.
-func (c *Client) MoveBook(ctx context.Context, req *librarypb.MoveBookRequest) (*librarypb.Book, error) {
+func (c *Client) MoveBook(ctx context.Context, req *librarypb.MoveBookRequest, opts ...gax.CallOption) (*librarypb.Book, error) {
     ctx = insertXGoog(ctx, c.xGoogHeader)
+    opts = append(c.CallOptions.MoveBook[0:len(c.CallOptions.MoveBook):len(c.CallOptions.MoveBook)], opts...)
     var resp *librarypb.Book
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
         var err error
         resp, err = c.client.MoveBook(ctx, req, settings.GRPC...)
         return err
-    }, c.CallOptions.MoveBook...)
+    }, opts...)
     if err != nil {
         return nil, err
     }
@@ -453,8 +465,9 @@ func (c *Client) MoveBook(ctx context.Context, req *librarypb.MoveBookRequest) (
 }
 
 // ListStrings lists a primitive resource. To test go page streaming.
-func (c *Client) ListStrings(ctx context.Context, req *librarypb.ListStringsRequest) *StringIterator {
+func (c *Client) ListStrings(ctx context.Context, req *librarypb.ListStringsRequest, opts ...gax.CallOption) *StringIterator {
     ctx = insertXGoog(ctx, c.xGoogHeader)
+    opts = append(c.CallOptions.ListStrings[0:len(c.CallOptions.ListStrings):len(c.CallOptions.ListStrings)], opts...)
     it := &StringIterator{}
     it.InternalFetch = func(pageSize int, pageToken string) ([]string, string, error) {
         var resp *librarypb.ListStringsResponse
@@ -468,7 +481,7 @@ func (c *Client) ListStrings(ctx context.Context, req *librarypb.ListStringsRequ
             var err error
             resp, err = c.client.ListStrings(ctx, req, settings.GRPC...)
             return err
-        }, c.CallOptions.ListStrings...)
+        }, opts...)
         if err != nil {
             return nil, "", err
         }
@@ -487,25 +500,27 @@ func (c *Client) ListStrings(ctx context.Context, req *librarypb.ListStringsRequ
 }
 
 // AddComments adds comments to a book
-func (c *Client) AddComments(ctx context.Context, req *librarypb.AddCommentsRequest) error {
+func (c *Client) AddComments(ctx context.Context, req *librarypb.AddCommentsRequest, opts ...gax.CallOption) error {
     ctx = insertXGoog(ctx, c.xGoogHeader)
+    opts = append(c.CallOptions.AddComments[0:len(c.CallOptions.AddComments):len(c.CallOptions.AddComments)], opts...)
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
         var err error
         _, err = c.client.AddComments(ctx, req, settings.GRPC...)
         return err
-    }, c.CallOptions.AddComments...)
+    }, opts...)
     return err
 }
 
 // GetBookFromArchive gets a book from an archive.
-func (c *Client) GetBookFromArchive(ctx context.Context, req *librarypb.GetBookFromArchiveRequest) (*librarypb.BookFromArchive, error) {
+func (c *Client) GetBookFromArchive(ctx context.Context, req *librarypb.GetBookFromArchiveRequest, opts ...gax.CallOption) (*librarypb.BookFromArchive, error) {
     ctx = insertXGoog(ctx, c.xGoogHeader)
+    opts = append(c.CallOptions.GetBookFromArchive[0:len(c.CallOptions.GetBookFromArchive):len(c.CallOptions.GetBookFromArchive)], opts...)
     var resp *librarypb.BookFromArchive
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
         var err error
         resp, err = c.client.GetBookFromArchive(ctx, req, settings.GRPC...)
         return err
-    }, c.CallOptions.GetBookFromArchive...)
+    }, opts...)
     if err != nil {
         return nil, err
     }
@@ -513,14 +528,15 @@ func (c *Client) GetBookFromArchive(ctx context.Context, req *librarypb.GetBookF
 }
 
 // GetBookFromAnywhere gets a book from a shelf or archive.
-func (c *Client) GetBookFromAnywhere(ctx context.Context, req *librarypb.GetBookFromAnywhereRequest) (*librarypb.BookFromAnywhere, error) {
+func (c *Client) GetBookFromAnywhere(ctx context.Context, req *librarypb.GetBookFromAnywhereRequest, opts ...gax.CallOption) (*librarypb.BookFromAnywhere, error) {
     ctx = insertXGoog(ctx, c.xGoogHeader)
+    opts = append(c.CallOptions.GetBookFromAnywhere[0:len(c.CallOptions.GetBookFromAnywhere):len(c.CallOptions.GetBookFromAnywhere)], opts...)
     var resp *librarypb.BookFromAnywhere
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
         var err error
         resp, err = c.client.GetBookFromAnywhere(ctx, req, settings.GRPC...)
         return err
-    }, c.CallOptions.GetBookFromAnywhere...)
+    }, opts...)
     if err != nil {
         return nil, err
     }
@@ -528,26 +544,28 @@ func (c *Client) GetBookFromAnywhere(ctx context.Context, req *librarypb.GetBook
 }
 
 // UpdateBookIndex updates the index of a book.
-func (c *Client) UpdateBookIndex(ctx context.Context, req *librarypb.UpdateBookIndexRequest) error {
+func (c *Client) UpdateBookIndex(ctx context.Context, req *librarypb.UpdateBookIndexRequest, opts ...gax.CallOption) error {
     ctx = insertXGoog(ctx, c.xGoogHeader)
+    opts = append(c.CallOptions.UpdateBookIndex[0:len(c.CallOptions.UpdateBookIndex):len(c.CallOptions.UpdateBookIndex)], opts...)
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
         var err error
         _, err = c.client.UpdateBookIndex(ctx, req, settings.GRPC...)
         return err
-    }, c.CallOptions.UpdateBookIndex...)
+    }, opts...)
     return err
 }
 
 // StreamShelves test server streaming
 // gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
-func (c *Client) StreamShelves(ctx context.Context, req *librarypb.StreamShelvesRequest) (librarypb.LibraryService_StreamShelvesClient, error) {
+func (c *Client) StreamShelves(ctx context.Context, req *librarypb.StreamShelvesRequest, opts ...gax.CallOption) (librarypb.LibraryService_StreamShelvesClient, error) {
     ctx = insertXGoog(ctx, c.xGoogHeader)
+    opts = append(c.CallOptions.StreamShelves[0:len(c.CallOptions.StreamShelves):len(c.CallOptions.StreamShelves)], opts...)
     var resp librarypb.LibraryService_StreamShelvesClient
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
         var err error
         resp, err = c.client.StreamShelves(ctx, req, settings.GRPC...)
         return err
-    }, c.CallOptions.StreamShelves...)
+    }, opts...)
     if err != nil {
         return nil, err
     }
@@ -556,14 +574,15 @@ func (c *Client) StreamShelves(ctx context.Context, req *librarypb.StreamShelves
 
 // StreamBooks test server streaming, non-paged responses.
 // gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
-func (c *Client) StreamBooks(ctx context.Context, req *librarypb.StreamBooksRequest) (librarypb.LibraryService_StreamBooksClient, error) {
+func (c *Client) StreamBooks(ctx context.Context, req *librarypb.StreamBooksRequest, opts ...gax.CallOption) (librarypb.LibraryService_StreamBooksClient, error) {
     ctx = insertXGoog(ctx, c.xGoogHeader)
+    opts = append(c.CallOptions.StreamBooks[0:len(c.CallOptions.StreamBooks):len(c.CallOptions.StreamBooks)], opts...)
     var resp librarypb.LibraryService_StreamBooksClient
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
         var err error
         resp, err = c.client.StreamBooks(ctx, req, settings.GRPC...)
         return err
-    }, c.CallOptions.StreamBooks...)
+    }, opts...)
     if err != nil {
         return nil, err
     }
@@ -572,14 +591,15 @@ func (c *Client) StreamBooks(ctx context.Context, req *librarypb.StreamBooksRequ
 
 // DiscussBook test bidi-streaming.
 // gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
-func (c *Client) DiscussBook(ctx context.Context) (librarypb.LibraryService_DiscussBookClient, error) {
+func (c *Client) DiscussBook(ctx context.Context, opts ...gax.CallOption) (librarypb.LibraryService_DiscussBookClient, error) {
     ctx = insertXGoog(ctx, c.xGoogHeader)
+    opts = append(c.CallOptions.DiscussBook[0:len(c.CallOptions.DiscussBook):len(c.CallOptions.DiscussBook)], opts...)
     var resp librarypb.LibraryService_DiscussBookClient
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
         var err error
         resp, err = c.client.DiscussBook(ctx, settings.GRPC...)
         return err
-    }, c.CallOptions.DiscussBook...)
+    }, opts...)
     if err != nil {
         return nil, err
     }
@@ -588,14 +608,15 @@ func (c *Client) DiscussBook(ctx context.Context) (librarypb.LibraryService_Disc
 
 // MonologAboutBook test client streaming.
 // gRPC streaming methods don't have an HTTP equivalent and don't need to have the google.api.http option.
-func (c *Client) MonologAboutBook(ctx context.Context) (librarypb.LibraryService_MonologAboutBookClient, error) {
+func (c *Client) MonologAboutBook(ctx context.Context, opts ...gax.CallOption) (librarypb.LibraryService_MonologAboutBookClient, error) {
     ctx = insertXGoog(ctx, c.xGoogHeader)
+    opts = append(c.CallOptions.MonologAboutBook[0:len(c.CallOptions.MonologAboutBook):len(c.CallOptions.MonologAboutBook)], opts...)
     var resp librarypb.LibraryService_MonologAboutBookClient
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
         var err error
         resp, err = c.client.MonologAboutBook(ctx, settings.GRPC...)
         return err
-    }, c.CallOptions.MonologAboutBook...)
+    }, opts...)
     if err != nil {
         return nil, err
     }
@@ -603,8 +624,9 @@ func (c *Client) MonologAboutBook(ctx context.Context) (librarypb.LibraryService
 }
 
 // FindRelatedBooks
-func (c *Client) FindRelatedBooks(ctx context.Context, req *librarypb.FindRelatedBooksRequest) *StringIterator {
+func (c *Client) FindRelatedBooks(ctx context.Context, req *librarypb.FindRelatedBooksRequest, opts ...gax.CallOption) *StringIterator {
     ctx = insertXGoog(ctx, c.xGoogHeader)
+    opts = append(c.CallOptions.FindRelatedBooks[0:len(c.CallOptions.FindRelatedBooks):len(c.CallOptions.FindRelatedBooks)], opts...)
     it := &StringIterator{}
     it.InternalFetch = func(pageSize int, pageToken string) ([]string, string, error) {
         var resp *librarypb.FindRelatedBooksResponse
@@ -618,7 +640,7 @@ func (c *Client) FindRelatedBooks(ctx context.Context, req *librarypb.FindRelate
             var err error
             resp, err = c.client.FindRelatedBooks(ctx, req, settings.GRPC...)
             return err
-        }, c.CallOptions.FindRelatedBooks...)
+        }, opts...)
         if err != nil {
             return nil, "", err
         }
@@ -637,14 +659,15 @@ func (c *Client) FindRelatedBooks(ctx context.Context, req *librarypb.FindRelate
 }
 
 // addLabel adds a label to the entity.
-func (c *Client) addLabel(ctx context.Context, req *taggerpb.AddLabelRequest) (*taggerpb.AddLabelResponse, error) {
+func (c *Client) addLabel(ctx context.Context, req *taggerpb.AddLabelRequest, opts ...gax.CallOption) (*taggerpb.AddLabelResponse, error) {
     ctx = insertXGoog(ctx, c.xGoogHeader)
+    opts = append(c.CallOptions.AddLabel[0:len(c.CallOptions.AddLabel):len(c.CallOptions.AddLabel)], opts...)
     var resp *taggerpb.AddLabelResponse
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
         var err error
         resp, err = c.labelerClient.AddLabel(ctx, req, settings.GRPC...)
         return err
-    }, c.CallOptions.AddLabel...)
+    }, opts...)
     if err != nil {
         return nil, err
     }
@@ -652,14 +675,15 @@ func (c *Client) addLabel(ctx context.Context, req *taggerpb.AddLabelRequest) (*
 }
 
 // GetBigBook test long-running operations
-func (c *Client) GetBigBook(ctx context.Context, req *librarypb.GetBookRequest) (*GetBigBookOperation, error) {
+func (c *Client) GetBigBook(ctx context.Context, req *librarypb.GetBookRequest, opts ...gax.CallOption) (*GetBigBookOperation, error) {
     ctx = insertXGoog(ctx, c.xGoogHeader)
+    opts = append(c.CallOptions.GetBigBook[0:len(c.CallOptions.GetBigBook):len(c.CallOptions.GetBigBook)], opts...)
     var resp *longrunningpb.Operation
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
         var err error
         resp, err = c.client.GetBigBook(ctx, req, settings.GRPC...)
         return err
-    }, c.CallOptions.GetBigBook...)
+    }, opts...)
     if err != nil {
         return nil, err
     }
@@ -670,14 +694,15 @@ func (c *Client) GetBigBook(ctx context.Context, req *librarypb.GetBookRequest) 
 }
 
 // GetBigNothing test long-running operations with empty return type.
-func (c *Client) GetBigNothing(ctx context.Context, req *librarypb.GetBookRequest) (*GetBigNothingOperation, error) {
+func (c *Client) GetBigNothing(ctx context.Context, req *librarypb.GetBookRequest, opts ...gax.CallOption) (*GetBigNothingOperation, error) {
     ctx = insertXGoog(ctx, c.xGoogHeader)
+    opts = append(c.CallOptions.GetBigNothing[0:len(c.CallOptions.GetBigNothing):len(c.CallOptions.GetBigNothing)], opts...)
     var resp *longrunningpb.Operation
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
         var err error
         resp, err = c.client.GetBigNothing(ctx, req, settings.GRPC...)
         return err
-    }, c.CallOptions.GetBigNothing...)
+    }, opts...)
     if err != nil {
         return nil, err
     }
@@ -688,14 +713,15 @@ func (c *Client) GetBigNothing(ctx context.Context, req *librarypb.GetBookReques
 }
 
 // TestOptionalRequiredFlatteningParams test optional flattening parameters of all types
-func (c *Client) TestOptionalRequiredFlatteningParams(ctx context.Context, req *librarypb.TestOptionalRequiredFlatteningParamsRequest) (*librarypb.TestOptionalRequiredFlatteningParamsResponse, error) {
+func (c *Client) TestOptionalRequiredFlatteningParams(ctx context.Context, req *librarypb.TestOptionalRequiredFlatteningParamsRequest, opts ...gax.CallOption) (*librarypb.TestOptionalRequiredFlatteningParamsResponse, error) {
     ctx = insertXGoog(ctx, c.xGoogHeader)
+    opts = append(c.CallOptions.TestOptionalRequiredFlatteningParams[0:len(c.CallOptions.TestOptionalRequiredFlatteningParams):len(c.CallOptions.TestOptionalRequiredFlatteningParams)], opts...)
     var resp *librarypb.TestOptionalRequiredFlatteningParamsResponse
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
         var err error
         resp, err = c.client.TestOptionalRequiredFlatteningParams(ctx, req, settings.GRPC...)
         return err
-    }, c.CallOptions.TestOptionalRequiredFlatteningParams...)
+    }, opts...)
     if err != nil {
         return nil, err
     }


### PR DESCRIPTION
Earlier PRs have added plumbing for options,
but did not provide a way for users to pass the options.

This commit fixes the problem.

Note that the append uses the three-argument slicing syntax,
to avoid overwriting parts of the original slice.