### PR TITLE
Remove spec from Python grpc stub mock

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/py/PythonSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonSurfaceNamer.java
@@ -141,11 +141,6 @@ public class PythonSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getCreateStubFunctionName(Interface apiInterface) {
-    return getGrpcClientTypeName(apiInterface);
-  }
-
-  @Override
   public String getGrpcClientTypeName(Interface apiInterface) {
     String fullName = getModelTypeFormatter().getFullNameFor(apiInterface) + "Stub";
     return getTypeNameConverter().getTypeName(fullName).getNickname();

--- a/src/main/resources/com/google/api/codegen/py/test.snip
+++ b/src/main/resources/com/google/api/codegen/py/test.snip
@@ -228,7 +228,7 @@
 
 @private unaryTestSetup(test, moduleName)
     @# Mock gRPC layer
-    grpc_stub = mock.Mock(spec={@test.createStubFunctionName})
+    grpc_stub = mock.Mock()
     mock_create_stub.return_value = grpc_stub
 
     client = {@moduleName}.{@test.serviceConstructorName}()
@@ -242,7 +242,7 @@
 
 @private requestStreamingTestSetup(test, moduleName)
     @# Mock gRPC layer
-    grpc_stub = mock.Mock(spec={@test.createStubFunctionName})
+    grpc_stub = mock.Mock()
     mock_create_stub.return_value = grpc_stub
 
     client = {@moduleName}.{@test.serviceConstructorName}()

--- a/src/test/java/com/google/api/codegen/testdata/python_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_test_library.baseline
@@ -39,7 +39,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_create_shelf(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -66,7 +66,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_create_shelf_exception(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -82,7 +82,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_get_shelf(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -111,7 +111,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_get_shelf_exception(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -128,7 +128,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_list_shelves(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -151,7 +151,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_list_shelves_exception(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -164,7 +164,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_delete_shelf(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -183,7 +183,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_delete_shelf_exception(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -199,7 +199,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_merge_shelves(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -228,7 +228,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_merge_shelves_exception(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -245,7 +245,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_create_book(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -275,7 +275,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_create_book_exception(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -292,7 +292,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_publish_series(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -323,7 +323,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_publish_series_exception(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -342,7 +342,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_get_book(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -370,7 +370,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_get_book_exception(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -386,7 +386,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_list_books(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -415,7 +415,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_list_books_exception(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -431,7 +431,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_delete_book(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -450,7 +450,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_delete_book_exception(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -466,7 +466,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_update_book(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -496,7 +496,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_update_book_exception(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -513,7 +513,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_move_book(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -543,7 +543,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_move_book_exception(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -560,7 +560,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_list_strings(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -583,7 +583,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_list_strings_exception(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -596,7 +596,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_add_comments(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -621,7 +621,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_add_comments_exception(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -642,7 +642,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_get_book_from_archive(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -670,7 +670,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_get_book_from_archive_exception(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -686,7 +686,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_get_book_from_anywhere(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -716,7 +716,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_get_book_from_anywhere_exception(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -733,7 +733,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_update_book_index(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -757,7 +757,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_update_book_index_exception(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -776,7 +776,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_stream_shelves(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -796,7 +796,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_stream_shelves_exception(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -809,7 +809,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_stream_books(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -839,7 +839,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_stream_books_exception(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -855,7 +855,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_discuss_book(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -886,7 +886,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_discuss_book_exception(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -904,7 +904,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_monolog_about_book(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -933,7 +933,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_monolog_about_book_exception(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -951,7 +951,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_find_related_books(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -983,7 +983,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_find_related_books_exception(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -1001,7 +1001,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_add_tag(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -1027,7 +1027,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_add_tag_exception(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -1044,7 +1044,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_add_label(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=tagger_pb2.LabelerStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -1070,7 +1070,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_add_label_exception(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=tagger_pb2.LabelerStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -1087,7 +1087,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_get_big_book(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -1116,7 +1116,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_get_big_book_exception(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -1136,7 +1136,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_get_big_nothing(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -1161,7 +1161,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_get_big_nothing_exception(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -1181,7 +1181,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_test_optional_required_flattening_params(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()
@@ -1257,7 +1257,7 @@ class TestLibraryServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_test_optional_required_flattening_params_exception(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=library_pb2.LibraryServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = library_service_client.LibraryServiceClient()

--- a/src/test/java/com/google/api/codegen/testdata/python_test_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_test_no_path_templates.baseline
@@ -34,7 +34,7 @@ class TestNoTemplatesAPIServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_increment(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=no_path_templates_pb2.NoTemplatesAPIServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = no_templates_api_service_client.NoTemplatesAPIServiceClient()
@@ -47,7 +47,7 @@ class TestNoTemplatesAPIServiceClient(unittest2.TestCase):
     @mock.patch('google.gax.config.create_stub', spec=True)
     def test_increment_exception(self, mock_create_stub):
         # Mock gRPC layer
-        grpc_stub = mock.Mock(spec=no_path_templates_pb2.NoTemplatesAPIServiceStub)
+        grpc_stub = mock.Mock()
         mock_create_stub.return_value = grpc_stub
 
         client = no_templates_api_service_client.NoTemplatesAPIServiceClient()


### PR DESCRIPTION
The grpc stub object cannot be mocked from the class name because the methods are attached after instantiation.

Alternatives Considered:
1. Spec from an instantiated object - Creating a grpc stub is too complicated for a simple unit test
2. Spec from a list of methods - The constructor of the API client requires all methods to be present. Additionally, any client with LRO, needs all the LRO methods for the `OperationsClient`.