### PR TITLE
Support multiple overrides files

### DIFF
--- a/src/main/java/com/google/api/codegen/DiscoveryFragmentGeneratorApi.java
+++ b/src/main/java/com/google/api/codegen/DiscoveryFragmentGeneratorApi.java
@@ -66,7 +66,7 @@ public class DiscoveryFragmentGeneratorApi {
       ToolOptions.createOption(
           String.class,
           "overrides",
-          "A comma dielimited list of paths to sample config override files.",
+          "A comma delimited list of paths to sample config override files.",
           "");
 
   public static final Option<List<String>> GENERATOR_CONFIG_FILES =

--- a/src/main/java/com/google/api/codegen/DiscoveryFragmentGeneratorApi.java
+++ b/src/main/java/com/google/api/codegen/DiscoveryFragmentGeneratorApi.java
@@ -62,9 +62,12 @@ public class DiscoveryFragmentGeneratorApi {
           "The name of the output file or folder to put generated code.",
           "");
 
-  public static final Option<String> OVERRIDES_FILE =
+  public static final Option<String> OVERRIDE_FILES =
       ToolOptions.createOption(
-          String.class, "overrides", "The path to the sample config overrides file.", "");
+          String.class,
+          "overrides",
+          "A comma dielimited list of paths to sample config override files.",
+          "");
 
   public static final Option<List<String>> GENERATOR_CONFIG_FILES =
       ToolOptions.createOption(
@@ -107,15 +110,14 @@ public class DiscoveryFragmentGeneratorApi {
       return;
     }
 
-    String overridesFilename = options.get(OVERRIDES_FILE);
-    JsonNode overridesJson = null;
-    if (!Strings.isNullOrEmpty(overridesFilename)) {
+    String[] filenames = options.get(OVERRIDE_FILES).split(",");
+    List<JsonNode> overrides = new ArrayList<>();
+    for (String filename : filenames) {
       try {
         BufferedReader reader =
-            com.google.common.io.Files.newReader(
-                new File(overridesFilename), Charset.forName("UTF8"));
+            com.google.common.io.Files.newReader(new File(filename), Charset.forName("UTF8"));
         ObjectMapper mapper = new ObjectMapper();
-        overridesJson = mapper.readTree(reader);
+        overrides.add(mapper.readTree(reader));
       } catch (FileNotFoundException e) {
         // Do nothing if the overrides file doesn't exist. Avoiding crashes for
         // this scenario makes parts of the automation around samplegen simpler.
@@ -133,7 +135,7 @@ public class DiscoveryFragmentGeneratorApi {
 
     DiscoveryProviderFactory providerFactory = createProviderFactory(factory);
     DiscoveryProvider provider =
-        providerFactory.create(discovery.getService(), apiaryConfig, overridesJson, id);
+        providerFactory.create(discovery.getService(), apiaryConfig, overrides, id);
 
     for (Api api : discovery.getService().getApisList()) {
       for (Method method : api.getMethodsList()) {

--- a/src/main/java/com/google/api/codegen/DiscoveryFragmentGeneratorTool.java
+++ b/src/main/java/com/google/api/codegen/DiscoveryFragmentGeneratorTool.java
@@ -43,7 +43,7 @@ public class DiscoveryFragmentGeneratorTool {
     options.addOption(
         Option.builder()
             .longOpt("overrides")
-            .desc("A comma dielimited list of paths to sample config override files.")
+            .desc("A comma delimited list of paths to sample config override files.")
             .hasArg()
             .argName("OVERRIDES")
             .build());

--- a/src/main/java/com/google/api/codegen/DiscoveryFragmentGeneratorTool.java
+++ b/src/main/java/com/google/api/codegen/DiscoveryFragmentGeneratorTool.java
@@ -43,7 +43,7 @@ public class DiscoveryFragmentGeneratorTool {
     options.addOption(
         Option.builder()
             .longOpt("overrides")
-            .desc("The path to the sample config overrides file")
+            .desc("A comma dielimited list of paths to sample config override files.")
             .hasArg()
             .argName("OVERRIDES")
             .build());
@@ -96,7 +96,7 @@ public class DiscoveryFragmentGeneratorTool {
     options.set(DiscoveryFragmentGeneratorApi.DISCOVERY_DOC, discoveryDoc);
     options.set(
         DiscoveryFragmentGeneratorApi.GENERATOR_CONFIG_FILES, Arrays.asList(generatorConfigs));
-    options.set(DiscoveryFragmentGeneratorApi.OVERRIDES_FILE, overridesFile);
+    options.set(DiscoveryFragmentGeneratorApi.OVERRIDE_FILES, overridesFile);
     options.set(DiscoveryFragmentGeneratorApi.OUTPUT_FILE, outputDirectory);
     options.set(DiscoveryFragmentGeneratorApi.AUTH_INSTRUCTIONS_URL, authInstructions);
     DiscoveryFragmentGeneratorApi generator = new DiscoveryFragmentGeneratorApi(options);

--- a/src/main/java/com/google/api/codegen/discovery/DiscoveryProviderFactory.java
+++ b/src/main/java/com/google/api/codegen/discovery/DiscoveryProviderFactory.java
@@ -17,10 +17,11 @@ package com.google.api.codegen.discovery;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.api.Service;
 import com.google.api.codegen.ApiaryConfig;
+import java.util.List;
 
 /** A factory for DiscoveryProviders which perform code generation. */
 public interface DiscoveryProviderFactory {
   /** Create the provider from the given service, apiaryConfig, sampleConfigOverrides, and id. */
   DiscoveryProvider create(
-      Service service, ApiaryConfig apiaryConfig, JsonNode sampleConfigOverrides, String id);
+      Service service, ApiaryConfig apiaryConfig, List<JsonNode> sampleConfigOverrides, String id);
 }

--- a/src/main/java/com/google/api/codegen/discovery/MainDiscoveryProviderFactory.java
+++ b/src/main/java/com/google/api/codegen/discovery/MainDiscoveryProviderFactory.java
@@ -85,16 +85,16 @@ public class MainDiscoveryProviderFactory implements DiscoveryProviderFactory {
           .build();
 
   public static DiscoveryProvider defaultCreate(
-      Service service, ApiaryConfig apiaryConfig, JsonNode sampleConfigOverrides, String id) {
+      Service service, ApiaryConfig apiaryConfig, List<JsonNode> sampleConfigOverrides, String id) {
     // Use nodes corresponding to language pattern fields matching current language.
     List<JsonNode> overrides = new ArrayList<JsonNode>();
     // Sort patterns to ensure deterministic ordering of overrides
-    if (sampleConfigOverrides != null) {
-      List<String> languagePatterns = Lists.newArrayList(sampleConfigOverrides.fieldNames());
+    for (JsonNode override : sampleConfigOverrides) {
+      List<String> languagePatterns = Lists.newArrayList(override.fieldNames());
       Collections.sort(languagePatterns);
       for (String languagePattern : languagePatterns) {
         if (Pattern.matches(languagePattern, id)) {
-          overrides.add(sampleConfigOverrides.get(languagePattern));
+          overrides.add(override.get(languagePattern));
         }
       }
     }
@@ -130,7 +130,7 @@ public class MainDiscoveryProviderFactory implements DiscoveryProviderFactory {
 
   @Override
   public DiscoveryProvider create(
-      Service service, ApiaryConfig apiaryConfig, JsonNode sampleConfigOverrides, String id) {
+      Service service, ApiaryConfig apiaryConfig, List<JsonNode> sampleConfigOverrides, String id) {
     return defaultCreate(service, apiaryConfig, sampleConfigOverrides, id);
   }
 }

--- a/src/test/java/com/google/api/codegen/DiscoveryGeneratorTestBase.java
+++ b/src/test/java/com/google/api/codegen/DiscoveryGeneratorTestBase.java
@@ -32,6 +32,8 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
@@ -101,9 +103,13 @@ public abstract class DiscoveryGeneratorTestBase extends ConfigBaselineTestCase 
     // This field is manually populated to test the end-to-end behavior of the
     // "auth_instructions" flag.
     discoveryImporter.getConfig().setAuthInstructionsUrl("https://foo.com/bar");
+    List<JsonNode> overrides = new ArrayList<JsonNode>();
+    if (overridesJson != null) {
+      overrides.add(overridesJson);
+    }
     DiscoveryProvider provider =
         MainDiscoveryProviderFactory.defaultCreate(
-            discoveryImporter.getService(), discoveryImporter.getConfig(), overridesJson, id);
+            discoveryImporter.getService(), discoveryImporter.getConfig(), overrides, id);
 
     Doc output = Doc.EMPTY;
     for (Api api : discoveryImporter.getService().getApisList()) {


### PR DESCRIPTION
Add support for a comma-delimited list of overrides files. These files
are parsed and applied in the order they are listed.