### PR TITLE
Use unittest, not unittest2.

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/py/PythonImportSectionTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonImportSectionTransformer.java
@@ -108,7 +108,7 @@ public class PythonImportSectionTransformer implements ImportSectionTransformer 
   }
 
   private List<ImportFileView> generateTestStandardImports() {
-    return ImmutableList.of(createImport("mock"), createImport("unittest2"));
+    return ImmutableList.of(createImport("mock"), createImport("unittest"));
   }
 
   private List<ImportFileView> generateTestExternalImports(GapicInterfaceContext context) {

--- a/src/main/resources/com/google/api/codegen/py/test.snip
+++ b/src/main/resources/com/google/api/codegen/py/test.snip
@@ -4,7 +4,7 @@
 @snippet generate(apiTest)
     {@header(apiTest.fileHeader)}
 
-    class {@apiTest.testClass.name}(unittest2.TestCase):
+    class {@apiTest.testClass.name}(unittest.TestCase):
 
         @join test : apiTest.testClass.testCases
             {@testCase(test, apiTest.testClass.apiVariableName)}

--- a/src/test/java/com/google/api/codegen/testdata/python_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_test_library.baseline
@@ -16,7 +16,7 @@
 """Unit tests."""
 
 import mock
-import unittest2
+import unittest
 
 from google.gax import errors
 from google.rpc import status_pb2
@@ -34,7 +34,7 @@ class CustomException(Exception):
     pass
 
 
-class TestLibraryServiceClient(unittest2.TestCase):
+class TestLibraryServiceClient(unittest.TestCase):
 
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_create_shelf(self, mock_create_stub):

--- a/src/test/java/com/google/api/codegen/testdata/python_test_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_test_no_path_templates.baseline
@@ -16,7 +16,7 @@
 """Unit tests."""
 
 import mock
-import unittest2
+import unittest
 
 from google.gax import errors
 
@@ -29,7 +29,7 @@ class CustomException(Exception):
     pass
 
 
-class TestNoTemplatesAPIServiceClient(unittest2.TestCase):
+class TestNoTemplatesAPIServiceClient(unittest.TestCase):
 
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_increment(self, mock_create_stub):


### PR DESCRIPTION
We do not need to support Python 2.6, which is the only reason to use `unittest2`.