### PR TITLE
Fix multi-segment default strings

### DIFF
--- a/src/main/java/com/google/api/codegen/discovery/DefaultString.java
+++ b/src/main/java/com/google/api/codegen/discovery/DefaultString.java
@@ -75,7 +75,8 @@ public class DefaultString {
     return "";
   }
 
-  private static final Set<String> WILDCARD_PATTERNS = ImmutableSet.of("[^/]+", ".+", ".*");
+  private static final Set<String> WILDCARD_PATTERNS =
+      ImmutableSet.of("[^/]+", "[^/]*", ".+", ".*");
 
   /** Returns a default string from `pattern`, or null if the pattern is not supported. */
   @VisibleForTesting

--- a/src/test/java/com/google/api/codegen/discovery/DefaultStringTest.java
+++ b/src/test/java/com/google/api/codegen/discovery/DefaultStringTest.java
@@ -26,7 +26,7 @@ public class DefaultStringTest {
         DefaultString.getNonTrivialPlaceholder("[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?", "my-%s");
     Truth.assertThat(def).isEqualTo("");
 
-    def = DefaultString.getNonTrivialPlaceholder("^projects/[^/]*$", "my-%s");
+    def = DefaultString.getNonTrivialPlaceholder("^projects/[^/]+$", "my-%s");
     Truth.assertThat(def).isEqualTo("projects/my-project");
 
     def = DefaultString.getNonTrivialPlaceholder("bar", "my-%s");
@@ -53,10 +53,10 @@ public class DefaultStringTest {
   public void testDefault() {
     ImmutableMap<String, String> tests =
         ImmutableMap.<String, String>builder()
-            .put("^billingAccounts/[^/]*$", "billingAccounts/my-billing-account")
-            .put("^projects/[^/]*/topics/[^/]*$", "projects/my-project/topics/my-topic")
+            .put("^billingAccounts/[^/]+$", "billingAccounts/my-billing-account")
+            .put("^projects/[^/]+/topics/[^/]+$", "projects/my-project/topics/my-topic")
             .put(
-                "^projects/[^/]*/regions/[^/]*/operations/[^/]*$",
+                "^projects/[^/]+/regions/.*/operations/.+$",
                 "projects/my-project/regions/my-region/operations/my-operation")
             .build();
 

--- a/src/test/java/com/google/api/codegen/discovery/DefaultStringTest.java
+++ b/src/test/java/com/google/api/codegen/discovery/DefaultStringTest.java
@@ -24,19 +24,13 @@ public class DefaultStringTest {
   public void testOf() {
     String def =
         DefaultString.getNonTrivialPlaceholder("[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?", "my-%s");
-    String sample = DefaultString.getSample("compute", "zone", "[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?");
     Truth.assertThat(def).isEqualTo("");
-    Truth.assertThat(sample).isEqualTo("us-central1-f");
 
     def = DefaultString.getNonTrivialPlaceholder("^projects/[^/]*$", "my-%s");
-    sample = DefaultString.getSample("pubsub", "project", "^projects/[^/]*$");
     Truth.assertThat(def).isEqualTo("projects/my-project");
-    Truth.assertThat(sample).isEqualTo("");
 
     def = DefaultString.getNonTrivialPlaceholder("bar", "my-%s");
-    sample = DefaultString.getSample("foo", "bar", null);
     Truth.assertThat(def).isEqualTo("");
-    Truth.assertThat(sample).isEqualTo("");
   }
 
   @Test

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/cloudbilling.v1.json
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/cloudbilling.v1.json
@@ -1,343 +1,357 @@
 {
- "kind": "discovery#restDescription",
- "etag": "\"tbys6C40o18GZwyMen5GMkdK-3s/M2VzqGfwqR0FviWkPggfCzE5zZU\"",
- "discoveryVersion": "v1",
- "id": "cloudbilling:v1",
- "name": "cloudbilling",
- "version": "v1",
- "revision": "20151222",
- "title": "Google Cloud Billing API",
- "description": "Retrieves Google Developers Console billing accounts and associates them with projects.",
- "ownerDomain": "google.com",
- "ownerName": "Google",
- "icons": {
-  "x16": "http://www.google.com/images/icons/product/search-16.gif",
-  "x32": "http://www.google.com/images/icons/product/search-32.gif"
- },
- "documentationLink": "https://cloud.google.com/billing/",
- "protocol": "rest",
- "baseUrl": "https://cloudbilling.googleapis.com/",
- "basePath": "",
- "rootUrl": "https://cloudbilling.googleapis.com/",
- "servicePath": "",
- "batchPath": "batch",
- "parameters": {
-  "access_token": {
-   "type": "string",
-   "description": "OAuth access token.",
-   "location": "query"
-  },
-  "alt": {
-   "type": "string",
-   "description": "Data format for response.",
-   "default": "json",
-   "enumDescriptions": [
-    "Responses with Content-Type of application/json",
-    "Media download with context-dependent Content-Type",
-    "Responses with Content-Type of application/x-protobuf"
-   ],
-   "location": "query"
-  },
-  "bearer_token": {
-   "type": "string",
-   "description": "OAuth bearer token.",
-   "location": "query"
-  },
-  "callback": {
-   "type": "string",
-   "description": "JSONP",
-   "location": "query"
-  },
-  "fields": {
-   "type": "string",
-   "description": "Selector specifying which fields to include in a partial response.",
-   "location": "query"
-  },
-  "key": {
-   "type": "string",
-   "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.",
-   "location": "query"
-  },
-  "oauth_token": {
-   "type": "string",
-   "description": "OAuth 2.0 token for the current user.",
-   "location": "query"
-  },
-  "pp": {
-   "type": "boolean",
-   "description": "Pretty-print response.",
-   "default": "true",
-   "location": "query"
-  },
-  "prettyPrint": {
-   "type": "boolean",
-   "description": "Returns response with indentations and line breaks.",
-   "default": "true",
-   "location": "query"
-  },
-  "quotaUser": {
-   "type": "string",
-   "description": "Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.",
-   "location": "query"
-  },
-  "upload_protocol": {
-   "type": "string",
-   "description": "Upload protocol for media (e.g. \"raw\", \"multipart\").",
-   "location": "query"
-  },
-  "uploadType": {
-   "type": "string",
-   "description": "Legacy upload protocol for media (e.g. \"media\", \"multipart\").",
-   "location": "query"
-  },
-  "$.xgafv": {
-   "type": "string",
-   "description": "V1 error format.",
-   "enumDescriptions": [
-    "v1 error format",
-    "v2 error format"
-   ],
-   "location": "query"
-  }
- },
- "auth": {
-  "oauth2": {
-   "scopes": {
-    "https://www.googleapis.com/auth/cloud-platform": {
-     "description": "View and manage your data across Google Cloud Platform services"
-    }
-   }
-  }
- },
- "schemas": {
-  "BillingAccount": {
-   "id": "BillingAccount",
-   "type": "object",
-   "description": "A billing account in [Google Developers Console](https://console.developers.google.com/). You can assign a billing account to one or more projects.",
-   "properties": {
-    "name": {
-     "type": "string",
-     "description": "The resource name of the billing account. The resource name has the form `billingAccounts/{billing_account_id}`. For example, `billingAccounts/012345-567890-ABCDEF` would be the resource name for billing account `012345-567890-ABCDEF`."
-    },
-    "open": {
-     "type": "boolean",
-     "description": "True if the billing account is open, and will therefore be charged for any usage on associated projects. False if the billing account is closed, and therefore projects associated with it will be unable to use paid services."
-    },
-    "displayName": {
-     "type": "string",
-     "description": "The display name given to the billing account, such as `My Billing Account`. This name is displayed in the Google Developers Console."
-    }
-   }
-  },
-  "ListBillingAccountsResponse": {
-   "id": "ListBillingAccountsResponse",
-   "type": "object",
-   "description": "Response message for `ListBillingAccounts`.",
-   "properties": {
-    "billingAccounts": {
-     "type": "array",
-     "description": "A list of billing accounts.",
-     "items": {
-      "$ref": "BillingAccount"
-     }
-    },
-    "nextPageToken": {
-     "type": "string",
-     "description": "A token to retrieve the next page of results. To retrieve the next page, call `ListBillingAccounts` again with the `page_token` field set to this value. This field is empty if there are no more results to retrieve."
-    }
-   }
-  },
-  "ListProjectBillingInfoResponse": {
-   "id": "ListProjectBillingInfoResponse",
-   "type": "object",
-   "description": "Request message for `ListProjectBillingInfoResponse`.",
-   "properties": {
-    "projectBillingInfo": {
-     "type": "array",
-     "description": "A list of `ProjectBillingInfo` resources representing the projects associated with the billing account.",
-     "items": {
-      "$ref": "ProjectBillingInfo"
-     }
-    },
-    "nextPageToken": {
-     "type": "string",
-     "description": "A token to retrieve the next page of results. To retrieve the next page, call `ListProjectBillingInfo` again with the `page_token` field set to this value. This field is empty if there are no more results to retrieve."
-    }
-   }
-  },
-  "ProjectBillingInfo": {
-   "id": "ProjectBillingInfo",
-   "type": "object",
-   "description": "Encapsulation of billing information for a Developers Console project. A project has at most one associated billing account at a time (but a billing account can be assigned to multiple projects).",
-   "properties": {
-    "name": {
-     "type": "string",
-     "description": "The resource name for the `ProjectBillingInfo`; has the form `projects/{project_id}/billingInfo`. For example, the resource name for the billing information for project `tokyo-rain-123` would be `projects/tokyo-rain-123/billingInfo`. This field is read-only."
-    },
-    "projectId": {
-     "type": "string",
-     "description": "The ID of the project that this `ProjectBillingInfo` represents, such as `tokyo-rain-123`. This is a convenience field so that you don't need to parse the `name` field to obtain a project ID. This field is read-only."
-    },
-    "billingAccountName": {
-     "type": "string",
-     "description": "The resource name of the billing account associated with the project, if any. For example, `billingAccounts/012345-567890-ABCDEF`."
-    },
-    "billingEnabled": {
-     "type": "boolean",
-     "description": "True if the project is associated with an open billing account, to which usage on the project is charged. False if the project is associated with a closed billing account, or no billing account at all, and therefore cannot use paid services. This field is read-only."
-    }
-   }
-  }
- },
- "resources": {
-  "billingAccounts": {
-   "methods": {
-    "get": {
-     "id": "cloudbilling.billingAccounts.get",
-     "path": "v1/{+name}",
-     "httpMethod": "GET",
-     "description": "Gets information about a billing account. The current authenticated user must be an [owner of the billing account](https://support.google.com/cloud/answer/4430947).",
-     "parameters": {
-      "name": {
-       "type": "string",
-       "description": "The resource name of the billing account to retrieve. For example, `billingAccounts/012345-567890-ABCDEF`.",
-       "required": true,
-       "pattern": "^billingAccounts/[^/]*$",
-       "location": "path"
-      }
-     },
-     "parameterOrder": [
-      "name"
-     ],
-     "response": {
-      "$ref": "BillingAccount"
-     },
-     "scopes": [
-      "https://www.googleapis.com/auth/cloud-platform"
-     ]
-    },
-    "list": {
-     "id": "cloudbilling.billingAccounts.list",
-     "path": "v1/billingAccounts",
-     "httpMethod": "GET",
-     "description": "Lists the billing accounts that the current authenticated user [owns](https://support.google.com/cloud/answer/4430947).",
-     "parameters": {
-      "pageSize": {
-       "type": "integer",
-       "description": "Requested page size. The maximum page size is 100; this is also the default.",
-       "format": "int32",
-       "location": "query"
-      },
-      "pageToken": {
-       "type": "string",
-       "description": "A token identifying a page of results to return. This should be a `next_page_token` value returned from a previous `ListBillingAccounts` call. If unspecified, the first page of results is returned.",
-       "location": "query"
-      }
-     },
-     "response": {
-      "$ref": "ListBillingAccountsResponse"
-     },
-     "scopes": [
-      "https://www.googleapis.com/auth/cloud-platform"
-     ]
-    }
-   },
-   "resources": {
-    "projects": {
-     "methods": {
-      "list": {
-       "id": "cloudbilling.billingAccounts.projects.list",
-       "path": "v1/{+name}/projects",
-       "httpMethod": "GET",
-       "description": "Lists the projects associated with a billing account. The current authenticated user must be an [owner of the billing account](https://support.google.com/cloud/answer/4430947).",
-       "parameters": {
-        "name": {
-         "type": "string",
-         "description": "The resource name of the billing account associated with the projects that you want to list. For example, `billingAccounts/012345-567890-ABCDEF`.",
-         "required": true,
-         "pattern": "^billingAccounts/[^/]*$",
-         "location": "path"
-        },
-        "pageSize": {
-         "type": "integer",
-         "description": "Requested page size. The maximum page size is 100; this is also the default.",
-         "format": "int32",
-         "location": "query"
-        },
-        "pageToken": {
-         "type": "string",
-         "description": "A token identifying a page of results to be returned. This should be a `next_page_token` value returned from a previous `ListProjectBillingInfo` call. If unspecified, the first page of results is returned.",
-         "location": "query"
+  "id": "cloudbilling:v1",
+  "auth": {
+    "oauth2": {
+      "scopes": {
+        "https://www.googleapis.com/auth/cloud-platform": {
+          "description": "View and manage your data across Google Cloud Platform services"
         }
-       },
-       "parameterOrder": [
-        "name"
-       ],
-       "response": {
-        "$ref": "ListProjectBillingInfoResponse"
-       },
-       "scopes": [
-        "https://www.googleapis.com/auth/cloud-platform"
-       ]
       }
-     }
     }
-   }
   },
-  "projects": {
-   "methods": {
-    "getBillingInfo": {
-     "id": "cloudbilling.projects.getBillingInfo",
-     "path": "v1/{+name}/billingInfo",
-     "httpMethod": "GET",
-     "description": "Gets the billing information for a project. The current authenticated user must have [permission to view the project](https://cloud.google.com/docs/permissions-overview#h.bgs0oxofvnoo ).",
-     "parameters": {
-      "name": {
-       "type": "string",
-       "description": "The resource name of the project for which billing information is retrieved. For example, `projects/tokyo-rain-123`.",
-       "required": true,
-       "pattern": "^projects/[^/]*$",
-       "location": "path"
+  "description": "Allows developers to manage billing for their Google Cloud Platform projects\n    programmatically.",
+  "protocol": "rest",
+  "title": "Google Cloud Billing API",
+  "resources": {
+    "projects": {
+      "methods": {
+        "updateBillingInfo": {
+          "id": "cloudbilling.projects.updateBillingInfo",
+          "response": {
+            "$ref": "ProjectBillingInfo"
+          },
+          "parameterOrder": [
+            "name"
+          ],
+          "description": "Sets or updates the billing account associated with a project. You specify\nthe new billing account by setting the `billing_account_name` in the\n`ProjectBillingInfo` resource to the resource name of a billing account.\nAssociating a project with an open billing account enables billing on the\nproject and allows charges for resource usage. If the project already had a\nbilling account, this method changes the billing account used for resource\nusage charges.\n\n*Note:* Incurred charges that have not yet been reported in the transaction\nhistory of the Google Cloud Console may be billed to the new billing\naccount, even if the charge occurred before the new billing account was\nassigned to the project.\n\nThe current authenticated user must have ownership privileges for both the\n[project](https://cloud.google.com/docs/permissions-overview#h.bgs0oxofvnoo\n) and the [billing\naccount](https://support.google.com/cloud/answer/4430947).\n\nYou can disable billing on the project by setting the\n`billing_account_name` field to empty. This action disassociates the\ncurrent billing account from the project. Any billable activity of your\nin-use services will stop, and your application could stop functioning as\nexpected. Any unbilled charges to date will be billed to the previously\nassociated account. The current authenticated user must be either an owner\nof the project or an owner of the billing account for the project.\n\nNote that associating a project with a *closed* billing account will have\nmuch the same effect as disabling billing on the project: any paid\nresources used by the project will be shut down. Thus, unless you wish to\ndisable billing, you should always call this method with the name of an\n*open* billing account.",
+          "request": {
+            "$ref": "ProjectBillingInfo"
+          },
+          "flatPath": "v1/projects/{projectsId}/billingInfo",
+          "httpMethod": "PUT",
+          "parameters": {
+            "name": {
+              "description": "The resource name of the project associated with the billing information\nthat you want to update. For example, `projects/tokyo-rain-123`.",
+              "required": true,
+              "pattern": "^projects/[^/]+$",
+              "location": "path",
+              "type": "string"
+            }
+          },
+          "path": "v1/{+name}/billingInfo",
+          "scopes": [
+            "https://www.googleapis.com/auth/cloud-platform"
+          ]
+        },
+        "getBillingInfo": {
+          "id": "cloudbilling.projects.getBillingInfo",
+          "response": {
+            "$ref": "ProjectBillingInfo"
+          },
+          "parameterOrder": [
+            "name"
+          ],
+          "description": "Gets the billing information for a project. The current authenticated user\nmust have [permission to view the\nproject](https://cloud.google.com/docs/permissions-overview#h.bgs0oxofvnoo\n).",
+          "flatPath": "v1/projects/{projectsId}/billingInfo",
+          "httpMethod": "GET",
+          "parameters": {
+            "name": {
+              "description": "The resource name of the project for which billing information is\nretrieved. For example, `projects/tokyo-rain-123`.",
+              "required": true,
+              "pattern": "^projects/[^/]+$",
+              "location": "path",
+              "type": "string"
+            }
+          },
+          "path": "v1/{+name}/billingInfo",
+          "scopes": [
+            "https://www.googleapis.com/auth/cloud-platform"
+          ]
+        }
       }
-     },
-     "parameterOrder": [
-      "name"
-     ],
-     "response": {
-      "$ref": "ProjectBillingInfo"
-     },
-     "scopes": [
-      "https://www.googleapis.com/auth/cloud-platform"
-     ]
     },
-    "updateBillingInfo": {
-     "id": "cloudbilling.projects.updateBillingInfo",
-     "path": "v1/{+name}/billingInfo",
-     "httpMethod": "PUT",
-     "description": "Sets or updates the billing account associated with a project. You specify the new billing account by setting the `billing_account_name` in the `ProjectBillingInfo` resource to the resource name of a billing account. Associating a project with an open billing account enables billing on the project and allows charges for resource usage. If the project already had a billing account, this method changes the billing account used for resource usage charges. *Note:* Incurred charges that have not yet been reported in the transaction history of the Google Developers Console may be billed to the new billing account, even if the charge occurred before the new billing account was assigned to the project. The current authenticated user must have ownership privileges for both the [project](https://cloud.google.com/docs/permissions-overview#h.bgs0oxofvnoo ) and the [billing account](https://support.google.com/cloud/answer/4430947). You can disable billing on the project by setting the `billing_account_name` field to empty. This action disassociates the current billing account from the project. Any billable activity of your in-use services will stop, and your application could stop functioning as expected. Any unbilled charges to date will be billed to the previously associated account. The current authenticated user must be either an owner of the project or an owner of the billing account for the project. Note that associating a project with a *closed* billing account will have much the same effect as disabling billing on the project: any paid resources used by the project will be shut down. Thus, unless you wish to disable billing, you should always call this method with the name of an *open* billing account.",
-     "parameters": {
-      "name": {
-       "type": "string",
-       "description": "The resource name of the project associated with the billing information that you want to update. For example, `projects/tokyo-rain-123`.",
-       "required": true,
-       "pattern": "^projects/[^/]*$",
-       "location": "path"
+    "billingAccounts": {
+      "resources": {
+        "projects": {
+          "methods": {
+            "list": {
+              "id": "cloudbilling.billingAccounts.projects.list",
+              "response": {
+                "$ref": "ListProjectBillingInfoResponse"
+              },
+              "parameterOrder": [
+                "name"
+              ],
+              "description": "Lists the projects associated with a billing account. The current\nauthenticated user must be an [owner of the billing\naccount](https://support.google.com/cloud/answer/4430947).",
+              "flatPath": "v1/billingAccounts/{billingAccountsId}/projects",
+              "httpMethod": "GET",
+              "parameters": {
+                "pageSize": {
+                  "description": "Requested page size. The maximum page size is 100; this is also the\ndefault.",
+                  "location": "query",
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "name": {
+                  "description": "The resource name of the billing account associated with the projects that\nyou want to list. For example, `billingAccounts/012345-567890-ABCDEF`.",
+                  "required": true,
+                  "pattern": "^billingAccounts/[^/]+$",
+                  "location": "path",
+                  "type": "string"
+                },
+                "pageToken": {
+                  "description": "A token identifying a page of results to be returned. This should be a\n`next_page_token` value returned from a previous `ListProjectBillingInfo`\ncall. If unspecified, the first page of results is returned.",
+                  "location": "query",
+                  "type": "string"
+                }
+              },
+              "path": "v1/{+name}/projects",
+              "scopes": [
+                "https://www.googleapis.com/auth/cloud-platform"
+              ]
+            }
+          }
+        }
+      },
+      "methods": {
+        "get": {
+          "id": "cloudbilling.billingAccounts.get",
+          "response": {
+            "$ref": "BillingAccount"
+          },
+          "parameterOrder": [
+            "name"
+          ],
+          "description": "Gets information about a billing account. The current authenticated user\nmust be an [owner of the billing\naccount](https://support.google.com/cloud/answer/4430947).",
+          "flatPath": "v1/billingAccounts/{billingAccountsId}",
+          "httpMethod": "GET",
+          "parameters": {
+            "name": {
+              "description": "The resource name of the billing account to retrieve. For example,\n`billingAccounts/012345-567890-ABCDEF`.",
+              "required": true,
+              "pattern": "^billingAccounts/[^/]+$",
+              "location": "path",
+              "type": "string"
+            }
+          },
+          "path": "v1/{+name}",
+          "scopes": [
+            "https://www.googleapis.com/auth/cloud-platform"
+          ]
+        },
+        "list": {
+          "id": "cloudbilling.billingAccounts.list",
+          "response": {
+            "$ref": "ListBillingAccountsResponse"
+          },
+          "parameterOrder": [],
+          "description": "Lists the billing accounts that the current authenticated user\n[owns](https://support.google.com/cloud/answer/4430947).",
+          "flatPath": "v1/billingAccounts",
+          "httpMethod": "GET",
+          "parameters": {
+            "pageSize": {
+              "description": "Requested page size. The maximum page size is 100; this is also the\ndefault.",
+              "location": "query",
+              "type": "integer",
+              "format": "int32"
+            },
+            "pageToken": {
+              "description": "A token identifying a page of results to return. This should be a\n`next_page_token` value returned from a previous `ListBillingAccounts`\ncall. If unspecified, the first page of results is returned.",
+              "location": "query",
+              "type": "string"
+            }
+          },
+          "path": "v1/billingAccounts",
+          "scopes": [
+            "https://www.googleapis.com/auth/cloud-platform"
+          ]
+        }
       }
-     },
-     "parameterOrder": [
-      "name"
-     ],
-     "request": {
-      "$ref": "ProjectBillingInfo"
-     },
-     "response": {
-      "$ref": "ProjectBillingInfo"
-     },
-     "scopes": [
-      "https://www.googleapis.com/auth/cloud-platform"
-     ]
     }
-   }
-  }
- }
+  },
+  "schemas": {
+    "ProjectBillingInfo": {
+      "description": "Encapsulation of billing information for a Cloud Console project. A project\nhas at most one associated billing account at a time (but a billing account\ncan be assigned to multiple projects).",
+      "type": "object",
+      "properties": {
+        "billingEnabled": {
+          "description": "True if the project is associated with an open billing account, to which\nusage on the project is charged. False if the project is associated with a\nclosed billing account, or no billing account at all, and therefore cannot\nuse paid services. This field is read-only.",
+          "type": "boolean"
+        },
+        "name": {
+          "description": "The resource name for the `ProjectBillingInfo`; has the form\n`projects/{project_id}/billingInfo`. For example, the resource name for the\nbilling information for project `tokyo-rain-123` would be\n`projects/tokyo-rain-123/billingInfo`. This field is read-only.",
+          "type": "string"
+        },
+        "projectId": {
+          "description": "The ID of the project that this `ProjectBillingInfo` represents, such as\n`tokyo-rain-123`. This is a convenience field so that you don't need to\nparse the `name` field to obtain a project ID. This field is read-only.",
+          "type": "string"
+        },
+        "billingAccountName": {
+          "description": "The resource name of the billing account associated with the project, if\nany. For example, `billingAccounts/012345-567890-ABCDEF`.",
+          "type": "string"
+        }
+      },
+      "id": "ProjectBillingInfo"
+    },
+    "ListProjectBillingInfoResponse": {
+      "description": "Request message for `ListProjectBillingInfoResponse`.",
+      "type": "object",
+      "properties": {
+        "nextPageToken": {
+          "description": "A token to retrieve the next page of results. To retrieve the next page,\ncall `ListProjectBillingInfo` again with the `page_token` field set to this\nvalue. This field is empty if there are no more results to retrieve.",
+          "type": "string"
+        },
+        "projectBillingInfo": {
+          "description": "A list of `ProjectBillingInfo` resources representing the projects\nassociated with the billing account.",
+          "type": "array",
+          "items": {
+            "$ref": "ProjectBillingInfo"
+          }
+        }
+      },
+      "id": "ListProjectBillingInfoResponse"
+    },
+    "ListBillingAccountsResponse": {
+      "description": "Response message for `ListBillingAccounts`.",
+      "type": "object",
+      "properties": {
+        "nextPageToken": {
+          "description": "A token to retrieve the next page of results. To retrieve the next page,\ncall `ListBillingAccounts` again with the `page_token` field set to this\nvalue. This field is empty if there are no more results to retrieve.",
+          "type": "string"
+        },
+        "billingAccounts": {
+          "description": "A list of billing accounts.",
+          "type": "array",
+          "items": {
+            "$ref": "BillingAccount"
+          }
+        }
+      },
+      "id": "ListBillingAccountsResponse"
+    },
+    "BillingAccount": {
+      "description": "A billing account in [Google Cloud\nConsole](https://console.cloud.google.com/). You can assign a billing account\nto one or more projects.",
+      "type": "object",
+      "properties": {
+        "displayName": {
+          "description": "The display name given to the billing account, such as `My Billing\nAccount`. This name is displayed in the Google Cloud Console.",
+          "type": "string"
+        },
+        "open": {
+          "description": "True if the billing account is open, and will therefore be charged for any\nusage on associated projects. False if the billing account is closed, and\ntherefore projects associated with it will be unable to use paid services.",
+          "type": "boolean"
+        },
+        "name": {
+          "description": "The resource name of the billing account. The resource name has the form\n`billingAccounts/{billing_account_id}`. For example,\n`billingAccounts/012345-567890-ABCDEF` would be the resource name for\nbilling account `012345-567890-ABCDEF`.",
+          "type": "string"
+        }
+      },
+      "id": "BillingAccount"
+    }
+  },
+  "revision": "20170210",
+  "basePath": "",
+  "icons": {
+    "x32": "http://www.google.com/images/icons/product/search-32.gif",
+    "x16": "http://www.google.com/images/icons/product/search-16.gif"
+  },
+  "discoveryVersion": "v1",
+  "baseUrl": "https://cloudbilling.googleapis.com/",
+  "name": "cloudbilling",
+  "parameters": {
+    "access_token": {
+      "description": "OAuth access token.",
+      "type": "string",
+      "location": "query"
+    },
+    "prettyPrint": {
+      "description": "Returns response with indentations and line breaks.",
+      "default": "true",
+      "type": "boolean",
+      "location": "query"
+    },
+    "key": {
+      "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.",
+      "type": "string",
+      "location": "query"
+    },
+    "quotaUser": {
+      "description": "Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.",
+      "type": "string",
+      "location": "query"
+    },
+    "pp": {
+      "description": "Pretty-print response.",
+      "default": "true",
+      "type": "boolean",
+      "location": "query"
+    },
+    "fields": {
+      "description": "Selector specifying which fields to include in a partial response.",
+      "type": "string",
+      "location": "query"
+    },
+    "alt": {
+      "description": "Data format for response.",
+      "location": "query",
+      "enum": [
+        "json",
+        "media",
+        "proto"
+      ],
+      "default": "json",
+      "enumDescriptions": [
+        "Responses with Content-Type of application/json",
+        "Media download with context-dependent Content-Type",
+        "Responses with Content-Type of application/x-protobuf"
+      ],
+      "type": "string"
+    },
+    "$.xgafv": {
+      "description": "V1 error format.",
+      "enum": [
+        "1",
+        "2"
+      ],
+      "enumDescriptions": [
+        "v1 error format",
+        "v2 error format"
+      ],
+      "type": "string",
+      "location": "query"
+    },
+    "callback": {
+      "description": "JSONP",
+      "type": "string",
+      "location": "query"
+    },
+    "oauth_token": {
+      "description": "OAuth 2.0 token for the current user.",
+      "type": "string",
+      "location": "query"
+    },
+    "uploadType": {
+      "description": "Legacy upload protocol for media (e.g. \"media\", \"multipart\").",
+      "type": "string",
+      "location": "query"
+    },
+    "bearer_token": {
+      "description": "OAuth bearer token.",
+      "type": "string",
+      "location": "query"
+    },
+    "upload_protocol": {
+      "description": "Upload protocol for media (e.g. \"raw\", \"multipart\").",
+      "type": "string",
+      "location": "query"
+    }
+  },
+  "documentationLink": "https://cloud.google.com/billing/",
+  "ownerDomain": "google.com",
+  "batchPath": "batch",
+  "servicePath": "",
+  "ownerName": "Google",
+  "version": "v1",
+  "rootUrl": "https://cloudbilling.googleapis.com/",
+  "kind": "discovery#restDescription"
 }

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_cloudbilling.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_cloudbilling.v1.json.baseline
@@ -165,8 +165,8 @@ namespace CloudbillingSample
                 ApplicationName = "Google-CloudbillingSample/0.1",
             });
 
-            // The resource name of the billing account associated with the projects that you want to list. For
-            // example, `billingAccounts/012345-567890-ABCDEF`.
+            // The resource name of the billing account associated with the projects that
+            // you want to list. For example, `billingAccounts/012345-567890-ABCDEF`.
             string name = "billingAccounts/my-billing-account";  // TODO: Update placeholder value.
 
             BillingAccountsResource.ProjectsResource.ListRequest request = cloudbillingService.BillingAccounts.Projects.List(name);
@@ -238,8 +238,8 @@ namespace CloudbillingSample
                 ApplicationName = "Google-CloudbillingSample/0.1",
             });
 
-            // The resource name of the project for which billing information is retrieved. For example,
-            // `projects/tokyo-rain-123`.
+            // The resource name of the project for which billing information is
+            // retrieved. For example, `projects/tokyo-rain-123`.
             string name = "projects/my-project";  // TODO: Update placeholder value.
 
             ProjectsResource.GetBillingInfoRequest request = cloudbillingService.Projects.GetBillingInfo(name);
@@ -299,8 +299,8 @@ namespace CloudbillingSample
                 ApplicationName = "Google-CloudbillingSample/0.1",
             });
 
-            // The resource name of the project associated with the billing information that you want to update.
-            // For example, `projects/tokyo-rain-123`.
+            // The resource name of the project associated with the billing information
+            // that you want to update. For example, `projects/tokyo-rain-123`.
             string name = "projects/my-project";  // TODO: Update placeholder value.
 
             // TODO: Assign values to desired properties of `requestBody`. All existing

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_cloudresourcemanager.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_cloudresourcemanager.v1.json.baseline
@@ -36,7 +36,7 @@ namespace CloudResourceManagerSample
             });
 
             // The name of the operation resource.
-            string name = "my-name";  // TODO: Update placeholder value.
+            string name = "operations/my-operation";  // TODO: Update placeholder value.
 
             OperationsResource.GetRequest request = cloudResourceManagerService.Operations.Get(name);
 
@@ -96,7 +96,7 @@ namespace CloudResourceManagerSample
             });
 
             // The resource name of the Organization to fetch, e.g. "organizations/1234".
-            string name = "my-name";  // TODO: Update placeholder value.
+            string name = "organizations/my-organization";  // TODO: Update placeholder value.
 
             OrganizationsResource.GetRequest request = cloudResourceManagerService.Organizations.Get(name);
 
@@ -158,7 +158,7 @@ namespace CloudResourceManagerSample
             // REQUIRED: The resource for which the policy is being requested.
             // `resource` is usually specified as a path. For example, a Project
             // resource is specified as `projects/{project}`.
-            string resource = "my-resource";  // TODO: Update placeholder value.
+            string resource = "organizations/my-organization";  // TODO: Update placeholder value.
 
             // TODO: Assign values to desired properties of `requestBody`:
             Data.GetIamPolicyRequest requestBody = new Data.GetIamPolicyRequest();
@@ -295,7 +295,7 @@ namespace CloudResourceManagerSample
             // REQUIRED: The resource for which the policy is being specified.
             // `resource` is usually specified as a path. For example, a Project
             // resource is specified as `projects/{project}`.
-            string resource = "my-resource";  // TODO: Update placeholder value.
+            string resource = "organizations/my-organization";  // TODO: Update placeholder value.
 
             // TODO: Assign values to desired properties of `requestBody`:
             Data.SetIamPolicyRequest requestBody = new Data.SetIamPolicyRequest();
@@ -360,7 +360,7 @@ namespace CloudResourceManagerSample
             // REQUIRED: The resource for which the policy detail is being requested.
             // `resource` is usually specified as a path. For example, a Project
             // resource is specified as `projects/{project}`.
-            string resource = "my-resource";  // TODO: Update placeholder value.
+            string resource = "organizations/my-organization";  // TODO: Update placeholder value.
 
             // TODO: Assign values to desired properties of `requestBody`:
             Data.TestIamPermissionsRequest requestBody = new Data.TestIamPermissionsRequest();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_genomics.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_genomics.v1.json.baseline
@@ -1200,7 +1200,7 @@ namespace GenomicsSample
             });
 
             // REQUIRED: The resource for which policy is being specified. Format is `datasets/`.
-            string resource = "my-resource";  // TODO: Update placeholder value.
+            string resource = "datasets/my-dataset";  // TODO: Update placeholder value.
 
             // TODO: Assign values to desired properties of `requestBody`:
             Data.GetIamPolicyRequest requestBody = new Data.GetIamPolicyRequest();
@@ -1396,7 +1396,7 @@ namespace GenomicsSample
             });
 
             // REQUIRED: The resource for which policy is being specified. Format is `datasets/`.
-            string resource = "my-resource";  // TODO: Update placeholder value.
+            string resource = "datasets/my-dataset";  // TODO: Update placeholder value.
 
             // TODO: Assign values to desired properties of `requestBody`:
             Data.SetIamPolicyRequest requestBody = new Data.SetIamPolicyRequest();
@@ -1459,7 +1459,7 @@ namespace GenomicsSample
             });
 
             // REQUIRED: The resource for which policy is being specified. Format is `datasets/`.
-            string resource = "my-resource";  // TODO: Update placeholder value.
+            string resource = "datasets/my-dataset";  // TODO: Update placeholder value.
 
             // TODO: Assign values to desired properties of `requestBody`:
             Data.TestIamPermissionsRequest requestBody = new Data.TestIamPermissionsRequest();
@@ -1584,7 +1584,7 @@ namespace GenomicsSample
             });
 
             // The name of the operation resource to be cancelled.
-            string name = "my-name";  // TODO: Update placeholder value.
+            string name = "operations/my-operation";  // TODO: Update placeholder value.
 
             // TODO: Assign values to desired properties of `requestBody`:
             Data.CancelOperationRequest requestBody = new Data.CancelOperationRequest();
@@ -1644,7 +1644,7 @@ namespace GenomicsSample
             });
 
             // The name of the operation resource.
-            string name = "my-name";  // TODO: Update placeholder value.
+            string name = "operations/my-operation";  // TODO: Update placeholder value.
 
             OperationsResource.GetRequest request = genomicsService.Operations.Get(name);
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_logging.v2beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_logging.v2beta1.json.baseline
@@ -38,7 +38,7 @@ namespace LoggingSample
             // [LOG_ID] must be URL-encoded. For example, "projects/my-project-id/logs/syslog",
             // "organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity". For more
             // information about log names, see LogEntry.
-            string logName = "my-log-name";  // TODO: Update placeholder value.
+            string logName = "billingAccounts/my-billing-account/logs/my-log";  // TODO: Update placeholder value.
 
             BillingAccountsResource.LogsResource.DeleteRequest request = loggingService.BillingAccounts.Logs.Delete(logName);
 
@@ -97,7 +97,7 @@ namespace LoggingSample
             // Required. The resource name that owns the logs:
             // "projects/[PROJECT_ID]"
             // "organizations/[ORGANIZATION_ID]"
-            string parent = "my-parent";  // TODO: Update placeholder value.
+            string parent = "billingAccounts/my-billing-account";  // TODO: Update placeholder value.
 
             BillingAccountsResource.LogsResource.ListRequest request = loggingService.BillingAccounts.Logs.List(parent);
 
@@ -372,7 +372,7 @@ namespace LoggingSample
             // [LOG_ID] must be URL-encoded. For example, "projects/my-project-id/logs/syslog",
             // "organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity". For more
             // information about log names, see LogEntry.
-            string logName = "my-log-name";  // TODO: Update placeholder value.
+            string logName = "organizations/my-organization/logs/my-log";  // TODO: Update placeholder value.
 
             OrganizationsResource.LogsResource.DeleteRequest request = loggingService.Organizations.Logs.Delete(logName);
 
@@ -431,7 +431,7 @@ namespace LoggingSample
             // Required. The resource name that owns the logs:
             // "projects/[PROJECT_ID]"
             // "organizations/[ORGANIZATION_ID]"
-            string parent = "my-parent";  // TODO: Update placeholder value.
+            string parent = "organizations/my-organization";  // TODO: Update placeholder value.
 
             OrganizationsResource.LogsResource.ListRequest request = loggingService.Organizations.Logs.List(parent);
 
@@ -505,7 +505,7 @@ namespace LoggingSample
             // [LOG_ID] must be URL-encoded. For example, "projects/my-project-id/logs/syslog",
             // "organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity". For more
             // information about log names, see LogEntry.
-            string logName = "my-log-name";  // TODO: Update placeholder value.
+            string logName = "projects/my-project/logs/my-log";  // TODO: Update placeholder value.
 
             ProjectsResource.LogsResource.DeleteRequest request = loggingService.Projects.Logs.Delete(logName);
 
@@ -564,7 +564,7 @@ namespace LoggingSample
             // Required. The resource name that owns the logs:
             // "projects/[PROJECT_ID]"
             // "organizations/[ORGANIZATION_ID]"
-            string parent = "my-parent";  // TODO: Update placeholder value.
+            string parent = "projects/my-project";  // TODO: Update placeholder value.
 
             ProjectsResource.LogsResource.ListRequest request = loggingService.Projects.Logs.List(parent);
 
@@ -638,7 +638,7 @@ namespace LoggingSample
             // The resource name of the project in which to create the metric:
             // "projects/[PROJECT_ID]"
             // The new metric must be provided in the request.
-            string parent = "my-parent";  // TODO: Update placeholder value.
+            string parent = "projects/my-project";  // TODO: Update placeholder value.
 
             // TODO: Assign values to desired properties of `requestBody`:
             Data.LogMetric requestBody = new Data.LogMetric();
@@ -699,7 +699,7 @@ namespace LoggingSample
 
             // The resource name of the metric to delete:
             // "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
-            string metricName = "my-metric-name";  // TODO: Update placeholder value.
+            string metricName = "projects/my-project/metrics/my-metric";  // TODO: Update placeholder value.
 
             ProjectsResource.MetricsResource.DeleteRequest request = loggingService.Projects.Metrics.Delete(metricName);
 
@@ -757,7 +757,7 @@ namespace LoggingSample
 
             // The resource name of the desired metric:
             // "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
-            string metricName = "my-metric-name";  // TODO: Update placeholder value.
+            string metricName = "projects/my-project/metrics/my-metric";  // TODO: Update placeholder value.
 
             ProjectsResource.MetricsResource.GetRequest request = loggingService.Projects.Metrics.Get(metricName);
 
@@ -818,7 +818,7 @@ namespace LoggingSample
 
             // Required. The name of the project containing the metrics:
             // "projects/[PROJECT_ID]"
-            string parent = "my-parent";  // TODO: Update placeholder value.
+            string parent = "projects/my-project";  // TODO: Update placeholder value.
 
             ProjectsResource.MetricsResource.ListRequest request = loggingService.Projects.Metrics.List(parent);
 
@@ -893,7 +893,7 @@ namespace LoggingSample
             // "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
             // The updated metric must be provided in the request and it's name field must be the same as
             // [METRIC_ID] If the metric does not exist in [PROJECT_ID], then a new metric is created.
-            string metricName = "my-metric-name";  // TODO: Update placeholder value.
+            string metricName = "projects/my-project/metrics/my-metric";  // TODO: Update placeholder value.
 
             // TODO: Assign values to desired properties of `requestBody`. All existing
             // properties will be replaced:
@@ -960,7 +960,7 @@ namespace LoggingSample
             // "projects/[PROJECT_ID]"
             // "organizations/[ORGANIZATION_ID]"
             // Examples: "projects/my-logging-project", "organizations/123456789".
-            string parent = "my-parent";  // TODO: Update placeholder value.
+            string parent = "projects/my-project";  // TODO: Update placeholder value.
 
             // TODO: Assign values to desired properties of `requestBody`:
             Data.LogSink requestBody = new Data.LogSink();
@@ -1025,7 +1025,7 @@ namespace LoggingSample
             // "organizations/[ORGANIZATION_ID]/sinks/[SINK_ID]"
             // It is an error if the sink does not exist. Example: "projects/my-project-id/sinks/my-sink-id". It
             // is an error if the sink does not exist.
-            string sinkName = "my-sink-name";  // TODO: Update placeholder value.
+            string sinkName = "projects/my-project/sinks/my-sink";  // TODO: Update placeholder value.
 
             ProjectsResource.SinksResource.DeleteRequest request = loggingService.Projects.Sinks.Delete(sinkName);
 
@@ -1085,7 +1085,7 @@ namespace LoggingSample
             // "projects/[PROJECT_ID]/sinks/[SINK_ID]"
             // "organizations/[ORGANIZATION_ID]/sinks/[SINK_ID]"
             // Example: "projects/my-project-id/sinks/my-sink-id".
-            string sinkName = "my-sink-name";  // TODO: Update placeholder value.
+            string sinkName = "projects/my-project/sinks/my-sink";  // TODO: Update placeholder value.
 
             ProjectsResource.SinksResource.GetRequest request = loggingService.Projects.Sinks.Get(sinkName);
 
@@ -1146,7 +1146,7 @@ namespace LoggingSample
 
             // Required. The parent resource whose sinks are to be listed. Examples:
             // "projects/my-logging-project", "organizations/123456789".
-            string parent = "my-parent";  // TODO: Update placeholder value.
+            string parent = "projects/my-project";  // TODO: Update placeholder value.
 
             ProjectsResource.SinksResource.ListRequest request = loggingService.Projects.Sinks.List(parent);
 
@@ -1222,7 +1222,7 @@ namespace LoggingSample
             // "projects/[PROJECT_ID]/sinks/[SINK_ID]"
             // "organizations/[ORGANIZATION_ID]/sinks/[SINK_ID]"
             // Example: "projects/my-project-id/sinks/my-sink-id".
-            string sinkName = "my-sink-name";  // TODO: Update placeholder value.
+            string sinkName = "projects/my-project/sinks/my-sink";  // TODO: Update placeholder value.
 
             // TODO: Assign values to desired properties of `requestBody`. All existing
             // properties will be replaced:

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_pubsub.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_pubsub.v1.json.baseline
@@ -38,7 +38,7 @@ namespace PubsubSample
             // REQUIRED: The resource for which the policy is being requested.
             // `resource` is usually specified as a path. For example, a Project
             // resource is specified as `projects/{project}`.
-            string resource = "my-resource";  // TODO: Update placeholder value.
+            string resource = "projects/my-project/snapshots/my-snapshot";  // TODO: Update placeholder value.
 
             ProjectsResource.SnapshotsResource.GetIamPolicyRequest request = pubsubService.Projects.Snapshots.GetIamPolicy(resource);
 
@@ -100,7 +100,7 @@ namespace PubsubSample
             // REQUIRED: The resource for which the policy is being specified.
             // `resource` is usually specified as a path. For example, a Project
             // resource is specified as `projects/{project}`.
-            string resource = "my-resource";  // TODO: Update placeholder value.
+            string resource = "projects/my-project/snapshots/my-snapshot";  // TODO: Update placeholder value.
 
             // TODO: Assign values to desired properties of `requestBody`:
             Data.SetIamPolicyRequest requestBody = new Data.SetIamPolicyRequest();
@@ -165,7 +165,7 @@ namespace PubsubSample
             // REQUIRED: The resource for which the policy detail is being requested.
             // `resource` is usually specified as a path. For example, a Project
             // resource is specified as `projects/{project}`.
-            string resource = "my-resource";  // TODO: Update placeholder value.
+            string resource = "projects/my-project/snapshots/my-snapshot";  // TODO: Update placeholder value.
 
             // TODO: Assign values to desired properties of `requestBody`:
             Data.TestIamPermissionsRequest requestBody = new Data.TestIamPermissionsRequest();
@@ -228,7 +228,7 @@ namespace PubsubSample
 
             // The subscription whose message is being acknowledged.
             // Format is `projects/{project}/subscriptions/{sub}`.
-            string subscription = "my-subscription";  // TODO: Update placeholder value.
+            string subscription = "projects/my-project/subscriptions/my-subscription";  // TODO: Update placeholder value.
 
             // TODO: Assign values to desired properties of `requestBody`:
             Data.AcknowledgeRequest requestBody = new Data.AcknowledgeRequest();
@@ -293,7 +293,7 @@ namespace PubsubSample
             // (`[0-9]`), dashes (`-`), underscores (`_`), periods (`.`), tildes (`~`),
             // plus (`+`) or percent signs (`%`). It must be between 3 and 255 characters
             // in length, and it must not start with `"goog"`.
-            string name = "my-name";  // TODO: Update placeholder value.
+            string name = "projects/my-project/subscriptions/my-subscription";  // TODO: Update placeholder value.
 
             // TODO: Assign values to desired properties of `requestBody`. All existing
             // properties will be replaced:
@@ -355,7 +355,7 @@ namespace PubsubSample
 
             // The subscription to delete.
             // Format is `projects/{project}/subscriptions/{sub}`.
-            string subscription = "my-subscription";  // TODO: Update placeholder value.
+            string subscription = "projects/my-project/subscriptions/my-subscription";  // TODO: Update placeholder value.
 
             ProjectsResource.SubscriptionsResource.DeleteRequest request = pubsubService.Projects.Subscriptions.Delete(subscription);
 
@@ -413,7 +413,7 @@ namespace PubsubSample
 
             // The name of the subscription to get.
             // Format is `projects/{project}/subscriptions/{sub}`.
-            string subscription = "my-subscription";  // TODO: Update placeholder value.
+            string subscription = "projects/my-project/subscriptions/my-subscription";  // TODO: Update placeholder value.
 
             ProjectsResource.SubscriptionsResource.GetRequest request = pubsubService.Projects.Subscriptions.Get(subscription);
 
@@ -475,7 +475,7 @@ namespace PubsubSample
             // REQUIRED: The resource for which the policy is being requested.
             // `resource` is usually specified as a path. For example, a Project
             // resource is specified as `projects/{project}`.
-            string resource = "my-resource";  // TODO: Update placeholder value.
+            string resource = "projects/my-project/subscriptions/my-subscription";  // TODO: Update placeholder value.
 
             ProjectsResource.SubscriptionsResource.GetIamPolicyRequest request = pubsubService.Projects.Subscriptions.GetIamPolicy(resource);
 
@@ -536,7 +536,7 @@ namespace PubsubSample
 
             // The name of the cloud project that subscriptions belong to.
             // Format is `projects/{project}`.
-            string project = "my-project";  // TODO: Update placeholder value.
+            string project = "projects/my-project";  // TODO: Update placeholder value.
 
             ProjectsResource.SubscriptionsResource.ListRequest request = pubsubService.Projects.Subscriptions.List(project);
 
@@ -608,7 +608,7 @@ namespace PubsubSample
 
             // The name of the subscription.
             // Format is `projects/{project}/subscriptions/{sub}`.
-            string subscription = "my-subscription";  // TODO: Update placeholder value.
+            string subscription = "projects/my-project/subscriptions/my-subscription";  // TODO: Update placeholder value.
 
             // TODO: Assign values to desired properties of `requestBody`:
             Data.ModifyAckDeadlineRequest requestBody = new Data.ModifyAckDeadlineRequest();
@@ -668,7 +668,7 @@ namespace PubsubSample
 
             // The name of the subscription.
             // Format is `projects/{project}/subscriptions/{sub}`.
-            string subscription = "my-subscription";  // TODO: Update placeholder value.
+            string subscription = "projects/my-project/subscriptions/my-subscription";  // TODO: Update placeholder value.
 
             // TODO: Assign values to desired properties of `requestBody`:
             Data.ModifyPushConfigRequest requestBody = new Data.ModifyPushConfigRequest();
@@ -729,7 +729,7 @@ namespace PubsubSample
 
             // The subscription from which messages should be pulled.
             // Format is `projects/{project}/subscriptions/{sub}`.
-            string subscription = "my-subscription";  // TODO: Update placeholder value.
+            string subscription = "projects/my-project/subscriptions/my-subscription";  // TODO: Update placeholder value.
 
             // TODO: Assign values to desired properties of `requestBody`:
             Data.PullRequest requestBody = new Data.PullRequest();
@@ -794,7 +794,7 @@ namespace PubsubSample
             // REQUIRED: The resource for which the policy is being specified.
             // `resource` is usually specified as a path. For example, a Project
             // resource is specified as `projects/{project}`.
-            string resource = "my-resource";  // TODO: Update placeholder value.
+            string resource = "projects/my-project/subscriptions/my-subscription";  // TODO: Update placeholder value.
 
             // TODO: Assign values to desired properties of `requestBody`:
             Data.SetIamPolicyRequest requestBody = new Data.SetIamPolicyRequest();
@@ -859,7 +859,7 @@ namespace PubsubSample
             // REQUIRED: The resource for which the policy detail is being requested.
             // `resource` is usually specified as a path. For example, a Project
             // resource is specified as `projects/{project}`.
-            string resource = "my-resource";  // TODO: Update placeholder value.
+            string resource = "projects/my-project/subscriptions/my-subscription";  // TODO: Update placeholder value.
 
             // TODO: Assign values to desired properties of `requestBody`:
             Data.TestIamPermissionsRequest requestBody = new Data.TestIamPermissionsRequest();
@@ -927,7 +927,7 @@ namespace PubsubSample
             // underscores (`_`), periods (`.`), tildes (`~`), plus (`+`) or percent
             // signs (`%`). It must be between 3 and 255 characters in length, and it
             // must not start with `"goog"`.
-            string name = "my-name";  // TODO: Update placeholder value.
+            string name = "projects/my-project/topics/my-topic";  // TODO: Update placeholder value.
 
             // TODO: Assign values to desired properties of `requestBody`. All existing
             // properties will be replaced:
@@ -989,7 +989,7 @@ namespace PubsubSample
 
             // Name of the topic to delete.
             // Format is `projects/{project}/topics/{topic}`.
-            string topic = "my-topic";  // TODO: Update placeholder value.
+            string topic = "projects/my-project/topics/my-topic";  // TODO: Update placeholder value.
 
             ProjectsResource.TopicsResource.DeleteRequest request = pubsubService.Projects.Topics.Delete(topic);
 
@@ -1047,7 +1047,7 @@ namespace PubsubSample
 
             // The name of the topic to get.
             // Format is `projects/{project}/topics/{topic}`.
-            string topic = "my-topic";  // TODO: Update placeholder value.
+            string topic = "projects/my-project/topics/my-topic";  // TODO: Update placeholder value.
 
             ProjectsResource.TopicsResource.GetRequest request = pubsubService.Projects.Topics.Get(topic);
 
@@ -1109,7 +1109,7 @@ namespace PubsubSample
             // REQUIRED: The resource for which the policy is being requested.
             // `resource` is usually specified as a path. For example, a Project
             // resource is specified as `projects/{project}`.
-            string resource = "my-resource";  // TODO: Update placeholder value.
+            string resource = "projects/my-project/topics/my-topic";  // TODO: Update placeholder value.
 
             ProjectsResource.TopicsResource.GetIamPolicyRequest request = pubsubService.Projects.Topics.GetIamPolicy(resource);
 
@@ -1170,7 +1170,7 @@ namespace PubsubSample
 
             // The name of the cloud project that topics belong to.
             // Format is `projects/{project}`.
-            string project = "my-project";  // TODO: Update placeholder value.
+            string project = "projects/my-project";  // TODO: Update placeholder value.
 
             ProjectsResource.TopicsResource.ListRequest request = pubsubService.Projects.Topics.List(project);
 
@@ -1243,7 +1243,7 @@ namespace PubsubSample
 
             // The messages in the request will be published on this topic.
             // Format is `projects/{project}/topics/{topic}`.
-            string topic = "my-topic";  // TODO: Update placeholder value.
+            string topic = "projects/my-project/topics/my-topic";  // TODO: Update placeholder value.
 
             // TODO: Assign values to desired properties of `requestBody`:
             Data.PublishRequest requestBody = new Data.PublishRequest();
@@ -1308,7 +1308,7 @@ namespace PubsubSample
             // REQUIRED: The resource for which the policy is being specified.
             // `resource` is usually specified as a path. For example, a Project
             // resource is specified as `projects/{project}`.
-            string resource = "my-resource";  // TODO: Update placeholder value.
+            string resource = "projects/my-project/topics/my-topic";  // TODO: Update placeholder value.
 
             // TODO: Assign values to desired properties of `requestBody`:
             Data.SetIamPolicyRequest requestBody = new Data.SetIamPolicyRequest();
@@ -1372,7 +1372,7 @@ namespace PubsubSample
 
             // The name of the topic that subscriptions are attached to.
             // Format is `projects/{project}/topics/{topic}`.
-            string topic = "my-topic";  // TODO: Update placeholder value.
+            string topic = "projects/my-project/topics/my-topic";  // TODO: Update placeholder value.
 
             ProjectsResource.TopicsResource.SubscriptionsResource.ListRequest request = pubsubService.Projects.Topics.Subscriptions.List(topic);
 
@@ -1446,7 +1446,7 @@ namespace PubsubSample
             // REQUIRED: The resource for which the policy detail is being requested.
             // `resource` is usually specified as a path. For example, a Project
             // resource is specified as `projects/{project}`.
-            string resource = "my-resource";  // TODO: Update placeholder value.
+            string resource = "projects/my-project/topics/my-topic";  // TODO: Update placeholder value.
 
             // TODO: Assign values to desired properties of `requestBody`:
             Data.TestIamPermissionsRequest requestBody = new Data.TestIamPermissionsRequest();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_storagetransfer.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/csharp/csharp_storagetransfer.v1.json.baseline
@@ -214,7 +214,7 @@ namespace StoragetransferSample
             });
 
             // The job to get. Required.
-            string jobName = "my-job-name";  // TODO: Update placeholder value.
+            string jobName = "transferJobs/my-transfer-job";  // TODO: Update placeholder value.
 
             TransferJobsResource.GetRequest request = storagetransferService.TransferJobs.Get(jobName);
 
@@ -343,7 +343,7 @@ namespace StoragetransferSample
             });
 
             // The name of job to update. Required.
-            string jobName = "my-job-name";  // TODO: Update placeholder value.
+            string jobName = "transferJobs/my-transfer-job";  // TODO: Update placeholder value.
 
             // TODO: Assign values to desired properties of `requestBody`. Only assigned
             // properties will be changed:
@@ -404,7 +404,7 @@ namespace StoragetransferSample
             });
 
             // The name of the operation resource to be cancelled.
-            string name = "my-name";  // TODO: Update placeholder value.
+            string name = "transferOperations/my-transfer-operation";  // TODO: Update placeholder value.
 
             TransferOperationsResource.CancelRequest request = storagetransferService.TransferOperations.Cancel(name);
 
@@ -458,7 +458,7 @@ namespace StoragetransferSample
             });
 
             // The name of the operation resource to be deleted.
-            string name = "my-name";  // TODO: Update placeholder value.
+            string name = "transferOperations/my-transfer-operation";  // TODO: Update placeholder value.
 
             TransferOperationsResource.DeleteRequest request = storagetransferService.TransferOperations.Delete(name);
 
@@ -515,7 +515,7 @@ namespace StoragetransferSample
             });
 
             // The name of the operation resource.
-            string name = "my-name";  // TODO: Update placeholder value.
+            string name = "transferOperations/my-transfer-operation";  // TODO: Update placeholder value.
 
             TransferOperationsResource.GetRequest request = storagetransferService.TransferOperations.Get(name);
 
@@ -646,7 +646,7 @@ namespace StoragetransferSample
             });
 
             // The name of the transfer operation. Required.
-            string name = "my-name";  // TODO: Update placeholder value.
+            string name = "transferOperations/my-transfer-operation";  // TODO: Update placeholder value.
 
             // TODO: Assign values to desired properties of `requestBody`:
             Data.PauseTransferOperationRequest requestBody = new Data.PauseTransferOperationRequest();
@@ -705,7 +705,7 @@ namespace StoragetransferSample
             });
 
             // The name of the transfer operation. Required.
-            string name = "my-name";  // TODO: Update placeholder value.
+            string name = "transferOperations/my-transfer-operation";  // TODO: Update placeholder value.
 
             // TODO: Assign values to desired properties of `requestBody`:
             Data.ResumeTransferOperationRequest requestBody = new Data.ResumeTransferOperationRequest();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudbilling.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudbilling.v1.json.baseline
@@ -136,8 +136,8 @@ func main() {
     log.Fatal(err)
   }
 
-  // The resource name of the billing account associated with the projects that you want to list. For
-  // example, `billingAccounts/012345-567890-ABCDEF`.
+  // The resource name of the billing account associated with the projects that
+  // you want to list. For example, `billingAccounts/012345-567890-ABCDEF`.
   name := "billingAccounts/my-billing-account"  // TODO: Update placeholder value.
 
   req := cloudbillingService.BillingAccounts.Projects.List(name)
@@ -189,8 +189,8 @@ func main() {
     log.Fatal(err)
   }
 
-  // The resource name of the project for which billing information is retrieved. For example,
-  // `projects/tokyo-rain-123`.
+  // The resource name of the project for which billing information is
+  // retrieved. For example, `projects/tokyo-rain-123`.
   name := "projects/my-project"  // TODO: Update placeholder value.
 
   resp, err := cloudbillingService.Projects.GetBillingInfo(name).Context(ctx).Do()
@@ -239,8 +239,8 @@ func main() {
     log.Fatal(err)
   }
 
-  // The resource name of the project associated with the billing information that you want to update.
-  // For example, `projects/tokyo-rain-123`.
+  // The resource name of the project associated with the billing information
+  // that you want to update. For example, `projects/tokyo-rain-123`.
   name := "projects/my-project"  // TODO: Update placeholder value.
 
   rb := &cloudbilling.ProjectBillingInfo{

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudresourcemanager.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_cloudresourcemanager.v1.json.baseline
@@ -38,7 +38,7 @@ func main() {
   }
 
   // The name of the operation resource.
-  name := "my-name"  // TODO: Update placeholder value.
+  name := "operations/my-operation"  // TODO: Update placeholder value.
 
   resp, err := cloudresourcemanagerService.Operations.Get(name).Context(ctx).Do()
   if err != nil {
@@ -87,7 +87,7 @@ func main() {
   }
 
   // The resource name of the Organization to fetch, e.g. "organizations/1234".
-  name := "my-name"  // TODO: Update placeholder value.
+  name := "organizations/my-organization"  // TODO: Update placeholder value.
 
   resp, err := cloudresourcemanagerService.Organizations.Get(name).Context(ctx).Do()
   if err != nil {
@@ -138,7 +138,7 @@ func main() {
   // REQUIRED: The resource for which the policy is being requested.
   // `resource` is usually specified as a path. For example, a Project
   // resource is specified as `projects/{project}`.
-  resource := "my-resource"  // TODO: Update placeholder value.
+  resource := "organizations/my-organization"  // TODO: Update placeholder value.
 
   rb := &cloudresourcemanager.GetIamPolicyRequest{
     // TODO: Add desired fields of the request body.
@@ -246,7 +246,7 @@ func main() {
   // REQUIRED: The resource for which the policy is being specified.
   // `resource` is usually specified as a path. For example, a Project
   // resource is specified as `projects/{project}`.
-  resource := "my-resource"  // TODO: Update placeholder value.
+  resource := "organizations/my-organization"  // TODO: Update placeholder value.
 
   rb := &cloudresourcemanager.SetIamPolicyRequest{
     // TODO: Add desired fields of the request body.
@@ -301,7 +301,7 @@ func main() {
   // REQUIRED: The resource for which the policy detail is being requested.
   // `resource` is usually specified as a path. For example, a Project
   // resource is specified as `projects/{project}`.
-  resource := "my-resource"  // TODO: Update placeholder value.
+  resource := "organizations/my-organization"  // TODO: Update placeholder value.
 
   rb := &cloudresourcemanager.TestIamPermissionsRequest{
     // TODO: Add desired fields of the request body.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_genomics.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_genomics.v1.json.baseline
@@ -1001,7 +1001,7 @@ func main() {
   }
 
   // REQUIRED: The resource for which policy is being specified. Format is `datasets/`.
-  resource := "my-resource"  // TODO: Update placeholder value.
+  resource := "datasets/my-dataset"  // TODO: Update placeholder value.
 
   rb := &genomics.GetIamPolicyRequest{
     // TODO: Add desired fields of the request body.
@@ -1157,7 +1157,7 @@ func main() {
   }
 
   // REQUIRED: The resource for which policy is being specified. Format is `datasets/`.
-  resource := "my-resource"  // TODO: Update placeholder value.
+  resource := "datasets/my-dataset"  // TODO: Update placeholder value.
 
   rb := &genomics.SetIamPolicyRequest{
     // TODO: Add desired fields of the request body.
@@ -1210,7 +1210,7 @@ func main() {
   }
 
   // REQUIRED: The resource for which policy is being specified. Format is `datasets/`.
-  resource := "my-resource"  // TODO: Update placeholder value.
+  resource := "datasets/my-dataset"  // TODO: Update placeholder value.
 
   rb := &genomics.TestIamPermissionsRequest{
     // TODO: Add desired fields of the request body.
@@ -1316,7 +1316,7 @@ func main() {
   }
 
   // The name of the operation resource to be cancelled.
-  name := "my-name"  // TODO: Update placeholder value.
+  name := "operations/my-operation"  // TODO: Update placeholder value.
 
   rb := &genomics.CancelOperationRequest{
     // TODO: Add desired fields of the request body.
@@ -1369,7 +1369,7 @@ func main() {
   }
 
   // The name of the operation resource.
-  name := "my-name"  // TODO: Update placeholder value.
+  name := "operations/my-operation"  // TODO: Update placeholder value.
 
   resp, err := genomicsService.Operations.Get(name).Context(ctx).Do()
   if err != nil {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_logging.v2beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_logging.v2beta1.json.baseline
@@ -43,7 +43,7 @@ func main() {
   // [LOG_ID] must be URL-encoded. For example, "projects/my-project-id/logs/syslog",
   // "organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity". For more
   // information about log names, see LogEntry.
-  logName := "my-log-name"  // TODO: Update placeholder value.
+  logName := "billingAccounts/my-billing-account/logs/my-log"  // TODO: Update placeholder value.
 
   resp, err := loggingService.BillingAccounts.Logs.Delete(logName).Context(ctx).Do()
   if err != nil {
@@ -94,7 +94,7 @@ func main() {
   // Required. The resource name that owns the logs:
   // "projects/[PROJECT_ID]"
   // "organizations/[ORGANIZATION_ID]"
-  parent := "my-parent"  // TODO: Update placeholder value.
+  parent := "billingAccounts/my-billing-account"  // TODO: Update placeholder value.
 
   req := loggingService.BillingAccounts.Logs.List(parent)
   if err := req.Pages(ctx, func(page *logging.ListLogsResponse) error {
@@ -303,7 +303,7 @@ func main() {
   // [LOG_ID] must be URL-encoded. For example, "projects/my-project-id/logs/syslog",
   // "organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity". For more
   // information about log names, see LogEntry.
-  logName := "my-log-name"  // TODO: Update placeholder value.
+  logName := "organizations/my-organization/logs/my-log"  // TODO: Update placeholder value.
 
   resp, err := loggingService.Organizations.Logs.Delete(logName).Context(ctx).Do()
   if err != nil {
@@ -354,7 +354,7 @@ func main() {
   // Required. The resource name that owns the logs:
   // "projects/[PROJECT_ID]"
   // "organizations/[ORGANIZATION_ID]"
-  parent := "my-parent"  // TODO: Update placeholder value.
+  parent := "organizations/my-organization"  // TODO: Update placeholder value.
 
   req := loggingService.Organizations.Logs.List(parent)
   if err := req.Pages(ctx, func(page *logging.ListLogsResponse) error {
@@ -411,7 +411,7 @@ func main() {
   // [LOG_ID] must be URL-encoded. For example, "projects/my-project-id/logs/syslog",
   // "organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity". For more
   // information about log names, see LogEntry.
-  logName := "my-log-name"  // TODO: Update placeholder value.
+  logName := "projects/my-project/logs/my-log"  // TODO: Update placeholder value.
 
   resp, err := loggingService.Projects.Logs.Delete(logName).Context(ctx).Do()
   if err != nil {
@@ -462,7 +462,7 @@ func main() {
   // Required. The resource name that owns the logs:
   // "projects/[PROJECT_ID]"
   // "organizations/[ORGANIZATION_ID]"
-  parent := "my-parent"  // TODO: Update placeholder value.
+  parent := "projects/my-project"  // TODO: Update placeholder value.
 
   req := loggingService.Projects.Logs.List(parent)
   if err := req.Pages(ctx, func(page *logging.ListLogsResponse) error {
@@ -516,7 +516,7 @@ func main() {
   // The resource name of the project in which to create the metric:
   // "projects/[PROJECT_ID]"
   // The new metric must be provided in the request.
-  parent := "my-parent"  // TODO: Update placeholder value.
+  parent := "projects/my-project"  // TODO: Update placeholder value.
 
   rb := &logging.LogMetric{
     // TODO: Add desired fields of the request body.
@@ -570,7 +570,7 @@ func main() {
 
   // The resource name of the metric to delete:
   // "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
-  metricName := "my-metric-name"  // TODO: Update placeholder value.
+  metricName := "projects/my-project/metrics/my-metric"  // TODO: Update placeholder value.
 
   resp, err := loggingService.Projects.Metrics.Delete(metricName).Context(ctx).Do()
   if err != nil {
@@ -620,7 +620,7 @@ func main() {
 
   // The resource name of the desired metric:
   // "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
-  metricName := "my-metric-name"  // TODO: Update placeholder value.
+  metricName := "projects/my-project/metrics/my-metric"  // TODO: Update placeholder value.
 
   resp, err := loggingService.Projects.Metrics.Get(metricName).Context(ctx).Do()
   if err != nil {
@@ -670,7 +670,7 @@ func main() {
 
   // Required. The name of the project containing the metrics:
   // "projects/[PROJECT_ID]"
-  parent := "my-parent"  // TODO: Update placeholder value.
+  parent := "projects/my-project"  // TODO: Update placeholder value.
 
   req := loggingService.Projects.Metrics.List(parent)
   if err := req.Pages(ctx, func(page *logging.ListLogMetricsResponse) error {
@@ -725,7 +725,7 @@ func main() {
   // "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
   // The updated metric must be provided in the request and it's name field must be the same as
   // [METRIC_ID] If the metric does not exist in [PROJECT_ID], then a new metric is created.
-  metricName := "my-metric-name"  // TODO: Update placeholder value.
+  metricName := "projects/my-project/metrics/my-metric"  // TODO: Update placeholder value.
 
   rb := &logging.LogMetric{
     // TODO: Add desired fields of the request body. All existing fields
@@ -782,7 +782,7 @@ func main() {
   // "projects/[PROJECT_ID]"
   // "organizations/[ORGANIZATION_ID]"
   // Examples: "projects/my-logging-project", "organizations/123456789".
-  parent := "my-parent"  // TODO: Update placeholder value.
+  parent := "projects/my-project"  // TODO: Update placeholder value.
 
   rb := &logging.LogSink{
     // TODO: Add desired fields of the request body.
@@ -840,7 +840,7 @@ func main() {
   // "organizations/[ORGANIZATION_ID]/sinks/[SINK_ID]"
   // It is an error if the sink does not exist. Example: "projects/my-project-id/sinks/my-sink-id". It
   // is an error if the sink does not exist.
-  sinkName := "my-sink-name"  // TODO: Update placeholder value.
+  sinkName := "projects/my-project/sinks/my-sink"  // TODO: Update placeholder value.
 
   resp, err := loggingService.Projects.Sinks.Delete(sinkName).Context(ctx).Do()
   if err != nil {
@@ -892,7 +892,7 @@ func main() {
   // "projects/[PROJECT_ID]/sinks/[SINK_ID]"
   // "organizations/[ORGANIZATION_ID]/sinks/[SINK_ID]"
   // Example: "projects/my-project-id/sinks/my-sink-id".
-  sinkName := "my-sink-name"  // TODO: Update placeholder value.
+  sinkName := "projects/my-project/sinks/my-sink"  // TODO: Update placeholder value.
 
   resp, err := loggingService.Projects.Sinks.Get(sinkName).Context(ctx).Do()
   if err != nil {
@@ -942,7 +942,7 @@ func main() {
 
   // Required. The parent resource whose sinks are to be listed. Examples:
   // "projects/my-logging-project", "organizations/123456789".
-  parent := "my-parent"  // TODO: Update placeholder value.
+  parent := "projects/my-project"  // TODO: Update placeholder value.
 
   req := loggingService.Projects.Sinks.List(parent)
   if err := req.Pages(ctx, func(page *logging.ListSinksResponse) error {
@@ -998,7 +998,7 @@ func main() {
   // "projects/[PROJECT_ID]/sinks/[SINK_ID]"
   // "organizations/[ORGANIZATION_ID]/sinks/[SINK_ID]"
   // Example: "projects/my-project-id/sinks/my-sink-id".
-  sinkName := "my-sink-name"  // TODO: Update placeholder value.
+  sinkName := "projects/my-project/sinks/my-sink"  // TODO: Update placeholder value.
 
   rb := &logging.LogSink{
     // TODO: Add desired fields of the request body. All existing fields

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_pubsub.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_pubsub.v1.json.baseline
@@ -40,7 +40,7 @@ func main() {
   // REQUIRED: The resource for which the policy is being requested.
   // `resource` is usually specified as a path. For example, a Project
   // resource is specified as `projects/{project}`.
-  resource := "my-resource"  // TODO: Update placeholder value.
+  resource := "projects/my-project/snapshots/my-snapshot"  // TODO: Update placeholder value.
 
   resp, err := pubsubService.Projects.Snapshots.GetIamPolicy(resource).Context(ctx).Do()
   if err != nil {
@@ -91,7 +91,7 @@ func main() {
   // REQUIRED: The resource for which the policy is being specified.
   // `resource` is usually specified as a path. For example, a Project
   // resource is specified as `projects/{project}`.
-  resource := "my-resource"  // TODO: Update placeholder value.
+  resource := "projects/my-project/snapshots/my-snapshot"  // TODO: Update placeholder value.
 
   rb := &pubsub.SetIamPolicyRequest{
     // TODO: Add desired fields of the request body.
@@ -146,7 +146,7 @@ func main() {
   // REQUIRED: The resource for which the policy detail is being requested.
   // `resource` is usually specified as a path. For example, a Project
   // resource is specified as `projects/{project}`.
-  resource := "my-resource"  // TODO: Update placeholder value.
+  resource := "projects/my-project/snapshots/my-snapshot"  // TODO: Update placeholder value.
 
   rb := &pubsub.TestIamPermissionsRequest{
     // TODO: Add desired fields of the request body.
@@ -200,7 +200,7 @@ func main() {
 
   // The subscription whose message is being acknowledged.
   // Format is `projects/{project}/subscriptions/{sub}`.
-  subscription := "my-subscription"  // TODO: Update placeholder value.
+  subscription := "projects/my-project/subscriptions/my-subscription"  // TODO: Update placeholder value.
 
   rb := &pubsub.AcknowledgeRequest{
     // TODO: Add desired fields of the request body.
@@ -258,7 +258,7 @@ func main() {
   // (`[0-9]`), dashes (`-`), underscores (`_`), periods (`.`), tildes (`~`),
   // plus (`+`) or percent signs (`%`). It must be between 3 and 255 characters
   // in length, and it must not start with `"goog"`.
-  name := "my-name"  // TODO: Update placeholder value.
+  name := "projects/my-project/subscriptions/my-subscription"  // TODO: Update placeholder value.
 
   rb := &pubsub.Subscription{
     // TODO: Add desired fields of the request body. All existing fields
@@ -313,7 +313,7 @@ func main() {
 
   // The subscription to delete.
   // Format is `projects/{project}/subscriptions/{sub}`.
-  subscription := "my-subscription"  // TODO: Update placeholder value.
+  subscription := "projects/my-project/subscriptions/my-subscription"  // TODO: Update placeholder value.
 
   resp, err := pubsubService.Projects.Subscriptions.Delete(subscription).Context(ctx).Do()
   if err != nil {
@@ -363,7 +363,7 @@ func main() {
 
   // The name of the subscription to get.
   // Format is `projects/{project}/subscriptions/{sub}`.
-  subscription := "my-subscription"  // TODO: Update placeholder value.
+  subscription := "projects/my-project/subscriptions/my-subscription"  // TODO: Update placeholder value.
 
   resp, err := pubsubService.Projects.Subscriptions.Get(subscription).Context(ctx).Do()
   if err != nil {
@@ -414,7 +414,7 @@ func main() {
   // REQUIRED: The resource for which the policy is being requested.
   // `resource` is usually specified as a path. For example, a Project
   // resource is specified as `projects/{project}`.
-  resource := "my-resource"  // TODO: Update placeholder value.
+  resource := "projects/my-project/subscriptions/my-subscription"  // TODO: Update placeholder value.
 
   resp, err := pubsubService.Projects.Subscriptions.GetIamPolicy(resource).Context(ctx).Do()
   if err != nil {
@@ -464,7 +464,7 @@ func main() {
 
   // The name of the cloud project that subscriptions belong to.
   // Format is `projects/{project}`.
-  project := "my-project"  // TODO: Update placeholder value.
+  project := "projects/my-project"  // TODO: Update placeholder value.
 
   req := pubsubService.Projects.Subscriptions.List(project)
   if err := req.Pages(ctx, func(page *pubsub.ListSubscriptionsResponse) error {
@@ -517,7 +517,7 @@ func main() {
 
   // The name of the subscription.
   // Format is `projects/{project}/subscriptions/{sub}`.
-  subscription := "my-subscription"  // TODO: Update placeholder value.
+  subscription := "projects/my-project/subscriptions/my-subscription"  // TODO: Update placeholder value.
 
   rb := &pubsub.ModifyAckDeadlineRequest{
     // TODO: Add desired fields of the request body.
@@ -571,7 +571,7 @@ func main() {
 
   // The name of the subscription.
   // Format is `projects/{project}/subscriptions/{sub}`.
-  subscription := "my-subscription"  // TODO: Update placeholder value.
+  subscription := "projects/my-project/subscriptions/my-subscription"  // TODO: Update placeholder value.
 
   rb := &pubsub.ModifyPushConfigRequest{
     // TODO: Add desired fields of the request body.
@@ -625,7 +625,7 @@ func main() {
 
   // The subscription from which messages should be pulled.
   // Format is `projects/{project}/subscriptions/{sub}`.
-  subscription := "my-subscription"  // TODO: Update placeholder value.
+  subscription := "projects/my-project/subscriptions/my-subscription"  // TODO: Update placeholder value.
 
   rb := &pubsub.PullRequest{
     // TODO: Add desired fields of the request body.
@@ -680,7 +680,7 @@ func main() {
   // REQUIRED: The resource for which the policy is being specified.
   // `resource` is usually specified as a path. For example, a Project
   // resource is specified as `projects/{project}`.
-  resource := "my-resource"  // TODO: Update placeholder value.
+  resource := "projects/my-project/subscriptions/my-subscription"  // TODO: Update placeholder value.
 
   rb := &pubsub.SetIamPolicyRequest{
     // TODO: Add desired fields of the request body.
@@ -735,7 +735,7 @@ func main() {
   // REQUIRED: The resource for which the policy detail is being requested.
   // `resource` is usually specified as a path. For example, a Project
   // resource is specified as `projects/{project}`.
-  resource := "my-resource"  // TODO: Update placeholder value.
+  resource := "projects/my-project/subscriptions/my-subscription"  // TODO: Update placeholder value.
 
   rb := &pubsub.TestIamPermissionsRequest{
     // TODO: Add desired fields of the request body.
@@ -793,7 +793,7 @@ func main() {
   // underscores (`_`), periods (`.`), tildes (`~`), plus (`+`) or percent
   // signs (`%`). It must be between 3 and 255 characters in length, and it
   // must not start with `"goog"`.
-  name := "my-name"  // TODO: Update placeholder value.
+  name := "projects/my-project/topics/my-topic"  // TODO: Update placeholder value.
 
   rb := &pubsub.Topic{
     // TODO: Add desired fields of the request body. All existing fields
@@ -848,7 +848,7 @@ func main() {
 
   // Name of the topic to delete.
   // Format is `projects/{project}/topics/{topic}`.
-  topic := "my-topic"  // TODO: Update placeholder value.
+  topic := "projects/my-project/topics/my-topic"  // TODO: Update placeholder value.
 
   resp, err := pubsubService.Projects.Topics.Delete(topic).Context(ctx).Do()
   if err != nil {
@@ -898,7 +898,7 @@ func main() {
 
   // The name of the topic to get.
   // Format is `projects/{project}/topics/{topic}`.
-  topic := "my-topic"  // TODO: Update placeholder value.
+  topic := "projects/my-project/topics/my-topic"  // TODO: Update placeholder value.
 
   resp, err := pubsubService.Projects.Topics.Get(topic).Context(ctx).Do()
   if err != nil {
@@ -949,7 +949,7 @@ func main() {
   // REQUIRED: The resource for which the policy is being requested.
   // `resource` is usually specified as a path. For example, a Project
   // resource is specified as `projects/{project}`.
-  resource := "my-resource"  // TODO: Update placeholder value.
+  resource := "projects/my-project/topics/my-topic"  // TODO: Update placeholder value.
 
   resp, err := pubsubService.Projects.Topics.GetIamPolicy(resource).Context(ctx).Do()
   if err != nil {
@@ -999,7 +999,7 @@ func main() {
 
   // The name of the cloud project that topics belong to.
   // Format is `projects/{project}`.
-  project := "my-project"  // TODO: Update placeholder value.
+  project := "projects/my-project"  // TODO: Update placeholder value.
 
   req := pubsubService.Projects.Topics.List(project)
   if err := req.Pages(ctx, func(page *pubsub.ListTopicsResponse) error {
@@ -1052,7 +1052,7 @@ func main() {
 
   // The messages in the request will be published on this topic.
   // Format is `projects/{project}/topics/{topic}`.
-  topic := "my-topic"  // TODO: Update placeholder value.
+  topic := "projects/my-project/topics/my-topic"  // TODO: Update placeholder value.
 
   rb := &pubsub.PublishRequest{
     // TODO: Add desired fields of the request body.
@@ -1107,7 +1107,7 @@ func main() {
   // REQUIRED: The resource for which the policy is being specified.
   // `resource` is usually specified as a path. For example, a Project
   // resource is specified as `projects/{project}`.
-  resource := "my-resource"  // TODO: Update placeholder value.
+  resource := "projects/my-project/topics/my-topic"  // TODO: Update placeholder value.
 
   rb := &pubsub.SetIamPolicyRequest{
     // TODO: Add desired fields of the request body.
@@ -1161,7 +1161,7 @@ func main() {
 
   // The name of the topic that subscriptions are attached to.
   // Format is `projects/{project}/topics/{topic}`.
-  topic := "my-topic"  // TODO: Update placeholder value.
+  topic := "projects/my-project/topics/my-topic"  // TODO: Update placeholder value.
 
   req := pubsubService.Projects.Topics.Subscriptions.List(topic)
   if err := req.Pages(ctx, func(page *pubsub.ListTopicSubscriptionsResponse) error {
@@ -1215,7 +1215,7 @@ func main() {
   // REQUIRED: The resource for which the policy detail is being requested.
   // `resource` is usually specified as a path. For example, a Project
   // resource is specified as `projects/{project}`.
-  resource := "my-resource"  // TODO: Update placeholder value.
+  resource := "projects/my-project/topics/my-topic"  // TODO: Update placeholder value.
 
   rb := &pubsub.TestIamPermissionsRequest{
     // TODO: Add desired fields of the request body.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_storagetransfer.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/go/go_storagetransfer.v1.json.baseline
@@ -184,7 +184,7 @@ func main() {
   }
 
   // The job to get. Required.
-  jobName := "my-job-name"  // TODO: Update placeholder value.
+  jobName := "transferJobs/my-transfer-job"  // TODO: Update placeholder value.
 
   resp, err := storagetransferService.TransferJobs.Get(jobName).Context(ctx).Do()
   if err != nil {
@@ -282,7 +282,7 @@ func main() {
   }
 
   // The name of job to update. Required.
-  jobName := "my-job-name"  // TODO: Update placeholder value.
+  jobName := "transferJobs/my-transfer-job"  // TODO: Update placeholder value.
 
   rb := &storagetransfer.UpdateTransferJobRequest{
     // TODO: Add desired fields of the request body. Only assigned fields
@@ -336,7 +336,7 @@ func main() {
   }
 
   // The name of the operation resource to be cancelled.
-  name := "my-name"  // TODO: Update placeholder value.
+  name := "transferOperations/my-transfer-operation"  // TODO: Update placeholder value.
 
   resp, err := storagetransferService.TransferOperations.Cancel(name).Context(ctx).Do()
   if err != nil {
@@ -385,7 +385,7 @@ func main() {
   }
 
   // The name of the operation resource to be deleted.
-  name := "my-name"  // TODO: Update placeholder value.
+  name := "transferOperations/my-transfer-operation"  // TODO: Update placeholder value.
 
   resp, err := storagetransferService.TransferOperations.Delete(name).Context(ctx).Do()
   if err != nil {
@@ -434,7 +434,7 @@ func main() {
   }
 
   // The name of the operation resource.
-  name := "my-name"  // TODO: Update placeholder value.
+  name := "transferOperations/my-transfer-operation"  // TODO: Update placeholder value.
 
   resp, err := storagetransferService.TransferOperations.Get(name).Context(ctx).Do()
   if err != nil {
@@ -535,7 +535,7 @@ func main() {
   }
 
   // The name of the transfer operation. Required.
-  name := "my-name"  // TODO: Update placeholder value.
+  name := "transferOperations/my-transfer-operation"  // TODO: Update placeholder value.
 
   rb := &storagetransfer.PauseTransferOperationRequest{
     // TODO: Add desired fields of the request body.
@@ -588,7 +588,7 @@ func main() {
   }
 
   // The name of the transfer operation. Required.
-  name := "my-name"  // TODO: Update placeholder value.
+  name := "transferOperations/my-transfer-operation"  // TODO: Update placeholder value.
 
   rb := &storagetransfer.ResumeTransferOperationRequest{
     // TODO: Add desired fields of the request body.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_cloudbilling.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_cloudbilling.v1.json.baseline
@@ -151,8 +151,8 @@ import java.util.Arrays;
 
 public class CloudbillingExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
-    // The resource name of the billing account associated with the projects that you want to list. For
-    // example, `billingAccounts/012345-567890-ABCDEF`.
+    // The resource name of the billing account associated with the projects that
+    // you want to list. For example, `billingAccounts/012345-567890-ABCDEF`.
     String name = "billingAccounts/my-billing-account";  // TODO: Update placeholder value.
 
     Cloudbilling cloudbillingService = createCloudbillingService();
@@ -217,8 +217,8 @@ import java.util.Arrays;
 
 public class CloudbillingExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
-    // The resource name of the project for which billing information is retrieved. For example,
-    // `projects/tokyo-rain-123`.
+    // The resource name of the project for which billing information is
+    // retrieved. For example, `projects/tokyo-rain-123`.
     String name = "projects/my-project";  // TODO: Update placeholder value.
 
     Cloudbilling cloudbillingService = createCloudbillingService();
@@ -275,8 +275,8 @@ import java.util.Arrays;
 
 public class CloudbillingExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
-    // The resource name of the project associated with the billing information that you want to update.
-    // For example, `projects/tokyo-rain-123`.
+    // The resource name of the project associated with the billing information
+    // that you want to update. For example, `projects/tokyo-rain-123`.
     String name = "projects/my-project";  // TODO: Update placeholder value.
 
     // TODO: Assign values to desired fields of `requestBody`. All existing

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_cloudresourcemanager.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_cloudresourcemanager.v1.json.baseline
@@ -30,7 +30,7 @@ import java.util.Arrays;
 public class CloudResourceManagerExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The name of the operation resource.
-    String name = "my-name";  // TODO: Update placeholder value.
+    String name = "operations/my-operation";  // TODO: Update placeholder value.
 
     CloudResourceManager cloudResourceManagerService = createCloudResourceManagerService();
     CloudResourceManager.Operations.Get request = cloudResourceManagerService.operations().get(name);
@@ -87,7 +87,7 @@ import java.util.Arrays;
 public class CloudResourceManagerExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The resource name of the Organization to fetch, e.g. "organizations/1234".
-    String name = "my-name";  // TODO: Update placeholder value.
+    String name = "organizations/my-organization";  // TODO: Update placeholder value.
 
     CloudResourceManager cloudResourceManagerService = createCloudResourceManagerService();
     CloudResourceManager.Organizations.Get request = cloudResourceManagerService.organizations().get(name);
@@ -147,7 +147,7 @@ public class CloudResourceManagerExample {
     // REQUIRED: The resource for which the policy is being requested.
     // `resource` is usually specified as a path. For example, a Project
     // resource is specified as `projects/{project}`.
-    String resource = "my-resource";  // TODO: Update placeholder value.
+    String resource = "organizations/my-organization";  // TODO: Update placeholder value.
 
     // TODO: Assign values to desired fields of `requestBody`:
     GetIamPolicyRequest requestBody = new GetIamPolicyRequest();
@@ -277,7 +277,7 @@ public class CloudResourceManagerExample {
     // REQUIRED: The resource for which the policy is being specified.
     // `resource` is usually specified as a path. For example, a Project
     // resource is specified as `projects/{project}`.
-    String resource = "my-resource";  // TODO: Update placeholder value.
+    String resource = "organizations/my-organization";  // TODO: Update placeholder value.
 
     // TODO: Assign values to desired fields of `requestBody`:
     SetIamPolicyRequest requestBody = new SetIamPolicyRequest();
@@ -340,7 +340,7 @@ public class CloudResourceManagerExample {
     // REQUIRED: The resource for which the policy detail is being requested.
     // `resource` is usually specified as a path. For example, a Project
     // resource is specified as `projects/{project}`.
-    String resource = "my-resource";  // TODO: Update placeholder value.
+    String resource = "organizations/my-organization";  // TODO: Update placeholder value.
 
     // TODO: Assign values to desired fields of `requestBody`:
     TestIamPermissionsRequest requestBody = new TestIamPermissionsRequest();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_genomics.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_genomics.v1.json.baseline
@@ -1141,7 +1141,7 @@ import java.util.Arrays;
 public class GenomicsExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
     // REQUIRED: The resource for which policy is being specified. Format is `datasets/`.
-    String resource = "my-resource";  // TODO: Update placeholder value.
+    String resource = "datasets/my-dataset";  // TODO: Update placeholder value.
 
     // TODO: Assign values to desired fields of `requestBody`:
     GetIamPolicyRequest requestBody = new GetIamPolicyRequest();
@@ -1326,7 +1326,7 @@ import java.util.Arrays;
 public class GenomicsExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
     // REQUIRED: The resource for which policy is being specified. Format is `datasets/`.
-    String resource = "my-resource";  // TODO: Update placeholder value.
+    String resource = "datasets/my-dataset";  // TODO: Update placeholder value.
 
     // TODO: Assign values to desired fields of `requestBody`:
     SetIamPolicyRequest requestBody = new SetIamPolicyRequest();
@@ -1387,7 +1387,7 @@ import java.util.Arrays;
 public class GenomicsExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
     // REQUIRED: The resource for which policy is being specified. Format is `datasets/`.
-    String resource = "my-resource";  // TODO: Update placeholder value.
+    String resource = "datasets/my-dataset";  // TODO: Update placeholder value.
 
     // TODO: Assign values to desired fields of `requestBody`:
     TestIamPermissionsRequest requestBody = new TestIamPermissionsRequest();
@@ -1508,7 +1508,7 @@ import java.util.Arrays;
 public class GenomicsExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The name of the operation resource to be cancelled.
-    String name = "my-name";  // TODO: Update placeholder value.
+    String name = "operations/my-operation";  // TODO: Update placeholder value.
 
     // TODO: Assign values to desired fields of `requestBody`:
     CancelOperationRequest requestBody = new CancelOperationRequest();
@@ -1565,7 +1565,7 @@ import java.util.Arrays;
 public class GenomicsExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The name of the operation resource.
-    String name = "my-name";  // TODO: Update placeholder value.
+    String name = "operations/my-operation";  // TODO: Update placeholder value.
 
     Genomics genomicsService = createGenomicsService();
     Genomics.Operations.Get request = genomicsService.operations().get(name);

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_logging.v2beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_logging.v2beta1.json.baseline
@@ -34,7 +34,7 @@ public class LoggingExample {
     // [LOG_ID] must be URL-encoded. For example, "projects/my-project-id/logs/syslog",
     // "organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity". For more
     // information about log names, see LogEntry.
-    String logName = "my-log-name";  // TODO: Update placeholder value.
+    String logName = "billingAccounts/my-billing-account/logs/my-log";  // TODO: Update placeholder value.
 
     Logging loggingService = createLoggingService();
     Logging.BillingAccounts.Logs.Delete request = loggingService.billingAccounts().logs().delete(logName);
@@ -90,7 +90,7 @@ public class LoggingExample {
     // Required. The resource name that owns the logs:
     // "projects/[PROJECT_ID]"
     // "organizations/[ORGANIZATION_ID]"
-    String parent = "my-parent";  // TODO: Update placeholder value.
+    String parent = "billingAccounts/my-billing-account";  // TODO: Update placeholder value.
 
     Logging loggingService = createLoggingService();
     Logging.BillingAccounts.Logs.List request = loggingService.billingAccounts().logs().list(parent);
@@ -347,7 +347,7 @@ public class LoggingExample {
     // [LOG_ID] must be URL-encoded. For example, "projects/my-project-id/logs/syslog",
     // "organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity". For more
     // information about log names, see LogEntry.
-    String logName = "my-log-name";  // TODO: Update placeholder value.
+    String logName = "organizations/my-organization/logs/my-log";  // TODO: Update placeholder value.
 
     Logging loggingService = createLoggingService();
     Logging.Organizations.Logs.Delete request = loggingService.organizations().logs().delete(logName);
@@ -403,7 +403,7 @@ public class LoggingExample {
     // Required. The resource name that owns the logs:
     // "projects/[PROJECT_ID]"
     // "organizations/[ORGANIZATION_ID]"
-    String parent = "my-parent";  // TODO: Update placeholder value.
+    String parent = "organizations/my-organization";  // TODO: Update placeholder value.
 
     Logging loggingService = createLoggingService();
     Logging.Organizations.Logs.List request = loggingService.organizations().logs().list(parent);
@@ -472,7 +472,7 @@ public class LoggingExample {
     // [LOG_ID] must be URL-encoded. For example, "projects/my-project-id/logs/syslog",
     // "organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity". For more
     // information about log names, see LogEntry.
-    String logName = "my-log-name";  // TODO: Update placeholder value.
+    String logName = "projects/my-project/logs/my-log";  // TODO: Update placeholder value.
 
     Logging loggingService = createLoggingService();
     Logging.Projects.Logs.Delete request = loggingService.projects().logs().delete(logName);
@@ -528,7 +528,7 @@ public class LoggingExample {
     // Required. The resource name that owns the logs:
     // "projects/[PROJECT_ID]"
     // "organizations/[ORGANIZATION_ID]"
-    String parent = "my-parent";  // TODO: Update placeholder value.
+    String parent = "projects/my-project";  // TODO: Update placeholder value.
 
     Logging loggingService = createLoggingService();
     Logging.Projects.Logs.List request = loggingService.projects().logs().list(parent);
@@ -595,7 +595,7 @@ public class LoggingExample {
     // The resource name of the project in which to create the metric:
     // "projects/[PROJECT_ID]"
     // The new metric must be provided in the request.
-    String parent = "my-parent";  // TODO: Update placeholder value.
+    String parent = "projects/my-project";  // TODO: Update placeholder value.
 
     // TODO: Assign values to desired fields of `requestBody`:
     LogMetric requestBody = new LogMetric();
@@ -655,7 +655,7 @@ public class LoggingExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The resource name of the metric to delete:
     // "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
-    String metricName = "my-metric-name";  // TODO: Update placeholder value.
+    String metricName = "projects/my-project/metrics/my-metric";  // TODO: Update placeholder value.
 
     Logging loggingService = createLoggingService();
     Logging.Projects.Metrics.Delete request = loggingService.projects().metrics().delete(metricName);
@@ -710,7 +710,7 @@ public class LoggingExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The resource name of the desired metric:
     // "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
-    String metricName = "my-metric-name";  // TODO: Update placeholder value.
+    String metricName = "projects/my-project/metrics/my-metric";  // TODO: Update placeholder value.
 
     Logging loggingService = createLoggingService();
     Logging.Projects.Metrics.Get request = loggingService.projects().metrics().get(metricName);
@@ -769,7 +769,7 @@ public class LoggingExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
     // Required. The name of the project containing the metrics:
     // "projects/[PROJECT_ID]"
-    String parent = "my-parent";  // TODO: Update placeholder value.
+    String parent = "projects/my-project";  // TODO: Update placeholder value.
 
     Logging loggingService = createLoggingService();
     Logging.Projects.Metrics.List request = loggingService.projects().metrics().list(parent);
@@ -837,7 +837,7 @@ public class LoggingExample {
     // "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
     // The updated metric must be provided in the request and it's name field must be the same as
     // [METRIC_ID] If the metric does not exist in [PROJECT_ID], then a new metric is created.
-    String metricName = "my-metric-name";  // TODO: Update placeholder value.
+    String metricName = "projects/my-project/metrics/my-metric";  // TODO: Update placeholder value.
 
     // TODO: Assign values to desired fields of `requestBody`. All existing
     // fields will be replaced:
@@ -901,7 +901,7 @@ public class LoggingExample {
     // "projects/[PROJECT_ID]"
     // "organizations/[ORGANIZATION_ID]"
     // Examples: "projects/my-logging-project", "organizations/123456789".
-    String parent = "my-parent";  // TODO: Update placeholder value.
+    String parent = "projects/my-project";  // TODO: Update placeholder value.
 
     // TODO: Assign values to desired fields of `requestBody`:
     LogSink requestBody = new LogSink();
@@ -965,7 +965,7 @@ public class LoggingExample {
     // "organizations/[ORGANIZATION_ID]/sinks/[SINK_ID]"
     // It is an error if the sink does not exist. Example: "projects/my-project-id/sinks/my-sink-id". It
     // is an error if the sink does not exist.
-    String sinkName = "my-sink-name";  // TODO: Update placeholder value.
+    String sinkName = "projects/my-project/sinks/my-sink";  // TODO: Update placeholder value.
 
     Logging loggingService = createLoggingService();
     Logging.Projects.Sinks.Delete request = loggingService.projects().sinks().delete(sinkName);
@@ -1022,7 +1022,7 @@ public class LoggingExample {
     // "projects/[PROJECT_ID]/sinks/[SINK_ID]"
     // "organizations/[ORGANIZATION_ID]/sinks/[SINK_ID]"
     // Example: "projects/my-project-id/sinks/my-sink-id".
-    String sinkName = "my-sink-name";  // TODO: Update placeholder value.
+    String sinkName = "projects/my-project/sinks/my-sink";  // TODO: Update placeholder value.
 
     Logging loggingService = createLoggingService();
     Logging.Projects.Sinks.Get request = loggingService.projects().sinks().get(sinkName);
@@ -1081,7 +1081,7 @@ public class LoggingExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
     // Required. The parent resource whose sinks are to be listed. Examples:
     // "projects/my-logging-project", "organizations/123456789".
-    String parent = "my-parent";  // TODO: Update placeholder value.
+    String parent = "projects/my-project";  // TODO: Update placeholder value.
 
     Logging loggingService = createLoggingService();
     Logging.Projects.Sinks.List request = loggingService.projects().sinks().list(parent);
@@ -1150,7 +1150,7 @@ public class LoggingExample {
     // "projects/[PROJECT_ID]/sinks/[SINK_ID]"
     // "organizations/[ORGANIZATION_ID]/sinks/[SINK_ID]"
     // Example: "projects/my-project-id/sinks/my-sink-id".
-    String sinkName = "my-sink-name";  // TODO: Update placeholder value.
+    String sinkName = "projects/my-project/sinks/my-sink";  // TODO: Update placeholder value.
 
     // TODO: Assign values to desired fields of `requestBody`. All existing
     // fields will be replaced:

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_pubsub.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_pubsub.v1.json.baseline
@@ -32,7 +32,7 @@ public class PubsubExample {
     // REQUIRED: The resource for which the policy is being requested.
     // `resource` is usually specified as a path. For example, a Project
     // resource is specified as `projects/{project}`.
-    String resource = "my-resource";  // TODO: Update placeholder value.
+    String resource = "projects/my-project/snapshots/my-snapshot";  // TODO: Update placeholder value.
 
     Pubsub pubsubService = createPubsubService();
     Pubsub.Projects.Snapshots.GetIamPolicy request = pubsubService.projects().snapshots().getIamPolicy(resource);
@@ -92,7 +92,7 @@ public class PubsubExample {
     // REQUIRED: The resource for which the policy is being specified.
     // `resource` is usually specified as a path. For example, a Project
     // resource is specified as `projects/{project}`.
-    String resource = "my-resource";  // TODO: Update placeholder value.
+    String resource = "projects/my-project/snapshots/my-snapshot";  // TODO: Update placeholder value.
 
     // TODO: Assign values to desired fields of `requestBody`:
     SetIamPolicyRequest requestBody = new SetIamPolicyRequest();
@@ -155,7 +155,7 @@ public class PubsubExample {
     // REQUIRED: The resource for which the policy detail is being requested.
     // `resource` is usually specified as a path. For example, a Project
     // resource is specified as `projects/{project}`.
-    String resource = "my-resource";  // TODO: Update placeholder value.
+    String resource = "projects/my-project/snapshots/my-snapshot";  // TODO: Update placeholder value.
 
     // TODO: Assign values to desired fields of `requestBody`:
     TestIamPermissionsRequest requestBody = new TestIamPermissionsRequest();
@@ -216,7 +216,7 @@ public class PubsubExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The subscription whose message is being acknowledged.
     // Format is `projects/{project}/subscriptions/{sub}`.
-    String subscription = "my-subscription";  // TODO: Update placeholder value.
+    String subscription = "projects/my-project/subscriptions/my-subscription";  // TODO: Update placeholder value.
 
     // TODO: Assign values to desired fields of `requestBody`:
     AcknowledgeRequest requestBody = new AcknowledgeRequest();
@@ -278,7 +278,7 @@ public class PubsubExample {
     // (`[0-9]`), dashes (`-`), underscores (`_`), periods (`.`), tildes (`~`),
     // plus (`+`) or percent signs (`%`). It must be between 3 and 255 characters
     // in length, and it must not start with `"goog"`.
-    String name = "my-name";  // TODO: Update placeholder value.
+    String name = "projects/my-project/subscriptions/my-subscription";  // TODO: Update placeholder value.
 
     // TODO: Assign values to desired fields of `requestBody`. All existing
     // fields will be replaced:
@@ -339,7 +339,7 @@ public class PubsubExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The subscription to delete.
     // Format is `projects/{project}/subscriptions/{sub}`.
-    String subscription = "my-subscription";  // TODO: Update placeholder value.
+    String subscription = "projects/my-project/subscriptions/my-subscription";  // TODO: Update placeholder value.
 
     Pubsub pubsubService = createPubsubService();
     Pubsub.Projects.Subscriptions.Delete request = pubsubService.projects().subscriptions().delete(subscription);
@@ -394,7 +394,7 @@ public class PubsubExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The name of the subscription to get.
     // Format is `projects/{project}/subscriptions/{sub}`.
-    String subscription = "my-subscription";  // TODO: Update placeholder value.
+    String subscription = "projects/my-project/subscriptions/my-subscription";  // TODO: Update placeholder value.
 
     Pubsub pubsubService = createPubsubService();
     Pubsub.Projects.Subscriptions.Get request = pubsubService.projects().subscriptions().get(subscription);
@@ -453,7 +453,7 @@ public class PubsubExample {
     // REQUIRED: The resource for which the policy is being requested.
     // `resource` is usually specified as a path. For example, a Project
     // resource is specified as `projects/{project}`.
-    String resource = "my-resource";  // TODO: Update placeholder value.
+    String resource = "projects/my-project/subscriptions/my-subscription";  // TODO: Update placeholder value.
 
     Pubsub pubsubService = createPubsubService();
     Pubsub.Projects.Subscriptions.GetIamPolicy request = pubsubService.projects().subscriptions().getIamPolicy(resource);
@@ -512,7 +512,7 @@ public class PubsubExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The name of the cloud project that subscriptions belong to.
     // Format is `projects/{project}`.
-    String project = "my-project";  // TODO: Update placeholder value.
+    String project = "projects/my-project";  // TODO: Update placeholder value.
 
     Pubsub pubsubService = createPubsubService();
     Pubsub.Projects.Subscriptions.List request = pubsubService.projects().subscriptions().list(project);
@@ -578,7 +578,7 @@ public class PubsubExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The name of the subscription.
     // Format is `projects/{project}/subscriptions/{sub}`.
-    String subscription = "my-subscription";  // TODO: Update placeholder value.
+    String subscription = "projects/my-project/subscriptions/my-subscription";  // TODO: Update placeholder value.
 
     // TODO: Assign values to desired fields of `requestBody`:
     ModifyAckDeadlineRequest requestBody = new ModifyAckDeadlineRequest();
@@ -636,7 +636,7 @@ public class PubsubExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The name of the subscription.
     // Format is `projects/{project}/subscriptions/{sub}`.
-    String subscription = "my-subscription";  // TODO: Update placeholder value.
+    String subscription = "projects/my-project/subscriptions/my-subscription";  // TODO: Update placeholder value.
 
     // TODO: Assign values to desired fields of `requestBody`:
     ModifyPushConfigRequest requestBody = new ModifyPushConfigRequest();
@@ -695,7 +695,7 @@ public class PubsubExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The subscription from which messages should be pulled.
     // Format is `projects/{project}/subscriptions/{sub}`.
-    String subscription = "my-subscription";  // TODO: Update placeholder value.
+    String subscription = "projects/my-project/subscriptions/my-subscription";  // TODO: Update placeholder value.
 
     // TODO: Assign values to desired fields of `requestBody`:
     PullRequest requestBody = new PullRequest();
@@ -758,7 +758,7 @@ public class PubsubExample {
     // REQUIRED: The resource for which the policy is being specified.
     // `resource` is usually specified as a path. For example, a Project
     // resource is specified as `projects/{project}`.
-    String resource = "my-resource";  // TODO: Update placeholder value.
+    String resource = "projects/my-project/subscriptions/my-subscription";  // TODO: Update placeholder value.
 
     // TODO: Assign values to desired fields of `requestBody`:
     SetIamPolicyRequest requestBody = new SetIamPolicyRequest();
@@ -821,7 +821,7 @@ public class PubsubExample {
     // REQUIRED: The resource for which the policy detail is being requested.
     // `resource` is usually specified as a path. For example, a Project
     // resource is specified as `projects/{project}`.
-    String resource = "my-resource";  // TODO: Update placeholder value.
+    String resource = "projects/my-project/subscriptions/my-subscription";  // TODO: Update placeholder value.
 
     // TODO: Assign values to desired fields of `requestBody`:
     TestIamPermissionsRequest requestBody = new TestIamPermissionsRequest();
@@ -886,7 +886,7 @@ public class PubsubExample {
     // underscores (`_`), periods (`.`), tildes (`~`), plus (`+`) or percent
     // signs (`%`). It must be between 3 and 255 characters in length, and it
     // must not start with `"goog"`.
-    String name = "my-name";  // TODO: Update placeholder value.
+    String name = "projects/my-project/topics/my-topic";  // TODO: Update placeholder value.
 
     // TODO: Assign values to desired fields of `requestBody`. All existing
     // fields will be replaced:
@@ -947,7 +947,7 @@ public class PubsubExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
     // Name of the topic to delete.
     // Format is `projects/{project}/topics/{topic}`.
-    String topic = "my-topic";  // TODO: Update placeholder value.
+    String topic = "projects/my-project/topics/my-topic";  // TODO: Update placeholder value.
 
     Pubsub pubsubService = createPubsubService();
     Pubsub.Projects.Topics.Delete request = pubsubService.projects().topics().delete(topic);
@@ -1002,7 +1002,7 @@ public class PubsubExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The name of the topic to get.
     // Format is `projects/{project}/topics/{topic}`.
-    String topic = "my-topic";  // TODO: Update placeholder value.
+    String topic = "projects/my-project/topics/my-topic";  // TODO: Update placeholder value.
 
     Pubsub pubsubService = createPubsubService();
     Pubsub.Projects.Topics.Get request = pubsubService.projects().topics().get(topic);
@@ -1061,7 +1061,7 @@ public class PubsubExample {
     // REQUIRED: The resource for which the policy is being requested.
     // `resource` is usually specified as a path. For example, a Project
     // resource is specified as `projects/{project}`.
-    String resource = "my-resource";  // TODO: Update placeholder value.
+    String resource = "projects/my-project/topics/my-topic";  // TODO: Update placeholder value.
 
     Pubsub pubsubService = createPubsubService();
     Pubsub.Projects.Topics.GetIamPolicy request = pubsubService.projects().topics().getIamPolicy(resource);
@@ -1120,7 +1120,7 @@ public class PubsubExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The name of the cloud project that topics belong to.
     // Format is `projects/{project}`.
-    String project = "my-project";  // TODO: Update placeholder value.
+    String project = "projects/my-project";  // TODO: Update placeholder value.
 
     Pubsub pubsubService = createPubsubService();
     Pubsub.Projects.Topics.List request = pubsubService.projects().topics().list(project);
@@ -1187,7 +1187,7 @@ public class PubsubExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The messages in the request will be published on this topic.
     // Format is `projects/{project}/topics/{topic}`.
-    String topic = "my-topic";  // TODO: Update placeholder value.
+    String topic = "projects/my-project/topics/my-topic";  // TODO: Update placeholder value.
 
     // TODO: Assign values to desired fields of `requestBody`:
     PublishRequest requestBody = new PublishRequest();
@@ -1250,7 +1250,7 @@ public class PubsubExample {
     // REQUIRED: The resource for which the policy is being specified.
     // `resource` is usually specified as a path. For example, a Project
     // resource is specified as `projects/{project}`.
-    String resource = "my-resource";  // TODO: Update placeholder value.
+    String resource = "projects/my-project/topics/my-topic";  // TODO: Update placeholder value.
 
     // TODO: Assign values to desired fields of `requestBody`:
     SetIamPolicyRequest requestBody = new SetIamPolicyRequest();
@@ -1311,7 +1311,7 @@ public class PubsubExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The name of the topic that subscriptions are attached to.
     // Format is `projects/{project}/topics/{topic}`.
-    String topic = "my-topic";  // TODO: Update placeholder value.
+    String topic = "projects/my-project/topics/my-topic";  // TODO: Update placeholder value.
 
     Pubsub pubsubService = createPubsubService();
     Pubsub.Projects.Topics.Subscriptions.List request = pubsubService.projects().topics().subscriptions().list(topic);
@@ -1379,7 +1379,7 @@ public class PubsubExample {
     // REQUIRED: The resource for which the policy detail is being requested.
     // `resource` is usually specified as a path. For example, a Project
     // resource is specified as `projects/{project}`.
-    String resource = "my-resource";  // TODO: Update placeholder value.
+    String resource = "projects/my-project/topics/my-topic";  // TODO: Update placeholder value.
 
     // TODO: Assign values to desired fields of `requestBody`:
     TestIamPermissionsRequest requestBody = new TestIamPermissionsRequest();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_storagetransfer.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/java/java_storagetransfer.v1.json.baseline
@@ -199,7 +199,7 @@ import java.util.Arrays;
 public class StoragetransferExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The job to get. Required.
-    String jobName = "my-job-name";  // TODO: Update placeholder value.
+    String jobName = "transferJobs/my-transfer-job";  // TODO: Update placeholder value.
 
     Storagetransfer storagetransferService = createStoragetransferService();
     Storagetransfer.TransferJobs.Get request = storagetransferService.transferJobs().get(jobName);
@@ -320,7 +320,7 @@ import java.util.Arrays;
 public class StoragetransferExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The name of job to update. Required.
-    String jobName = "my-job-name";  // TODO: Update placeholder value.
+    String jobName = "transferJobs/my-transfer-job";  // TODO: Update placeholder value.
 
     // TODO: Assign values to desired fields of `requestBody`. Only assigned
     // fields will be changed:
@@ -380,7 +380,7 @@ import java.util.Arrays;
 public class StoragetransferExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The name of the operation resource to be cancelled.
-    String name = "my-name";  // TODO: Update placeholder value.
+    String name = "transferOperations/my-transfer-operation";  // TODO: Update placeholder value.
 
     Storagetransfer storagetransferService = createStoragetransferService();
     Storagetransfer.TransferOperations.Cancel request = storagetransferService.transferOperations().cancel(name);
@@ -433,7 +433,7 @@ import java.util.Arrays;
 public class StoragetransferExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The name of the operation resource to be deleted.
-    String name = "my-name";  // TODO: Update placeholder value.
+    String name = "transferOperations/my-transfer-operation";  // TODO: Update placeholder value.
 
     Storagetransfer storagetransferService = createStoragetransferService();
     Storagetransfer.TransferOperations.Delete request = storagetransferService.transferOperations().delete(name);
@@ -487,7 +487,7 @@ import java.util.Arrays;
 public class StoragetransferExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The name of the operation resource.
-    String name = "my-name";  // TODO: Update placeholder value.
+    String name = "transferOperations/my-transfer-operation";  // TODO: Update placeholder value.
 
     Storagetransfer storagetransferService = createStoragetransferService();
     Storagetransfer.TransferOperations.Get request = storagetransferService.transferOperations().get(name);
@@ -610,7 +610,7 @@ import java.util.Arrays;
 public class StoragetransferExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The name of the transfer operation. Required.
-    String name = "my-name";  // TODO: Update placeholder value.
+    String name = "transferOperations/my-transfer-operation";  // TODO: Update placeholder value.
 
     // TODO: Assign values to desired fields of `requestBody`:
     PauseTransferOperationRequest requestBody = new PauseTransferOperationRequest();
@@ -667,7 +667,7 @@ import java.util.Arrays;
 public class StoragetransferExample {
   public static void main(String args[]) throws IOException, GeneralSecurityException {
     // The name of the transfer operation. Required.
-    String name = "my-name";  // TODO: Update placeholder value.
+    String name = "transferOperations/my-transfer-operation";  // TODO: Update placeholder value.
 
     // TODO: Assign values to desired fields of `requestBody`:
     ResumeTransferOperationRequest requestBody = new ResumeTransferOperationRequest();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/js/js_cloudbilling.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/js/js_cloudbilling.v1.json.baseline
@@ -156,8 +156,8 @@
     <script>
     function makeApiCall() {
       var params = {
-        // The resource name of the billing account associated with the projects that you want to list. For
-        // example, `billingAccounts/012345-567890-ABCDEF`.
+        // The resource name of the billing account associated with the projects that
+        // you want to list. For example, `billingAccounts/012345-567890-ABCDEF`.
         name: 'billingAccounts/my-billing-account',  // TODO: Update placeholder value.
       };
 
@@ -235,8 +235,8 @@
     <script>
     function makeApiCall() {
       var params = {
-        // The resource name of the project for which billing information is retrieved. For example,
-        // `projects/tokyo-rain-123`.
+        // The resource name of the project for which billing information is
+        // retrieved. For example, `projects/tokyo-rain-123`.
         name: 'projects/my-project',  // TODO: Update placeholder value.
       };
 
@@ -302,8 +302,8 @@
     <script>
     function makeApiCall() {
       var params = {
-        // The resource name of the project associated with the billing information that you want to update.
-        // For example, `projects/tokyo-rain-123`.
+        // The resource name of the project associated with the billing information
+        // that you want to update. For example, `projects/tokyo-rain-123`.
         name: 'projects/my-project',  // TODO: Update placeholder value.
       };
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/js/js_cloudresourcemanager.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/js/js_cloudresourcemanager.v1.json.baseline
@@ -15,7 +15,7 @@
     function makeApiCall() {
       var params = {
         // The name of the operation resource.
-        name: 'my-name',  // TODO: Update placeholder value.
+        name: 'operations/my-operation',  // TODO: Update placeholder value.
       };
 
       var request = gapi.client.cloudresourcemanager.operations.get(params);
@@ -81,7 +81,7 @@
     function makeApiCall() {
       var params = {
         // The resource name of the Organization to fetch, e.g. "organizations/1234".
-        name: 'my-name',  // TODO: Update placeholder value.
+        name: 'organizations/my-organization',  // TODO: Update placeholder value.
       };
 
       var request = gapi.client.cloudresourcemanager.organizations.get(params);
@@ -149,7 +149,7 @@
         // REQUIRED: The resource for which the policy is being requested.
         // `resource` is usually specified as a path. For example, a Project
         // resource is specified as `projects/{project}`.
-        resource: 'my-resource',  // TODO: Update placeholder value.
+        resource: 'organizations/my-organization',  // TODO: Update placeholder value.
       };
 
       var getIamPolicyRequestBody = {
@@ -298,7 +298,7 @@
         // REQUIRED: The resource for which the policy is being specified.
         // `resource` is usually specified as a path. For example, a Project
         // resource is specified as `projects/{project}`.
-        resource: 'my-resource',  // TODO: Update placeholder value.
+        resource: 'organizations/my-organization',  // TODO: Update placeholder value.
       };
 
       var setIamPolicyRequestBody = {
@@ -370,7 +370,7 @@
         // REQUIRED: The resource for which the policy detail is being requested.
         // `resource` is usually specified as a path. For example, a Project
         // resource is specified as `projects/{project}`.
-        resource: 'my-resource',  // TODO: Update placeholder value.
+        resource: 'organizations/my-organization',  // TODO: Update placeholder value.
       };
 
       var testIamPermissionsRequestBody = {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/js/js_genomics.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/js/js_genomics.v1.json.baseline
@@ -1300,7 +1300,7 @@
     function makeApiCall() {
       var params = {
         // REQUIRED: The resource for which policy is being specified. Format is `datasets/`.
-        resource: 'my-resource',  // TODO: Update placeholder value.
+        resource: 'datasets/my-dataset',  // TODO: Update placeholder value.
       };
 
       var getIamPolicyRequestBody = {
@@ -1516,7 +1516,7 @@
     function makeApiCall() {
       var params = {
         // REQUIRED: The resource for which policy is being specified. Format is `datasets/`.
-        resource: 'my-resource',  // TODO: Update placeholder value.
+        resource: 'datasets/my-dataset',  // TODO: Update placeholder value.
       };
 
       var setIamPolicyRequestBody = {
@@ -1586,7 +1586,7 @@
     function makeApiCall() {
       var params = {
         // REQUIRED: The resource for which policy is being specified. Format is `datasets/`.
-        resource: 'my-resource',  // TODO: Update placeholder value.
+        resource: 'datasets/my-dataset',  // TODO: Update placeholder value.
       };
 
       var testIamPermissionsRequestBody = {
@@ -1726,7 +1726,7 @@
     function makeApiCall() {
       var params = {
         // The name of the operation resource to be cancelled.
-        name: 'my-name',  // TODO: Update placeholder value.
+        name: 'operations/my-operation',  // TODO: Update placeholder value.
       };
 
       var cancelOperationRequestBody = {
@@ -1793,7 +1793,7 @@
     function makeApiCall() {
       var params = {
         // The name of the operation resource.
-        name: 'my-name',  // TODO: Update placeholder value.
+        name: 'operations/my-operation',  // TODO: Update placeholder value.
       };
 
       var request = gapi.client.genomics.operations.get(params);

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/js/js_logging.v2beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/js/js_logging.v2beta1.json.baseline
@@ -20,7 +20,7 @@
         // [LOG_ID] must be URL-encoded. For example, "projects/my-project-id/logs/syslog",
         // "organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity". For more
         // information about log names, see LogEntry.
-        logName: 'my-log-name',  // TODO: Update placeholder value.
+        logName: 'billingAccounts/my-billing-account/logs/my-log',  // TODO: Update placeholder value.
       };
 
       var request = gapi.client.logging.billingAccounts.logs.delete(params);
@@ -85,7 +85,7 @@
         // Required. The resource name that owns the logs:
         // "projects/[PROJECT_ID]"
         // "organizations/[ORGANIZATION_ID]"
-        parent: 'my-parent',  // TODO: Update placeholder value.
+        parent: 'billingAccounts/my-billing-account',  // TODO: Update placeholder value.
       };
 
       executeRequest(params);
@@ -385,7 +385,7 @@
         // [LOG_ID] must be URL-encoded. For example, "projects/my-project-id/logs/syslog",
         // "organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity". For more
         // information about log names, see LogEntry.
-        logName: 'my-log-name',  // TODO: Update placeholder value.
+        logName: 'organizations/my-organization/logs/my-log',  // TODO: Update placeholder value.
       };
 
       var request = gapi.client.logging.organizations.logs.delete(params);
@@ -450,7 +450,7 @@
         // Required. The resource name that owns the logs:
         // "projects/[PROJECT_ID]"
         // "organizations/[ORGANIZATION_ID]"
-        parent: 'my-parent',  // TODO: Update placeholder value.
+        parent: 'organizations/my-organization',  // TODO: Update placeholder value.
       };
 
       executeRequest(params);
@@ -533,7 +533,7 @@
         // [LOG_ID] must be URL-encoded. For example, "projects/my-project-id/logs/syslog",
         // "organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity". For more
         // information about log names, see LogEntry.
-        logName: 'my-log-name',  // TODO: Update placeholder value.
+        logName: 'projects/my-project/logs/my-log',  // TODO: Update placeholder value.
       };
 
       var request = gapi.client.logging.projects.logs.delete(params);
@@ -598,7 +598,7 @@
         // Required. The resource name that owns the logs:
         // "projects/[PROJECT_ID]"
         // "organizations/[ORGANIZATION_ID]"
-        parent: 'my-parent',  // TODO: Update placeholder value.
+        parent: 'projects/my-project',  // TODO: Update placeholder value.
       };
 
       executeRequest(params);
@@ -678,7 +678,7 @@
         // The resource name of the project in which to create the metric:
         // "projects/[PROJECT_ID]"
         // The new metric must be provided in the request.
-        parent: 'my-parent',  // TODO: Update placeholder value.
+        parent: 'projects/my-project',  // TODO: Update placeholder value.
       };
 
       var logMetricBody = {
@@ -749,7 +749,7 @@
       var params = {
         // The resource name of the metric to delete:
         // "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
-        metricName: 'my-metric-name',  // TODO: Update placeholder value.
+        metricName: 'projects/my-project/metrics/my-metric',  // TODO: Update placeholder value.
       };
 
       var request = gapi.client.logging.projects.metrics.delete(params);
@@ -813,7 +813,7 @@
       var params = {
         // The resource name of the desired metric:
         // "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
-        metricName: 'my-metric-name',  // TODO: Update placeholder value.
+        metricName: 'projects/my-project/metrics/my-metric',  // TODO: Update placeholder value.
       };
 
       var request = gapi.client.logging.projects.metrics.get(params);
@@ -880,7 +880,7 @@
       var params = {
         // Required. The name of the project containing the metrics:
         // "projects/[PROJECT_ID]"
-        parent: 'my-parent',  // TODO: Update placeholder value.
+        parent: 'projects/my-project',  // TODO: Update placeholder value.
       };
 
       executeRequest(params);
@@ -961,7 +961,7 @@
         // "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
         // The updated metric must be provided in the request and it's name field must be the same as
         // [METRIC_ID] If the metric does not exist in [PROJECT_ID], then a new metric is created.
-        metricName: 'my-metric-name',  // TODO: Update placeholder value.
+        metricName: 'projects/my-project/metrics/my-metric',  // TODO: Update placeholder value.
       };
 
       var logMetricBody = {
@@ -1035,7 +1035,7 @@
         // "projects/[PROJECT_ID]"
         // "organizations/[ORGANIZATION_ID]"
         // Examples: "projects/my-logging-project", "organizations/123456789".
-        parent: 'my-parent',  // TODO: Update placeholder value.
+        parent: 'projects/my-project',  // TODO: Update placeholder value.
       };
 
       var logSinkBody = {
@@ -1110,7 +1110,7 @@
         // "organizations/[ORGANIZATION_ID]/sinks/[SINK_ID]"
         // It is an error if the sink does not exist. Example: "projects/my-project-id/sinks/my-sink-id". It
         // is an error if the sink does not exist.
-        sinkName: 'my-sink-name',  // TODO: Update placeholder value.
+        sinkName: 'projects/my-project/sinks/my-sink',  // TODO: Update placeholder value.
       };
 
       var request = gapi.client.logging.projects.sinks.delete(params);
@@ -1176,7 +1176,7 @@
         // "projects/[PROJECT_ID]/sinks/[SINK_ID]"
         // "organizations/[ORGANIZATION_ID]/sinks/[SINK_ID]"
         // Example: "projects/my-project-id/sinks/my-sink-id".
-        sinkName: 'my-sink-name',  // TODO: Update placeholder value.
+        sinkName: 'projects/my-project/sinks/my-sink',  // TODO: Update placeholder value.
       };
 
       var request = gapi.client.logging.projects.sinks.get(params);
@@ -1243,7 +1243,7 @@
       var params = {
         // Required. The parent resource whose sinks are to be listed. Examples:
         // "projects/my-logging-project", "organizations/123456789".
-        parent: 'my-parent',  // TODO: Update placeholder value.
+        parent: 'projects/my-project',  // TODO: Update placeholder value.
       };
 
       executeRequest(params);
@@ -1325,7 +1325,7 @@
         // "projects/[PROJECT_ID]/sinks/[SINK_ID]"
         // "organizations/[ORGANIZATION_ID]/sinks/[SINK_ID]"
         // Example: "projects/my-project-id/sinks/my-sink-id".
-        sinkName: 'my-sink-name',  // TODO: Update placeholder value.
+        sinkName: 'projects/my-project/sinks/my-sink',  // TODO: Update placeholder value.
       };
 
       var logSinkBody = {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/js/js_pubsub.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/js/js_pubsub.v1.json.baseline
@@ -17,7 +17,7 @@
         // REQUIRED: The resource for which the policy is being requested.
         // `resource` is usually specified as a path. For example, a Project
         // resource is specified as `projects/{project}`.
-        resource: 'my-resource',  // TODO: Update placeholder value.
+        resource: 'projects/my-project/snapshots/my-snapshot',  // TODO: Update placeholder value.
       };
 
       var request = gapi.client.pubsub.projects.snapshots.getIamPolicy(params);
@@ -85,7 +85,7 @@
         // REQUIRED: The resource for which the policy is being specified.
         // `resource` is usually specified as a path. For example, a Project
         // resource is specified as `projects/{project}`.
-        resource: 'my-resource',  // TODO: Update placeholder value.
+        resource: 'projects/my-project/snapshots/my-snapshot',  // TODO: Update placeholder value.
       };
 
       var setIamPolicyRequestBody = {
@@ -157,7 +157,7 @@
         // REQUIRED: The resource for which the policy detail is being requested.
         // `resource` is usually specified as a path. For example, a Project
         // resource is specified as `projects/{project}`.
-        resource: 'my-resource',  // TODO: Update placeholder value.
+        resource: 'projects/my-project/snapshots/my-snapshot',  // TODO: Update placeholder value.
       };
 
       var testIamPermissionsRequestBody = {
@@ -228,7 +228,7 @@
       var params = {
         // The subscription whose message is being acknowledged.
         // Format is `projects/{project}/subscriptions/{sub}`.
-        subscription: 'my-subscription',  // TODO: Update placeholder value.
+        subscription: 'projects/my-project/subscriptions/my-subscription',  // TODO: Update placeholder value.
       };
 
       var acknowledgeRequestBody = {
@@ -300,7 +300,7 @@
         // (`[0-9]`), dashes (`-`), underscores (`_`), periods (`.`), tildes (`~`),
         // plus (`+`) or percent signs (`%`). It must be between 3 and 255 characters
         // in length, and it must not start with `"goog"`.
-        name: 'my-name',  // TODO: Update placeholder value.
+        name: 'projects/my-project/subscriptions/my-subscription',  // TODO: Update placeholder value.
       };
 
       var subscriptionBody = {
@@ -372,7 +372,7 @@
       var params = {
         // The subscription to delete.
         // Format is `projects/{project}/subscriptions/{sub}`.
-        subscription: 'my-subscription',  // TODO: Update placeholder value.
+        subscription: 'projects/my-project/subscriptions/my-subscription',  // TODO: Update placeholder value.
       };
 
       var request = gapi.client.pubsub.projects.subscriptions.delete(params);
@@ -436,7 +436,7 @@
       var params = {
         // The name of the subscription to get.
         // Format is `projects/{project}/subscriptions/{sub}`.
-        subscription: 'my-subscription',  // TODO: Update placeholder value.
+        subscription: 'projects/my-project/subscriptions/my-subscription',  // TODO: Update placeholder value.
       };
 
       var request = gapi.client.pubsub.projects.subscriptions.get(params);
@@ -504,7 +504,7 @@
         // REQUIRED: The resource for which the policy is being requested.
         // `resource` is usually specified as a path. For example, a Project
         // resource is specified as `projects/{project}`.
-        resource: 'my-resource',  // TODO: Update placeholder value.
+        resource: 'projects/my-project/subscriptions/my-subscription',  // TODO: Update placeholder value.
       };
 
       var request = gapi.client.pubsub.projects.subscriptions.getIamPolicy(params);
@@ -571,7 +571,7 @@
       var params = {
         // The name of the cloud project that subscriptions belong to.
         // Format is `projects/{project}`.
-        project: 'my-project',  // TODO: Update placeholder value.
+        project: 'projects/my-project',  // TODO: Update placeholder value.
       };
 
       executeRequest(params);
@@ -650,7 +650,7 @@
       var params = {
         // The name of the subscription.
         // Format is `projects/{project}/subscriptions/{sub}`.
-        subscription: 'my-subscription',  // TODO: Update placeholder value.
+        subscription: 'projects/my-project/subscriptions/my-subscription',  // TODO: Update placeholder value.
       };
 
       var modifyAckDeadlineRequestBody = {
@@ -718,7 +718,7 @@
       var params = {
         // The name of the subscription.
         // Format is `projects/{project}/subscriptions/{sub}`.
-        subscription: 'my-subscription',  // TODO: Update placeholder value.
+        subscription: 'projects/my-project/subscriptions/my-subscription',  // TODO: Update placeholder value.
       };
 
       var modifyPushConfigRequestBody = {
@@ -786,7 +786,7 @@
       var params = {
         // The subscription from which messages should be pulled.
         // Format is `projects/{project}/subscriptions/{sub}`.
-        subscription: 'my-subscription',  // TODO: Update placeholder value.
+        subscription: 'projects/my-project/subscriptions/my-subscription',  // TODO: Update placeholder value.
       };
 
       var pullRequestBody = {
@@ -858,7 +858,7 @@
         // REQUIRED: The resource for which the policy is being specified.
         // `resource` is usually specified as a path. For example, a Project
         // resource is specified as `projects/{project}`.
-        resource: 'my-resource',  // TODO: Update placeholder value.
+        resource: 'projects/my-project/subscriptions/my-subscription',  // TODO: Update placeholder value.
       };
 
       var setIamPolicyRequestBody = {
@@ -930,7 +930,7 @@
         // REQUIRED: The resource for which the policy detail is being requested.
         // `resource` is usually specified as a path. For example, a Project
         // resource is specified as `projects/{project}`.
-        resource: 'my-resource',  // TODO: Update placeholder value.
+        resource: 'projects/my-project/subscriptions/my-subscription',  // TODO: Update placeholder value.
       };
 
       var testIamPermissionsRequestBody = {
@@ -1005,7 +1005,7 @@
         // underscores (`_`), periods (`.`), tildes (`~`), plus (`+`) or percent
         // signs (`%`). It must be between 3 and 255 characters in length, and it
         // must not start with `"goog"`.
-        name: 'my-name',  // TODO: Update placeholder value.
+        name: 'projects/my-project/topics/my-topic',  // TODO: Update placeholder value.
       };
 
       var topicBody = {
@@ -1077,7 +1077,7 @@
       var params = {
         // Name of the topic to delete.
         // Format is `projects/{project}/topics/{topic}`.
-        topic: 'my-topic',  // TODO: Update placeholder value.
+        topic: 'projects/my-project/topics/my-topic',  // TODO: Update placeholder value.
       };
 
       var request = gapi.client.pubsub.projects.topics.delete(params);
@@ -1141,7 +1141,7 @@
       var params = {
         // The name of the topic to get.
         // Format is `projects/{project}/topics/{topic}`.
-        topic: 'my-topic',  // TODO: Update placeholder value.
+        topic: 'projects/my-project/topics/my-topic',  // TODO: Update placeholder value.
       };
 
       var request = gapi.client.pubsub.projects.topics.get(params);
@@ -1209,7 +1209,7 @@
         // REQUIRED: The resource for which the policy is being requested.
         // `resource` is usually specified as a path. For example, a Project
         // resource is specified as `projects/{project}`.
-        resource: 'my-resource',  // TODO: Update placeholder value.
+        resource: 'projects/my-project/topics/my-topic',  // TODO: Update placeholder value.
       };
 
       var request = gapi.client.pubsub.projects.topics.getIamPolicy(params);
@@ -1276,7 +1276,7 @@
       var params = {
         // The name of the cloud project that topics belong to.
         // Format is `projects/{project}`.
-        project: 'my-project',  // TODO: Update placeholder value.
+        project: 'projects/my-project',  // TODO: Update placeholder value.
       };
 
       executeRequest(params);
@@ -1355,7 +1355,7 @@
       var params = {
         // The messages in the request will be published on this topic.
         // Format is `projects/{project}/topics/{topic}`.
-        topic: 'my-topic',  // TODO: Update placeholder value.
+        topic: 'projects/my-project/topics/my-topic',  // TODO: Update placeholder value.
       };
 
       var publishRequestBody = {
@@ -1427,7 +1427,7 @@
         // REQUIRED: The resource for which the policy is being specified.
         // `resource` is usually specified as a path. For example, a Project
         // resource is specified as `projects/{project}`.
-        resource: 'my-resource',  // TODO: Update placeholder value.
+        resource: 'projects/my-project/topics/my-topic',  // TODO: Update placeholder value.
       };
 
       var setIamPolicyRequestBody = {
@@ -1498,7 +1498,7 @@
       var params = {
         // The name of the topic that subscriptions are attached to.
         // Format is `projects/{project}/topics/{topic}`.
-        topic: 'my-topic',  // TODO: Update placeholder value.
+        topic: 'projects/my-project/topics/my-topic',  // TODO: Update placeholder value.
       };
 
       executeRequest(params);
@@ -1578,7 +1578,7 @@
         // REQUIRED: The resource for which the policy detail is being requested.
         // `resource` is usually specified as a path. For example, a Project
         // resource is specified as `projects/{project}`.
-        resource: 'my-resource',  // TODO: Update placeholder value.
+        resource: 'projects/my-project/topics/my-topic',  // TODO: Update placeholder value.
       };
 
       var testIamPermissionsRequestBody = {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/js/js_storagetransfer.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/js/js_storagetransfer.v1.json.baseline
@@ -208,7 +208,7 @@
     function makeApiCall() {
       var params = {
         // The job to get. Required.
-        jobName: 'my-job-name',  // TODO: Update placeholder value.
+        jobName: 'transferJobs/my-transfer-job',  // TODO: Update placeholder value.
       };
 
       var request = gapi.client.storagetransfer.transferJobs.get(params);
@@ -349,7 +349,7 @@
     function makeApiCall() {
       var params = {
         // The name of job to update. Required.
-        jobName: 'my-job-name',  // TODO: Update placeholder value.
+        jobName: 'transferJobs/my-transfer-job',  // TODO: Update placeholder value.
       };
 
       var updateTransferJobRequestBody = {
@@ -420,7 +420,7 @@
     function makeApiCall() {
       var params = {
         // The name of the operation resource to be cancelled.
-        name: 'my-name',  // TODO: Update placeholder value.
+        name: 'transferOperations/my-transfer-operation',  // TODO: Update placeholder value.
       };
 
       var request = gapi.client.storagetransfer.transferOperations.cancel(params);
@@ -483,7 +483,7 @@
     function makeApiCall() {
       var params = {
         // The name of the operation resource to be deleted.
-        name: 'my-name',  // TODO: Update placeholder value.
+        name: 'transferOperations/my-transfer-operation',  // TODO: Update placeholder value.
       };
 
       var request = gapi.client.storagetransfer.transferOperations.delete(params);
@@ -546,7 +546,7 @@
     function makeApiCall() {
       var params = {
         // The name of the operation resource.
-        name: 'my-name',  // TODO: Update placeholder value.
+        name: 'transferOperations/my-transfer-operation',  // TODO: Update placeholder value.
       };
 
       var request = gapi.client.storagetransfer.transferOperations.get(params);
@@ -690,7 +690,7 @@
     function makeApiCall() {
       var params = {
         // The name of the transfer operation. Required.
-        name: 'my-name',  // TODO: Update placeholder value.
+        name: 'transferOperations/my-transfer-operation',  // TODO: Update placeholder value.
       };
 
       var pauseTransferOperationRequestBody = {
@@ -757,7 +757,7 @@
     function makeApiCall() {
       var params = {
         // The name of the transfer operation. Required.
-        name: 'my-name',  // TODO: Update placeholder value.
+        name: 'transferOperations/my-transfer-operation',  // TODO: Update placeholder value.
       };
 
       var resumeTransferOperationRequestBody = {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_cloudbilling.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_cloudbilling.v1.json.baseline
@@ -127,8 +127,8 @@ var cloudbilling = google.cloudbilling('v1');
 
 authorize(function(authClient) {
   var request = {
-    // The resource name of the billing account associated with the projects that you want to list. For
-    // example, `billingAccounts/012345-567890-ABCDEF`.
+    // The resource name of the billing account associated with the projects that
+    // you want to list. For example, `billingAccounts/012345-567890-ABCDEF`.
     name: 'billingAccounts/my-billing-account',  // TODO: Update placeholder value.
 
     auth: authClient,
@@ -190,8 +190,8 @@ var cloudbilling = google.cloudbilling('v1');
 
 authorize(function(authClient) {
   var request = {
-    // The resource name of the project for which billing information is retrieved. For example,
-    // `projects/tokyo-rain-123`.
+    // The resource name of the project for which billing information is
+    // retrieved. For example, `projects/tokyo-rain-123`.
     name: 'projects/my-project',  // TODO: Update placeholder value.
 
     auth: authClient,
@@ -240,8 +240,8 @@ var cloudbilling = google.cloudbilling('v1');
 
 authorize(function(authClient) {
   var request = {
-    // The resource name of the project associated with the billing information that you want to update.
-    // For example, `projects/tokyo-rain-123`.
+    // The resource name of the project associated with the billing information
+    // that you want to update. For example, `projects/tokyo-rain-123`.
     name: 'projects/my-project',  // TODO: Update placeholder value.
 
     resource: {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_cloudresourcemanager.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_cloudresourcemanager.v1.json.baseline
@@ -19,7 +19,7 @@ var cloudResourceManager = google.cloudresourcemanager('v1');
 authorize(function(authClient) {
   var request = {
     // The name of the operation resource.
-    name: 'my-name',  // TODO: Update placeholder value.
+    name: 'operations/my-operation',  // TODO: Update placeholder value.
 
     auth: authClient,
   };
@@ -68,7 +68,7 @@ var cloudResourceManager = google.cloudresourcemanager('v1');
 authorize(function(authClient) {
   var request = {
     // The resource name of the Organization to fetch, e.g. "organizations/1234".
-    name: 'my-name',  // TODO: Update placeholder value.
+    name: 'organizations/my-organization',  // TODO: Update placeholder value.
 
     auth: authClient,
   };
@@ -119,7 +119,7 @@ authorize(function(authClient) {
     // REQUIRED: The resource for which the policy is being requested.
     // `resource` is usually specified as a path. For example, a Project
     // resource is specified as `projects/{project}`.
-    resource_: 'my-resource',  // TODO: Update placeholder value.
+    resource_: 'organizations/my-organization',  // TODO: Update placeholder value.
 
     resource: {
       // TODO: Add desired properties to the request body.
@@ -237,7 +237,7 @@ authorize(function(authClient) {
     // REQUIRED: The resource for which the policy is being specified.
     // `resource` is usually specified as a path. For example, a Project
     // resource is specified as `projects/{project}`.
-    resource_: 'my-resource',  // TODO: Update placeholder value.
+    resource_: 'organizations/my-organization',  // TODO: Update placeholder value.
 
     resource: {
       // TODO: Add desired properties to the request body.
@@ -292,7 +292,7 @@ authorize(function(authClient) {
     // REQUIRED: The resource for which the policy detail is being requested.
     // `resource` is usually specified as a path. For example, a Project
     // resource is specified as `projects/{project}`.
-    resource_: 'my-resource',  // TODO: Update placeholder value.
+    resource_: 'organizations/my-organization',  // TODO: Update placeholder value.
 
     resource: {
       // TODO: Add desired properties to the request body.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_genomics.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_genomics.v1.json.baseline
@@ -1000,7 +1000,7 @@ var genomics = google.genomics('v1');
 authorize(function(authClient) {
   var request = {
     // REQUIRED: The resource for which policy is being specified. Format is `datasets/`.
-    resource_: 'my-resource',  // TODO: Update placeholder value.
+    resource_: 'datasets/my-dataset',  // TODO: Update placeholder value.
 
     resource: {
       // TODO: Add desired properties to the request body.
@@ -1166,7 +1166,7 @@ var genomics = google.genomics('v1');
 authorize(function(authClient) {
   var request = {
     // REQUIRED: The resource for which policy is being specified. Format is `datasets/`.
-    resource_: 'my-resource',  // TODO: Update placeholder value.
+    resource_: 'datasets/my-dataset',  // TODO: Update placeholder value.
 
     resource: {
       // TODO: Add desired properties to the request body.
@@ -1219,7 +1219,7 @@ var genomics = google.genomics('v1');
 authorize(function(authClient) {
   var request = {
     // REQUIRED: The resource for which policy is being specified. Format is `datasets/`.
-    resource_: 'my-resource',  // TODO: Update placeholder value.
+    resource_: 'datasets/my-dataset',  // TODO: Update placeholder value.
 
     resource: {
       // TODO: Add desired properties to the request body.
@@ -1325,7 +1325,7 @@ var genomics = google.genomics('v1');
 authorize(function(authClient) {
   var request = {
     // The name of the operation resource to be cancelled.
-    name: 'my-name',  // TODO: Update placeholder value.
+    name: 'operations/my-operation',  // TODO: Update placeholder value.
 
     resource: {
       // TODO: Add desired properties to the request body.
@@ -1375,7 +1375,7 @@ var genomics = google.genomics('v1');
 authorize(function(authClient) {
   var request = {
     // The name of the operation resource.
-    name: 'my-name',  // TODO: Update placeholder value.
+    name: 'operations/my-operation',  // TODO: Update placeholder value.
 
     auth: authClient,
   };

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_logging.v2beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_logging.v2beta1.json.baseline
@@ -24,7 +24,7 @@ authorize(function(authClient) {
     // [LOG_ID] must be URL-encoded. For example, "projects/my-project-id/logs/syslog",
     // "organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity". For more
     // information about log names, see LogEntry.
-    logName: 'my-log-name',  // TODO: Update placeholder value.
+    logName: 'billingAccounts/my-billing-account/logs/my-log',  // TODO: Update placeholder value.
 
     auth: authClient,
   };
@@ -72,7 +72,7 @@ authorize(function(authClient) {
     // Required. The resource name that owns the logs:
     // "projects/[PROJECT_ID]"
     // "organizations/[ORGANIZATION_ID]"
-    parent: 'my-parent',  // TODO: Update placeholder value.
+    parent: 'billingAccounts/my-billing-account',  // TODO: Update placeholder value.
 
     auth: authClient,
   };
@@ -311,7 +311,7 @@ authorize(function(authClient) {
     // [LOG_ID] must be URL-encoded. For example, "projects/my-project-id/logs/syslog",
     // "organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity". For more
     // information about log names, see LogEntry.
-    logName: 'my-log-name',  // TODO: Update placeholder value.
+    logName: 'organizations/my-organization/logs/my-log',  // TODO: Update placeholder value.
 
     auth: authClient,
   };
@@ -359,7 +359,7 @@ authorize(function(authClient) {
     // Required. The resource name that owns the logs:
     // "projects/[PROJECT_ID]"
     // "organizations/[ORGANIZATION_ID]"
-    parent: 'my-parent',  // TODO: Update placeholder value.
+    parent: 'organizations/my-organization',  // TODO: Update placeholder value.
 
     auth: authClient,
   };
@@ -426,7 +426,7 @@ authorize(function(authClient) {
     // [LOG_ID] must be URL-encoded. For example, "projects/my-project-id/logs/syslog",
     // "organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity". For more
     // information about log names, see LogEntry.
-    logName: 'my-log-name',  // TODO: Update placeholder value.
+    logName: 'projects/my-project/logs/my-log',  // TODO: Update placeholder value.
 
     auth: authClient,
   };
@@ -474,7 +474,7 @@ authorize(function(authClient) {
     // Required. The resource name that owns the logs:
     // "projects/[PROJECT_ID]"
     // "organizations/[ORGANIZATION_ID]"
-    parent: 'my-parent',  // TODO: Update placeholder value.
+    parent: 'projects/my-project',  // TODO: Update placeholder value.
 
     auth: authClient,
   };
@@ -538,7 +538,7 @@ authorize(function(authClient) {
     // The resource name of the project in which to create the metric:
     // "projects/[PROJECT_ID]"
     // The new metric must be provided in the request.
-    parent: 'my-parent',  // TODO: Update placeholder value.
+    parent: 'projects/my-project',  // TODO: Update placeholder value.
 
     resource: {
       // TODO: Add desired properties to the request body.
@@ -592,7 +592,7 @@ authorize(function(authClient) {
   var request = {
     // The resource name of the metric to delete:
     // "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
-    metricName: 'my-metric-name',  // TODO: Update placeholder value.
+    metricName: 'projects/my-project/metrics/my-metric',  // TODO: Update placeholder value.
 
     auth: authClient,
   };
@@ -639,7 +639,7 @@ authorize(function(authClient) {
   var request = {
     // The resource name of the desired metric:
     // "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
-    metricName: 'my-metric-name',  // TODO: Update placeholder value.
+    metricName: 'projects/my-project/metrics/my-metric',  // TODO: Update placeholder value.
 
     auth: authClient,
   };
@@ -689,7 +689,7 @@ authorize(function(authClient) {
   var request = {
     // Required. The name of the project containing the metrics:
     // "projects/[PROJECT_ID]"
-    parent: 'my-parent',  // TODO: Update placeholder value.
+    parent: 'projects/my-project',  // TODO: Update placeholder value.
 
     auth: authClient,
   };
@@ -754,7 +754,7 @@ authorize(function(authClient) {
     // "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
     // The updated metric must be provided in the request and it's name field must be the same as
     // [METRIC_ID] If the metric does not exist in [PROJECT_ID], then a new metric is created.
-    metricName: 'my-metric-name',  // TODO: Update placeholder value.
+    metricName: 'projects/my-project/metrics/my-metric',  // TODO: Update placeholder value.
 
     resource: {
       // TODO: Add desired properties to the request body. All existing properties
@@ -811,7 +811,7 @@ authorize(function(authClient) {
     // "projects/[PROJECT_ID]"
     // "organizations/[ORGANIZATION_ID]"
     // Examples: "projects/my-logging-project", "organizations/123456789".
-    parent: 'my-parent',  // TODO: Update placeholder value.
+    parent: 'projects/my-project',  // TODO: Update placeholder value.
 
     resource: {
       // TODO: Add desired properties to the request body.
@@ -869,7 +869,7 @@ authorize(function(authClient) {
     // "organizations/[ORGANIZATION_ID]/sinks/[SINK_ID]"
     // It is an error if the sink does not exist. Example: "projects/my-project-id/sinks/my-sink-id". It
     // is an error if the sink does not exist.
-    sinkName: 'my-sink-name',  // TODO: Update placeholder value.
+    sinkName: 'projects/my-project/sinks/my-sink',  // TODO: Update placeholder value.
 
     auth: authClient,
   };
@@ -918,7 +918,7 @@ authorize(function(authClient) {
     // "projects/[PROJECT_ID]/sinks/[SINK_ID]"
     // "organizations/[ORGANIZATION_ID]/sinks/[SINK_ID]"
     // Example: "projects/my-project-id/sinks/my-sink-id".
-    sinkName: 'my-sink-name',  // TODO: Update placeholder value.
+    sinkName: 'projects/my-project/sinks/my-sink',  // TODO: Update placeholder value.
 
     auth: authClient,
   };
@@ -968,7 +968,7 @@ authorize(function(authClient) {
   var request = {
     // Required. The parent resource whose sinks are to be listed. Examples:
     // "projects/my-logging-project", "organizations/123456789".
-    parent: 'my-parent',  // TODO: Update placeholder value.
+    parent: 'projects/my-project',  // TODO: Update placeholder value.
 
     auth: authClient,
   };
@@ -1034,7 +1034,7 @@ authorize(function(authClient) {
     // "projects/[PROJECT_ID]/sinks/[SINK_ID]"
     // "organizations/[ORGANIZATION_ID]/sinks/[SINK_ID]"
     // Example: "projects/my-project-id/sinks/my-sink-id".
-    sinkName: 'my-sink-name',  // TODO: Update placeholder value.
+    sinkName: 'projects/my-project/sinks/my-sink',  // TODO: Update placeholder value.
 
     resource: {
       // TODO: Add desired properties to the request body. All existing properties

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_pubsub.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_pubsub.v1.json.baseline
@@ -21,7 +21,7 @@ authorize(function(authClient) {
     // REQUIRED: The resource for which the policy is being requested.
     // `resource` is usually specified as a path. For example, a Project
     // resource is specified as `projects/{project}`.
-    resource_: 'my-resource',  // TODO: Update placeholder value.
+    resource_: 'projects/my-project/snapshots/my-snapshot',  // TODO: Update placeholder value.
 
     auth: authClient,
   };
@@ -72,7 +72,7 @@ authorize(function(authClient) {
     // REQUIRED: The resource for which the policy is being specified.
     // `resource` is usually specified as a path. For example, a Project
     // resource is specified as `projects/{project}`.
-    resource_: 'my-resource',  // TODO: Update placeholder value.
+    resource_: 'projects/my-project/snapshots/my-snapshot',  // TODO: Update placeholder value.
 
     resource: {
       // TODO: Add desired properties to the request body.
@@ -127,7 +127,7 @@ authorize(function(authClient) {
     // REQUIRED: The resource for which the policy detail is being requested.
     // `resource` is usually specified as a path. For example, a Project
     // resource is specified as `projects/{project}`.
-    resource_: 'my-resource',  // TODO: Update placeholder value.
+    resource_: 'projects/my-project/snapshots/my-snapshot',  // TODO: Update placeholder value.
 
     resource: {
       // TODO: Add desired properties to the request body.
@@ -181,7 +181,7 @@ authorize(function(authClient) {
   var request = {
     // The subscription whose message is being acknowledged.
     // Format is `projects/{project}/subscriptions/{sub}`.
-    subscription: 'my-subscription',  // TODO: Update placeholder value.
+    subscription: 'projects/my-project/subscriptions/my-subscription',  // TODO: Update placeholder value.
 
     resource: {
       // TODO: Add desired properties to the request body.
@@ -236,7 +236,7 @@ authorize(function(authClient) {
     // (`[0-9]`), dashes (`-`), underscores (`_`), periods (`.`), tildes (`~`),
     // plus (`+`) or percent signs (`%`). It must be between 3 and 255 characters
     // in length, and it must not start with `"goog"`.
-    name: 'my-name',  // TODO: Update placeholder value.
+    name: 'projects/my-project/subscriptions/my-subscription',  // TODO: Update placeholder value.
 
     resource: {
       // TODO: Add desired properties to the request body. All existing properties
@@ -291,7 +291,7 @@ authorize(function(authClient) {
   var request = {
     // The subscription to delete.
     // Format is `projects/{project}/subscriptions/{sub}`.
-    subscription: 'my-subscription',  // TODO: Update placeholder value.
+    subscription: 'projects/my-project/subscriptions/my-subscription',  // TODO: Update placeholder value.
 
     auth: authClient,
   };
@@ -338,7 +338,7 @@ authorize(function(authClient) {
   var request = {
     // The name of the subscription to get.
     // Format is `projects/{project}/subscriptions/{sub}`.
-    subscription: 'my-subscription',  // TODO: Update placeholder value.
+    subscription: 'projects/my-project/subscriptions/my-subscription',  // TODO: Update placeholder value.
 
     auth: authClient,
   };
@@ -389,7 +389,7 @@ authorize(function(authClient) {
     // REQUIRED: The resource for which the policy is being requested.
     // `resource` is usually specified as a path. For example, a Project
     // resource is specified as `projects/{project}`.
-    resource_: 'my-resource',  // TODO: Update placeholder value.
+    resource_: 'projects/my-project/subscriptions/my-subscription',  // TODO: Update placeholder value.
 
     auth: authClient,
   };
@@ -439,7 +439,7 @@ authorize(function(authClient) {
   var request = {
     // The name of the cloud project that subscriptions belong to.
     // Format is `projects/{project}`.
-    project: 'my-project',  // TODO: Update placeholder value.
+    project: 'projects/my-project',  // TODO: Update placeholder value.
 
     auth: authClient,
   };
@@ -502,7 +502,7 @@ authorize(function(authClient) {
   var request = {
     // The name of the subscription.
     // Format is `projects/{project}/subscriptions/{sub}`.
-    subscription: 'my-subscription',  // TODO: Update placeholder value.
+    subscription: 'projects/my-project/subscriptions/my-subscription',  // TODO: Update placeholder value.
 
     resource: {
       // TODO: Add desired properties to the request body.
@@ -553,7 +553,7 @@ authorize(function(authClient) {
   var request = {
     // The name of the subscription.
     // Format is `projects/{project}/subscriptions/{sub}`.
-    subscription: 'my-subscription',  // TODO: Update placeholder value.
+    subscription: 'projects/my-project/subscriptions/my-subscription',  // TODO: Update placeholder value.
 
     resource: {
       // TODO: Add desired properties to the request body.
@@ -604,7 +604,7 @@ authorize(function(authClient) {
   var request = {
     // The subscription from which messages should be pulled.
     // Format is `projects/{project}/subscriptions/{sub}`.
-    subscription: 'my-subscription',  // TODO: Update placeholder value.
+    subscription: 'projects/my-project/subscriptions/my-subscription',  // TODO: Update placeholder value.
 
     resource: {
       // TODO: Add desired properties to the request body.
@@ -659,7 +659,7 @@ authorize(function(authClient) {
     // REQUIRED: The resource for which the policy is being specified.
     // `resource` is usually specified as a path. For example, a Project
     // resource is specified as `projects/{project}`.
-    resource_: 'my-resource',  // TODO: Update placeholder value.
+    resource_: 'projects/my-project/subscriptions/my-subscription',  // TODO: Update placeholder value.
 
     resource: {
       // TODO: Add desired properties to the request body.
@@ -714,7 +714,7 @@ authorize(function(authClient) {
     // REQUIRED: The resource for which the policy detail is being requested.
     // `resource` is usually specified as a path. For example, a Project
     // resource is specified as `projects/{project}`.
-    resource_: 'my-resource',  // TODO: Update placeholder value.
+    resource_: 'projects/my-project/subscriptions/my-subscription',  // TODO: Update placeholder value.
 
     resource: {
       // TODO: Add desired properties to the request body.
@@ -772,7 +772,7 @@ authorize(function(authClient) {
     // underscores (`_`), periods (`.`), tildes (`~`), plus (`+`) or percent
     // signs (`%`). It must be between 3 and 255 characters in length, and it
     // must not start with `"goog"`.
-    name: 'my-name',  // TODO: Update placeholder value.
+    name: 'projects/my-project/topics/my-topic',  // TODO: Update placeholder value.
 
     resource: {
       // TODO: Add desired properties to the request body. All existing properties
@@ -827,7 +827,7 @@ authorize(function(authClient) {
   var request = {
     // Name of the topic to delete.
     // Format is `projects/{project}/topics/{topic}`.
-    topic: 'my-topic',  // TODO: Update placeholder value.
+    topic: 'projects/my-project/topics/my-topic',  // TODO: Update placeholder value.
 
     auth: authClient,
   };
@@ -874,7 +874,7 @@ authorize(function(authClient) {
   var request = {
     // The name of the topic to get.
     // Format is `projects/{project}/topics/{topic}`.
-    topic: 'my-topic',  // TODO: Update placeholder value.
+    topic: 'projects/my-project/topics/my-topic',  // TODO: Update placeholder value.
 
     auth: authClient,
   };
@@ -925,7 +925,7 @@ authorize(function(authClient) {
     // REQUIRED: The resource for which the policy is being requested.
     // `resource` is usually specified as a path. For example, a Project
     // resource is specified as `projects/{project}`.
-    resource_: 'my-resource',  // TODO: Update placeholder value.
+    resource_: 'projects/my-project/topics/my-topic',  // TODO: Update placeholder value.
 
     auth: authClient,
   };
@@ -975,7 +975,7 @@ authorize(function(authClient) {
   var request = {
     // The name of the cloud project that topics belong to.
     // Format is `projects/{project}`.
-    project: 'my-project',  // TODO: Update placeholder value.
+    project: 'projects/my-project',  // TODO: Update placeholder value.
 
     auth: authClient,
   };
@@ -1038,7 +1038,7 @@ authorize(function(authClient) {
   var request = {
     // The messages in the request will be published on this topic.
     // Format is `projects/{project}/topics/{topic}`.
-    topic: 'my-topic',  // TODO: Update placeholder value.
+    topic: 'projects/my-project/topics/my-topic',  // TODO: Update placeholder value.
 
     resource: {
       // TODO: Add desired properties to the request body.
@@ -1093,7 +1093,7 @@ authorize(function(authClient) {
     // REQUIRED: The resource for which the policy is being specified.
     // `resource` is usually specified as a path. For example, a Project
     // resource is specified as `projects/{project}`.
-    resource_: 'my-resource',  // TODO: Update placeholder value.
+    resource_: 'projects/my-project/topics/my-topic',  // TODO: Update placeholder value.
 
     resource: {
       // TODO: Add desired properties to the request body.
@@ -1147,7 +1147,7 @@ authorize(function(authClient) {
   var request = {
     // The name of the topic that subscriptions are attached to.
     // Format is `projects/{project}/topics/{topic}`.
-    topic: 'my-topic',  // TODO: Update placeholder value.
+    topic: 'projects/my-project/topics/my-topic',  // TODO: Update placeholder value.
 
     auth: authClient,
   };
@@ -1211,7 +1211,7 @@ authorize(function(authClient) {
     // REQUIRED: The resource for which the policy detail is being requested.
     // `resource` is usually specified as a path. For example, a Project
     // resource is specified as `projects/{project}`.
-    resource_: 'my-resource',  // TODO: Update placeholder value.
+    resource_: 'projects/my-project/topics/my-topic',  // TODO: Update placeholder value.
 
     resource: {
       // TODO: Add desired properties to the request body.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_storagetransfer.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_storagetransfer.v1.json.baseline
@@ -165,7 +165,7 @@ var storagetransfer = google.storagetransfer('v1');
 authorize(function(authClient) {
   var request = {
     // The job to get. Required.
-    jobName: 'my-job-name',  // TODO: Update placeholder value.
+    jobName: 'transferJobs/my-transfer-job',  // TODO: Update placeholder value.
 
     auth: authClient,
   };
@@ -273,7 +273,7 @@ var storagetransfer = google.storagetransfer('v1');
 authorize(function(authClient) {
   var request = {
     // The name of job to update. Required.
-    jobName: 'my-job-name',  // TODO: Update placeholder value.
+    jobName: 'transferJobs/my-transfer-job',  // TODO: Update placeholder value.
 
     resource: {
       // TODO: Add desired properties to the request body. Only these properties
@@ -327,7 +327,7 @@ var storagetransfer = google.storagetransfer('v1');
 authorize(function(authClient) {
   var request = {
     // The name of the operation resource to be cancelled.
-    name: 'my-name',  // TODO: Update placeholder value.
+    name: 'transferOperations/my-transfer-operation',  // TODO: Update placeholder value.
 
     auth: authClient,
   };
@@ -373,7 +373,7 @@ var storagetransfer = google.storagetransfer('v1');
 authorize(function(authClient) {
   var request = {
     // The name of the operation resource to be deleted.
-    name: 'my-name',  // TODO: Update placeholder value.
+    name: 'transferOperations/my-transfer-operation',  // TODO: Update placeholder value.
 
     auth: authClient,
   };
@@ -419,7 +419,7 @@ var storagetransfer = google.storagetransfer('v1');
 authorize(function(authClient) {
   var request = {
     // The name of the operation resource.
-    name: 'my-name',  // TODO: Update placeholder value.
+    name: 'transferOperations/my-transfer-operation',  // TODO: Update placeholder value.
 
     auth: authClient,
   };
@@ -530,7 +530,7 @@ var storagetransfer = google.storagetransfer('v1');
 authorize(function(authClient) {
   var request = {
     // The name of the transfer operation. Required.
-    name: 'my-name',  // TODO: Update placeholder value.
+    name: 'transferOperations/my-transfer-operation',  // TODO: Update placeholder value.
 
     resource: {
       // TODO: Add desired properties to the request body.
@@ -580,7 +580,7 @@ var storagetransfer = google.storagetransfer('v1');
 authorize(function(authClient) {
   var request = {
     // The name of the transfer operation. Required.
-    name: 'my-name',  // TODO: Update placeholder value.
+    name: 'transferOperations/my-transfer-operation',  // TODO: Update placeholder value.
 
     resource: {
       // TODO: Add desired properties to the request body.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_cloudbilling.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_cloudbilling.v1.json.baseline
@@ -102,8 +102,8 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 
 $service = new Google_Service_Cloudbilling($client);
 
-// The resource name of the billing account associated with the projects that you want to list. For
-// example, `billingAccounts/012345-567890-ABCDEF`.
+// The resource name of the billing account associated with the projects that
+// you want to list. For example, `billingAccounts/012345-567890-ABCDEF`.
 $name = 'billingAccounts/my-billing-account';  // TODO: Update placeholder value.
 
 $optParams = [];
@@ -146,8 +146,8 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 
 $service = new Google_Service_Cloudbilling($client);
 
-// The resource name of the project for which billing information is retrieved. For example,
-// `projects/tokyo-rain-123`.
+// The resource name of the project for which billing information is
+// retrieved. For example, `projects/tokyo-rain-123`.
 $name = 'projects/my-project';  // TODO: Update placeholder value.
 
 $response = $service->projects->getBillingInfo($name);
@@ -182,8 +182,8 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 
 $service = new Google_Service_Cloudbilling($client);
 
-// The resource name of the project associated with the billing information that you want to update.
-// For example, `projects/tokyo-rain-123`.
+// The resource name of the project associated with the billing information
+// that you want to update. For example, `projects/tokyo-rain-123`.
 $name = 'projects/my-project';  // TODO: Update placeholder value.
 
 // TODO: Assign values to desired properties of `requestBody`. All existing

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_cloudresourcemanager.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_cloudresourcemanager.v1.json.baseline
@@ -27,7 +27,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudResourceManager($client);
 
 // The name of the operation resource.
-$name = 'my-name';  // TODO: Update placeholder value.
+$name = 'operations/my-operation';  // TODO: Update placeholder value.
 
 $response = $service->operations->get($name);
 
@@ -62,7 +62,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_CloudResourceManager($client);
 
 // The resource name of the Organization to fetch, e.g. "organizations/1234".
-$name = 'my-name';  // TODO: Update placeholder value.
+$name = 'organizations/my-organization';  // TODO: Update placeholder value.
 
 $response = $service->organizations->get($name);
 
@@ -99,7 +99,7 @@ $service = new Google_Service_CloudResourceManager($client);
 // REQUIRED: The resource for which the policy is being requested.
 // `resource` is usually specified as a path. For example, a Project
 // resource is specified as `projects/{project}`.
-$resource = 'my-resource';  // TODO: Update placeholder value.
+$resource = 'organizations/my-organization';  // TODO: Update placeholder value.
 
 // TODO: Assign values to desired properties of `requestBody`:
 $requestBody = new Google_Service_CloudResourceManager_GetIamPolicyRequest();
@@ -180,7 +180,7 @@ $service = new Google_Service_CloudResourceManager($client);
 // REQUIRED: The resource for which the policy is being specified.
 // `resource` is usually specified as a path. For example, a Project
 // resource is specified as `projects/{project}`.
-$resource = 'my-resource';  // TODO: Update placeholder value.
+$resource = 'organizations/my-organization';  // TODO: Update placeholder value.
 
 // TODO: Assign values to desired properties of `requestBody`:
 $requestBody = new Google_Service_CloudResourceManager_SetIamPolicyRequest();
@@ -220,7 +220,7 @@ $service = new Google_Service_CloudResourceManager($client);
 // REQUIRED: The resource for which the policy detail is being requested.
 // `resource` is usually specified as a path. For example, a Project
 // resource is specified as `projects/{project}`.
-$resource = 'my-resource';  // TODO: Update placeholder value.
+$resource = 'organizations/my-organization';  // TODO: Update placeholder value.
 
 // TODO: Assign values to desired properties of `requestBody`:
 $requestBody = new Google_Service_CloudResourceManager_TestIamPermissionsRequest();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_genomics.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_genomics.v1.json.baseline
@@ -710,7 +710,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Genomics($client);
 
 // REQUIRED: The resource for which policy is being specified. Format is `datasets/`.
-$resource = 'my-resource';  // TODO: Update placeholder value.
+$resource = 'datasets/my-dataset';  // TODO: Update placeholder value.
 
 // TODO: Assign values to desired properties of `requestBody`:
 $requestBody = new Google_Service_Genomics_GetIamPolicyRequest();
@@ -827,7 +827,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Genomics($client);
 
 // REQUIRED: The resource for which policy is being specified. Format is `datasets/`.
-$resource = 'my-resource';  // TODO: Update placeholder value.
+$resource = 'datasets/my-dataset';  // TODO: Update placeholder value.
 
 // TODO: Assign values to desired properties of `requestBody`:
 $requestBody = new Google_Service_Genomics_SetIamPolicyRequest();
@@ -865,7 +865,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Genomics($client);
 
 // REQUIRED: The resource for which policy is being specified. Format is `datasets/`.
-$resource = 'my-resource';  // TODO: Update placeholder value.
+$resource = 'datasets/my-dataset';  // TODO: Update placeholder value.
 
 // TODO: Assign values to desired properties of `requestBody`:
 $requestBody = new Google_Service_Genomics_TestIamPermissionsRequest();
@@ -941,7 +941,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Genomics($client);
 
 // The name of the operation resource to be cancelled.
-$name = 'my-name';  // TODO: Update placeholder value.
+$name = 'operations/my-operation';  // TODO: Update placeholder value.
 
 // TODO: Assign values to desired properties of `requestBody`:
 $requestBody = new Google_Service_Genomics_CancelOperationRequest();
@@ -976,7 +976,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Genomics($client);
 
 // The name of the operation resource.
-$name = 'my-name';  // TODO: Update placeholder value.
+$name = 'operations/my-operation';  // TODO: Update placeholder value.
 
 $response = $service->operations->get($name);
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_logging.v2beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_logging.v2beta1.json.baseline
@@ -32,7 +32,7 @@ $service = new Google_Service_Logging($client);
 // [LOG_ID] must be URL-encoded. For example, "projects/my-project-id/logs/syslog",
 // "organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity". For more
 // information about log names, see LogEntry.
-$logName = 'my-log-name';  // TODO: Update placeholder value.
+$logName = 'billingAccounts/my-billing-account/logs/my-log';  // TODO: Update placeholder value.
 
 $service->billingAccounts_logs->delete($logName);
 ?>
@@ -66,7 +66,7 @@ $service = new Google_Service_Logging($client);
 // Required. The resource name that owns the logs:
 // "projects/[PROJECT_ID]"
 // "organizations/[ORGANIZATION_ID]"
-$parent = 'my-parent';  // TODO: Update placeholder value.
+$parent = 'billingAccounts/my-billing-account';  // TODO: Update placeholder value.
 
 $optParams = [];
 
@@ -230,7 +230,7 @@ $service = new Google_Service_Logging($client);
 // [LOG_ID] must be URL-encoded. For example, "projects/my-project-id/logs/syslog",
 // "organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity". For more
 // information about log names, see LogEntry.
-$logName = 'my-log-name';  // TODO: Update placeholder value.
+$logName = 'organizations/my-organization/logs/my-log';  // TODO: Update placeholder value.
 
 $service->organizations_logs->delete($logName);
 ?>
@@ -264,7 +264,7 @@ $service = new Google_Service_Logging($client);
 // Required. The resource name that owns the logs:
 // "projects/[PROJECT_ID]"
 // "organizations/[ORGANIZATION_ID]"
-$parent = 'my-parent';  // TODO: Update placeholder value.
+$parent = 'organizations/my-organization';  // TODO: Update placeholder value.
 
 $optParams = [];
 
@@ -312,7 +312,7 @@ $service = new Google_Service_Logging($client);
 // [LOG_ID] must be URL-encoded. For example, "projects/my-project-id/logs/syslog",
 // "organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity". For more
 // information about log names, see LogEntry.
-$logName = 'my-log-name';  // TODO: Update placeholder value.
+$logName = 'projects/my-project/logs/my-log';  // TODO: Update placeholder value.
 
 $service->projects_logs->delete($logName);
 ?>
@@ -346,7 +346,7 @@ $service = new Google_Service_Logging($client);
 // Required. The resource name that owns the logs:
 // "projects/[PROJECT_ID]"
 // "organizations/[ORGANIZATION_ID]"
-$parent = 'my-parent';  // TODO: Update placeholder value.
+$parent = 'projects/my-project';  // TODO: Update placeholder value.
 
 $optParams = [];
 
@@ -391,7 +391,7 @@ $service = new Google_Service_Logging($client);
 // The resource name of the project in which to create the metric:
 // "projects/[PROJECT_ID]"
 // The new metric must be provided in the request.
-$parent = 'my-parent';  // TODO: Update placeholder value.
+$parent = 'projects/my-project';  // TODO: Update placeholder value.
 
 // TODO: Assign values to desired properties of `requestBody`:
 $requestBody = new Google_Service_Logging_LogMetric();
@@ -430,7 +430,7 @@ $service = new Google_Service_Logging($client);
 
 // The resource name of the metric to delete:
 // "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
-$metricName = 'my-metric-name';  // TODO: Update placeholder value.
+$metricName = 'projects/my-project/metrics/my-metric';  // TODO: Update placeholder value.
 
 $service->projects_metrics->delete($metricName);
 ?>
@@ -463,7 +463,7 @@ $service = new Google_Service_Logging($client);
 
 // The resource name of the desired metric:
 // "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
-$metricName = 'my-metric-name';  // TODO: Update placeholder value.
+$metricName = 'projects/my-project/metrics/my-metric';  // TODO: Update placeholder value.
 
 $response = $service->projects_metrics->get($metricName);
 
@@ -499,7 +499,7 @@ $service = new Google_Service_Logging($client);
 
 // Required. The name of the project containing the metrics:
 // "projects/[PROJECT_ID]"
-$parent = 'my-parent';  // TODO: Update placeholder value.
+$parent = 'projects/my-project';  // TODO: Update placeholder value.
 
 $optParams = [];
 
@@ -545,7 +545,7 @@ $service = new Google_Service_Logging($client);
 // "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
 // The updated metric must be provided in the request and it's name field must be the same as
 // [METRIC_ID] If the metric does not exist in [PROJECT_ID], then a new metric is created.
-$metricName = 'my-metric-name';  // TODO: Update placeholder value.
+$metricName = 'projects/my-project/metrics/my-metric';  // TODO: Update placeholder value.
 
 // TODO: Assign values to desired properties of `requestBody`. All existing
 // properties will be replaced:
@@ -587,7 +587,7 @@ $service = new Google_Service_Logging($client);
 // "projects/[PROJECT_ID]"
 // "organizations/[ORGANIZATION_ID]"
 // Examples: "projects/my-logging-project", "organizations/123456789".
-$parent = 'my-parent';  // TODO: Update placeholder value.
+$parent = 'projects/my-project';  // TODO: Update placeholder value.
 
 // TODO: Assign values to desired properties of `requestBody`:
 $requestBody = new Google_Service_Logging_LogSink();
@@ -630,7 +630,7 @@ $service = new Google_Service_Logging($client);
 // "organizations/[ORGANIZATION_ID]/sinks/[SINK_ID]"
 // It is an error if the sink does not exist. Example: "projects/my-project-id/sinks/my-sink-id". It
 // is an error if the sink does not exist.
-$sinkName = 'my-sink-name';  // TODO: Update placeholder value.
+$sinkName = 'projects/my-project/sinks/my-sink';  // TODO: Update placeholder value.
 
 $service->projects_sinks->delete($sinkName);
 ?>
@@ -665,7 +665,7 @@ $service = new Google_Service_Logging($client);
 // "projects/[PROJECT_ID]/sinks/[SINK_ID]"
 // "organizations/[ORGANIZATION_ID]/sinks/[SINK_ID]"
 // Example: "projects/my-project-id/sinks/my-sink-id".
-$sinkName = 'my-sink-name';  // TODO: Update placeholder value.
+$sinkName = 'projects/my-project/sinks/my-sink';  // TODO: Update placeholder value.
 
 $response = $service->projects_sinks->get($sinkName);
 
@@ -701,7 +701,7 @@ $service = new Google_Service_Logging($client);
 
 // Required. The parent resource whose sinks are to be listed. Examples:
 // "projects/my-logging-project", "organizations/123456789".
-$parent = 'my-parent';  // TODO: Update placeholder value.
+$parent = 'projects/my-project';  // TODO: Update placeholder value.
 
 $optParams = [];
 
@@ -748,7 +748,7 @@ $service = new Google_Service_Logging($client);
 // "projects/[PROJECT_ID]/sinks/[SINK_ID]"
 // "organizations/[ORGANIZATION_ID]/sinks/[SINK_ID]"
 // Example: "projects/my-project-id/sinks/my-sink-id".
-$sinkName = 'my-sink-name';  // TODO: Update placeholder value.
+$sinkName = 'projects/my-project/sinks/my-sink';  // TODO: Update placeholder value.
 
 // TODO: Assign values to desired properties of `requestBody`. All existing
 // properties will be replaced:

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_pubsub.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_pubsub.v1.json.baseline
@@ -29,7 +29,7 @@ $service = new Google_Service_Pubsub($client);
 // REQUIRED: The resource for which the policy is being requested.
 // `resource` is usually specified as a path. For example, a Project
 // resource is specified as `projects/{project}`.
-$resource = 'my-resource';  // TODO: Update placeholder value.
+$resource = 'projects/my-project/snapshots/my-snapshot';  // TODO: Update placeholder value.
 
 $response = $service->projects_snapshots->getIamPolicy($resource);
 
@@ -66,7 +66,7 @@ $service = new Google_Service_Pubsub($client);
 // REQUIRED: The resource for which the policy is being specified.
 // `resource` is usually specified as a path. For example, a Project
 // resource is specified as `projects/{project}`.
-$resource = 'my-resource';  // TODO: Update placeholder value.
+$resource = 'projects/my-project/snapshots/my-snapshot';  // TODO: Update placeholder value.
 
 // TODO: Assign values to desired properties of `requestBody`:
 $requestBody = new Google_Service_Pubsub_SetIamPolicyRequest();
@@ -106,7 +106,7 @@ $service = new Google_Service_Pubsub($client);
 // REQUIRED: The resource for which the policy detail is being requested.
 // `resource` is usually specified as a path. For example, a Project
 // resource is specified as `projects/{project}`.
-$resource = 'my-resource';  // TODO: Update placeholder value.
+$resource = 'projects/my-project/snapshots/my-snapshot';  // TODO: Update placeholder value.
 
 // TODO: Assign values to desired properties of `requestBody`:
 $requestBody = new Google_Service_Pubsub_TestIamPermissionsRequest();
@@ -145,7 +145,7 @@ $service = new Google_Service_Pubsub($client);
 
 // The subscription whose message is being acknowledged.
 // Format is `projects/{project}/subscriptions/{sub}`.
-$subscription = 'my-subscription';  // TODO: Update placeholder value.
+$subscription = 'projects/my-project/subscriptions/my-subscription';  // TODO: Update placeholder value.
 
 // TODO: Assign values to desired properties of `requestBody`:
 $requestBody = new Google_Service_Pubsub_AcknowledgeRequest();
@@ -185,7 +185,7 @@ $service = new Google_Service_Pubsub($client);
 // (`[0-9]`), dashes (`-`), underscores (`_`), periods (`.`), tildes (`~`),
 // plus (`+`) or percent signs (`%`). It must be between 3 and 255 characters
 // in length, and it must not start with `"goog"`.
-$name = 'my-name';  // TODO: Update placeholder value.
+$name = 'projects/my-project/subscriptions/my-subscription';  // TODO: Update placeholder value.
 
 // TODO: Assign values to desired properties of `requestBody`. All existing
 // properties will be replaced:
@@ -225,7 +225,7 @@ $service = new Google_Service_Pubsub($client);
 
 // The subscription to delete.
 // Format is `projects/{project}/subscriptions/{sub}`.
-$subscription = 'my-subscription';  // TODO: Update placeholder value.
+$subscription = 'projects/my-project/subscriptions/my-subscription';  // TODO: Update placeholder value.
 
 $service->projects_subscriptions->delete($subscription);
 ?>
@@ -258,7 +258,7 @@ $service = new Google_Service_Pubsub($client);
 
 // The name of the subscription to get.
 // Format is `projects/{project}/subscriptions/{sub}`.
-$subscription = 'my-subscription';  // TODO: Update placeholder value.
+$subscription = 'projects/my-project/subscriptions/my-subscription';  // TODO: Update placeholder value.
 
 $response = $service->projects_subscriptions->get($subscription);
 
@@ -295,7 +295,7 @@ $service = new Google_Service_Pubsub($client);
 // REQUIRED: The resource for which the policy is being requested.
 // `resource` is usually specified as a path. For example, a Project
 // resource is specified as `projects/{project}`.
-$resource = 'my-resource';  // TODO: Update placeholder value.
+$resource = 'projects/my-project/subscriptions/my-subscription';  // TODO: Update placeholder value.
 
 $response = $service->projects_subscriptions->getIamPolicy($resource);
 
@@ -331,7 +331,7 @@ $service = new Google_Service_Pubsub($client);
 
 // The name of the cloud project that subscriptions belong to.
 // Format is `projects/{project}`.
-$project = 'my-project';  // TODO: Update placeholder value.
+$project = 'projects/my-project';  // TODO: Update placeholder value.
 
 $optParams = [];
 
@@ -375,7 +375,7 @@ $service = new Google_Service_Pubsub($client);
 
 // The name of the subscription.
 // Format is `projects/{project}/subscriptions/{sub}`.
-$subscription = 'my-subscription';  // TODO: Update placeholder value.
+$subscription = 'projects/my-project/subscriptions/my-subscription';  // TODO: Update placeholder value.
 
 // TODO: Assign values to desired properties of `requestBody`:
 $requestBody = new Google_Service_Pubsub_ModifyAckDeadlineRequest();
@@ -411,7 +411,7 @@ $service = new Google_Service_Pubsub($client);
 
 // The name of the subscription.
 // Format is `projects/{project}/subscriptions/{sub}`.
-$subscription = 'my-subscription';  // TODO: Update placeholder value.
+$subscription = 'projects/my-project/subscriptions/my-subscription';  // TODO: Update placeholder value.
 
 // TODO: Assign values to desired properties of `requestBody`:
 $requestBody = new Google_Service_Pubsub_ModifyPushConfigRequest();
@@ -447,7 +447,7 @@ $service = new Google_Service_Pubsub($client);
 
 // The subscription from which messages should be pulled.
 // Format is `projects/{project}/subscriptions/{sub}`.
-$subscription = 'my-subscription';  // TODO: Update placeholder value.
+$subscription = 'projects/my-project/subscriptions/my-subscription';  // TODO: Update placeholder value.
 
 // TODO: Assign values to desired properties of `requestBody`:
 $requestBody = new Google_Service_Pubsub_PullRequest();
@@ -487,7 +487,7 @@ $service = new Google_Service_Pubsub($client);
 // REQUIRED: The resource for which the policy is being specified.
 // `resource` is usually specified as a path. For example, a Project
 // resource is specified as `projects/{project}`.
-$resource = 'my-resource';  // TODO: Update placeholder value.
+$resource = 'projects/my-project/subscriptions/my-subscription';  // TODO: Update placeholder value.
 
 // TODO: Assign values to desired properties of `requestBody`:
 $requestBody = new Google_Service_Pubsub_SetIamPolicyRequest();
@@ -527,7 +527,7 @@ $service = new Google_Service_Pubsub($client);
 // REQUIRED: The resource for which the policy detail is being requested.
 // `resource` is usually specified as a path. For example, a Project
 // resource is specified as `projects/{project}`.
-$resource = 'my-resource';  // TODO: Update placeholder value.
+$resource = 'projects/my-project/subscriptions/my-subscription';  // TODO: Update placeholder value.
 
 // TODO: Assign values to desired properties of `requestBody`:
 $requestBody = new Google_Service_Pubsub_TestIamPermissionsRequest();
@@ -570,7 +570,7 @@ $service = new Google_Service_Pubsub($client);
 // underscores (`_`), periods (`.`), tildes (`~`), plus (`+`) or percent
 // signs (`%`). It must be between 3 and 255 characters in length, and it
 // must not start with `"goog"`.
-$name = 'my-name';  // TODO: Update placeholder value.
+$name = 'projects/my-project/topics/my-topic';  // TODO: Update placeholder value.
 
 // TODO: Assign values to desired properties of `requestBody`. All existing
 // properties will be replaced:
@@ -610,7 +610,7 @@ $service = new Google_Service_Pubsub($client);
 
 // Name of the topic to delete.
 // Format is `projects/{project}/topics/{topic}`.
-$topic = 'my-topic';  // TODO: Update placeholder value.
+$topic = 'projects/my-project/topics/my-topic';  // TODO: Update placeholder value.
 
 $service->projects_topics->delete($topic);
 ?>
@@ -643,7 +643,7 @@ $service = new Google_Service_Pubsub($client);
 
 // The name of the topic to get.
 // Format is `projects/{project}/topics/{topic}`.
-$topic = 'my-topic';  // TODO: Update placeholder value.
+$topic = 'projects/my-project/topics/my-topic';  // TODO: Update placeholder value.
 
 $response = $service->projects_topics->get($topic);
 
@@ -680,7 +680,7 @@ $service = new Google_Service_Pubsub($client);
 // REQUIRED: The resource for which the policy is being requested.
 // `resource` is usually specified as a path. For example, a Project
 // resource is specified as `projects/{project}`.
-$resource = 'my-resource';  // TODO: Update placeholder value.
+$resource = 'projects/my-project/topics/my-topic';  // TODO: Update placeholder value.
 
 $response = $service->projects_topics->getIamPolicy($resource);
 
@@ -716,7 +716,7 @@ $service = new Google_Service_Pubsub($client);
 
 // The name of the cloud project that topics belong to.
 // Format is `projects/{project}`.
-$project = 'my-project';  // TODO: Update placeholder value.
+$project = 'projects/my-project';  // TODO: Update placeholder value.
 
 $optParams = [];
 
@@ -760,7 +760,7 @@ $service = new Google_Service_Pubsub($client);
 
 // The messages in the request will be published on this topic.
 // Format is `projects/{project}/topics/{topic}`.
-$topic = 'my-topic';  // TODO: Update placeholder value.
+$topic = 'projects/my-project/topics/my-topic';  // TODO: Update placeholder value.
 
 // TODO: Assign values to desired properties of `requestBody`:
 $requestBody = new Google_Service_Pubsub_PublishRequest();
@@ -800,7 +800,7 @@ $service = new Google_Service_Pubsub($client);
 // REQUIRED: The resource for which the policy is being specified.
 // `resource` is usually specified as a path. For example, a Project
 // resource is specified as `projects/{project}`.
-$resource = 'my-resource';  // TODO: Update placeholder value.
+$resource = 'projects/my-project/topics/my-topic';  // TODO: Update placeholder value.
 
 // TODO: Assign values to desired properties of `requestBody`:
 $requestBody = new Google_Service_Pubsub_SetIamPolicyRequest();
@@ -839,7 +839,7 @@ $service = new Google_Service_Pubsub($client);
 
 // The name of the topic that subscriptions are attached to.
 // Format is `projects/{project}/topics/{topic}`.
-$topic = 'my-topic';  // TODO: Update placeholder value.
+$topic = 'projects/my-project/topics/my-topic';  // TODO: Update placeholder value.
 
 $optParams = [];
 
@@ -884,7 +884,7 @@ $service = new Google_Service_Pubsub($client);
 // REQUIRED: The resource for which the policy detail is being requested.
 // `resource` is usually specified as a path. For example, a Project
 // resource is specified as `projects/{project}`.
-$resource = 'my-resource';  // TODO: Update placeholder value.
+$resource = 'projects/my-project/topics/my-topic';  // TODO: Update placeholder value.
 
 // TODO: Assign values to desired properties of `requestBody`:
 $requestBody = new Google_Service_Pubsub_TestIamPermissionsRequest();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_storagetransfer.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/php/php_storagetransfer.v1.json.baseline
@@ -130,7 +130,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storagetransfer($client);
 
 // The job to get. Required.
-$jobName = 'my-job-name';  // TODO: Update placeholder value.
+$jobName = 'transferJobs/my-transfer-job';  // TODO: Update placeholder value.
 
 $response = $service->transferJobs->get($jobName);
 
@@ -205,7 +205,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storagetransfer($client);
 
 // The name of job to update. Required.
-$jobName = 'my-job-name';  // TODO: Update placeholder value.
+$jobName = 'transferJobs/my-transfer-job';  // TODO: Update placeholder value.
 
 // TODO: Assign values to desired properties of `requestBody`. Only assigned
 // properties will be changed:
@@ -244,7 +244,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storagetransfer($client);
 
 // The name of the operation resource to be cancelled.
-$name = 'my-name';  // TODO: Update placeholder value.
+$name = 'transferOperations/my-transfer-operation';  // TODO: Update placeholder value.
 
 $service->transferOperations->cancel($name);
 ?>
@@ -276,7 +276,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storagetransfer($client);
 
 // The name of the operation resource to be deleted.
-$name = 'my-name';  // TODO: Update placeholder value.
+$name = 'transferOperations/my-transfer-operation';  // TODO: Update placeholder value.
 
 $service->transferOperations->delete($name);
 ?>
@@ -308,7 +308,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storagetransfer($client);
 
 // The name of the operation resource.
-$name = 'my-name';  // TODO: Update placeholder value.
+$name = 'transferOperations/my-transfer-operation';  // TODO: Update placeholder value.
 
 $response = $service->transferOperations->get($name);
 
@@ -386,7 +386,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storagetransfer($client);
 
 // The name of the transfer operation. Required.
-$name = 'my-name';  // TODO: Update placeholder value.
+$name = 'transferOperations/my-transfer-operation';  // TODO: Update placeholder value.
 
 // TODO: Assign values to desired properties of `requestBody`:
 $requestBody = new Google_Service_Storagetransfer_PauseTransferOperationRequest();
@@ -421,7 +421,7 @@ $client->addScope('https://www.googleapis.com/auth/cloud-platform');
 $service = new Google_Service_Storagetransfer($client);
 
 // The name of the transfer operation. Required.
-$name = 'my-name';  // TODO: Update placeholder value.
+$name = 'transferOperations/my-transfer-operation';  // TODO: Update placeholder value.
 
 // TODO: Assign values to desired properties of `requestBody`:
 $requestBody = new Google_Service_Storagetransfer_ResumeTransferOperationRequest();

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_cloudbilling.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_cloudbilling.v1.json.baseline
@@ -89,8 +89,8 @@ credentials = GoogleCredentials.get_application_default()
 
 service = discovery.build('cloudbilling', 'v1', credentials=credentials)
 
-# The resource name of the billing account associated with the projects that you want to list. For
-# example, `billingAccounts/012345-567890-ABCDEF`.
+# The resource name of the billing account associated with the projects that
+# you want to list. For example, `billingAccounts/012345-567890-ABCDEF`.
 name = 'billingAccounts/my-billing-account'  # TODO: Update placeholder value.
 
 request = service.billingAccounts().projects().list(name=name)
@@ -126,8 +126,8 @@ credentials = GoogleCredentials.get_application_default()
 
 service = discovery.build('cloudbilling', 'v1', credentials=credentials)
 
-# The resource name of the project for which billing information is retrieved. For example,
-# `projects/tokyo-rain-123`.
+# The resource name of the project for which billing information is
+# retrieved. For example, `projects/tokyo-rain-123`.
 name = 'projects/my-project'  # TODO: Update placeholder value.
 
 request = service.projects().getBillingInfo(name=name)
@@ -159,8 +159,8 @@ credentials = GoogleCredentials.get_application_default()
 
 service = discovery.build('cloudbilling', 'v1', credentials=credentials)
 
-# The resource name of the project associated with the billing information that you want to update.
-# For example, `projects/tokyo-rain-123`.
+# The resource name of the project associated with the billing information
+# that you want to update. For example, `projects/tokyo-rain-123`.
 name = 'projects/my-project'  # TODO: Update placeholder value.
 
 project_billing_info_body = {

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_cloudresourcemanager.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_cloudresourcemanager.v1.json.baseline
@@ -24,7 +24,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('cloudresourcemanager', 'v1', credentials=credentials)
 
 # The name of the operation resource.
-name = 'my-name'  # TODO: Update placeholder value.
+name = 'operations/my-operation'  # TODO: Update placeholder value.
 
 request = service.operations().get(name=name)
 response = request.execute()
@@ -56,7 +56,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('cloudresourcemanager', 'v1', credentials=credentials)
 
 # The resource name of the Organization to fetch, e.g. "organizations/1234".
-name = 'my-name'  # TODO: Update placeholder value.
+name = 'organizations/my-organization'  # TODO: Update placeholder value.
 
 request = service.organizations().get(name=name)
 response = request.execute()
@@ -90,7 +90,7 @@ service = discovery.build('cloudresourcemanager', 'v1', credentials=credentials)
 # REQUIRED: The resource for which the policy is being requested.
 # `resource` is usually specified as a path. For example, a Project
 # resource is specified as `projects/{project}`.
-resource = 'my-resource'  # TODO: Update placeholder value.
+resource = 'organizations/my-organization'  # TODO: Update placeholder value.
 
 get_iam_policy_request_body = {
     # TODO: Add desired entries to the request body.
@@ -165,7 +165,7 @@ service = discovery.build('cloudresourcemanager', 'v1', credentials=credentials)
 # REQUIRED: The resource for which the policy is being specified.
 # `resource` is usually specified as a path. For example, a Project
 # resource is specified as `projects/{project}`.
-resource = 'my-resource'  # TODO: Update placeholder value.
+resource = 'organizations/my-organization'  # TODO: Update placeholder value.
 
 set_iam_policy_request_body = {
     # TODO: Add desired entries to the request body.
@@ -203,7 +203,7 @@ service = discovery.build('cloudresourcemanager', 'v1', credentials=credentials)
 # REQUIRED: The resource for which the policy detail is being requested.
 # `resource` is usually specified as a path. For example, a Project
 # resource is specified as `projects/{project}`.
-resource = 'my-resource'  # TODO: Update placeholder value.
+resource = 'organizations/my-organization'  # TODO: Update placeholder value.
 
 test_iam_permissions_request_body = {
     # TODO: Add desired entries to the request body.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_genomics.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_genomics.v1.json.baseline
@@ -651,7 +651,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('genomics', 'v1', credentials=credentials)
 
 # REQUIRED: The resource for which policy is being specified. Format is `datasets/`.
-resource = 'my-resource'  # TODO: Update placeholder value.
+resource = 'datasets/my-dataset'  # TODO: Update placeholder value.
 
 get_iam_policy_request_body = {
     # TODO: Add desired entries to the request body.
@@ -757,7 +757,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('genomics', 'v1', credentials=credentials)
 
 # REQUIRED: The resource for which policy is being specified. Format is `datasets/`.
-resource = 'my-resource'  # TODO: Update placeholder value.
+resource = 'datasets/my-dataset'  # TODO: Update placeholder value.
 
 set_iam_policy_request_body = {
     # TODO: Add desired entries to the request body.
@@ -793,7 +793,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('genomics', 'v1', credentials=credentials)
 
 # REQUIRED: The resource for which policy is being specified. Format is `datasets/`.
-resource = 'my-resource'  # TODO: Update placeholder value.
+resource = 'datasets/my-dataset'  # TODO: Update placeholder value.
 
 test_iam_permissions_request_body = {
     # TODO: Add desired entries to the request body.
@@ -864,7 +864,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('genomics', 'v1', credentials=credentials)
 
 # The name of the operation resource to be cancelled.
-name = 'my-name'  # TODO: Update placeholder value.
+name = 'operations/my-operation'  # TODO: Update placeholder value.
 
 cancel_operation_request_body = {
     # TODO: Add desired entries to the request body.
@@ -897,7 +897,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('genomics', 'v1', credentials=credentials)
 
 # The name of the operation resource.
-name = 'my-name'  # TODO: Update placeholder value.
+name = 'operations/my-operation'  # TODO: Update placeholder value.
 
 request = service.operations().get(name=name)
 response = request.execute()

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_logging.v2beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_logging.v2beta1.json.baseline
@@ -28,7 +28,7 @@ service = discovery.build('logging', 'v2beta1', credentials=credentials)
 # [LOG_ID] must be URL-encoded. For example, "projects/my-project-id/logs/syslog",
 # "organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity". For more
 # information about log names, see LogEntry.
-log_name = 'my-log-name'  # TODO: Update placeholder value.
+log_name = 'billingAccounts/my-billing-account/logs/my-log'  # TODO: Update placeholder value.
 
 request = service.billingAccounts().logs().delete(logName=log_name)
 request.execute()
@@ -59,7 +59,7 @@ service = discovery.build('logging', 'v2beta1', credentials=credentials)
 # Required. The resource name that owns the logs:
 # "projects/[PROJECT_ID]"
 # "organizations/[ORGANIZATION_ID]"
-parent = 'my-parent'  # TODO: Update placeholder value.
+parent = 'billingAccounts/my-billing-account'  # TODO: Update placeholder value.
 
 request = service.billingAccounts().logs().list(parent=parent)
 while request is not None:
@@ -202,7 +202,7 @@ service = discovery.build('logging', 'v2beta1', credentials=credentials)
 # [LOG_ID] must be URL-encoded. For example, "projects/my-project-id/logs/syslog",
 # "organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity". For more
 # information about log names, see LogEntry.
-log_name = 'my-log-name'  # TODO: Update placeholder value.
+log_name = 'organizations/my-organization/logs/my-log'  # TODO: Update placeholder value.
 
 request = service.organizations().logs().delete(logName=log_name)
 request.execute()
@@ -233,7 +233,7 @@ service = discovery.build('logging', 'v2beta1', credentials=credentials)
 # Required. The resource name that owns the logs:
 # "projects/[PROJECT_ID]"
 # "organizations/[ORGANIZATION_ID]"
-parent = 'my-parent'  # TODO: Update placeholder value.
+parent = 'organizations/my-organization'  # TODO: Update placeholder value.
 
 request = service.organizations().logs().list(parent=parent)
 while request is not None:
@@ -273,7 +273,7 @@ service = discovery.build('logging', 'v2beta1', credentials=credentials)
 # [LOG_ID] must be URL-encoded. For example, "projects/my-project-id/logs/syslog",
 # "organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity". For more
 # information about log names, see LogEntry.
-log_name = 'my-log-name'  # TODO: Update placeholder value.
+log_name = 'projects/my-project/logs/my-log'  # TODO: Update placeholder value.
 
 request = service.projects().logs().delete(logName=log_name)
 request.execute()
@@ -304,7 +304,7 @@ service = discovery.build('logging', 'v2beta1', credentials=credentials)
 # Required. The resource name that owns the logs:
 # "projects/[PROJECT_ID]"
 # "organizations/[ORGANIZATION_ID]"
-parent = 'my-parent'  # TODO: Update placeholder value.
+parent = 'projects/my-project'  # TODO: Update placeholder value.
 
 request = service.projects().logs().list(parent=parent)
 while request is not None:
@@ -342,7 +342,7 @@ service = discovery.build('logging', 'v2beta1', credentials=credentials)
 # The resource name of the project in which to create the metric:
 # "projects/[PROJECT_ID]"
 # The new metric must be provided in the request.
-parent = 'my-parent'  # TODO: Update placeholder value.
+parent = 'projects/my-project'  # TODO: Update placeholder value.
 
 log_metric_body = {
     # TODO: Add desired entries to the request body.
@@ -378,7 +378,7 @@ service = discovery.build('logging', 'v2beta1', credentials=credentials)
 
 # The resource name of the metric to delete:
 # "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
-metric_name = 'my-metric-name'  # TODO: Update placeholder value.
+metric_name = 'projects/my-project/metrics/my-metric'  # TODO: Update placeholder value.
 
 request = service.projects().metrics().delete(metricName=metric_name)
 request.execute()
@@ -408,7 +408,7 @@ service = discovery.build('logging', 'v2beta1', credentials=credentials)
 
 # The resource name of the desired metric:
 # "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
-metric_name = 'my-metric-name'  # TODO: Update placeholder value.
+metric_name = 'projects/my-project/metrics/my-metric'  # TODO: Update placeholder value.
 
 request = service.projects().metrics().get(metricName=metric_name)
 response = request.execute()
@@ -441,7 +441,7 @@ service = discovery.build('logging', 'v2beta1', credentials=credentials)
 
 # Required. The name of the project containing the metrics:
 # "projects/[PROJECT_ID]"
-parent = 'my-parent'  # TODO: Update placeholder value.
+parent = 'projects/my-project'  # TODO: Update placeholder value.
 
 request = service.projects().metrics().list(parent=parent)
 while request is not None:
@@ -480,7 +480,7 @@ service = discovery.build('logging', 'v2beta1', credentials=credentials)
 # "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
 # The updated metric must be provided in the request and it's name field must be the same as
 # [METRIC_ID] If the metric does not exist in [PROJECT_ID], then a new metric is created.
-metric_name = 'my-metric-name'  # TODO: Update placeholder value.
+metric_name = 'projects/my-project/metrics/my-metric'  # TODO: Update placeholder value.
 
 log_metric_body = {
     # TODO: Add desired entries to the request body. All existing entries
@@ -520,7 +520,7 @@ service = discovery.build('logging', 'v2beta1', credentials=credentials)
 # "projects/[PROJECT_ID]"
 # "organizations/[ORGANIZATION_ID]"
 # Examples: "projects/my-logging-project", "organizations/123456789".
-parent = 'my-parent'  # TODO: Update placeholder value.
+parent = 'projects/my-project'  # TODO: Update placeholder value.
 
 log_sink_body = {
     # TODO: Add desired entries to the request body.
@@ -560,7 +560,7 @@ service = discovery.build('logging', 'v2beta1', credentials=credentials)
 # "organizations/[ORGANIZATION_ID]/sinks/[SINK_ID]"
 # It is an error if the sink does not exist. Example: "projects/my-project-id/sinks/my-sink-id". It
 # is an error if the sink does not exist.
-sink_name = 'my-sink-name'  # TODO: Update placeholder value.
+sink_name = 'projects/my-project/sinks/my-sink'  # TODO: Update placeholder value.
 
 request = service.projects().sinks().delete(sinkName=sink_name)
 request.execute()
@@ -592,7 +592,7 @@ service = discovery.build('logging', 'v2beta1', credentials=credentials)
 # "projects/[PROJECT_ID]/sinks/[SINK_ID]"
 # "organizations/[ORGANIZATION_ID]/sinks/[SINK_ID]"
 # Example: "projects/my-project-id/sinks/my-sink-id".
-sink_name = 'my-sink-name'  # TODO: Update placeholder value.
+sink_name = 'projects/my-project/sinks/my-sink'  # TODO: Update placeholder value.
 
 request = service.projects().sinks().get(sinkName=sink_name)
 response = request.execute()
@@ -625,7 +625,7 @@ service = discovery.build('logging', 'v2beta1', credentials=credentials)
 
 # Required. The parent resource whose sinks are to be listed. Examples:
 # "projects/my-logging-project", "organizations/123456789".
-parent = 'my-parent'  # TODO: Update placeholder value.
+parent = 'projects/my-project'  # TODO: Update placeholder value.
 
 request = service.projects().sinks().list(parent=parent)
 while request is not None:
@@ -665,7 +665,7 @@ service = discovery.build('logging', 'v2beta1', credentials=credentials)
 # "projects/[PROJECT_ID]/sinks/[SINK_ID]"
 # "organizations/[ORGANIZATION_ID]/sinks/[SINK_ID]"
 # Example: "projects/my-project-id/sinks/my-sink-id".
-sink_name = 'my-sink-name'  # TODO: Update placeholder value.
+sink_name = 'projects/my-project/sinks/my-sink'  # TODO: Update placeholder value.
 
 log_sink_body = {
     # TODO: Add desired entries to the request body. All existing entries

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_pubsub.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_pubsub.v1.json.baseline
@@ -26,7 +26,7 @@ service = discovery.build('pubsub', 'v1', credentials=credentials)
 # REQUIRED: The resource for which the policy is being requested.
 # `resource` is usually specified as a path. For example, a Project
 # resource is specified as `projects/{project}`.
-resource = 'my-resource'  # TODO: Update placeholder value.
+resource = 'projects/my-project/snapshots/my-snapshot'  # TODO: Update placeholder value.
 
 request = service.projects().snapshots().getIamPolicy(resource=resource)
 response = request.execute()
@@ -60,7 +60,7 @@ service = discovery.build('pubsub', 'v1', credentials=credentials)
 # REQUIRED: The resource for which the policy is being specified.
 # `resource` is usually specified as a path. For example, a Project
 # resource is specified as `projects/{project}`.
-resource = 'my-resource'  # TODO: Update placeholder value.
+resource = 'projects/my-project/snapshots/my-snapshot'  # TODO: Update placeholder value.
 
 set_iam_policy_request_body = {
     # TODO: Add desired entries to the request body.
@@ -98,7 +98,7 @@ service = discovery.build('pubsub', 'v1', credentials=credentials)
 # REQUIRED: The resource for which the policy detail is being requested.
 # `resource` is usually specified as a path. For example, a Project
 # resource is specified as `projects/{project}`.
-resource = 'my-resource'  # TODO: Update placeholder value.
+resource = 'projects/my-project/snapshots/my-snapshot'  # TODO: Update placeholder value.
 
 test_iam_permissions_request_body = {
     # TODO: Add desired entries to the request body.
@@ -134,7 +134,7 @@ service = discovery.build('pubsub', 'v1', credentials=credentials)
 
 # The subscription whose message is being acknowledged.
 # Format is `projects/{project}/subscriptions/{sub}`.
-subscription = 'my-subscription'  # TODO: Update placeholder value.
+subscription = 'projects/my-project/subscriptions/my-subscription'  # TODO: Update placeholder value.
 
 acknowledge_request_body = {
     # TODO: Add desired entries to the request body.
@@ -172,7 +172,7 @@ service = discovery.build('pubsub', 'v1', credentials=credentials)
 # (`[0-9]`), dashes (`-`), underscores (`_`), periods (`.`), tildes (`~`),
 # plus (`+`) or percent signs (`%`). It must be between 3 and 255 characters
 # in length, and it must not start with `"goog"`.
-name = 'my-name'  # TODO: Update placeholder value.
+name = 'projects/my-project/subscriptions/my-subscription'  # TODO: Update placeholder value.
 
 subscription_body = {
     # TODO: Add desired entries to the request body. All existing entries
@@ -209,7 +209,7 @@ service = discovery.build('pubsub', 'v1', credentials=credentials)
 
 # The subscription to delete.
 # Format is `projects/{project}/subscriptions/{sub}`.
-subscription = 'my-subscription'  # TODO: Update placeholder value.
+subscription = 'projects/my-project/subscriptions/my-subscription'  # TODO: Update placeholder value.
 
 request = service.projects().subscriptions().delete(subscription=subscription)
 request.execute()
@@ -239,7 +239,7 @@ service = discovery.build('pubsub', 'v1', credentials=credentials)
 
 # The name of the subscription to get.
 # Format is `projects/{project}/subscriptions/{sub}`.
-subscription = 'my-subscription'  # TODO: Update placeholder value.
+subscription = 'projects/my-project/subscriptions/my-subscription'  # TODO: Update placeholder value.
 
 request = service.projects().subscriptions().get(subscription=subscription)
 response = request.execute()
@@ -273,7 +273,7 @@ service = discovery.build('pubsub', 'v1', credentials=credentials)
 # REQUIRED: The resource for which the policy is being requested.
 # `resource` is usually specified as a path. For example, a Project
 # resource is specified as `projects/{project}`.
-resource = 'my-resource'  # TODO: Update placeholder value.
+resource = 'projects/my-project/subscriptions/my-subscription'  # TODO: Update placeholder value.
 
 request = service.projects().subscriptions().getIamPolicy(resource=resource)
 response = request.execute()
@@ -306,7 +306,7 @@ service = discovery.build('pubsub', 'v1', credentials=credentials)
 
 # The name of the cloud project that subscriptions belong to.
 # Format is `projects/{project}`.
-project = 'my-project'  # TODO: Update placeholder value.
+project = 'projects/my-project'  # TODO: Update placeholder value.
 
 request = service.projects().subscriptions().list(project=project)
 while request is not None:
@@ -342,7 +342,7 @@ service = discovery.build('pubsub', 'v1', credentials=credentials)
 
 # The name of the subscription.
 # Format is `projects/{project}/subscriptions/{sub}`.
-subscription = 'my-subscription'  # TODO: Update placeholder value.
+subscription = 'projects/my-project/subscriptions/my-subscription'  # TODO: Update placeholder value.
 
 modify_ack_deadline_request_body = {
     # TODO: Add desired entries to the request body.
@@ -375,7 +375,7 @@ service = discovery.build('pubsub', 'v1', credentials=credentials)
 
 # The name of the subscription.
 # Format is `projects/{project}/subscriptions/{sub}`.
-subscription = 'my-subscription'  # TODO: Update placeholder value.
+subscription = 'projects/my-project/subscriptions/my-subscription'  # TODO: Update placeholder value.
 
 modify_push_config_request_body = {
     # TODO: Add desired entries to the request body.
@@ -409,7 +409,7 @@ service = discovery.build('pubsub', 'v1', credentials=credentials)
 
 # The subscription from which messages should be pulled.
 # Format is `projects/{project}/subscriptions/{sub}`.
-subscription = 'my-subscription'  # TODO: Update placeholder value.
+subscription = 'projects/my-project/subscriptions/my-subscription'  # TODO: Update placeholder value.
 
 pull_request_body = {
     # TODO: Add desired entries to the request body.
@@ -447,7 +447,7 @@ service = discovery.build('pubsub', 'v1', credentials=credentials)
 # REQUIRED: The resource for which the policy is being specified.
 # `resource` is usually specified as a path. For example, a Project
 # resource is specified as `projects/{project}`.
-resource = 'my-resource'  # TODO: Update placeholder value.
+resource = 'projects/my-project/subscriptions/my-subscription'  # TODO: Update placeholder value.
 
 set_iam_policy_request_body = {
     # TODO: Add desired entries to the request body.
@@ -485,7 +485,7 @@ service = discovery.build('pubsub', 'v1', credentials=credentials)
 # REQUIRED: The resource for which the policy detail is being requested.
 # `resource` is usually specified as a path. For example, a Project
 # resource is specified as `projects/{project}`.
-resource = 'my-resource'  # TODO: Update placeholder value.
+resource = 'projects/my-project/subscriptions/my-subscription'  # TODO: Update placeholder value.
 
 test_iam_permissions_request_body = {
     # TODO: Add desired entries to the request body.
@@ -526,7 +526,7 @@ service = discovery.build('pubsub', 'v1', credentials=credentials)
 # underscores (`_`), periods (`.`), tildes (`~`), plus (`+`) or percent
 # signs (`%`). It must be between 3 and 255 characters in length, and it
 # must not start with `"goog"`.
-name = 'my-name'  # TODO: Update placeholder value.
+name = 'projects/my-project/topics/my-topic'  # TODO: Update placeholder value.
 
 topic_body = {
     # TODO: Add desired entries to the request body. All existing entries
@@ -563,7 +563,7 @@ service = discovery.build('pubsub', 'v1', credentials=credentials)
 
 # Name of the topic to delete.
 # Format is `projects/{project}/topics/{topic}`.
-topic = 'my-topic'  # TODO: Update placeholder value.
+topic = 'projects/my-project/topics/my-topic'  # TODO: Update placeholder value.
 
 request = service.projects().topics().delete(topic=topic)
 request.execute()
@@ -593,7 +593,7 @@ service = discovery.build('pubsub', 'v1', credentials=credentials)
 
 # The name of the topic to get.
 # Format is `projects/{project}/topics/{topic}`.
-topic = 'my-topic'  # TODO: Update placeholder value.
+topic = 'projects/my-project/topics/my-topic'  # TODO: Update placeholder value.
 
 request = service.projects().topics().get(topic=topic)
 response = request.execute()
@@ -627,7 +627,7 @@ service = discovery.build('pubsub', 'v1', credentials=credentials)
 # REQUIRED: The resource for which the policy is being requested.
 # `resource` is usually specified as a path. For example, a Project
 # resource is specified as `projects/{project}`.
-resource = 'my-resource'  # TODO: Update placeholder value.
+resource = 'projects/my-project/topics/my-topic'  # TODO: Update placeholder value.
 
 request = service.projects().topics().getIamPolicy(resource=resource)
 response = request.execute()
@@ -660,7 +660,7 @@ service = discovery.build('pubsub', 'v1', credentials=credentials)
 
 # The name of the cloud project that topics belong to.
 # Format is `projects/{project}`.
-project = 'my-project'  # TODO: Update placeholder value.
+project = 'projects/my-project'  # TODO: Update placeholder value.
 
 request = service.projects().topics().list(project=project)
 while request is not None:
@@ -697,7 +697,7 @@ service = discovery.build('pubsub', 'v1', credentials=credentials)
 
 # The messages in the request will be published on this topic.
 # Format is `projects/{project}/topics/{topic}`.
-topic = 'my-topic'  # TODO: Update placeholder value.
+topic = 'projects/my-project/topics/my-topic'  # TODO: Update placeholder value.
 
 publish_request_body = {
     # TODO: Add desired entries to the request body.
@@ -735,7 +735,7 @@ service = discovery.build('pubsub', 'v1', credentials=credentials)
 # REQUIRED: The resource for which the policy is being specified.
 # `resource` is usually specified as a path. For example, a Project
 # resource is specified as `projects/{project}`.
-resource = 'my-resource'  # TODO: Update placeholder value.
+resource = 'projects/my-project/topics/my-topic'  # TODO: Update placeholder value.
 
 set_iam_policy_request_body = {
     # TODO: Add desired entries to the request body.
@@ -772,7 +772,7 @@ service = discovery.build('pubsub', 'v1', credentials=credentials)
 
 # The name of the topic that subscriptions are attached to.
 # Format is `projects/{project}/topics/{topic}`.
-topic = 'my-topic'  # TODO: Update placeholder value.
+topic = 'projects/my-project/topics/my-topic'  # TODO: Update placeholder value.
 
 request = service.projects().topics().subscriptions().list(topic=topic)
 while request is not None:
@@ -810,7 +810,7 @@ service = discovery.build('pubsub', 'v1', credentials=credentials)
 # REQUIRED: The resource for which the policy detail is being requested.
 # `resource` is usually specified as a path. For example, a Project
 # resource is specified as `projects/{project}`.
-resource = 'my-resource'  # TODO: Update placeholder value.
+resource = 'projects/my-project/topics/my-topic'  # TODO: Update placeholder value.
 
 test_iam_permissions_request_body = {
     # TODO: Add desired entries to the request body.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_storagetransfer.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_storagetransfer.v1.json.baseline
@@ -119,7 +119,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('storagetransfer', 'v1', credentials=credentials)
 
 # The job to get. Required.
-job_name = 'my-job-name'  # TODO: Update placeholder value.
+job_name = 'transferJobs/my-transfer-job'  # TODO: Update placeholder value.
 
 request = service.transferJobs().get(jobName=job_name)
 response = request.execute()
@@ -184,7 +184,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('storagetransfer', 'v1', credentials=credentials)
 
 # The name of job to update. Required.
-job_name = 'my-job-name'  # TODO: Update placeholder value.
+job_name = 'transferJobs/my-transfer-job'  # TODO: Update placeholder value.
 
 update_transfer_job_request_body = {
     # TODO: Add desired entries to the request body. Only assigned entries
@@ -220,7 +220,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('storagetransfer', 'v1', credentials=credentials)
 
 # The name of the operation resource to be cancelled.
-name = 'my-name'  # TODO: Update placeholder value.
+name = 'transferOperations/my-transfer-operation'  # TODO: Update placeholder value.
 
 request = service.transferOperations().cancel(name=name)
 request.execute()
@@ -248,7 +248,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('storagetransfer', 'v1', credentials=credentials)
 
 # The name of the operation resource to be deleted.
-name = 'my-name'  # TODO: Update placeholder value.
+name = 'transferOperations/my-transfer-operation'  # TODO: Update placeholder value.
 
 request = service.transferOperations().delete(name=name)
 request.execute()
@@ -277,7 +277,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('storagetransfer', 'v1', credentials=credentials)
 
 # The name of the operation resource.
-name = 'my-name'  # TODO: Update placeholder value.
+name = 'transferOperations/my-transfer-operation'  # TODO: Update placeholder value.
 
 request = service.transferOperations().get(name=name)
 response = request.execute()
@@ -344,7 +344,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('storagetransfer', 'v1', credentials=credentials)
 
 # The name of the transfer operation. Required.
-name = 'my-name'  # TODO: Update placeholder value.
+name = 'transferOperations/my-transfer-operation'  # TODO: Update placeholder value.
 
 pause_transfer_operation_request_body = {
     # TODO: Add desired entries to the request body.
@@ -376,7 +376,7 @@ credentials = GoogleCredentials.get_application_default()
 service = discovery.build('storagetransfer', 'v1', credentials=credentials)
 
 # The name of the transfer operation. Required.
-name = 'my-name'  # TODO: Update placeholder value.
+name = 'transferOperations/my-transfer-operation'  # TODO: Update placeholder value.
 
 resume_transfer_operation_request_body = {
     # TODO: Add desired entries to the request body.

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_cloudbilling.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_cloudbilling.v1.json.baseline
@@ -87,8 +87,8 @@ service = Google::Apis::CloudbillingV1::CloudbillingService.new
 service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
-# The resource name of the billing account associated with the projects that you want to list. For
-# example, `billingAccounts/012345-567890-ABCDEF`.
+# The resource name of the billing account associated with the projects that
+# you want to list. For example, `billingAccounts/012345-567890-ABCDEF`.
 name = 'billingAccounts/my-billing-account'  # TODO: Update placeholder value.
 
 project_billing_info2 = service.fetch_all(items: :project_billing_info) do |token|
@@ -123,8 +123,8 @@ service = Google::Apis::CloudbillingV1::CloudbillingService.new
 service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
-# The resource name of the project for which billing information is retrieved. For example,
-# `projects/tokyo-rain-123`.
+# The resource name of the project for which billing information is
+# retrieved. For example, `projects/tokyo-rain-123`.
 name = 'projects/my-project'  # TODO: Update placeholder value.
 
 response = service.get_project_billing_info(name)
@@ -155,8 +155,8 @@ service = Google::Apis::CloudbillingV1::CloudbillingService.new
 service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
-# The resource name of the project associated with the billing information that you want to update.
-# For example, `projects/tokyo-rain-123`.
+# The resource name of the project associated with the billing information
+# that you want to update. For example, `projects/tokyo-rain-123`.
 name = 'projects/my-project'  # TODO: Update placeholder value.
 
 # TODO: Assign values to desired members of `request_body`. All existing

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_cloudresourcemanager.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_cloudresourcemanager.v1.json.baseline
@@ -24,7 +24,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 # The name of the operation resource.
-name = 'my-name'  # TODO: Update placeholder value.
+name = 'operations/my-operation'  # TODO: Update placeholder value.
 
 response = service.get_operation(name)
 
@@ -55,7 +55,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 # The resource name of the Organization to fetch, e.g. "organizations/1234".
-name = 'my-name'  # TODO: Update placeholder value.
+name = 'organizations/my-organization'  # TODO: Update placeholder value.
 
 response = service.get_organization(name)
 
@@ -88,7 +88,7 @@ service.authorization = \
 # REQUIRED: The resource for which the policy is being requested.
 # `resource` is usually specified as a path. For example, a Project
 # resource is specified as `projects/{project}`.
-resource = 'my-resource'  # TODO: Update placeholder value.
+resource = 'organizations/my-organization'  # TODO: Update placeholder value.
 
 # TODO: Assign values to desired members of `request_body`:
 request_body = Google::Apis::CloudresourcemanagerV1::GetIamPolicyRequest.new
@@ -160,7 +160,7 @@ service.authorization = \
 # REQUIRED: The resource for which the policy is being specified.
 # `resource` is usually specified as a path. For example, a Project
 # resource is specified as `projects/{project}`.
-resource = 'my-resource'  # TODO: Update placeholder value.
+resource = 'organizations/my-organization'  # TODO: Update placeholder value.
 
 # TODO: Assign values to desired members of `request_body`:
 request_body = Google::Apis::CloudresourcemanagerV1::SetIamPolicyRequest.new
@@ -196,7 +196,7 @@ service.authorization = \
 # REQUIRED: The resource for which the policy detail is being requested.
 # `resource` is usually specified as a path. For example, a Project
 # resource is specified as `projects/{project}`.
-resource = 'my-resource'  # TODO: Update placeholder value.
+resource = 'organizations/my-organization'  # TODO: Update placeholder value.
 
 # TODO: Assign values to desired members of `request_body`:
 request_body = Google::Apis::CloudresourcemanagerV1::TestIamPermissionsRequest.new

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_genomics.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_genomics.v1.json.baseline
@@ -624,7 +624,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 # REQUIRED: The resource for which policy is being specified. Format is `datasets/`.
-resource = 'my-resource'  # TODO: Update placeholder value.
+resource = 'datasets/my-dataset'  # TODO: Update placeholder value.
 
 # TODO: Assign values to desired members of `request_body`:
 request_body = Google::Apis::GenomicsV1::GetIamPolicyRequest.new
@@ -725,7 +725,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 # REQUIRED: The resource for which policy is being specified. Format is `datasets/`.
-resource = 'my-resource'  # TODO: Update placeholder value.
+resource = 'datasets/my-dataset'  # TODO: Update placeholder value.
 
 # TODO: Assign values to desired members of `request_body`:
 request_body = Google::Apis::GenomicsV1::SetIamPolicyRequest.new
@@ -759,7 +759,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 # REQUIRED: The resource for which policy is being specified. Format is `datasets/`.
-resource = 'my-resource'  # TODO: Update placeholder value.
+resource = 'datasets/my-dataset'  # TODO: Update placeholder value.
 
 # TODO: Assign values to desired members of `request_body`:
 request_body = Google::Apis::GenomicsV1::TestIamPermissionsRequest.new
@@ -826,7 +826,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 # The name of the operation resource to be cancelled.
-name = 'my-name'  # TODO: Update placeholder value.
+name = 'operations/my-operation'  # TODO: Update placeholder value.
 
 # TODO: Assign values to desired members of `request_body`:
 request_body = Google::Apis::GenomicsV1::CancelOperationRequest.new
@@ -857,7 +857,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 # The name of the operation resource.
-name = 'my-name'  # TODO: Update placeholder value.
+name = 'operations/my-operation'  # TODO: Update placeholder value.
 
 response = service.get_operation(name)
 

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_logging.v2beta1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_logging.v2beta1.json.baseline
@@ -28,7 +28,7 @@ service.authorization = \
 # [LOG_ID] must be URL-encoded. For example, "projects/my-project-id/logs/syslog",
 # "organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity". For more
 # information about log names, see LogEntry.
-log_name = 'my-log-name'  # TODO: Update placeholder value.
+log_name = 'billingAccounts/my-billing-account/logs/my-log'  # TODO: Update placeholder value.
 
 service.delete_billing_account_log(log_name)
 # BEFORE RUNNING:
@@ -58,7 +58,7 @@ service.authorization = \
 # Required. The resource name that owns the logs:
 # "projects/[PROJECT_ID]"
 # "organizations/[ORGANIZATION_ID]"
-parent = 'my-parent'  # TODO: Update placeholder value.
+parent = 'billingAccounts/my-billing-account'  # TODO: Update placeholder value.
 
 log_names = service.fetch_all(items: :log_names) do |token|
   service.list_billing_account_logs(parent, page_token: token)
@@ -196,7 +196,7 @@ service.authorization = \
 # [LOG_ID] must be URL-encoded. For example, "projects/my-project-id/logs/syslog",
 # "organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity". For more
 # information about log names, see LogEntry.
-log_name = 'my-log-name'  # TODO: Update placeholder value.
+log_name = 'organizations/my-organization/logs/my-log'  # TODO: Update placeholder value.
 
 service.delete_organization_log(log_name)
 # BEFORE RUNNING:
@@ -226,7 +226,7 @@ service.authorization = \
 # Required. The resource name that owns the logs:
 # "projects/[PROJECT_ID]"
 # "organizations/[ORGANIZATION_ID]"
-parent = 'my-parent'  # TODO: Update placeholder value.
+parent = 'organizations/my-organization'  # TODO: Update placeholder value.
 
 log_names = service.fetch_all(items: :log_names) do |token|
   service.list_organization_logs(parent, page_token: token)
@@ -265,7 +265,7 @@ service.authorization = \
 # [LOG_ID] must be URL-encoded. For example, "projects/my-project-id/logs/syslog",
 # "organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity". For more
 # information about log names, see LogEntry.
-log_name = 'my-log-name'  # TODO: Update placeholder value.
+log_name = 'projects/my-project/logs/my-log'  # TODO: Update placeholder value.
 
 service.delete_log(log_name)
 # BEFORE RUNNING:
@@ -295,7 +295,7 @@ service.authorization = \
 # Required. The resource name that owns the logs:
 # "projects/[PROJECT_ID]"
 # "organizations/[ORGANIZATION_ID]"
-parent = 'my-parent'  # TODO: Update placeholder value.
+parent = 'projects/my-project'  # TODO: Update placeholder value.
 
 log_names = service.fetch_all(items: :log_names) do |token|
   service.list_logs(parent, page_token: token)
@@ -332,7 +332,7 @@ service.authorization = \
 # The resource name of the project in which to create the metric:
 # "projects/[PROJECT_ID]"
 # The new metric must be provided in the request.
-parent = 'my-parent'  # TODO: Update placeholder value.
+parent = 'projects/my-project'  # TODO: Update placeholder value.
 
 # TODO: Assign values to desired members of `request_body`:
 request_body = Google::Apis::LoggingV2beta1::LogMetric.new
@@ -366,7 +366,7 @@ service.authorization = \
 
 # The resource name of the metric to delete:
 # "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
-metric_name = 'my-metric-name'  # TODO: Update placeholder value.
+metric_name = 'projects/my-project/metrics/my-metric'  # TODO: Update placeholder value.
 
 service.delete_project_metric(metric_name)
 # BEFORE RUNNING:
@@ -395,7 +395,7 @@ service.authorization = \
 
 # The resource name of the desired metric:
 # "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
-metric_name = 'my-metric-name'  # TODO: Update placeholder value.
+metric_name = 'projects/my-project/metrics/my-metric'  # TODO: Update placeholder value.
 
 response = service.get_project_metric(metric_name)
 
@@ -427,7 +427,7 @@ service.authorization = \
 
 # Required. The name of the project containing the metrics:
 # "projects/[PROJECT_ID]"
-parent = 'my-parent'  # TODO: Update placeholder value.
+parent = 'projects/my-project'  # TODO: Update placeholder value.
 
 metrics = service.fetch_all(items: :metrics) do |token|
   service.list_project_metrics(parent, page_token: token)
@@ -465,7 +465,7 @@ service.authorization = \
 # "projects/[PROJECT_ID]/metrics/[METRIC_ID]"
 # The updated metric must be provided in the request and it's name field must be the same as
 # [METRIC_ID] If the metric does not exist in [PROJECT_ID], then a new metric is created.
-metric_name = 'my-metric-name'  # TODO: Update placeholder value.
+metric_name = 'projects/my-project/metrics/my-metric'  # TODO: Update placeholder value.
 
 # TODO: Assign values to desired members of `request_body`. All existing
 # members will be replaced:
@@ -503,7 +503,7 @@ service.authorization = \
 # "projects/[PROJECT_ID]"
 # "organizations/[ORGANIZATION_ID]"
 # Examples: "projects/my-logging-project", "organizations/123456789".
-parent = 'my-parent'  # TODO: Update placeholder value.
+parent = 'projects/my-project'  # TODO: Update placeholder value.
 
 # TODO: Assign values to desired members of `request_body`:
 request_body = Google::Apis::LoggingV2beta1::LogSink.new
@@ -541,7 +541,7 @@ service.authorization = \
 # "organizations/[ORGANIZATION_ID]/sinks/[SINK_ID]"
 # It is an error if the sink does not exist. Example: "projects/my-project-id/sinks/my-sink-id". It
 # is an error if the sink does not exist.
-sink_name = 'my-sink-name'  # TODO: Update placeholder value.
+sink_name = 'projects/my-project/sinks/my-sink'  # TODO: Update placeholder value.
 
 service.delete_project_sink(sink_name)
 # BEFORE RUNNING:
@@ -572,7 +572,7 @@ service.authorization = \
 # "projects/[PROJECT_ID]/sinks/[SINK_ID]"
 # "organizations/[ORGANIZATION_ID]/sinks/[SINK_ID]"
 # Example: "projects/my-project-id/sinks/my-sink-id".
-sink_name = 'my-sink-name'  # TODO: Update placeholder value.
+sink_name = 'projects/my-project/sinks/my-sink'  # TODO: Update placeholder value.
 
 response = service.get_project_sink(sink_name)
 
@@ -604,7 +604,7 @@ service.authorization = \
 
 # Required. The parent resource whose sinks are to be listed. Examples:
 # "projects/my-logging-project", "organizations/123456789".
-parent = 'my-parent'  # TODO: Update placeholder value.
+parent = 'projects/my-project'  # TODO: Update placeholder value.
 
 sinks = service.fetch_all(items: :sinks) do |token|
   service.list_project_sinks(parent, page_token: token)
@@ -643,7 +643,7 @@ service.authorization = \
 # "projects/[PROJECT_ID]/sinks/[SINK_ID]"
 # "organizations/[ORGANIZATION_ID]/sinks/[SINK_ID]"
 # Example: "projects/my-project-id/sinks/my-sink-id".
-sink_name = 'my-sink-name'  # TODO: Update placeholder value.
+sink_name = 'projects/my-project/sinks/my-sink'  # TODO: Update placeholder value.
 
 # TODO: Assign values to desired members of `request_body`. All existing
 # members will be replaced:

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_pubsub.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_pubsub.v1.json.baseline
@@ -26,7 +26,7 @@ service.authorization = \
 # REQUIRED: The resource for which the policy is being requested.
 # `resource` is usually specified as a path. For example, a Project
 # resource is specified as `projects/{project}`.
-resource = 'my-resource'  # TODO: Update placeholder value.
+resource = 'projects/my-project/snapshots/my-snapshot'  # TODO: Update placeholder value.
 
 response = service.get_project_snapshot_iam_policy(resource)
 
@@ -59,7 +59,7 @@ service.authorization = \
 # REQUIRED: The resource for which the policy is being specified.
 # `resource` is usually specified as a path. For example, a Project
 # resource is specified as `projects/{project}`.
-resource = 'my-resource'  # TODO: Update placeholder value.
+resource = 'projects/my-project/snapshots/my-snapshot'  # TODO: Update placeholder value.
 
 # TODO: Assign values to desired members of `request_body`:
 request_body = Google::Apis::PubsubV1::SetIamPolicyRequest.new
@@ -95,7 +95,7 @@ service.authorization = \
 # REQUIRED: The resource for which the policy detail is being requested.
 # `resource` is usually specified as a path. For example, a Project
 # resource is specified as `projects/{project}`.
-resource = 'my-resource'  # TODO: Update placeholder value.
+resource = 'projects/my-project/snapshots/my-snapshot'  # TODO: Update placeholder value.
 
 # TODO: Assign values to desired members of `request_body`:
 request_body = Google::Apis::PubsubV1::TestIamPermissionsRequest.new
@@ -129,7 +129,7 @@ service.authorization = \
 
 # The subscription whose message is being acknowledged.
 # Format is `projects/{project}/subscriptions/{sub}`.
-subscription = 'my-subscription'  # TODO: Update placeholder value.
+subscription = 'projects/my-project/subscriptions/my-subscription'  # TODO: Update placeholder value.
 
 # TODO: Assign values to desired members of `request_body`:
 request_body = Google::Apis::PubsubV1::AcknowledgeRequest.new
@@ -165,7 +165,7 @@ service.authorization = \
 # (`[0-9]`), dashes (`-`), underscores (`_`), periods (`.`), tildes (`~`),
 # plus (`+`) or percent signs (`%`). It must be between 3 and 255 characters
 # in length, and it must not start with `"goog"`.
-name = 'my-name'  # TODO: Update placeholder value.
+name = 'projects/my-project/subscriptions/my-subscription'  # TODO: Update placeholder value.
 
 # TODO: Assign values to desired members of `request_body`. All existing
 # members will be replaced:
@@ -200,7 +200,7 @@ service.authorization = \
 
 # The subscription to delete.
 # Format is `projects/{project}/subscriptions/{sub}`.
-subscription = 'my-subscription'  # TODO: Update placeholder value.
+subscription = 'projects/my-project/subscriptions/my-subscription'  # TODO: Update placeholder value.
 
 service.delete_subscription(subscription)
 # BEFORE RUNNING:
@@ -229,7 +229,7 @@ service.authorization = \
 
 # The name of the subscription to get.
 # Format is `projects/{project}/subscriptions/{sub}`.
-subscription = 'my-subscription'  # TODO: Update placeholder value.
+subscription = 'projects/my-project/subscriptions/my-subscription'  # TODO: Update placeholder value.
 
 response = service.get_subscription(subscription)
 
@@ -262,7 +262,7 @@ service.authorization = \
 # REQUIRED: The resource for which the policy is being requested.
 # `resource` is usually specified as a path. For example, a Project
 # resource is specified as `projects/{project}`.
-resource = 'my-resource'  # TODO: Update placeholder value.
+resource = 'projects/my-project/subscriptions/my-subscription'  # TODO: Update placeholder value.
 
 response = service.get_project_subscription_iam_policy(resource)
 
@@ -294,7 +294,7 @@ service.authorization = \
 
 # The name of the cloud project that subscriptions belong to.
 # Format is `projects/{project}`.
-project = 'my-project'  # TODO: Update placeholder value.
+project = 'projects/my-project'  # TODO: Update placeholder value.
 
 subscriptions = service.fetch_all(items: :subscriptions) do |token|
   service.list_subscriptions(project, page_token: token)
@@ -329,7 +329,7 @@ service.authorization = \
 
 # The name of the subscription.
 # Format is `projects/{project}/subscriptions/{sub}`.
-subscription = 'my-subscription'  # TODO: Update placeholder value.
+subscription = 'projects/my-project/subscriptions/my-subscription'  # TODO: Update placeholder value.
 
 # TODO: Assign values to desired members of `request_body`:
 request_body = Google::Apis::PubsubV1::ModifyAckDeadlineRequest.new
@@ -360,7 +360,7 @@ service.authorization = \
 
 # The name of the subscription.
 # Format is `projects/{project}/subscriptions/{sub}`.
-subscription = 'my-subscription'  # TODO: Update placeholder value.
+subscription = 'projects/my-project/subscriptions/my-subscription'  # TODO: Update placeholder value.
 
 # TODO: Assign values to desired members of `request_body`:
 request_body = Google::Apis::PubsubV1::ModifyPushConfigRequest.new
@@ -392,7 +392,7 @@ service.authorization = \
 
 # The subscription from which messages should be pulled.
 # Format is `projects/{project}/subscriptions/{sub}`.
-subscription = 'my-subscription'  # TODO: Update placeholder value.
+subscription = 'projects/my-project/subscriptions/my-subscription'  # TODO: Update placeholder value.
 
 # TODO: Assign values to desired members of `request_body`:
 request_body = Google::Apis::PubsubV1::PullRequest.new
@@ -428,7 +428,7 @@ service.authorization = \
 # REQUIRED: The resource for which the policy is being specified.
 # `resource` is usually specified as a path. For example, a Project
 # resource is specified as `projects/{project}`.
-resource = 'my-resource'  # TODO: Update placeholder value.
+resource = 'projects/my-project/subscriptions/my-subscription'  # TODO: Update placeholder value.
 
 # TODO: Assign values to desired members of `request_body`:
 request_body = Google::Apis::PubsubV1::SetIamPolicyRequest.new
@@ -464,7 +464,7 @@ service.authorization = \
 # REQUIRED: The resource for which the policy detail is being requested.
 # `resource` is usually specified as a path. For example, a Project
 # resource is specified as `projects/{project}`.
-resource = 'my-resource'  # TODO: Update placeholder value.
+resource = 'projects/my-project/subscriptions/my-subscription'  # TODO: Update placeholder value.
 
 # TODO: Assign values to desired members of `request_body`:
 request_body = Google::Apis::PubsubV1::TestIamPermissionsRequest.new
@@ -503,7 +503,7 @@ service.authorization = \
 # underscores (`_`), periods (`.`), tildes (`~`), plus (`+`) or percent
 # signs (`%`). It must be between 3 and 255 characters in length, and it
 # must not start with `"goog"`.
-name = 'my-name'  # TODO: Update placeholder value.
+name = 'projects/my-project/topics/my-topic'  # TODO: Update placeholder value.
 
 # TODO: Assign values to desired members of `request_body`. All existing
 # members will be replaced:
@@ -538,7 +538,7 @@ service.authorization = \
 
 # Name of the topic to delete.
 # Format is `projects/{project}/topics/{topic}`.
-topic = 'my-topic'  # TODO: Update placeholder value.
+topic = 'projects/my-project/topics/my-topic'  # TODO: Update placeholder value.
 
 service.delete_topic(topic)
 # BEFORE RUNNING:
@@ -567,7 +567,7 @@ service.authorization = \
 
 # The name of the topic to get.
 # Format is `projects/{project}/topics/{topic}`.
-topic = 'my-topic'  # TODO: Update placeholder value.
+topic = 'projects/my-project/topics/my-topic'  # TODO: Update placeholder value.
 
 response = service.get_topic(topic)
 
@@ -600,7 +600,7 @@ service.authorization = \
 # REQUIRED: The resource for which the policy is being requested.
 # `resource` is usually specified as a path. For example, a Project
 # resource is specified as `projects/{project}`.
-resource = 'my-resource'  # TODO: Update placeholder value.
+resource = 'projects/my-project/topics/my-topic'  # TODO: Update placeholder value.
 
 response = service.get_project_topic_iam_policy(resource)
 
@@ -632,7 +632,7 @@ service.authorization = \
 
 # The name of the cloud project that topics belong to.
 # Format is `projects/{project}`.
-project = 'my-project'  # TODO: Update placeholder value.
+project = 'projects/my-project'  # TODO: Update placeholder value.
 
 topics = service.fetch_all(items: :topics) do |token|
   service.list_topics(project, page_token: token)
@@ -668,7 +668,7 @@ service.authorization = \
 
 # The messages in the request will be published on this topic.
 # Format is `projects/{project}/topics/{topic}`.
-topic = 'my-topic'  # TODO: Update placeholder value.
+topic = 'projects/my-project/topics/my-topic'  # TODO: Update placeholder value.
 
 # TODO: Assign values to desired members of `request_body`:
 request_body = Google::Apis::PubsubV1::PublishRequest.new
@@ -704,7 +704,7 @@ service.authorization = \
 # REQUIRED: The resource for which the policy is being specified.
 # `resource` is usually specified as a path. For example, a Project
 # resource is specified as `projects/{project}`.
-resource = 'my-resource'  # TODO: Update placeholder value.
+resource = 'projects/my-project/topics/my-topic'  # TODO: Update placeholder value.
 
 # TODO: Assign values to desired members of `request_body`:
 request_body = Google::Apis::PubsubV1::SetIamPolicyRequest.new
@@ -739,7 +739,7 @@ service.authorization = \
 
 # The name of the topic that subscriptions are attached to.
 # Format is `projects/{project}/topics/{topic}`.
-topic = 'my-topic'  # TODO: Update placeholder value.
+topic = 'projects/my-project/topics/my-topic'  # TODO: Update placeholder value.
 
 subscriptions = service.fetch_all(items: :subscriptions) do |token|
   service.list_topic_subscriptions(topic, page_token: token)
@@ -776,7 +776,7 @@ service.authorization = \
 # REQUIRED: The resource for which the policy detail is being requested.
 # `resource` is usually specified as a path. For example, a Project
 # resource is specified as `projects/{project}`.
-resource = 'my-resource'  # TODO: Update placeholder value.
+resource = 'projects/my-project/topics/my-topic'  # TODO: Update placeholder value.
 
 # TODO: Assign values to desired members of `request_body`:
 request_body = Google::Apis::PubsubV1::TestIamPermissionsRequest.new

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_storagetransfer.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_storagetransfer.v1.json.baseline
@@ -115,7 +115,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 # The job to get. Required.
-job_name = 'my-job-name'  # TODO: Update placeholder value.
+job_name = 'transferJobs/my-transfer-job'  # TODO: Update placeholder value.
 
 response = service.get_transfer_job(job_name)
 
@@ -178,7 +178,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 # The name of job to update. Required.
-job_name = 'my-job-name'  # TODO: Update placeholder value.
+job_name = 'transferJobs/my-transfer-job'  # TODO: Update placeholder value.
 
 # TODO: Assign values to desired members of `request_body`. Only assigned
 # members will be changed:
@@ -212,7 +212,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 # The name of the operation resource to be cancelled.
-name = 'my-name'  # TODO: Update placeholder value.
+name = 'transferOperations/my-transfer-operation'  # TODO: Update placeholder value.
 
 service.cancel_transfer_operation(name)
 # BEFORE RUNNING:
@@ -239,7 +239,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 # The name of the operation resource to be deleted.
-name = 'my-name'  # TODO: Update placeholder value.
+name = 'transferOperations/my-transfer-operation'  # TODO: Update placeholder value.
 
 service.delete_transfer_operation(name)
 # BEFORE RUNNING:
@@ -267,7 +267,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 # The name of the operation resource.
-name = 'my-name'  # TODO: Update placeholder value.
+name = 'transferOperations/my-transfer-operation'  # TODO: Update placeholder value.
 
 response = service.get_transfer_operation(name)
 
@@ -332,7 +332,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 # The name of the transfer operation. Required.
-name = 'my-name'  # TODO: Update placeholder value.
+name = 'transferOperations/my-transfer-operation'  # TODO: Update placeholder value.
 
 # TODO: Assign values to desired members of `request_body`:
 request_body = Google::Apis::StoragetransferV1::PauseTransferOperationRequest.new
@@ -362,7 +362,7 @@ service.authorization = \
     Google::Auth.get_application_default(['https://www.googleapis.com/auth/cloud-platform'])
 
 # The name of the transfer operation. Required.
-name = 'my-name'  # TODO: Update placeholder value.
+name = 'transferOperations/my-transfer-operation'  # TODO: Update placeholder value.
 
 # TODO: Assign values to desired members of `request_body`:
 request_body = Google::Apis::StoragetransferV1::ResumeTransferOperationRequest.new


### PR DESCRIPTION
The Discovery service is now returning path wildcards as `[^/]+` instead
of `[^/]*`. This commit fixes that case, and adds support for two more
wildcard types: `.+` and `.*`.