### PR TITLE
config: Provide a way to override license

### DIFF
--- a/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
+++ b/src/main/java/com/google/api/codegen/config/GapicProductConfig.java
@@ -123,8 +123,14 @@ public abstract class GapicProductConfig implements ProductConfig {
     ImmutableList<String> copyrightLines = null;
     ImmutableList<String> licenseLines = null;
     try {
-      copyrightLines = loadCopyrightLines(model.getDiagCollector(), configProto.getLicenseHeader());
-      licenseLines = loadLicenseLines(model.getDiagCollector(), configProto.getLicenseHeader());
+      LicenseHeaderProto licenseHeader =
+          configProto
+              .getLicenseHeader()
+              .toBuilder()
+              .mergeFrom(settings.getLicenseHeaderOverride())
+              .build();
+      copyrightLines = loadCopyrightLines(model.getDiagCollector(), licenseHeader);
+      licenseLines = loadLicenseLines(model.getDiagCollector(), licenseHeader);
     } catch (Exception e) {
       model
           .getDiagCollector()

--- a/src/main/proto/com/google/api/codegen/config.proto
+++ b/src/main/proto/com/google/api/codegen/config.proto
@@ -111,6 +111,9 @@ message LanguageSettingsProto {
   // values are unqualified interface names (to specify the package/namespace,
   // use the package_name setting).
   map<string, string> interface_names = 4;
+
+  // Overrides ConfigProto::license_header.
+  LicenseHeaderProto license_header_override = 5;
 }
 
 // ReleaseLevel indicates the stage of development of a piece of code and


### PR DESCRIPTION
Previously all languages use the same license for a given service.

This PR provides a way for a language to override the license.
This is necessary for Go longrunning gapic client,
since it will be distributed along with cloud.google.com/go, not gax.