### PR TITLE
Support AsyncOperationFlattenedMethod to example doc

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTransformer.java
@@ -333,6 +333,10 @@ public class JavaGapicSurfaceTransformer implements ModelToViewTransformer {
       exampleApiMethod = searchExampleMethod(methods, ClientMethodType.RequestObjectMethod);
     }
     if (exampleApiMethod == null) {
+      exampleApiMethod =
+          searchExampleMethod(methods, ClientMethodType.AsyncOperationFlattenedMethod);
+    }
+    if (exampleApiMethod == null) {
       throw new RuntimeException("Could not find method to use as an example method");
     }
     return exampleApiMethod;

--- a/src/main/resources/com/google/api/codegen/java/main.snip
+++ b/src/main/resources/com/google/api/codegen/java/main.snip
@@ -37,6 +37,11 @@
          decoratedSampleCode = decorateSampleCode(xapiClass.doc.exampleApiMethod, coreSampleCode)
       {@renderServiceDoc(xapiClass.doc, decoratedSampleCode)}
     @end
+  @case "AsyncOperationFlattenedMethod"
+    @let coreSampleCode = asyncOperationMethodSampleCode(xapiClass.doc.exampleApiMethod), \
+         decoratedSampleCode = decorateSampleCode(xapiClass.doc.exampleApiMethod, coreSampleCode)
+      {@renderServiceDoc(xapiClass.doc, decoratedSampleCode)}
+    @end
   @default
     $unhandledCase: {@xapiClass.doc.exampleApiMethod.type}$
   @end


### PR DESCRIPTION
Example doc generated for Video Intelligence:

```
 <code>
  try (VideoIntelligenceServiceClient videoIntelligenceServiceClient = VideoIntelligenceServiceClient.create()) {
    String inputUri = "";
    List&lt;Feature&gt; features = new ArrayList&lt;&gt;();
    VideoContext videoContext = VideoContext.newBuilder().build();
    String outputUri = "";
    String locationId = "";
    AnnotateVideoResponse response = videoIntelligenceServiceClient.annotateVideoAsync(inputUri, features, videoContext, outputUri, locationId).get();
 }
</code>
```