### PR TITLE
Update gapic java generator to use ThreeTenBP & api-common-java.

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTransformer.java
@@ -438,7 +438,7 @@ public class JavaGapicSurfaceTransformer implements ModelToViewTransformer {
     typeTable.saveNicknameFor("com.google.api.core.BetaApi");
     typeTable.saveNicknameFor("com.google.api.gax.grpc.ChannelAndExecutor");
     typeTable.saveNicknameFor("com.google.api.gax.grpc.UnaryCallable");
-    typeTable.saveNicknameFor("com.google.api.gax.protobuf.PathTemplate");
+    typeTable.saveNicknameFor("com.google.api.pathtemplate.PathTemplate");
     typeTable.saveNicknameFor("io.grpc.ManagedChannel");
     typeTable.saveNicknameFor("java.io.Closeable");
     typeTable.saveNicknameFor("java.io.IOException");
@@ -479,7 +479,7 @@ public class JavaGapicSurfaceTransformer implements ModelToViewTransformer {
     typeTable.saveNicknameFor("com.google.common.collect.Sets");
     typeTable.saveNicknameFor("io.grpc.ManagedChannel");
     typeTable.saveNicknameFor("io.grpc.Status");
-    typeTable.saveNicknameFor("org.joda.time.Duration");
+    typeTable.saveNicknameFor("org.threeten.bp.Duration");
     typeTable.saveNicknameFor("java.io.IOException");
     typeTable.saveNicknameFor("java.util.List");
     typeTable.saveNicknameFor("java.util.concurrent.ScheduledExecutorService");

--- a/src/main/resources/com/google/api/codegen/java/settings.snip
+++ b/src/main/resources/com/google/api/codegen/java/settings.snip
@@ -45,7 +45,7 @@
      * {@doc.settingsClassName}.Builder {@doc.settingsBuilderVarName} =
      *     {@doc.settingsClassName}.defaultBuilder();
      * {@doc.settingsBuilderVarName}.{@doc.exampleApiMethodSettingsGetter}().getRetrySettingsBuilder()
-     *     .setTotalTimeout(Duration.standardSeconds(30));
+     *     .setTotalTimeout(Duration.ofSeconds(30));
      * {@doc.settingsClassName} {@doc.settingsVarName} = {@doc.settingsBuilderVarName}.build();
      * </code>
      * </pre>
@@ -485,13 +485,13 @@
     RetrySettings.Builder settingsBuilder = null;
     @join retryParamsDef : xsettingsClass.retryParamsDefinitions
       settingsBuilder = RetrySettings.newBuilder()
-          .setInitialRetryDelay(Duration.millis({@retryParamsDef.initialRetryDelay.getMillis}L))
+          .setInitialRetryDelay(Duration.ofMillis({@retryParamsDef.initialRetryDelay.getMillis}L))
           .setRetryDelayMultiplier({@retryParamsDef.retryDelayMultiplier})
-          .setMaxRetryDelay(Duration.millis({@retryParamsDef.maxRetryDelay.getMillis}L))
-          .setInitialRpcTimeout(Duration.millis({@retryParamsDef.initialRpcTimeout.getMillis}L))
+          .setMaxRetryDelay(Duration.ofMillis({@retryParamsDef.maxRetryDelay.getMillis}L))
+          .setInitialRpcTimeout(Duration.ofMillis({@retryParamsDef.initialRpcTimeout.getMillis}L))
           .setRpcTimeoutMultiplier({@retryParamsDef.rpcTimeoutMultiplier})
-          .setMaxRpcTimeout(Duration.millis({@retryParamsDef.maxRpcTimeout.getMillis}L))
-          .setTotalTimeout(Duration.millis({@retryParamsDef.totalTimeout.getMillis}L));
+          .setMaxRpcTimeout(Duration.ofMillis({@retryParamsDef.maxRpcTimeout.getMillis}L))
+          .setTotalTimeout(Duration.ofMillis({@retryParamsDef.totalTimeout.getMillis}L));
       definitions.put("{@retryParamsDef.key}", settingsBuilder);
     @end
     RETRY_PARAM_DEFINITIONS = definitions.build();
@@ -532,7 +532,7 @@
             {@settings.grpcMethodConstant},
             {@settings.operationResultTypeName}.class);
         @if settings.hasPollingInterval
-          {@settings.memberName}.setPollingInterval(Duration.millis({@settings.operationPollingIntervalMillis}));
+          {@settings.memberName}.setPollingInterval(Duration.ofMillis({@settings.operationPollingIntervalMillis}));
         @end
 
       @default
@@ -557,7 +557,7 @@
         builder.{@settings.settingsGetFunction}().getBatchingSettingsBuilder()
             .setElementCountThreshold({@settings.batchingConfig.elementCountThreshold}L)
             .setRequestByteThreshold({@settings.batchingConfig.requestByteThreshold}L)
-            .setDelayThreshold(Duration.millis({@settings.batchingConfig.delayThresholdMillis}))
+            .setDelayThreshold(Duration.ofMillis({@settings.batchingConfig.delayThresholdMillis}))
             .setFlowControlSettings(
               FlowControlSettings.newBuilder()
                 @if settings.batchingConfig.hasFlowControlElementLimit

--- a/src/test/java/com/google/api/codegen/testdata/java_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_main_library.baseline
@@ -24,7 +24,7 @@ import com.google.api.gax.grpc.OperationCallable;
 import com.google.api.gax.grpc.OperationFuture;
 import com.google.api.gax.grpc.StreamingCallable;
 import com.google.api.gax.grpc.UnaryCallable;
-import com.google.api.gax.protobuf.PathTemplate;
+import com.google.api.pathtemplate.PathTemplate;
 import com.google.api.resourcenames.ResourceName;
 import com.google.example.library.v1.AddCommentsRequest;
 import com.google.example.library.v1.ArchivedBookName;

--- a/src/test/java/com/google/api/codegen/testdata/java_main_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_main_no_path_templates.baseline
@@ -19,7 +19,7 @@ package com.google.gcloud.example;
 import com.google.api.core.BetaApi;
 import com.google.api.gax.grpc.ChannelAndExecutor;
 import com.google.api.gax.grpc.UnaryCallable;
-import com.google.api.gax.protobuf.PathTemplate;
+import com.google.api.pathtemplate.PathTemplate;
 import com.google.example.noPathTemplates.v1.IncrementRequest;
 import com.google.protobuf.Empty;
 import io.grpc.ManagedChannel;

--- a/src/test/java/com/google/api/codegen/testdata/java_settings_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_settings_library.baseline
@@ -108,7 +108,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.annotation.Generated;
-import org.joda.time.Duration;
+import org.threeten.bp.Duration;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
 /**
@@ -132,7 +132,7 @@ import org.joda.time.Duration;
  * LibrarySettings.Builder librarySettingsBuilder =
  *     LibrarySettings.defaultBuilder();
  * librarySettingsBuilder.createShelfSettings().getRetrySettingsBuilder()
- *     .setTotalTimeout(Duration.standardSeconds(30));
+ *     .setTotalTimeout(Duration.ofSeconds(30));
  * LibrarySettings librarySettings = librarySettingsBuilder.build();
  * </code>
  * </pre>
@@ -1003,13 +1003,13 @@ public class LibrarySettings extends ClientSettings {
       ImmutableMap.Builder<String, RetrySettings.Builder> definitions = ImmutableMap.builder();
       RetrySettings.Builder settingsBuilder = null;
       settingsBuilder = RetrySettings.newBuilder()
-          .setInitialRetryDelay(Duration.millis(100L))
+          .setInitialRetryDelay(Duration.ofMillis(100L))
           .setRetryDelayMultiplier(1.2)
-          .setMaxRetryDelay(Duration.millis(1000L))
-          .setInitialRpcTimeout(Duration.millis(300L))
+          .setMaxRetryDelay(Duration.ofMillis(1000L))
+          .setInitialRpcTimeout(Duration.ofMillis(300L))
           .setRpcTimeoutMultiplier(1.3)
-          .setMaxRpcTimeout(Duration.millis(3000L))
-          .setTotalTimeout(Duration.millis(30000L));
+          .setMaxRpcTimeout(Duration.ofMillis(3000L))
+          .setTotalTimeout(Duration.ofMillis(30000L));
       definitions.put("default", settingsBuilder);
       RETRY_PARAM_DEFINITIONS = definitions.build();
     }
@@ -1082,7 +1082,7 @@ public class LibrarySettings extends ClientSettings {
       getBigBookSettings = OperationCallSettings.newBuilder(
           METHOD_GET_BIG_BOOK,
           Book.class);
-      getBigBookSettings.setPollingInterval(Duration.millis(300000));
+      getBigBookSettings.setPollingInterval(Duration.ofMillis(300000));
 
 
       getBigNothingSettings = OperationCallSettings.newBuilder(
@@ -1147,7 +1147,7 @@ public class LibrarySettings extends ClientSettings {
       builder.publishSeriesSettings().getBatchingSettingsBuilder()
           .setElementCountThreshold(6L)
           .setRequestByteThreshold(100000L)
-          .setDelayThreshold(Duration.millis(500))
+          .setDelayThreshold(Duration.ofMillis(500))
           .setFlowControlSettings(
             FlowControlSettings.newBuilder()
               .setLimitExceededBehavior(LimitExceededBehavior.Ignore)
@@ -1183,7 +1183,7 @@ public class LibrarySettings extends ClientSettings {
       builder.addCommentsSettings().getBatchingSettingsBuilder()
           .setElementCountThreshold(6L)
           .setRequestByteThreshold(100000L)
-          .setDelayThreshold(Duration.millis(500))
+          .setDelayThreshold(Duration.ofMillis(500))
           .setFlowControlSettings(
             FlowControlSettings.newBuilder()
               .setLimitExceededBehavior(LimitExceededBehavior.Ignore)

--- a/src/test/java/com/google/api/codegen/testdata/java_settings_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_settings_no_path_templates.baseline
@@ -44,7 +44,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.annotation.Generated;
-import org.joda.time.Duration;
+import org.threeten.bp.Duration;
 
 // AUTO-GENERATED DOCUMENTATION AND CLASS
 /**


### PR DESCRIPTION
PathTemplate moved from gax to  api-common-java in https://github.com/googleapis/gax-java/pull/279
joda-time was replaced with ThreeTenBP in https://github.com/googleapis/gax-java/pull/294