### PR TITLE
Java: migrating off deprecated methods

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
@@ -236,6 +236,8 @@ public class SurfaceNamer extends NameFormatterDelegator {
   public String getFieldGetFunctionName(TypeRef type, Name identifier) {
     if (type.isRepeated() && !type.isMap()) {
       return publicMethodName(Name.from("get").join(identifier).join("list"));
+    } else if (type.isMap()) {
+      return publicMethodName(Name.from("get").join(identifier).join("map"));
     } else {
       return publicMethodName(Name.from("get").join(identifier));
     }

--- a/src/main/java/com/google/api/codegen/transformer/php/PhpSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpSurfaceNamer.java
@@ -62,6 +62,15 @@ public class PhpSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
+  public String getFieldGetFunctionName(TypeRef type, Name identifier) {
+    if (type.isRepeated() && !type.isMap()) {
+      return publicMethodName(Name.from("get").join(identifier).join("list"));
+    } else {
+      return publicMethodName(Name.from("get").join(identifier));
+    }
+  }
+
+  @Override
   public String getPathTemplateName(
       Interface apiInterface, SingleResourceNameConfig resourceNameConfig) {
     return inittedConstantName(Name.from(resourceNameConfig.getEntityName(), "name", "template"));

--- a/src/main/resources/com/google/api/codegen/java/mock_service.snip
+++ b/src/main/resources/com/google/api/codegen/java/mock_service.snip
@@ -26,10 +26,6 @@
       serviceImpl.addException(exception);
     }
 
-    public void setResponses(List<GeneratedMessageV3> responses) {
-      serviceImpl.setResponses(responses);
-    }
-
     @@Override
     public ServerServiceDefinition getServiceDefinition() {
       return serviceImpl.bindService();

--- a/src/main/resources/com/google/api/codegen/java/settings.snip
+++ b/src/main/resources/com/google/api/codegen/java/settings.snip
@@ -555,8 +555,8 @@
       @switch settings.type
       @case "BatchingApiCallable"
         builder.{@settings.settingsGetFunction}().getBatchingSettingsBuilder()
-            .setElementCountThreshold({@settings.batchingConfig.elementCountThreshold})
-            .setRequestByteThreshold({@settings.batchingConfig.requestByteThreshold})
+            .setElementCountThreshold({@settings.batchingConfig.elementCountThreshold}L)
+            .setRequestByteThreshold({@settings.batchingConfig.requestByteThreshold}L)
             .setDelayThreshold(Duration.millis({@settings.batchingConfig.delayThresholdMillis}))
             .setFlowControlSettings(
               FlowControlSettings.newBuilder()

--- a/src/test/java/com/google/api/codegen/testdata/java_mock_service_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_mock_service_library.baseline
@@ -44,10 +44,6 @@ public class MockLabeler implements MockGrpcService  {
     serviceImpl.addException(exception);
   }
 
-  public void setResponses(List<GeneratedMessageV3> responses) {
-    serviceImpl.setResponses(responses);
-  }
-
   @Override
   public ServerServiceDefinition getServiceDefinition() {
     return serviceImpl.bindService();
@@ -102,10 +98,6 @@ public class MockLibraryService implements MockGrpcService  {
   @Override
   public void addException(Exception exception) {
     serviceImpl.addException(exception);
-  }
-
-  public void setResponses(List<GeneratedMessageV3> responses) {
-    serviceImpl.setResponses(responses);
   }
 
   @Override

--- a/src/test/java/com/google/api/codegen/testdata/java_mock_service_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_mock_service_no_path_templates.baseline
@@ -44,10 +44,6 @@ public class MockNoTemplatesAPIService implements MockGrpcService  {
     serviceImpl.addException(exception);
   }
 
-  public void setResponses(List<GeneratedMessageV3> responses) {
-    serviceImpl.setResponses(responses);
-  }
-
   @Override
   public ServerServiceDefinition getServiceDefinition() {
     return serviceImpl.bindService();

--- a/src/test/java/com/google/api/codegen/testdata/java_settings_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_settings_library.baseline
@@ -1145,8 +1145,8 @@ public class LibrarySettings extends ClientSettings {
           .setRetrySettingsBuilder(RETRY_PARAM_DEFINITIONS.get("default"));
 
       builder.publishSeriesSettings().getBatchingSettingsBuilder()
-          .setElementCountThreshold(6)
-          .setRequestByteThreshold(100000)
+          .setElementCountThreshold(6L)
+          .setRequestByteThreshold(100000L)
           .setDelayThreshold(Duration.millis(500))
           .setFlowControlSettings(
             FlowControlSettings.newBuilder()
@@ -1181,8 +1181,8 @@ public class LibrarySettings extends ClientSettings {
           .setRetrySettingsBuilder(RETRY_PARAM_DEFINITIONS.get("default"));
 
       builder.addCommentsSettings().getBatchingSettingsBuilder()
-          .setElementCountThreshold(6)
-          .setRequestByteThreshold(100000)
+          .setElementCountThreshold(6L)
+          .setRequestByteThreshold(100000L)
           .setDelayThreshold(Duration.millis(500))
           .setFlowControlSettings(
             FlowControlSettings.newBuilder()

--- a/src/test/java/com/google/api/codegen/testdata/java_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_test_library.baseline
@@ -1055,7 +1055,7 @@ public class LibraryClientTest {
 
     Assert.assertEquals(name, actualRequest.getNameAsBookName());
     Assert.assertEquals(indexName, actualRequest.getIndexName());
-    Assert.assertEquals(indexMap, actualRequest.getIndexMap());
+    Assert.assertEquals(indexMap, actualRequest.getIndexMapMap());
   }
 
   @Test
@@ -1587,7 +1587,7 @@ public class LibraryClientTest {
     Assert.assertEquals(requiredRepeatedResourceNameOneof, actualRequest.getRequiredRepeatedResourceNameOneofListAsBookNameOneofList());
     Assert.assertEquals(requiredRepeatedFixed32, actualRequest.getRequiredRepeatedFixed32List());
     Assert.assertEquals(requiredRepeatedFixed64, actualRequest.getRequiredRepeatedFixed64List());
-    Assert.assertEquals(requiredMap, actualRequest.getRequiredMap());
+    Assert.assertEquals(requiredMap, actualRequest.getRequiredMapMap());
     Assert.assertEquals(optionalSingularInt32, actualRequest.getOptionalSingularInt32());
     Assert.assertEquals(optionalSingularInt64, actualRequest.getOptionalSingularInt64());
     Assert.assertEquals(optionalSingularFloat, actualRequest.getOptionalSingularFloat());
@@ -1614,7 +1614,7 @@ public class LibraryClientTest {
     Assert.assertEquals(optionalRepeatedResourceNameOneof, actualRequest.getOptionalRepeatedResourceNameOneofListAsBookNameOneofList());
     Assert.assertEquals(optionalRepeatedFixed32, actualRequest.getOptionalRepeatedFixed32List());
     Assert.assertEquals(optionalRepeatedFixed64, actualRequest.getOptionalRepeatedFixed64List());
-    Assert.assertEquals(optionalMap, actualRequest.getOptionalMap());
+    Assert.assertEquals(optionalMap, actualRequest.getOptionalMapMap());
   }
 
   @Test


### PR DESCRIPTION
Yes, `getIndexMapMap` looks funny, but that's because the name of the field itself ends in "map". It turns out that proto generates both `get${FieldName}` and `get${FieldName}Map`, and the first one is `@Deprecated`. 

This PR coordinates with upcoming PRs in gax-java & google-cloud-java.
