### PR TITLE
Fix API Explorer links

### DIFF
--- a/src/main/resources/com/google/api/codegen/py/README.rst.snip
+++ b/src/main/resources/com/google/api/codegen/py/README.rst.snip
@@ -8,7 +8,7 @@
 
   .. _`googleapis`: https://github.com/googleapis/googleapis/tree/master/{@metadata.protoPath}
   .. _`google-gax`: https://github.com/googleapis/gax-python
-  .. _`{@metadata.fullName}`: https://developers.google.com/apis-explorer/?hl=en_US#p/{@metadata.discoveryApiName}/{@metadata.majorVersion}
+  .. _`{@metadata.fullName}`: https://developers.google.com/apis-explorer/?hl=en_US#p/{@metadata.discoveryApiName}/{@metadata.majorVersion}/
 
   Getting started
   ---------------

--- a/src/main/resources/com/google/api/codegen/py/docs/index.rst.snip
+++ b/src/main/resources/com/google/api/codegen/py/docs/index.rst.snip
@@ -13,7 +13,7 @@
   
   .. _`google-gax`: https://github.com/googleapis/gax-python
   .. _`googleapis`: https://github.com/googleapis/googleapis/tree/master/{@metadata.protoPath}
-  .. _`{@metadata.fullName}`: https://developers.google.com/apis-explorer/?hl=en_US#p/{@metadata.discoveryApiName}/{@metadata.majorVersion}
+  .. _`{@metadata.fullName}`: https://developers.google.com/apis-explorer/?hl=en_US#p/{@metadata.discoveryApiName}/{@metadata.majorVersion}/
   
   
   APIs

--- a/src/main/resources/com/google/api/codegen/py/docs/starting.rst.snip
+++ b/src/main/resources/com/google/api/codegen/py/docs/starting.rst.snip
@@ -4,7 +4,7 @@
   
   {@metadata.gapicPackageName} will allow you to connect to the `{@metadata.fullName}`_ and access all its methods. In order to achieve this, you need to set up authentication as well as install the library locally.
   
-  .. _`{@metadata.fullName}`: https://developers.google.com/apis-explorer/?hl=en_US#p/{@metadata.discoveryApiName}/{@metadata.majorVersion}
+  .. _`{@metadata.fullName}`: https://developers.google.com/apis-explorer/?hl=en_US#p/{@metadata.discoveryApiName}/{@metadata.majorVersion}/
   
   
   Installation

--- a/src/main/resources/com/google/api/codegen/ruby/README.md.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/README.md.snip
@@ -8,7 +8,7 @@
 
   [googleapis]: https://github.com/googleapis/googleapis/tree/master/{@metadata.protoPath}
   [google-gax]: https://github.com/googleapis/gax-ruby
-  [{@metadata.fullName}]: https://developers.google.com/apis-explorer/?hl=en_US#p/{@metadata.discoveryApiName}/{@metadata.majorVersion}
+  [{@metadata.fullName}]: https://developers.google.com/apis-explorer/?hl=en_US#p/{@metadata.discoveryApiName}/{@metadata.majorVersion}/
 
   Getting started
   ---------------

--- a/src/test/java/com/google/api/codegen/testdata/python_README_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_README_library.baseline
@@ -8,7 +8,7 @@ easy-to-use client library for the `Google Example Library API`_ (v1) defined in
 
 .. _`googleapis`: https://github.com/googleapis/googleapis/tree/master/google/library
 .. _`google-gax`: https://github.com/googleapis/gax-python
-.. _`Google Example Library API`: https://developers.google.com/apis-explorer/?hl=en_US#p/library_example/v1
+.. _`Google Example Library API`: https://developers.google.com/apis-explorer/?hl=en_US#p/library_example/v1/
 
 Getting started
 ---------------

--- a/src/test/java/com/google/api/codegen/testdata/python_README_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_README_no_path_templates.baseline
@@ -8,7 +8,7 @@ easy-to-use client library for the `Google Fake API`_ (v1) defined in the google
 
 .. _`googleapis`: https://github.com/googleapis/googleapis/tree/master/google/library
 .. _`google-gax`: https://github.com/googleapis/gax-python
-.. _`Google Fake API`: https://developers.google.com/apis-explorer/?hl=en_US#p/no_path_templates/v1
+.. _`Google Fake API`: https://developers.google.com/apis-explorer/?hl=en_US#p/no_path_templates/v1/
 
 Getting started
 ---------------

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_README_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_README_library.baseline
@@ -8,7 +8,7 @@ easy-to-use client library for the `Google Example Library API`_ (v1) defined in
 
 .. _`googleapis`: https://github.com/googleapis/googleapis/tree/master/google/library
 .. _`google-gax`: https://github.com/googleapis/gax-python
-.. _`Google Example Library API`: https://developers.google.com/apis-explorer/?hl=en_US#p/library_example/v1
+.. _`Google Example Library API`: https://developers.google.com/apis-explorer/?hl=en_US#p/library_example/v1/
 
 Getting started
 ---------------

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_docs_index_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_docs_index_library.baseline
@@ -13,7 +13,7 @@ easy-to-use client library for the `Google Example Library API`_ (v1) defined in
 
 .. _`google-gax`: https://github.com/googleapis/gax-python
 .. _`googleapis`: https://github.com/googleapis/googleapis/tree/master/google/library
-.. _`Google Example Library API`: https://developers.google.com/apis-explorer/?hl=en_US#p/library_example/v1
+.. _`Google Example Library API`: https://developers.google.com/apis-explorer/?hl=en_US#p/library_example/v1/
 
 
 APIs

--- a/src/test/java/com/google/api/codegen/testdata/python_doc_docs_starting_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_doc_docs_starting_library.baseline
@@ -4,7 +4,7 @@ Getting started
 
 gapic-google-cloud-library-v1 will allow you to connect to the `Google Example Library API`_ and access all its methods. In order to achieve this, you need to set up authentication as well as install the library locally.
 
-.. _`Google Example Library API`: https://developers.google.com/apis-explorer/?hl=en_US#p/library_example/v1
+.. _`Google Example Library API`: https://developers.google.com/apis-explorer/?hl=en_US#p/library_example/v1/
 
 
 Installation

--- a/src/test/java/com/google/api/codegen/testdata/python_docs_index_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_docs_index_library.baseline
@@ -13,7 +13,7 @@ easy-to-use client library for the `Google Example Library API`_ (v1) defined in
 
 .. _`google-gax`: https://github.com/googleapis/gax-python
 .. _`googleapis`: https://github.com/googleapis/googleapis/tree/master/google/library
-.. _`Google Example Library API`: https://developers.google.com/apis-explorer/?hl=en_US#p/library_example/v1
+.. _`Google Example Library API`: https://developers.google.com/apis-explorer/?hl=en_US#p/library_example/v1/
 
 
 APIs

--- a/src/test/java/com/google/api/codegen/testdata/python_docs_index_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_docs_index_no_path_templates.baseline
@@ -13,7 +13,7 @@ easy-to-use client library for the `Google Fake API`_ (v1) defined in the google
 
 .. _`google-gax`: https://github.com/googleapis/gax-python
 .. _`googleapis`: https://github.com/googleapis/googleapis/tree/master/google/library
-.. _`Google Fake API`: https://developers.google.com/apis-explorer/?hl=en_US#p/no_path_templates/v1
+.. _`Google Fake API`: https://developers.google.com/apis-explorer/?hl=en_US#p/no_path_templates/v1/
 
 
 APIs

--- a/src/test/java/com/google/api/codegen/testdata/python_docs_starting_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_docs_starting_library.baseline
@@ -4,7 +4,7 @@ Getting started
 
 gapic-google-cloud-library-v1 will allow you to connect to the `Google Example Library API`_ and access all its methods. In order to achieve this, you need to set up authentication as well as install the library locally.
 
-.. _`Google Example Library API`: https://developers.google.com/apis-explorer/?hl=en_US#p/library_example/v1
+.. _`Google Example Library API`: https://developers.google.com/apis-explorer/?hl=en_US#p/library_example/v1/
 
 
 Installation

--- a/src/test/java/com/google/api/codegen/testdata/python_docs_starting_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/python_docs_starting_no_path_templates.baseline
@@ -4,7 +4,7 @@ Getting started
 
 gapic-google-cloud-library-v1 will allow you to connect to the `Google Fake API`_ and access all its methods. In order to achieve this, you need to set up authentication as well as install the library locally.
 
-.. _`Google Fake API`: https://developers.google.com/apis-explorer/?hl=en_US#p/no_path_templates/v1
+.. _`Google Fake API`: https://developers.google.com/apis-explorer/?hl=en_US#p/no_path_templates/v1/
 
 
 Installation

--- a/src/test/java/com/google/api/codegen/testdata/ruby_README_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_README_library.baseline
@@ -8,7 +8,7 @@ easy-to-use client library for the [Google Example Library API][] (v1) defined i
 
 [googleapis]: https://github.com/googleapis/googleapis/tree/master/google/library
 [google-gax]: https://github.com/googleapis/gax-ruby
-[Google Example Library API]: https://developers.google.com/apis-explorer/?hl=en_US#p/library_example/v1
+[Google Example Library API]: https://developers.google.com/apis-explorer/?hl=en_US#p/library_example/v1/
 
 Getting started
 ---------------

--- a/src/test/java/com/google/api/codegen/testdata/ruby_doc_README_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_doc_README_library.baseline
@@ -8,7 +8,7 @@ easy-to-use client library for the [Google Example Library API][] (v1) defined i
 
 [googleapis]: https://github.com/googleapis/googleapis/tree/master/google/library
 [google-gax]: https://github.com/googleapis/gax-ruby
-[Google Example Library API]: https://developers.google.com/apis-explorer/?hl=en_US#p/library_example/v1
+[Google Example Library API]: https://developers.google.com/apis-explorer/?hl=en_US#p/library_example/v1/
 
 Getting started
 ---------------


### PR DESCRIPTION
API Explorer expects links to end in a trailing slash

Fixes #1233 