### PR TITLE
Ruby: Fix init code for repeated fields inside messages.

### DIFF
--- a/src/main/resources/com/google/api/codegen/ruby/initcode.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/initcode.snip
@@ -16,9 +16,37 @@
 @end
 
 @private initLineStructure(line)
-  {@line.identifier} = {@line.typeName}.new
-  @join fieldSetting : line.fieldSettings
-    {@line.identifier}.{@fieldSetting.fieldSetFunction} = {@fieldSetting.identifier}
+  @switch line.fieldSettings.size.toString
+  @case "0"
+    {@line.identifier} = {@line.typeName}.new
+  @case "1"
+    {@singleLineInitStructure(line)}
+  @case "2"
+    {@singleLineInitStructure(line)}
+  @default
+    {@multiLineInitStructure(line)}
+  @end
+@end
+
+@private singleLineInitStructure(line)
+    {@line.identifier} = {@line.typeName}.new({@structureFieldsList(line.fieldSettings)})
+@end
+
+@private multiLineInitStructure(line)
+  {@line.identifier} = {@line.typeName}.new(
+    {@multilineStructureFieldsList(line.fieldSettings)}
+  )
+@end
+
+@private structureFieldsList(fieldSettings)
+  @join fieldSetting : fieldSettings on ", "
+    {@fieldSetting.fieldName}: {@fieldSetting.identifier}
+  @end
+@end
+
+@private multilineStructureFieldsList(fieldSettings)
+  @join fieldSetting : fieldSettings on ",".add(BREAK)
+    {@fieldSetting.fieldName}: {@fieldSetting.identifier}
   @end
 @end
 

--- a/src/test/java/com/google/api/codegen/testdata/ruby_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_doc_main_library.baseline
@@ -643,8 +643,7 @@ module Library
       #   shelf = Shelf.new
       #   books = []
       #   series_string = "foobar"
-      #   series_uuid = SeriesUuid.new
-      #   series_uuid.series_string = series_string
+      #   series_uuid = SeriesUuid.new(series_string: series_string)
       #   response = library_service_client.publish_series(shelf, books, series_uuid)
 
       def publish_series \
@@ -916,10 +915,11 @@ module Library
       #   comment = ''
       #   stage = Stage::UNSET
       #   alignment = Alignment::CHAR
-      #   comments_element = Comment.new
-      #   comments_element.comment = comment
-      #   comments_element.stage = stage
-      #   comments_element.alignment = alignment
+      #   comments_element = Comment.new(
+      #     comment: comment,
+      #     stage: stage,
+      #     alignment: alignment
+      #   )
       #   comments = [comments_element]
       #   library_service_client.add_comments(formatted_name, comments)
 
@@ -1116,8 +1116,7 @@ module Library
       #
       #   library_service_client = LibraryServiceClient.new
       #   name = ''
-      #   request = DiscussBookRequest.new
-      #   request.name = name
+      #   request = DiscussBookRequest.new(name: name)
       #   requests = [request]
       #   library_service_client.discuss_book(requests).each do |element|
       #     # Process element.
@@ -1151,8 +1150,7 @@ module Library
       #
       #   library_service_client = LibraryServiceClient.new
       #   name = ''
-      #   request = DiscussBookRequest.new
-      #   request.name = name
+      #   request = DiscussBookRequest.new(name: name)
       #   requests = [request]
       #   response = library_service_client.monolog_about_book(requests)
 

--- a/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
@@ -643,8 +643,7 @@ module Library
       #   shelf = Shelf.new
       #   books = []
       #   series_string = "foobar"
-      #   series_uuid = SeriesUuid.new
-      #   series_uuid.series_string = series_string
+      #   series_uuid = SeriesUuid.new(series_string: series_string)
       #   response = library_service_client.publish_series(shelf, books, series_uuid)
 
       def publish_series \
@@ -916,10 +915,11 @@ module Library
       #   comment = ''
       #   stage = Stage::UNSET
       #   alignment = Alignment::CHAR
-      #   comments_element = Comment.new
-      #   comments_element.comment = comment
-      #   comments_element.stage = stage
-      #   comments_element.alignment = alignment
+      #   comments_element = Comment.new(
+      #     comment: comment,
+      #     stage: stage,
+      #     alignment: alignment
+      #   )
       #   comments = [comments_element]
       #   library_service_client.add_comments(formatted_name, comments)
 
@@ -1116,8 +1116,7 @@ module Library
       #
       #   library_service_client = LibraryServiceClient.new
       #   name = ''
-      #   request = DiscussBookRequest.new
-      #   request.name = name
+      #   request = DiscussBookRequest.new(name: name)
       #   requests = [request]
       #   library_service_client.discuss_book(requests).each do |element|
       #     # Process element.
@@ -1151,8 +1150,7 @@ module Library
       #
       #   library_service_client = LibraryServiceClient.new
       #   name = ''
-      #   request = DiscussBookRequest.new
-      #   request.name = name
+      #   request = DiscussBookRequest.new(name: name)
       #   requests = [request]
       #   response = library_service_client.monolog_about_book(requests)
 

--- a/src/test/java/com/google/api/codegen/testdata/ruby_smoke_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_smoke_test_library.baseline
@@ -35,8 +35,7 @@ describe "LibraryServiceSmokeTest" do
     library_service_client = LibraryServiceClient.new
     formatted_name = LibraryServiceClient.book_path("testShelf-" + Time.new.to_i.to_s, project_id)
     rating = Rating::GOOD
-    book = Book.new
-    book.rating = rating
+    book = Book.new(rating: rating)
     response = library_service_client.update_book(formatted_name, book)
   end
 end


### PR DESCRIPTION
# What
Swaps the init code for a structure from assigning each field individually, to passing in the fields to the constructor.

## New
### Messages initialized with one or two fields
```rb
field1 = 1
field2 = Time.new
message = Message.new(field1: field1, field2: field2)
```

### Messages initialized with three or more fields
```rb
field1 = 1
field2 = Time.new
field3 = ''
message = Message.new(
  field1: field1, 
  field2: field2,
  field3: field3
)
```

## Old
```rb
field1 = 1
field2 = Time.new
field3 = ''
message = Message.new
message.field1 = field1
message.field2 = field2
message.field3 = field3
```

# Context
Found this bug while working through ruby unit tests. It seems that the old implementation would cause things like such to happen:

```rb
m = OtherMessage.new
repeated = [m]
message = Message.new
message.repeated_field = repeated # FAILS
```

Based on [this](https://developers.google.com/protocol-buffers/docs/reference/ruby-generated#repeated-fields), assigning to a repeated field is not allowed.

# Considerations
I thought simply swapping out the `=` operator to the `+=` would resolve this. In manual testing, I found this strategy to be buggy. If the type of the repeated field was a message, using `+=` would fail.
