### PR TITLE
go: properly detect LRO methods

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformer.java
@@ -358,10 +358,11 @@ public class GoGapicSurfaceTransformer implements ModelToViewTransformer {
       if (method.getResponseStreaming()) {
         kinds.add(ImportKind.SERVER_STREAM);
       }
-      if (serviceMessages.isLongRunningOperationType(method.getOutputType())) {
+      MethodConfig methodConfig = serviceConfig.getMethodConfig(method);
+      if (methodConfig.isLongRunningOperation()) {
         kinds.add(ImportKind.LRO);
       }
-      if (serviceConfig.getMethodConfig(method).isPageStreaming()) {
+      if (methodConfig.isPageStreaming()) {
         kinds.add(ImportKind.PAGE_STREAM);
       }
     }

--- a/src/test/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformerTest.java
+++ b/src/test/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformerTest.java
@@ -90,7 +90,8 @@ public class GoGapicSurfaceTransformerTest {
     transformer.addXApiImports(context, Collections.singletonList(method));
     transformer.generateRetryConfigDefinitions(context, Collections.singletonList(method));
     Truth.assertThat(context.getTypeTable().getImports()).doesNotContainKey("time");
-    Truth.assertThat(context.getTypeTable().getImports()).doesNotContainKey("longrunning");
+    Truth.assertThat(context.getTypeTable().getImports())
+        .doesNotContainKey("cloud.google.com/go/longrunning");
   }
 
   @Test
@@ -99,7 +100,8 @@ public class GoGapicSurfaceTransformerTest {
     transformer.addXApiImports(context, Collections.singletonList(method));
     transformer.generateRetryConfigDefinitions(context, Collections.singletonList(method));
     Truth.assertThat(context.getTypeTable().getImports()).containsKey("time");
-    Truth.assertThat(context.getTypeTable().getImports()).doesNotContainKey("longrunning");
+    Truth.assertThat(context.getTypeTable().getImports())
+        .doesNotContainKey("cloud.google.com/go/longrunning");
   }
 
   @Test
@@ -108,7 +110,8 @@ public class GoGapicSurfaceTransformerTest {
     transformer.addXApiImports(context, Collections.singletonList(method));
     transformer.generateRetryConfigDefinitions(context, Collections.singletonList(method));
     Truth.assertThat(context.getTypeTable().getImports()).containsKey("math");
-    Truth.assertThat(context.getTypeTable().getImports()).doesNotContainKey("longrunning");
+    Truth.assertThat(context.getTypeTable().getImports())
+        .doesNotContainKey("cloud.google.com/go/longrunning");
   }
 
   @Test
@@ -119,6 +122,13 @@ public class GoGapicSurfaceTransformerTest {
     Truth.assertThat(context.getTypeTable().getImports()).doesNotContainKey("math");
     Truth.assertThat(context.getTypeTable().getImports())
         .containsKey("cloud.google.com/go/longrunning");
+  }
+
+  @Test
+  public void testGetImportsNotLro() {
+    Method method = getMethod(context.getInterface(), "NotLroMethod");
+    Truth.assertThat(context.getTypeTable().getImports())
+        .doesNotContainKey("cloud.google.com/go/longrunning");
   }
 
   @Test

--- a/src/test/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformerTest.java
+++ b/src/test/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformerTest.java
@@ -127,6 +127,7 @@ public class GoGapicSurfaceTransformerTest {
   @Test
   public void testGetImportsNotLro() {
     Method method = getMethod(context.getInterface(), "NotLroMethod");
+    transformer.addXApiImports(context, Collections.singletonList(method));
     Truth.assertThat(context.getTypeTable().getImports())
         .doesNotContainKey("cloud.google.com/go/longrunning");
   }

--- a/src/test/java/com/google/api/codegen/transformer/go/testdata/myproto.proto
+++ b/src/test/java/com/google/api/codegen/transformer/go/testdata/myproto.proto
@@ -9,7 +9,11 @@ option go_package = "google.golang.org/genproto/googleapis/example/myproto/v1;my
 
 service Gopher {
   rpc SimpleMethod(SimpleRequest) returns (SimpleResponse);
+
   rpc LroMethod(SimpleRequest) returns (google.longrunning.Operation);
+  // Returns Operation, but doens't have long_running config in gapic.yaml
+  rpc NotLroMethod(SimpleRequest) returns (google.longrunning.Operation);
+
   rpc RetryMethod(SimpleRequest) returns (SimpleResponse);
   rpc PageStreamMethod(PageStreamRequest) returns (PageStreamResponse);
 

--- a/src/test/java/com/google/api/codegen/transformer/go/testdata/myproto.proto
+++ b/src/test/java/com/google/api/codegen/transformer/go/testdata/myproto.proto
@@ -11,7 +11,7 @@ service Gopher {
   rpc SimpleMethod(SimpleRequest) returns (SimpleResponse);
 
   rpc LroMethod(SimpleRequest) returns (google.longrunning.Operation);
-  // Returns Operation, but doens't have long_running config in gapic.yaml
+  // Returns Operation, but doesn't have long_running config in gapic.yaml
   rpc NotLroMethod(SimpleRequest) returns (google.longrunning.Operation);
 
   rpc RetryMethod(SimpleRequest) returns (SimpleResponse);

--- a/src/test/java/com/google/api/codegen/transformer/go/testdata/myproto_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/transformer/go/testdata/myproto_gapic.yaml
@@ -41,6 +41,14 @@ interfaces:
     retry_params_name: default
     timeout_millis: 1000
     request_object_method: false
+    long_running:
+      return_type: google.example.myproto.v1.SimpleResponse
+      metadata_type: google.example.myproto.v1.SimpleResponse
+  - name: NotLroMethod
+    retry_codes_name: non_idempotent
+    retry_params_name: default
+    timeout_millis: 1000
+    request_object_method: false
   - name: RetryMethod
     flattening:
       groups:


### PR DESCRIPTION
Methods that return Operation but has no LRO config
should not be treated as LRO by the importer.
This PR makes it possible to generate longrunning gapic client.