### PR TITLE
Add "development status" configuration for package metadata

### DIFF
--- a/src/main/java/com/google/api/codegen/DevelopmentStatus.java
+++ b/src/main/java/com/google/api/codegen/DevelopmentStatus.java
@@ -1,0 +1,38 @@
+/* Copyright 2016 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen;
+
+public enum DevelopmentStatus {
+  ALPHA,
+  BETA,
+  GA;
+
+  public static DevelopmentStatus fromString(String language) {
+    return Enum.valueOf(DevelopmentStatus.class, language.toUpperCase());
+  }
+
+  public String toTroveClassifier() {
+    switch (this) {
+      case ALPHA:
+        return "3 - Alpha";
+      case BETA:
+        return "4 - Beta";
+      case GA:
+        return "5 - Production/Stable";
+      default:
+        throw new IllegalStateException("Invalid development status");
+    }
+  }
+}

--- a/src/main/java/com/google/api/codegen/config/PackageMetadataConfig.java
+++ b/src/main/java/com/google/api/codegen/config/PackageMetadataConfig.java
@@ -58,6 +58,8 @@ public abstract class PackageMetadataConfig {
 
   protected abstract Map<TargetLanguage, Map<String, VersionBound>> protoPackageDependencies();
 
+  protected abstract Map<TargetLanguage, String> developmentStatus();
+
   /** The version of GAX that this package depends on. Configured per language. */
   public VersionBound gaxVersionBound(TargetLanguage language) {
     return gaxVersionBound().get(language);
@@ -94,6 +96,11 @@ public abstract class PackageMetadataConfig {
   /** The versions of the proto packages that this package depends on. Configured per language. */
   public Map<String, VersionBound> protoPackageDependencies(TargetLanguage language) {
     return protoPackageDependencies().get(language);
+  }
+
+  /** The development status of the client library. Configured per language. */
+  public String developmentStatus(TargetLanguage language) {
+    return developmentStatus().get(language);
   }
 
   /**
@@ -158,6 +165,8 @@ public abstract class PackageMetadataConfig {
 
     abstract Builder protoPackageDependencies(Map<TargetLanguage, Map<String, VersionBound>> val);
 
+    abstract Builder developmentStatus(Map<TargetLanguage, String> val);
+
     abstract Builder shortName(String val);
 
     abstract Builder packageType(PackageType val);
@@ -193,6 +202,7 @@ public abstract class PackageMetadataConfig {
         .apiCommonVersionBound(ImmutableMap.<TargetLanguage, VersionBound>of())
         .generatedPackageVersionBound(ImmutableMap.<TargetLanguage, VersionBound>of())
         .protoPackageDependencies(ImmutableMap.<TargetLanguage, Map<String, VersionBound>>of())
+        .developmentStatus(ImmutableMap.<TargetLanguage, String>of())
         .shortName("")
         .packageType(PackageType.GRPC_CLIENT)
         .generationLayer(GenerationLayer.PROTO)
@@ -226,6 +236,8 @@ public abstract class PackageMetadataConfig {
         .apiCommonVersionBound(
             createVersionMap(
                 (Map<String, Map<String, String>>) configMap.get("api_common_version")))
+        .developmentStatus(
+            buildMapWithDefault((Map<String, String>) configMap.get("development_status")))
         .protoPackageDependencies(createProtoPackageDependencies(configMap))
         .packageName(buildMapWithDefault((Map<String, String>) configMap.get("package_name")))
         .shortName((String) configMap.get("short_name"))

--- a/src/main/java/com/google/api/codegen/grpcmetadatagen/py/PythonGrpcMetadataTransformer.java
+++ b/src/main/java/com/google/api/codegen/grpcmetadatagen/py/PythonGrpcMetadataTransformer.java
@@ -14,6 +14,7 @@
  */
 package com.google.api.codegen.grpcmetadatagen.py;
 
+import com.google.api.codegen.DevelopmentStatus;
 import com.google.api.codegen.TargetLanguage;
 import com.google.api.codegen.config.PackageMetadataConfig;
 import com.google.api.codegen.transformer.PackageMetadataTransformer;
@@ -59,6 +60,9 @@ public class PythonGrpcMetadataTransformer {
                   TargetLanguage.PYTHON,
                   PROTO_PACKAGE_DEPENDENCY_WHITELIST)
               .namespacePackages(copierResult.namespacePackages())
+              .developmentStatus(
+                  DevelopmentStatus.fromString(config.developmentStatus(TargetLanguage.PYTHON))
+                      .toTroveClassifier())
               .build();
       views.add(view);
     }

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonPackageMetadataTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonPackageMetadataTransformer.java
@@ -14,6 +14,7 @@
  */
 package com.google.api.codegen.transformer.py;
 
+import com.google.api.codegen.DevelopmentStatus;
 import com.google.api.codegen.GapicContext;
 import com.google.api.codegen.SnippetSetRunner;
 import com.google.api.codegen.TargetLanguage;
@@ -108,6 +109,9 @@ public class PythonPackageMetadataTransformer implements ModelToViewTransformer 
         .generateMetadataView(packageConfig, model, template, outputPath, TargetLanguage.PYTHON)
         .namespacePackages(
             computeNamespacePackages(productConfig.getPackageName(), packageConfig.apiVersion()))
+        .developmentStatus(
+            DevelopmentStatus.fromString(packageConfig.developmentStatus(TargetLanguage.PYTHON))
+                .toTroveClassifier())
         .apiModules(apiModules)
         .typeModules(typeModules)
         .build();

--- a/src/main/java/com/google/api/codegen/viewmodel/metadata/PackageMetadataView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/metadata/PackageMetadataView.java
@@ -92,6 +92,9 @@ public abstract class PackageMetadataView implements ViewModel {
 
   public abstract String licenseName();
 
+  @Nullable
+  public abstract String developmentStatus();
+
   public abstract boolean hasMultipleServices();
 
   public abstract boolean hasSmokeTests();
@@ -177,6 +180,9 @@ public abstract class PackageMetadataView implements ViewModel {
 
     /** The name of the license that the package is licensed under. */
     public abstract Builder licenseName(String val);
+
+    /** The developement status of the package. E.g., "alpha". */
+    public abstract Builder developmentStatus(String val);
 
     /** Whether the package contains multiple service objects */
     public abstract Builder hasMultipleServices(boolean val);

--- a/src/main/resources/com/google/api/codegen/metadatagen/py/setup.py.snip
+++ b/src/main/resources/com/google/api/codegen/metadatagen/py/setup.py.snip
@@ -37,7 +37,7 @@
       author_email='{@metadata.email}',
       classifiers=[
         'Intended Audience :: Developers',
-        'Development Status :: 3 - Alpha',
+        'Development Status :: {@metadata.developmentStatus}',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python',

--- a/src/main/resources/com/google/api/codegen/py/setup.py.snip
+++ b/src/main/resources/com/google/api/codegen/py/setup.py.snip
@@ -31,7 +31,7 @@
       author_email='{@metadata.email}',
       classifiers=[
           'Intended Audience :: Developers',
-          'Development Status :: 3 - Alpha',
+          'Development Status :: {@metadata.developmentStatus}',
           'Intended Audience :: Developers',
           'License :: OSI Approved :: Apache Software License',
           'Programming Language :: Python',

--- a/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/common_protos_pkg.yaml
+++ b/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/common_protos_pkg.yaml
@@ -15,6 +15,9 @@ generation_layer: proto
 package_name:
   default: google-common-protos
 
+development_status:
+  python: 'alpha'
+
 generated_package_version:
   python:
     lower: '0.15.0'

--- a/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/library_pkg.yaml
+++ b/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/library_pkg.yaml
@@ -17,6 +17,9 @@ generation_layer: proto
 package_name:
   default: google-cloud-library-v1
 
+development_status:
+  python: 'alpha'
+
 generated_package_version:
   python:
     lower: '0.15.0'

--- a/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/library_stubs_pkg.yaml
+++ b/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/library_stubs_pkg.yaml
@@ -17,6 +17,9 @@ generation_layer: grpc
 package_name:
   default: google-cloud-library-v1
 
+development_status:
+  python: 'alpha'
+
 generated_package_version:
   python:
     lower: '0.15.0'

--- a/src/test/java/com/google/api/codegen/testdata/library_pkg.yaml
+++ b/src/test/java/com/google/api/codegen/testdata/library_pkg.yaml
@@ -25,6 +25,9 @@ generated_package_version:
   ruby:
     lower: '0.6.8'
 
+development_status:
+  python: alpha
+
 # Dependencies
 auth_version:
   python:


### PR DESCRIPTION
This is part of an effort to permit per-{lang x api} package version
and development status configuration.

Corresponding PRs at https://github.com/googleapis/googleapis/pull/321 and https://github.com/googleapis/googleapis/pull/321