### PR TITLE
go: move auth scope to a shared location

### DIFF
--- a/src/main/java/com/google/api/codegen/config/ProductServiceConfig.java
+++ b/src/main/java/com/google/api/codegen/config/ProductServiceConfig.java
@@ -18,7 +18,7 @@ import com.google.api.Authentication;
 import com.google.api.AuthenticationRule;
 import com.google.api.Service;
 import com.google.api.tools.framework.model.Model;
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
@@ -44,7 +44,7 @@ public class ProductServiceConfig {
   }
 
   /** Return a list of scopes for authentication. */
-  public Iterable<String> getAuthScopes(Model model) {
+  public List<String> getAuthScopes(Model model) {
     Set<String> result = new TreeSet<>();
     Service config = model.getServiceConfig();
     Authentication auth = config.getAuthentication();
@@ -54,11 +54,10 @@ public class ProductServiceConfig {
       // We are doing this for implementation simplicity so we don't have to compute which scopes
       // are subsets of the others.
       String scopesString = rule.getOauth().getCanonicalScopes();
-      List<String> scopes = Arrays.asList(scopesString.split(","));
-      for (String scope : scopes) {
+      for (String scope : scopesString.split(",")) {
         result.add(scope.trim());
       }
     }
-    return result;
+    return new ArrayList<>(result);
   }
 }

--- a/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformer.java
@@ -89,6 +89,7 @@ public class GoGapicSurfaceTransformer implements ModelToViewTransformer {
   private final PathTemplateTransformer pathTemplateTransformer = new PathTemplateTransformer();
   private final ServiceMessages serviceMessages = new ServiceMessages();
   private final ServiceTransformer serviceTransformer = new ServiceTransformer();
+  private final ProductServiceConfig productServiceConfig = new ProductServiceConfig();
   private final GapicCodePathMapper pathMapper;
 
   public GoGapicSurfaceTransformer(GapicCodePathMapper pathMapper) {
@@ -178,10 +179,8 @@ public class GoGapicSurfaceTransformer implements ModelToViewTransformer {
     }
     view.lroDetailViews(new ArrayList<LongRunningOperationDetailView>(lros.values()));
 
-    ProductServiceConfig productServiceConfig = new ProductServiceConfig();
     view.serviceAddress(productServiceConfig.getServiceAddress(apiInterface.getModel()));
     view.servicePort(productServiceConfig.getServicePort());
-    view.authScopes(productServiceConfig.getAuthScopes(apiInterface.getModel()));
 
     view.stubs(grpcStubTransformer.generateGrpcStubs(context));
 
@@ -238,6 +237,7 @@ public class GoGapicSurfaceTransformer implements ModelToViewTransformer {
         CommonRenderingUtil.getDocLines(
             model.getServiceConfig().getDocumentation().getSummary(), COMMENT_LINE_LENGTH));
     packageInfo.domainLayerLocation(productConfig.getDomainLayerLocation());
+    packageInfo.authScopes(productServiceConfig.getAuthScopes(model));
 
     packageInfo.fileHeader(
         fileHeaderTransformer.generateFileHeader(

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTransformer.java
@@ -82,6 +82,7 @@ public class JavaGapicSurfaceTransformer implements ModelToViewTransformer {
       new FileHeaderTransformer(importSectionTransformer);
   private final RetryDefinitionsTransformer retryDefinitionsTransformer =
       new RetryDefinitionsTransformer();
+  private final ProductServiceConfig productServiceConfig = new ProductServiceConfig();
 
   private static final String XAPI_TEMPLATE_FILENAME = "java/main.snip";
   private static final String XSETTINGS_TEMPLATE_FILENAME = "java/settings.snip";
@@ -383,7 +384,6 @@ public class JavaGapicSurfaceTransformer implements ModelToViewTransformer {
     xsettingsClass.doc(generateSettingsDoc(context, exampleApiMethod));
     String name = namer.getApiSettingsClassName(context.getInterfaceConfig());
     xsettingsClass.name(name);
-    ProductServiceConfig productServiceConfig = new ProductServiceConfig();
     xsettingsClass.serviceAddress(
         productServiceConfig.getServiceAddress(context.getInterface().getModel()));
     xsettingsClass.servicePort(productServiceConfig.getServicePort());
@@ -423,6 +423,7 @@ public class JavaGapicSurfaceTransformer implements ModelToViewTransformer {
     packageInfo.serviceTitle(model.getServiceConfig().getTitle());
     packageInfo.serviceDocs(serviceDocs);
     packageInfo.domainLayerLocation(productConfig.getDomainLayerLocation());
+    packageInfo.authScopes(productServiceConfig.getAuthScopes(model));
 
     packageInfo.fileHeader(
         fileHeaderTransformer.generateFileHeader(

--- a/src/main/java/com/google/api/codegen/viewmodel/PackageInfoView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/PackageInfoView.java
@@ -33,6 +33,8 @@ public abstract class PackageInfoView implements ViewModel {
 
   public abstract List<ServiceDocView> serviceDocs();
 
+  public abstract List<String> authScopes();
+
   public abstract String domainLayerLocation();
 
   @Nullable
@@ -61,6 +63,8 @@ public abstract class PackageInfoView implements ViewModel {
     public abstract Builder serviceTitle(String val);
 
     public abstract Builder serviceDocs(List<ServiceDocView> val);
+
+    public abstract Builder authScopes(List<String> val);
 
     public abstract Builder domainLayerLocation(String val);
 

--- a/src/main/java/com/google/api/codegen/viewmodel/StaticLangClientFileView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/StaticLangClientFileView.java
@@ -35,8 +35,6 @@ public abstract class StaticLangClientFileView implements ViewModel {
 
   public abstract FileHeaderView fileHeader();
 
-  public abstract Iterable<String> authScopes();
-
   public abstract List<PathTemplateView> pathTemplates();
 
   public abstract List<PathTemplateGetterFunctionView> pathTemplateGetters();
@@ -83,8 +81,6 @@ public abstract class StaticLangClientFileView implements ViewModel {
     public abstract Builder apiMethods(List<StaticLangApiMethodView> val);
 
     public abstract Builder fileHeader(FileHeaderView val);
-
-    public abstract Builder authScopes(Iterable<String> val);
 
     public abstract Builder clientTypeName(String val);
 

--- a/src/main/resources/com/google/api/codegen/go/doc.snip
+++ b/src/main/resources/com/google/api/codegen/go/doc.snip
@@ -26,4 +26,12 @@
         md["x-goog-api-client"] = []string{val}
         return metadata.NewContext(ctx, md)
     }
+
+    func DefaultAuthScopes() []string {
+      return []string{
+        @join scope : view.authScopes
+          "{@scope}",
+        @end
+      }
+    }
 @end

--- a/src/main/resources/com/google/api/codegen/go/main.snip
+++ b/src/main/resources/com/google/api/codegen/go/main.snip
@@ -27,11 +27,7 @@
     func {@view.defaultClientOptionFunctionName}() []option.ClientOption {
         return []option.ClientOption{
             option.WithEndpoint("{@view.serviceAddress}:{@view.servicePort}"),
-            option.WithScopes(
-                @join scope : view.authScopes
-                    "{@scope}",
-                @end
-            ),
+            option.WithScopes(DefaultAuthScopes()...),
         }
     }
 

--- a/src/test/java/com/google/api/codegen/testdata/go_doc_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_doc_library.baseline
@@ -34,3 +34,10 @@ func insertXGoog(ctx context.Context, val string) context.Context {
     md["x-goog-api-client"] = []string{val}
     return metadata.NewContext(ctx, md)
 }
+
+func DefaultAuthScopes() []string {
+  return []string{
+    "https://www.googleapis.com/auth/cloud-platform",
+    "https://www.googleapis.com/auth/library",
+  }
+}

--- a/src/test/java/com/google/api/codegen/testdata/go_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_main_library.baseline
@@ -75,10 +75,7 @@ type CallOptions struct {
 func defaultClientOptions() []option.ClientOption {
     return []option.ClientOption{
         option.WithEndpoint("library-example.googleapis.com:443"),
-        option.WithScopes(
-            "https://www.googleapis.com/auth/cloud-platform",
-            "https://www.googleapis.com/auth/library",
-        ),
+        option.WithScopes(DefaultAuthScopes()...),
     }
 }
 


### PR DESCRIPTION
This makes the scope visible to handwritten clients and tests,
particularly testutil.TokenSource.
This will later be used by smoke testing.