### PR TITLE
Improve Python unit tests.

### DIFF
--- a/src/main/resources/com/google/api/codegen/py/test.snip
+++ b/src/main/resources/com/google/api/codegen/py/test.snip
@@ -279,9 +279,10 @@
 @private unaryTestSuccessAsserts(test)
     grpc_stub.{@test.grpcStubCallString}.assert_called_once()
     @if test.asserts
-        args, kwargs = grpc_stub.{@test.grpcStubCallString}.call_args[0]
-        self.assertEqual(1, len(args))
-        self.assertFalse(kwargs)
+        args, kwargs = grpc_stub.{@test.grpcStubCallString}.call_args
+        self.assertEqual(len(args), 2)
+        self.assertEqual(len(kwargs), 1)
+        self.assertIn('metadata', kwargs)
         actual_request = args[0]
 
     @end
@@ -301,9 +302,10 @@
 
 @private requestStreamingTestSuccessAsserts(test)
     grpc_stub.{@test.grpcStubCallString}.assert_called_once()
-    args, kwargs = grpc_stub.{@test.grpcStubCallString}.call_args[0]
-    self.assertEqual(1, len(args))
-    self.assertFalse(kwargs)
+    args, kwargs = grpc_stub.{@test.grpcStubCallString}.call_args
+    self.assertEqual(len(args), 2)
+    self.assertEqual(len(kwargs), 1)
+    self.assertIn('metadata', kwargs)
     actual_requests = args[0]
     self.assertEqual(1, len(actual_requests))
     actual_request = list(actual_requests)[0]

--- a/src/test/java/com/google/api/codegen/testdata/python_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_test_library.baseline
@@ -58,9 +58,10 @@ class TestLibraryServiceClient(unittest.TestCase):
         self.assertEqual(expected_response, response)
 
         grpc_stub.CreateShelf.assert_called_once()
-        args, kwargs = grpc_stub.CreateShelf.call_args[0]
-        self.assertEqual(1, len(args))
-        self.assertFalse(kwargs)
+        args, kwargs = grpc_stub.CreateShelf.call_args
+        self.assertEqual(len(args), 2)
+        self.assertEqual(len(kwargs), 1)
+        self.assertIn('metadata', kwargs)
         actual_request = args[0]
 
         self.assertEqual(shelf, actual_request.shelf)
@@ -105,9 +106,10 @@ class TestLibraryServiceClient(unittest.TestCase):
         self.assertEqual(expected_response, response)
 
         grpc_stub.GetShelf.assert_called_once()
-        args, kwargs = grpc_stub.GetShelf.call_args[0]
-        self.assertEqual(1, len(args))
-        self.assertFalse(kwargs)
+        args, kwargs = grpc_stub.GetShelf.call_args
+        self.assertEqual(len(args), 2)
+        self.assertEqual(len(kwargs), 1)
+        self.assertIn('metadata', kwargs)
         actual_request = args[0]
 
         self.assertEqual(name, actual_request.name)
@@ -181,9 +183,10 @@ class TestLibraryServiceClient(unittest.TestCase):
         client.delete_shelf(name)
 
         grpc_stub.DeleteShelf.assert_called_once()
-        args, kwargs = grpc_stub.DeleteShelf.call_args[0]
-        self.assertEqual(1, len(args))
-        self.assertFalse(kwargs)
+        args, kwargs = grpc_stub.DeleteShelf.call_args
+        self.assertEqual(len(args), 2)
+        self.assertEqual(len(kwargs), 1)
+        self.assertIn('metadata', kwargs)
         actual_request = args[0]
 
         self.assertEqual(name, actual_request.name)
@@ -228,9 +231,10 @@ class TestLibraryServiceClient(unittest.TestCase):
         self.assertEqual(expected_response, response)
 
         grpc_stub.MergeShelves.assert_called_once()
-        args, kwargs = grpc_stub.MergeShelves.call_args[0]
-        self.assertEqual(1, len(args))
-        self.assertFalse(kwargs)
+        args, kwargs = grpc_stub.MergeShelves.call_args
+        self.assertEqual(len(args), 2)
+        self.assertEqual(len(kwargs), 1)
+        self.assertIn('metadata', kwargs)
         actual_request = args[0]
 
         self.assertEqual(name, actual_request.name)
@@ -278,9 +282,10 @@ class TestLibraryServiceClient(unittest.TestCase):
         self.assertEqual(expected_response, response)
 
         grpc_stub.CreateBook.assert_called_once()
-        args, kwargs = grpc_stub.CreateBook.call_args[0]
-        self.assertEqual(1, len(args))
-        self.assertFalse(kwargs)
+        args, kwargs = grpc_stub.CreateBook.call_args
+        self.assertEqual(len(args), 2)
+        self.assertEqual(len(kwargs), 1)
+        self.assertIn('metadata', kwargs)
         actual_request = args[0]
 
         self.assertEqual(name, actual_request.name)
@@ -328,9 +333,10 @@ class TestLibraryServiceClient(unittest.TestCase):
         self.assertEqual(expected_response, response)
 
         grpc_stub.PublishSeries.assert_called_once()
-        args, kwargs = grpc_stub.PublishSeries.call_args[0]
-        self.assertEqual(1, len(args))
-        self.assertFalse(kwargs)
+        args, kwargs = grpc_stub.PublishSeries.call_args
+        self.assertEqual(len(args), 2)
+        self.assertEqual(len(kwargs), 1)
+        self.assertIn('metadata', kwargs)
         actual_request = args[0]
 
         self.assertEqual(shelf, actual_request.shelf)
@@ -380,9 +386,10 @@ class TestLibraryServiceClient(unittest.TestCase):
         self.assertEqual(expected_response, response)
 
         grpc_stub.GetBook.assert_called_once()
-        args, kwargs = grpc_stub.GetBook.call_args[0]
-        self.assertEqual(1, len(args))
-        self.assertFalse(kwargs)
+        args, kwargs = grpc_stub.GetBook.call_args
+        self.assertEqual(len(args), 2)
+        self.assertEqual(len(kwargs), 1)
+        self.assertIn('metadata', kwargs)
         actual_request = args[0]
 
         self.assertEqual(name, actual_request.name)
@@ -428,9 +435,10 @@ class TestLibraryServiceClient(unittest.TestCase):
         self.assertEqual(expected_response.books[0], resources[0])
 
         grpc_stub.ListBooks.assert_called_once()
-        args, kwargs = grpc_stub.ListBooks.call_args[0]
-        self.assertEqual(1, len(args))
-        self.assertFalse(kwargs)
+        args, kwargs = grpc_stub.ListBooks.call_args
+        self.assertEqual(len(args), 2)
+        self.assertEqual(len(kwargs), 1)
+        self.assertIn('metadata', kwargs)
         actual_request = args[0]
 
         self.assertEqual(name, actual_request.name)
@@ -466,9 +474,10 @@ class TestLibraryServiceClient(unittest.TestCase):
         client.delete_book(name)
 
         grpc_stub.DeleteBook.assert_called_once()
-        args, kwargs = grpc_stub.DeleteBook.call_args[0]
-        self.assertEqual(1, len(args))
-        self.assertFalse(kwargs)
+        args, kwargs = grpc_stub.DeleteBook.call_args
+        self.assertEqual(len(args), 2)
+        self.assertEqual(len(kwargs), 1)
+        self.assertIn('metadata', kwargs)
         actual_request = args[0]
 
         self.assertEqual(name, actual_request.name)
@@ -514,9 +523,10 @@ class TestLibraryServiceClient(unittest.TestCase):
         self.assertEqual(expected_response, response)
 
         grpc_stub.UpdateBook.assert_called_once()
-        args, kwargs = grpc_stub.UpdateBook.call_args[0]
-        self.assertEqual(1, len(args))
-        self.assertFalse(kwargs)
+        args, kwargs = grpc_stub.UpdateBook.call_args
+        self.assertEqual(len(args), 2)
+        self.assertEqual(len(kwargs), 1)
+        self.assertIn('metadata', kwargs)
         actual_request = args[0]
 
         self.assertEqual(name, actual_request.name)
@@ -564,9 +574,10 @@ class TestLibraryServiceClient(unittest.TestCase):
         self.assertEqual(expected_response, response)
 
         grpc_stub.MoveBook.assert_called_once()
-        args, kwargs = grpc_stub.MoveBook.call_args[0]
-        self.assertEqual(1, len(args))
-        self.assertFalse(kwargs)
+        args, kwargs = grpc_stub.MoveBook.call_args
+        self.assertEqual(len(args), 2)
+        self.assertEqual(len(kwargs), 1)
+        self.assertIn('metadata', kwargs)
         actual_request = args[0]
 
         self.assertEqual(name, actual_request.name)
@@ -645,9 +656,10 @@ class TestLibraryServiceClient(unittest.TestCase):
         client.add_comments(name, comments)
 
         grpc_stub.AddComments.assert_called_once()
-        args, kwargs = grpc_stub.AddComments.call_args[0]
-        self.assertEqual(1, len(args))
-        self.assertFalse(kwargs)
+        args, kwargs = grpc_stub.AddComments.call_args
+        self.assertEqual(len(args), 2)
+        self.assertEqual(len(kwargs), 1)
+        self.assertIn('metadata', kwargs)
         actual_request = args[0]
 
         self.assertEqual(name, actual_request.name)
@@ -698,9 +710,10 @@ class TestLibraryServiceClient(unittest.TestCase):
         self.assertEqual(expected_response, response)
 
         grpc_stub.GetBookFromArchive.assert_called_once()
-        args, kwargs = grpc_stub.GetBookFromArchive.call_args[0]
-        self.assertEqual(1, len(args))
-        self.assertFalse(kwargs)
+        args, kwargs = grpc_stub.GetBookFromArchive.call_args
+        self.assertEqual(len(args), 2)
+        self.assertEqual(len(kwargs), 1)
+        self.assertIn('metadata', kwargs)
         actual_request = args[0]
 
         self.assertEqual(name, actual_request.name)
@@ -746,9 +759,10 @@ class TestLibraryServiceClient(unittest.TestCase):
         self.assertEqual(expected_response, response)
 
         grpc_stub.GetBookFromAnywhere.assert_called_once()
-        args, kwargs = grpc_stub.GetBookFromAnywhere.call_args[0]
-        self.assertEqual(1, len(args))
-        self.assertFalse(kwargs)
+        args, kwargs = grpc_stub.GetBookFromAnywhere.call_args
+        self.assertEqual(len(args), 2)
+        self.assertEqual(len(kwargs), 1)
+        self.assertIn('metadata', kwargs)
         actual_request = args[0]
 
         self.assertEqual(name, actual_request.name)
@@ -789,9 +803,10 @@ class TestLibraryServiceClient(unittest.TestCase):
         client.update_book_index(name, index_name, index_map)
 
         grpc_stub.UpdateBookIndex.assert_called_once()
-        args, kwargs = grpc_stub.UpdateBookIndex.call_args[0]
-        self.assertEqual(1, len(args))
-        self.assertFalse(kwargs)
+        args, kwargs = grpc_stub.UpdateBookIndex.call_args
+        self.assertEqual(len(args), 2)
+        self.assertEqual(len(kwargs), 1)
+        self.assertIn('metadata', kwargs)
         actual_request = args[0]
 
         self.assertEqual(name, actual_request.name)
@@ -876,9 +891,10 @@ class TestLibraryServiceClient(unittest.TestCase):
         self.assertEqual(expected_response, resources[0])
 
         grpc_stub.StreamBooks.assert_called_once()
-        args, kwargs = grpc_stub.StreamBooks.call_args[0]
-        self.assertEqual(1, len(args))
-        self.assertFalse(kwargs)
+        args, kwargs = grpc_stub.StreamBooks.call_args
+        self.assertEqual(len(args), 2)
+        self.assertEqual(len(kwargs), 1)
+        self.assertIn('metadata', kwargs)
         actual_request = args[0]
 
         self.assertEqual(name, actual_request.name)
@@ -925,9 +941,10 @@ class TestLibraryServiceClient(unittest.TestCase):
         self.assertEqual(expected_response, resources[0])
 
         grpc_stub.DiscussBook.assert_called_once()
-        args, kwargs = grpc_stub.DiscussBook.call_args[0]
-        self.assertEqual(1, len(args))
-        self.assertFalse(kwargs)
+        args, kwargs = grpc_stub.DiscussBook.call_args
+        self.assertEqual(len(args), 2)
+        self.assertEqual(len(kwargs), 1)
+        self.assertIn('metadata', kwargs)
         actual_requests = args[0]
         self.assertEqual(1, len(actual_requests))
         actual_request = list(actual_requests)[0]
@@ -975,9 +992,10 @@ class TestLibraryServiceClient(unittest.TestCase):
         self.assertEqual(expected_response, response)
 
         grpc_stub.MonologAboutBook.assert_called_once()
-        args, kwargs = grpc_stub.MonologAboutBook.call_args[0]
-        self.assertEqual(1, len(args))
-        self.assertFalse(kwargs)
+        args, kwargs = grpc_stub.MonologAboutBook.call_args
+        self.assertEqual(len(args), 2)
+        self.assertEqual(len(kwargs), 1)
+        self.assertIn('metadata', kwargs)
         actual_requests = args[0]
         self.assertEqual(1, len(actual_requests))
         actual_request = list(actual_requests)[0]
@@ -1028,9 +1046,10 @@ class TestLibraryServiceClient(unittest.TestCase):
         self.assertEqual(expected_response.names[0], resources[0])
 
         grpc_stub.FindRelatedBooks.assert_called_once()
-        args, kwargs = grpc_stub.FindRelatedBooks.call_args[0]
-        self.assertEqual(1, len(args))
-        self.assertFalse(kwargs)
+        args, kwargs = grpc_stub.FindRelatedBooks.call_args
+        self.assertEqual(len(args), 2)
+        self.assertEqual(len(kwargs), 1)
+        self.assertIn('metadata', kwargs)
         actual_request = args[0]
 
         self.assertEqual(names, actual_request.names)
@@ -1075,9 +1094,10 @@ class TestLibraryServiceClient(unittest.TestCase):
         self.assertEqual(expected_response, response)
 
         grpc_stub.AddTag.assert_called_once()
-        args, kwargs = grpc_stub.AddTag.call_args[0]
-        self.assertEqual(1, len(args))
-        self.assertFalse(kwargs)
+        args, kwargs = grpc_stub.AddTag.call_args
+        self.assertEqual(len(args), 2)
+        self.assertEqual(len(kwargs), 1)
+        self.assertIn('metadata', kwargs)
         actual_request = args[0]
 
         self.assertEqual(resource, actual_request.resource)
@@ -1121,9 +1141,10 @@ class TestLibraryServiceClient(unittest.TestCase):
         self.assertEqual(expected_response, response)
 
         grpc_stub.AddLabel.assert_called_once()
-        args, kwargs = grpc_stub.AddLabel.call_args[0]
-        self.assertEqual(1, len(args))
-        self.assertFalse(kwargs)
+        args, kwargs = grpc_stub.AddLabel.call_args
+        self.assertEqual(len(args), 2)
+        self.assertEqual(len(kwargs), 1)
+        self.assertIn('metadata', kwargs)
         actual_request = args[0]
 
         self.assertEqual(resource, actual_request.resource)
@@ -1172,9 +1193,10 @@ class TestLibraryServiceClient(unittest.TestCase):
         self.assertEqual(expected_response, response.result())
 
         grpc_stub.GetBigBook.assert_called_once()
-        args, kwargs = grpc_stub.GetBigBook.call_args[0]
-        self.assertEqual(1, len(args))
-        self.assertFalse(kwargs)
+        args, kwargs = grpc_stub.GetBigBook.call_args
+        self.assertEqual(len(args), 2)
+        self.assertEqual(len(kwargs), 1)
+        self.assertIn('metadata', kwargs)
         actual_request = args[0]
 
         self.assertEqual(name, actual_request.name)
@@ -1220,9 +1242,10 @@ class TestLibraryServiceClient(unittest.TestCase):
         self.assertEqual(expected_response, response.result())
 
         grpc_stub.GetBigNothing.assert_called_once()
-        args, kwargs = grpc_stub.GetBigNothing.call_args[0]
-        self.assertEqual(1, len(args))
-        self.assertFalse(kwargs)
+        args, kwargs = grpc_stub.GetBigNothing.call_args
+        self.assertEqual(len(args), 2)
+        self.assertEqual(len(kwargs), 1)
+        self.assertIn('metadata', kwargs)
         actual_request = args[0]
 
         self.assertEqual(name, actual_request.name)
@@ -1292,9 +1315,10 @@ class TestLibraryServiceClient(unittest.TestCase):
         self.assertEqual(expected_response, response)
 
         grpc_stub.TestOptionalRequiredFlatteningParams.assert_called_once()
-        args, kwargs = grpc_stub.TestOptionalRequiredFlatteningParams.call_args[0]
-        self.assertEqual(1, len(args))
-        self.assertFalse(kwargs)
+        args, kwargs = grpc_stub.TestOptionalRequiredFlatteningParams.call_args
+        self.assertEqual(len(args), 2)
+        self.assertEqual(len(kwargs), 1)
+        self.assertIn('metadata', kwargs)
         actual_request = args[0]
 
         self.assertEqual(required_singular_int32, actual_request.required_singular_int32)
@@ -1367,4 +1391,3 @@ class TestLibraryServiceClient(unittest.TestCase):
         grpc_stub.TestOptionalRequiredFlatteningParams.side_effect = CustomException()
 
         self.assertRaises(errors.GaxError, client.test_optional_required_flattening_params, required_singular_int32, required_singular_int64, required_singular_float, required_singular_double, required_singular_bool, required_singular_enum, required_singular_string, required_singular_bytes, required_singular_message, required_singular_resource_name, required_singular_resource_name_oneof, required_singular_fixed32, required_singular_fixed64, required_repeated_int32, required_repeated_int64, required_repeated_float, required_repeated_double, required_repeated_bool, required_repeated_enum, required_repeated_string, required_repeated_bytes, required_repeated_message, required_repeated_resource_name, required_repeated_resource_name_oneof, required_repeated_fixed32, required_repeated_fixed64, required_map)
-


### PR DESCRIPTION
This commit brings the number of Python unit test failures down from 30 to 5.

I would prefer that the unit tests also check `isinstance` on the arguments to the GRPC stub, but it was not clear to me where that lived in the snippet structure.

Fixes #1211.