### PR TITLE
java metadata: add grpc dependency

### DIFF
--- a/src/main/resources/com/google/api/codegen/metadatagen/java/grpc/grpc_package.snip
+++ b/src/main/resources/com/google/api/codegen/metadatagen/java/grpc/grpc_package.snip
@@ -25,6 +25,8 @@
   dependencies {
     compile "com.google.protobuf:protobuf-java:{@metadata.protoVersionBound.lower}"
     compile "com.google.api:api-common:{@metadata.apiCommonVersionBound.lower}"
+    compile "io.grpc:grpc-stub:{@metadata.grpcVersionBound.lower}"
+    compile "io.grpc:grpc-protobuf:{@metadata.grpcVersionBound.lower}"
     @join dependency : metadata.protoPackageDependencies
       compile "com.google.api.grpc:{@dependency.name}:{@dependency.versionBound.lower}"
     @end

--- a/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/java_common_protos.baseline
+++ b/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/java_common_protos.baseline
@@ -228,6 +228,8 @@ repositories {
 dependencies {
   compile "com.google.protobuf:protobuf-java:3.0.0"
   compile "com.google.api:api-common:0.0.2"
+  compile "io.grpc:grpc-stub:1.0.1"
+  compile "io.grpc:grpc-protobuf:1.0.1"
 }
 
 ext {

--- a/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/java_library.baseline
@@ -228,6 +228,8 @@ repositories {
 dependencies {
   compile "com.google.protobuf:protobuf-java:3.0.0"
   compile "com.google.api:api-common:0.0.2"
+  compile "io.grpc:grpc-stub:1.0.1"
+  compile "io.grpc:grpc-protobuf:1.0.1"
   compile "com.google.api.grpc:grpc-google-common-protos:0.1.6"
   compile "com.google.api.grpc:grpc-google-some-other-package-v1:0.0.0"
 }


### PR DESCRIPTION
I believe these are required to build both common protos and grpc clients.