### PR TITLE
change ProductServiceConfig to accept Model

### DIFF
--- a/src/main/java/com/google/api/codegen/config/ProductServiceConfig.java
+++ b/src/main/java/com/google/api/codegen/config/ProductServiceConfig.java
@@ -17,7 +17,7 @@ package com.google.api.codegen.config;
 import com.google.api.Authentication;
 import com.google.api.AuthenticationRule;
 import com.google.api.Service;
-import com.google.api.tools.framework.model.Interface;
+import com.google.api.tools.framework.model.Model;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -30,8 +30,8 @@ import java.util.TreeSet;
  */
 public class ProductServiceConfig {
   /** Return the service address. */
-  public String getServiceAddress(Interface apiInterface) {
-    return apiInterface.getModel().getServiceConfig().getName();
+  public String getServiceAddress(Model model) {
+    return model.getServiceConfig().getName();
   }
 
   /** Return the service port. TODO(cbao): Read the port from config. */
@@ -39,14 +39,14 @@ public class ProductServiceConfig {
     return 443;
   }
 
-  public String getTitle(Interface apiInterface) {
-    return apiInterface.getModel().getServiceConfig().getTitle();
+  public String getTitle(Model model) {
+    return model.getServiceConfig().getTitle();
   }
 
   /** Return a list of scopes for authentication. */
-  public Iterable<String> getAuthScopes(Interface apiInterface) {
+  public Iterable<String> getAuthScopes(Model model) {
     Set<String> result = new TreeSet<>();
-    Service config = apiInterface.getModel().getServiceConfig();
+    Service config = model.getServiceConfig();
     Authentication auth = config.getAuthentication();
     for (AuthenticationRule rule : auth.getRulesList()) {
       // Scopes form a union and the union is used for down-scoping, so adding more scopes that

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicClientTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicClientTransformer.java
@@ -230,9 +230,10 @@ public class CSharpGapicClientTransformer implements ModelToViewTransformer {
     String name = context.getNamer().getApiSettingsClassName(context.getInterfaceConfig());
     settingsClass.name(name);
     ProductServiceConfig productServiceConfig = new ProductServiceConfig();
-    settingsClass.serviceAddress(productServiceConfig.getServiceAddress(context.getInterface()));
+    settingsClass.serviceAddress(
+        productServiceConfig.getServiceAddress(context.getInterface().getModel()));
     settingsClass.servicePort(productServiceConfig.getServicePort());
-    settingsClass.authScopes(productServiceConfig.getAuthScopes(context.getInterface()));
+    settingsClass.authScopes(productServiceConfig.getAuthScopes(context.getInterface().getModel()));
     settingsClass.callSettings(generateCallSettings(context));
     settingsClass.pageStreamingDescriptors(
         pageStreamingTransformer.generateDescriptorClasses(context));
@@ -394,7 +395,8 @@ public class CSharpGapicClientTransformer implements ModelToViewTransformer {
     SurfaceNamer namer = context.getNamer();
     SettingsDocView.Builder settingsDoc = SettingsDocView.newBuilder();
     ProductServiceConfig productServiceConfig = new ProductServiceConfig();
-    settingsDoc.serviceAddress(productServiceConfig.getServiceAddress(context.getInterface()));
+    settingsDoc.serviceAddress(
+        productServiceConfig.getServiceAddress(context.getInterface().getModel()));
     settingsDoc.servicePort(productServiceConfig.getServicePort());
     settingsDoc.exampleApiMethodName(""); // Unused in C#
     settingsDoc.exampleApiMethodSettingsGetter(""); // Unused in C#

--- a/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformer.java
@@ -179,9 +179,9 @@ public class GoGapicSurfaceTransformer implements ModelToViewTransformer {
     view.lroDetailViews(new ArrayList<LongRunningOperationDetailView>(lros.values()));
 
     ProductServiceConfig productServiceConfig = new ProductServiceConfig();
-    view.serviceAddress(productServiceConfig.getServiceAddress(apiInterface));
+    view.serviceAddress(productServiceConfig.getServiceAddress(apiInterface.getModel()));
     view.servicePort(productServiceConfig.getServicePort());
-    view.authScopes(productServiceConfig.getAuthScopes(apiInterface));
+    view.authScopes(productServiceConfig.getAuthScopes(apiInterface.getModel()));
 
     view.stubs(grpcStubTransformer.generateGrpcStubs(context));
 

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTransformer.java
@@ -384,9 +384,11 @@ public class JavaGapicSurfaceTransformer implements ModelToViewTransformer {
     String name = namer.getApiSettingsClassName(context.getInterfaceConfig());
     xsettingsClass.name(name);
     ProductServiceConfig productServiceConfig = new ProductServiceConfig();
-    xsettingsClass.serviceAddress(productServiceConfig.getServiceAddress(context.getInterface()));
+    xsettingsClass.serviceAddress(
+        productServiceConfig.getServiceAddress(context.getInterface().getModel()));
     xsettingsClass.servicePort(productServiceConfig.getServicePort());
-    xsettingsClass.authScopes(productServiceConfig.getAuthScopes(context.getInterface()));
+    xsettingsClass.authScopes(
+        productServiceConfig.getAuthScopes(context.getInterface().getModel()));
 
     List<ApiCallSettingsView> apiCallSettings =
         apiCallableTransformer.generateCallSettings(context);
@@ -542,7 +544,8 @@ public class JavaGapicSurfaceTransformer implements ModelToViewTransformer {
     SurfaceNamer namer = context.getNamer();
     SettingsDocView.Builder settingsDoc = SettingsDocView.newBuilder();
     ProductServiceConfig productServiceConfig = new ProductServiceConfig();
-    settingsDoc.serviceAddress(productServiceConfig.getServiceAddress(context.getInterface()));
+    settingsDoc.serviceAddress(
+        productServiceConfig.getServiceAddress(context.getInterface().getModel()));
     settingsDoc.servicePort(productServiceConfig.getServicePort());
     settingsDoc.exampleApiMethodName(exampleApiMethod.name());
     settingsDoc.exampleApiMethodSettingsGetter(exampleApiMethod.settingsGetterName());

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTransformer.java
@@ -133,10 +133,11 @@ public class NodeJSGapicSurfaceTransformer implements ModelToViewTransformer {
     xapiClass.stubs(grpcStubTransformer.generateGrpcStubs(context));
 
     ProductServiceConfig productServiceConfig = new ProductServiceConfig();
-    xapiClass.serviceAddress(productServiceConfig.getServiceAddress(context.getInterface()));
+    xapiClass.serviceAddress(
+        productServiceConfig.getServiceAddress(context.getInterface().getModel()));
     xapiClass.servicePort(productServiceConfig.getServicePort());
-    xapiClass.serviceTitle(productServiceConfig.getTitle(context.getInterface()));
-    xapiClass.authScopes(productServiceConfig.getAuthScopes(context.getInterface()));
+    xapiClass.serviceTitle(productServiceConfig.getTitle(context.getInterface().getModel()));
+    xapiClass.authScopes(productServiceConfig.getAuthScopes(context.getInterface().getModel()));
     xapiClass.hasDefaultServiceAddress(context.getInterfaceConfig().hasDefaultServiceAddress());
     xapiClass.hasDefaultServiceScopes(context.getInterfaceConfig().hasDefaultServiceScopes());
 

--- a/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSurfaceTransformer.java
@@ -117,10 +117,11 @@ public class PhpGapicSurfaceTransformer implements ModelToViewTransformer {
     String name = namer.getApiWrapperClassName(context.getInterfaceConfig());
     xapiClass.name(name);
     ProductServiceConfig productServiceConfig = new ProductServiceConfig();
-    xapiClass.serviceAddress(productServiceConfig.getServiceAddress(context.getInterface()));
+    xapiClass.serviceAddress(
+        productServiceConfig.getServiceAddress(context.getInterface().getModel()));
     xapiClass.servicePort(productServiceConfig.getServicePort());
-    xapiClass.serviceTitle(productServiceConfig.getTitle(context.getInterface()));
-    xapiClass.authScopes(productServiceConfig.getAuthScopes(context.getInterface()));
+    xapiClass.serviceTitle(productServiceConfig.getTitle(context.getInterface().getModel()));
+    xapiClass.authScopes(productServiceConfig.getAuthScopes(context.getInterface().getModel()));
 
     xapiClass.pathTemplates(pathTemplateTransformer.generatePathTemplates(context));
     xapiClass.formatResourceFunctions(

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubyGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubyGapicSurfaceTransformer.java
@@ -120,10 +120,11 @@ public class RubyGapicSurfaceTransformer implements ModelToViewTransformer {
     xapiClass.stubs(grpcStubTransformer.generateGrpcStubs(context));
 
     ProductServiceConfig productServiceConfig = new ProductServiceConfig();
-    xapiClass.serviceAddress(productServiceConfig.getServiceAddress(context.getInterface()));
+    xapiClass.serviceAddress(
+        productServiceConfig.getServiceAddress(context.getInterface().getModel()));
     xapiClass.servicePort(productServiceConfig.getServicePort());
-    xapiClass.serviceTitle(productServiceConfig.getTitle(context.getInterface()));
-    xapiClass.authScopes(productServiceConfig.getAuthScopes(context.getInterface()));
+    xapiClass.serviceTitle(productServiceConfig.getTitle(context.getInterface().getModel()));
+    xapiClass.authScopes(productServiceConfig.getAuthScopes(context.getInterface().getModel()));
     xapiClass.hasDefaultServiceAddress(context.getInterfaceConfig().hasDefaultServiceAddress());
     xapiClass.hasDefaultServiceScopes(context.getInterfaceConfig().hasDefaultServiceScopes());
 

--- a/src/main/resources/com/google/api/codegen/py/main.snip
+++ b/src/main/resources/com/google/api/codegen/py/main.snip
@@ -89,7 +89,7 @@
 
 @private constantSection(service)
     @let ifaceConfig = context.getApiConfig.getInterfaceConfig(service)
-        SERVICE_ADDRESS = '{@context.getServiceConfig.getServiceAddress(service)}'
+        SERVICE_ADDRESS = '{@context.getServiceConfig.getServiceAddress(service.getModel)}'
         """The default address of the service."""
 
         DEFAULT_SERVICE_PORT = {@context.getServiceConfig.getServicePort()}
@@ -115,7 +115,7 @@
         @# The scopes needed to make gRPC calls to all of the methods defined in
         @# this service
         _ALL_SCOPES = (
-            @join auth_scope : context.getServiceConfig.getAuthScopes(service) on BREAK
+            @join auth_scope : context.getServiceConfig.getAuthScopes(service.getModel) on BREAK
                 '{@auth_scope}',
             @end
         )


### PR DESCRIPTION
The rest of Interface is not used, so we might as well just ask for Model.

Motivation: I'd like to add `getScopes` method to Go's `doc.go` which might be shared by multiple `Interface`s. Since `doc.go` is shared, it only has `Model`, not `Interface`.

Adding @geigerj because Python isn't on MVVM yet.