### PR TITLE
go: don't t.Log in success cases

### DIFF
--- a/src/main/resources/com/google/api/codegen/go/smoke.snip
+++ b/src/main/resources/com/google/api/codegen/go/smoke.snip
@@ -45,27 +45,17 @@
     @switch view.method.clientMethodType
     @case "PagedRequestObjectMethod"
       iter := {@call(view.method)}
-      resp, err := iter.Next()
-      if err == iterator.Done {
-        t.Log("no items")
-      } else if err != nil {
+      if _, err := iter.Next(); err != nil && err != iterator.Done {
         t.Error(err)
-      } else {
-        t.Log(resp)
       }
     @case "RequestObjectMethod"
       @if view.method.hasReturnValue
-        resp, err := {@call(view.method)}
-        if err != nil {
+        if _, err := {@call(view.method)}; err != nil {
           t.Error(err)
-        } else {
-          t.Log(resp)
         }
       @else
         if err := {@call(view.method)}; err != nil {
           t.Error(err)
-        } else {
-          t.Log("done")
         }
       @end
     @end

--- a/src/test/java/com/google/api/codegen/testdata/go_smoke_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_smoke_library.baseline
@@ -61,10 +61,7 @@ func TestLibraryServiceSmoke(t *testing.T) {
       Book: book,
   }
 
-  resp, err := c.UpdateBook(ctx, request)
-  if err != nil {
+  if _, err := c.UpdateBook(ctx, request); err != nil {
     t.Error(err)
-  } else {
-    t.Log(resp)
   }
 }


### PR DESCRIPTION
It is not required and unnecessarily chatty.

Fixes #1249.