### PR TITLE
Ruby: Remove aliasing from method samples and tests

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/DynamicLangApiMethodTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/DynamicLangApiMethodTransformer.java
@@ -63,6 +63,8 @@ public class DynamicLangApiMethodTransformer {
       apiMethod.type(ClientMethodType.OptionalArrayMethod);
     }
     apiMethod.apiClassName(namer.getApiWrapperClassName(context.getInterfaceConfig()));
+    apiMethod.fullyQualifiedApiClassName(
+        namer.getFullyQualifiedApiWrapperClassName(context.getInterfaceConfig()));
     apiMethod.apiVariableName(namer.getApiWrapperVariableName(context.getInterfaceConfig()));
     apiMethod.apiModuleName(namer.getApiWrapperModuleName());
     InitCodeOutputType initCodeOutputType =

--- a/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
@@ -273,6 +273,7 @@ public class InitCodeTransformer {
 
     String typeName = typeTable.getAndSaveNicknameFor(item.getType());
     surfaceLine.typeName(typeName);
+    surfaceLine.fullyQualifiedTypeName(typeTable.getFullNameFor(item.getType()));
     surfaceLine.typeConstructor(namer.getTypeConstructor(typeName));
 
     surfaceLine.fieldSettings(getFieldSettings(context, item.getChildren().values()));
@@ -391,6 +392,8 @@ public class InitCodeTransformer {
 
         initValue.apiWrapperName(
             context.getNamer().getApiWrapperClassName(context.getInterfaceConfig()));
+        initValue.fullyQualifiedApiWrapperName(
+            context.getNamer().getFullyQualifiedApiWrapperClassName(context.getInterfaceConfig()));
         initValue.formatFunctionName(
             context
                 .getNamer()

--- a/src/main/java/com/google/api/codegen/transformer/TestCaseTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/TestCaseTransformer.java
@@ -106,6 +106,8 @@ public class TestCaseTransformer {
         .responseTypeName(responseTypeName)
         .serviceConstructorName(
             namer.getApiWrapperClassConstructorName(methodContext.getInterface()))
+        .fullyQualifiedServiceClassName(
+            namer.getFullyQualifiedApiWrapperClassName(methodContext.getInterfaceConfig()))
         .clientMethodName(clientMethodName)
         .mockGrpcStubTypeName(namer.getMockGrpcServiceImplName(methodContext.getTargetInterface()))
         .createStubFunctionName(namer.getCreateStubFunctionName(methodContext.getTargetInterface()))

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubyModelTypeNameConverter.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubyModelTypeNameConverter.java
@@ -133,7 +133,8 @@ public class RubyModelTypeNameConverter implements ModelTypeNameConverter {
       return TypedValue.create(getTypeName(type), PRIMITIVE_ZERO_VALUE.get(type.getKind()));
     }
     if (type.isMessage()) {
-      return TypedValue.create(getTypeName(type), "%s.new");
+      TypeName typeName = getTypeName(type);
+      return TypedValue.create(typeName, typeName.getFullName() + ".new");
     }
     if (type.isEnum()) {
       return getEnumValue(type, type.getEnumType().getValues().get(0));
@@ -185,6 +186,6 @@ public class RubyModelTypeNameConverter implements ModelTypeNameConverter {
 
   @Override
   public TypedValue getEnumValue(TypeRef type, EnumValue value) {
-    return TypedValue.create(getTypeName(type), "%s::" + value.getSimpleName());
+    return TypedValue.create(getTypeName(type), ":" + value.getSimpleName());
   }
 }

--- a/src/main/java/com/google/api/codegen/viewmodel/FormattedInitValueView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/FormattedInitValueView.java
@@ -21,6 +21,8 @@ import java.util.List;
 public abstract class FormattedInitValueView implements InitValueView {
   public abstract String apiWrapperName();
 
+  public abstract String fullyQualifiedApiWrapperName();
+
   public abstract String formatFunctionName();
 
   public abstract List<String> formatArgs();
@@ -36,6 +38,8 @@ public abstract class FormattedInitValueView implements InitValueView {
   @AutoValue.Builder
   public abstract static class Builder {
     public abstract Builder apiWrapperName(String val);
+
+    public abstract Builder fullyQualifiedApiWrapperName(String val);
 
     public abstract Builder formatFunctionName(String val);
 

--- a/src/main/java/com/google/api/codegen/viewmodel/OptionalArrayMethodView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/OptionalArrayMethodView.java
@@ -26,6 +26,8 @@ public abstract class OptionalArrayMethodView implements ApiMethodView {
 
   public abstract String apiClassName();
 
+  public abstract String fullyQualifiedApiClassName();
+
   public abstract String apiVariableName();
 
   public abstract String apiModuleName();
@@ -88,6 +90,8 @@ public abstract class OptionalArrayMethodView implements ApiMethodView {
     public abstract Builder type(ClientMethodType val);
 
     public abstract Builder apiClassName(String val);
+
+    public abstract Builder fullyQualifiedApiClassName(String val);
 
     public abstract Builder apiVariableName(String val);
 

--- a/src/main/java/com/google/api/codegen/viewmodel/StructureInitCodeLineView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/StructureInitCodeLineView.java
@@ -25,6 +25,8 @@ public abstract class StructureInitCodeLineView implements InitCodeLineView {
 
   public abstract String typeName();
 
+  public abstract String fullyQualifiedTypeName();
+
   public abstract String typeConstructor();
 
   @Override
@@ -41,6 +43,8 @@ public abstract class StructureInitCodeLineView implements InitCodeLineView {
     public abstract Builder lineType(InitCodeLineType val);
 
     public abstract Builder typeName(String val);
+
+    public abstract Builder fullyQualifiedTypeName(String val);
 
     public abstract Builder typeConstructor(String val);
 

--- a/src/main/java/com/google/api/codegen/viewmodel/testing/TestCaseView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/testing/TestCaseView.java
@@ -45,6 +45,8 @@ public abstract class TestCaseView {
 
   public abstract String serviceConstructorName();
 
+  public abstract String fullyQualifiedServiceClassName();
+
   public abstract String mockServiceVarName();
 
   public abstract boolean hasRequestParameters();
@@ -73,6 +75,8 @@ public abstract class TestCaseView {
     public abstract Builder nameWithException(String val);
 
     public abstract Builder serviceConstructorName(String val);
+
+    public abstract Builder fullyQualifiedServiceClassName(String val);
 
     public abstract Builder mockServiceVarName(String val);
 

--- a/src/main/resources/com/google/api/codegen/ruby/initcode.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/initcode.snip
@@ -18,7 +18,7 @@
 @private initLineStructure(line)
   @switch line.fieldSettings.size.toString
   @case "0"
-    {@line.identifier} = {@line.typeName}.new
+    {@line.identifier} = {@line.fullyQualifiedTypeName}.new
   @case "1"
     {@singleLineInitStructure(line)}
   @case "2"
@@ -29,11 +29,11 @@
 @end
 
 @private singleLineInitStructure(line)
-    {@line.identifier} = {@line.typeName}.new({@structureFieldsList(line.fieldSettings)})
+    {@line.identifier} = {@line.fullyQualifiedTypeName}.new({@structureFieldsList(line.fieldSettings)})
 @end
 
 @private multiLineInitStructure(line)
-  {@line.identifier} = {@line.typeName}.new(
+  {@line.identifier} = {@line.fullyQualifiedTypeName}.new(
     {@multilineStructureFieldsList(line.fieldSettings)}
   )
 @end
@@ -79,7 +79,7 @@
   @case "SimpleInitValueView"
     {@initValue.initialValue}
   @case "FormattedInitValueView"
-    {@initValue.apiWrapperName}.{@initValue.formatFunctionName}\
+    {@initValue.fullyQualifiedApiWrapperName}.{@initValue.formatFunctionName}\
       ({@varList(initValue.formatArgs)})
   @default
     $unhandledCase: {@initValue.type}$

--- a/src/main/resources/com/google/api/codegen/ruby/method_sample.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/method_sample.snip
@@ -16,9 +16,7 @@
 @end
 
 @snippet sampleCodeCore(apiMethod)
-  {@aliasSection(apiMethod.initCode.importSection)}
-
-  {@apiMethod.apiVariableName} = {@apiMethod.apiClassName}.new
+  {@apiMethod.apiVariableName} = {@apiMethod.fullyQualifiedApiClassName}.new
   @if apiMethod.initCode.lines
     {@initCode(apiMethod.initCode)}
   @end
@@ -35,15 +33,6 @@
     @end
   @end
 @end
-
-@snippet aliasSection(importSection)
-  @join fileImport : importSection.appImports
-    @join alias : fileImport.types
-      {@alias.nickname} = {@alias.fullName}
-    @end
-  @end
-@end
-
 
 @private longRunningMethodSampleCode(apiMethod)
 

--- a/src/main/resources/com/google/api/codegen/ruby/test.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/test.snip
@@ -58,12 +58,8 @@
     @join test : testClass.testCases
 
       describe '{@test.clientMethodName}' do
-        custom_error = CustomTestError.new "Custom test error for {@test.serviceConstructorName}#{@test.clientMethodName}."
+        custom_error = CustomTestError.new "Custom test error for {@test.fullyQualifiedServiceClassName}#{@test.clientMethodName}."
 
-        @if {@aliasSection(test.initCode.importSection)}
-          {@aliasSection(test.mockResponse.initCode.importSection)}
-
-        @end
         {@testCase(test)}
 
         {@errorTestCase(test)}
@@ -130,7 +126,7 @@
     mock_stub = MockGrpcClientStub.new(:{@test.clientMethodName}, mock_method)
 
     {@test.grpcStubCallString}.stub(:new, mock_stub) do
-      client = {@test.serviceConstructorName}.new
+      client = {@test.fullyQualifiedServiceClassName}.new
 
       @# Call method
       {@methodCallWithResponse(test)}
@@ -160,7 +156,7 @@
     mock_stub = MockGrpcClientStub.new(:{@test.clientMethodName}, mock_method)
 
     {@test.grpcStubCallString}.stub(:new, mock_stub) do
-      client = {@test.serviceConstructorName}.new
+      client = {@test.fullyQualifiedServiceClassName}.new
 
       @# Call method
       {@methodCallWithResponse(test)}
@@ -198,7 +194,7 @@
     mock_stub = MockGrpcClientStub.new(:{@test.clientMethodName}, mock_method)
 
     {@test.grpcStubCallString}.stub(:new, mock_stub) do
-      client = {@test.serviceConstructorName}.new
+      client = {@test.fullyQualifiedServiceClassName}.new
 
       @# Call method
       {@methodCallWithResponse(test)}
@@ -216,7 +212,7 @@
     @end
     @# Create expected grpc response
     operation_error = Google::Rpc::Status.new(
-      message: 'Operation error for {@test.serviceConstructorName}#{@test.clientMethodName}.'
+      message: 'Operation error for {@test.fullyQualifiedServiceClassName}#{@test.clientMethodName}.'
     )
     operation = Google::Longrunning::Operation.new(
       name: 'operations/{@test.name}',
@@ -229,7 +225,7 @@
     mock_stub = MockGrpcClientStub.new(:{@test.clientMethodName}, mock_method)
 
     {@test.grpcStubCallString}.stub(:new, mock_stub) do
-      client = {@test.serviceConstructorName}.new
+      client = {@test.fullyQualifiedServiceClassName}.new
 
       @# Call method
       {@methodCallWithResponse(test)}
@@ -256,7 +252,7 @@
     mock_stub = MockGrpcClientStub.new(:{@test.clientMethodName}, mock_method)
 
     {@test.grpcStubCallString}.stub(:new, mock_stub) do
-      client = {@test.serviceConstructorName}.new
+      client = {@test.fullyQualifiedServiceClassName}.new
 
       @# Call method
       {@methodCallWithResponse(test)}
@@ -283,7 +279,7 @@
     mock_stub = MockGrpcClientStub.new(:{@test.clientMethodName}, mock_method)
 
     {@test.grpcStubCallString}.stub(:new, mock_stub) do
-      client = {@test.serviceConstructorName}.new
+      client = {@test.fullyQualifiedServiceClassName}.new
 
       @# Call method
       {@clientStreamingCall(test)}
@@ -311,7 +307,7 @@
     mock_stub = MockGrpcClientStub.new(:{@test.clientMethodName}, mock_method)
 
     {@test.grpcStubCallString}.stub(:new, mock_stub) do
-      client = {@test.serviceConstructorName}.new
+      client = {@test.fullyQualifiedServiceClassName}.new
 
       @# Call method
       {@clientStreamingCall(test)}
@@ -335,7 +331,7 @@
     mock_stub = MockGrpcClientStub.new(:{@test.clientMethodName}, mock_method)
 
     {@test.grpcStubCallString}.stub(:new, mock_stub) do
-      client = {@test.serviceConstructorName}.new
+      client = {@test.fullyQualifiedServiceClassName}.new
 
       @# Call method
       err = assert_raises Google::Gax::GaxError do
@@ -358,7 +354,7 @@
     mock_stub = MockGrpcClientStub.new(:{@test.clientMethodName}, mock_method)
 
     {@test.grpcStubCallString}.stub(:new, mock_stub) do
-      client = {@test.serviceConstructorName}.new
+      client = {@test.fullyQualifiedServiceClassName}.new
 
       @# Call method
       err = assert_raises Google::Gax::GaxError do
@@ -462,11 +458,7 @@
 @end
 
 @private expectedValue(assert)
-  @if assert.hasEnumTypeName
-    {@assert.enumTypeName}.lookup({@assert.expectedValueIdentifier})
-  @else
-    {@assert.expectedValueIdentifier}
-  @end
+  {@assert.expectedValueIdentifier}
 @end
 
 @private methodCallWithResponse(test)

--- a/src/test/java/com/google/api/codegen/testdata/ruby_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_doc_main_library.baseline
@@ -430,11 +430,8 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #   Shelf = Google::Example::Library::V1::Shelf
-      #
-      #   library_service_client = LibraryServiceClient.new
-      #   shelf = Shelf.new
+      #   library_service_client = Library::V1::LibraryServiceClient.new
+      #   shelf = Google::Example::Library::V1::Shelf.new
       #   response = library_service_client.create_shelf(shelf)
 
       def create_shelf \
@@ -463,10 +460,8 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   library_service_client = Library::V1::LibraryServiceClient.new
+      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
       #   options_ = ''
       #   response = library_service_client.get_shelf(formatted_name, options_)
 
@@ -499,9 +494,7 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
+      #   library_service_client = Library::V1::LibraryServiceClient.new
       #
       #   # Iterate over all results.
       #   library_service_client.list_shelves.each do |element|
@@ -532,10 +525,8 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   library_service_client = Library::V1::LibraryServiceClient.new
+      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
       #   library_service_client.delete_shelf(formatted_name)
 
       def delete_shelf \
@@ -564,11 +555,9 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
-      #   formatted_other_shelf_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   library_service_client = Library::V1::LibraryServiceClient.new
+      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
       #   response = library_service_client.merge_shelves(formatted_name, formatted_other_shelf_name)
 
       def merge_shelves \
@@ -596,12 +585,9 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   Book = Google::Example::Library::V1::Book
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
-      #   book = Book.new
+      #   library_service_client = Library::V1::LibraryServiceClient.new
+      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   book = Google::Example::Library::V1::Book.new
       #   response = library_service_client.create_book(formatted_name, book)
 
       def create_book \
@@ -635,15 +621,11 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #   SeriesUuid = Google::Example::Library::V1::SeriesUuid
-      #   Shelf = Google::Example::Library::V1::Shelf
-      #
-      #   library_service_client = LibraryServiceClient.new
-      #   shelf = Shelf.new
+      #   library_service_client = Library::V1::LibraryServiceClient.new
+      #   shelf = Google::Example::Library::V1::Shelf.new
       #   books = []
       #   series_string = "foobar"
-      #   series_uuid = SeriesUuid.new(series_string: series_string)
+      #   series_uuid = Google::Example::Library::V1::SeriesUuid.new(series_string: series_string)
       #   response = library_service_client.publish_series(shelf, books, series_uuid)
 
       def publish_series \
@@ -675,10 +657,8 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client = Library::V1::LibraryServiceClient.new
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   response = library_service_client.get_book(formatted_name)
 
       def get_book \
@@ -714,10 +694,8 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   library_service_client = Library::V1::LibraryServiceClient.new
+      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
       #
       #   # Iterate over all results.
       #   library_service_client.list_books(formatted_name).each do |element|
@@ -756,10 +734,8 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client = Library::V1::LibraryServiceClient.new
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   library_service_client.delete_book(formatted_name)
 
       def delete_book \
@@ -790,12 +766,9 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   Book = Google::Example::Library::V1::Book
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
-      #   book = Book.new
+      #   library_service_client = Library::V1::LibraryServiceClient.new
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   book = Google::Example::Library::V1::Book.new
       #   response = library_service_client.update_book(formatted_name, book)
 
       def update_book \
@@ -827,11 +800,9 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
-      #   formatted_other_shelf_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   library_service_client = Library::V1::LibraryServiceClient.new
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
       #   response = library_service_client.move_book(formatted_name, formatted_other_shelf_name)
 
       def move_book \
@@ -866,9 +837,7 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
+      #   library_service_client = Library::V1::LibraryServiceClient.new
       #
       #   # Iterate over all results.
       #   library_service_client.list_strings.each do |element|
@@ -905,17 +874,12 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   Alignment = Google::Example::Library::V1::SomeMessage2::SomeMessage3::Alignment
-      #   Comment = Google::Example::Library::V1::Comment
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #   Stage = Google::Example::Library::V1::Comment::Stage
-      #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client = Library::V1::LibraryServiceClient.new
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   comment = ''
-      #   stage = Stage::UNSET
-      #   alignment = Alignment::CHAR
-      #   comments_element = Comment.new(
+      #   stage = :UNSET
+      #   alignment = :CHAR
+      #   comments_element = Google::Example::Library::V1::Comment.new(
       #     comment: comment,
       #     stage: stage,
       #     alignment: alignment
@@ -947,10 +911,8 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.archived_book_path("[ARCHIVE_PATH]", "[BOOK_ID]")
+      #   library_service_client = Library::V1::LibraryServiceClient.new
+      #   formatted_name = Library::V1::LibraryServiceClient.archived_book_path("[ARCHIVE_PATH]", "[BOOK_ID]")
       #   response = library_service_client.get_book_from_archive(formatted_name)
 
       def get_book_from_archive \
@@ -977,11 +939,9 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
-      #   formatted_alt_book_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client = Library::V1::LibraryServiceClient.new
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   formatted_alt_book_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   response = library_service_client.get_book_from_anywhere(formatted_name, formatted_alt_book_name)
 
       def get_book_from_anywhere \
@@ -1010,10 +970,8 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client = Library::V1::LibraryServiceClient.new
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   index_name = "default index"
       #   index_map_item = ''
       #   index_map = { "default_key" => index_map_item }
@@ -1046,9 +1004,7 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
+      #   library_service_client = Library::V1::LibraryServiceClient.new
       #   library_service_client.stream_shelves.each do |element|
       #     # Process element.
       #   end
@@ -1073,9 +1029,7 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
+      #   library_service_client = Library::V1::LibraryServiceClient.new
       #   name = ''
       #   library_service_client.stream_books(name).each do |element|
       #     # Process element.
@@ -1111,12 +1065,9 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   DiscussBookRequest = Google::Example::Library::V1::DiscussBookRequest
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
+      #   library_service_client = Library::V1::LibraryServiceClient.new
       #   name = ''
-      #   request = DiscussBookRequest.new(name: name)
+      #   request = Google::Example::Library::V1::DiscussBookRequest.new(name: name)
       #   requests = [request]
       #   library_service_client.discuss_book(requests).each do |element|
       #     # Process element.
@@ -1145,12 +1096,9 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   DiscussBookRequest = Google::Example::Library::V1::DiscussBookRequest
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
+      #   library_service_client = Library::V1::LibraryServiceClient.new
       #   name = ''
-      #   request = DiscussBookRequest.new(name: name)
+      #   request = Google::Example::Library::V1::DiscussBookRequest.new(name: name)
       #   requests = [request]
       #   response = library_service_client.monolog_about_book(requests)
 
@@ -1178,9 +1126,7 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
+      #   library_service_client = Library::V1::LibraryServiceClient.new
       #   names_element = ''
       #   names = [names_element]
       #   shelves = []
@@ -1227,10 +1173,8 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_resource = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client = Library::V1::LibraryServiceClient.new
+      #   formatted_resource = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   tag = ''
       #   response = library_service_client.add_tag(formatted_resource, tag)
 
@@ -1261,10 +1205,8 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_resource = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client = Library::V1::LibraryServiceClient.new
+      #   formatted_resource = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   label = ''
       #   response = library_service_client.add_label(formatted_resource, label)
 
@@ -1291,10 +1233,8 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client = Library::V1::LibraryServiceClient.new
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #
       #   # Register a callback during the method call.
       #   operation = library_service_client.get_big_book(formatted_name) do |op|
@@ -1352,10 +1292,8 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client = Library::V1::LibraryServiceClient.new
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #
       #   # Register a callback during the method call.
       #   operation = library_service_client.get_big_nothing(formatted_name) do |op|
@@ -1465,20 +1403,16 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   InnerEnum = Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerEnum
-      #   InnerMessage = Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
+      #   library_service_client = Library::V1::LibraryServiceClient.new
       #   required_singular_int32 = 0
       #   required_singular_int64 = 0
       #   required_singular_float = 0.0
       #   required_singular_double = 0.0
       #   required_singular_bool = false
-      #   required_singular_enum = InnerEnum::ZERO
+      #   required_singular_enum = :ZERO
       #   required_singular_string = ''
       #   required_singular_bytes = ''
-      #   required_singular_message = InnerMessage.new
+      #   required_singular_message = Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage.new
       #   required_singular_resource_name = ''
       #   required_singular_resource_name_oneof = ''
       #   required_singular_fixed32 = 0

--- a/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
@@ -430,11 +430,8 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #   Shelf = Google::Example::Library::V1::Shelf
-      #
-      #   library_service_client = LibraryServiceClient.new
-      #   shelf = Shelf.new
+      #   library_service_client = Library::V1::LibraryServiceClient.new
+      #   shelf = Google::Example::Library::V1::Shelf.new
       #   response = library_service_client.create_shelf(shelf)
 
       def create_shelf \
@@ -463,10 +460,8 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   library_service_client = Library::V1::LibraryServiceClient.new
+      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
       #   options_ = ''
       #   response = library_service_client.get_shelf(formatted_name, options_)
 
@@ -499,9 +494,7 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
+      #   library_service_client = Library::V1::LibraryServiceClient.new
       #
       #   # Iterate over all results.
       #   library_service_client.list_shelves.each do |element|
@@ -532,10 +525,8 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   library_service_client = Library::V1::LibraryServiceClient.new
+      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
       #   library_service_client.delete_shelf(formatted_name)
 
       def delete_shelf \
@@ -564,11 +555,9 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
-      #   formatted_other_shelf_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   library_service_client = Library::V1::LibraryServiceClient.new
+      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
       #   response = library_service_client.merge_shelves(formatted_name, formatted_other_shelf_name)
 
       def merge_shelves \
@@ -596,12 +585,9 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   Book = Google::Example::Library::V1::Book
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
-      #   book = Book.new
+      #   library_service_client = Library::V1::LibraryServiceClient.new
+      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   book = Google::Example::Library::V1::Book.new
       #   response = library_service_client.create_book(formatted_name, book)
 
       def create_book \
@@ -635,15 +621,11 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #   SeriesUuid = Google::Example::Library::V1::SeriesUuid
-      #   Shelf = Google::Example::Library::V1::Shelf
-      #
-      #   library_service_client = LibraryServiceClient.new
-      #   shelf = Shelf.new
+      #   library_service_client = Library::V1::LibraryServiceClient.new
+      #   shelf = Google::Example::Library::V1::Shelf.new
       #   books = []
       #   series_string = "foobar"
-      #   series_uuid = SeriesUuid.new(series_string: series_string)
+      #   series_uuid = Google::Example::Library::V1::SeriesUuid.new(series_string: series_string)
       #   response = library_service_client.publish_series(shelf, books, series_uuid)
 
       def publish_series \
@@ -675,10 +657,8 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client = Library::V1::LibraryServiceClient.new
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   response = library_service_client.get_book(formatted_name)
 
       def get_book \
@@ -714,10 +694,8 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   library_service_client = Library::V1::LibraryServiceClient.new
+      #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
       #
       #   # Iterate over all results.
       #   library_service_client.list_books(formatted_name).each do |element|
@@ -756,10 +734,8 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client = Library::V1::LibraryServiceClient.new
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   library_service_client.delete_book(formatted_name)
 
       def delete_book \
@@ -790,12 +766,9 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   Book = Google::Example::Library::V1::Book
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
-      #   book = Book.new
+      #   library_service_client = Library::V1::LibraryServiceClient.new
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   book = Google::Example::Library::V1::Book.new
       #   response = library_service_client.update_book(formatted_name, book)
 
       def update_book \
@@ -827,11 +800,9 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
-      #   formatted_other_shelf_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
+      #   library_service_client = Library::V1::LibraryServiceClient.new
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
       #   response = library_service_client.move_book(formatted_name, formatted_other_shelf_name)
 
       def move_book \
@@ -866,9 +837,7 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
+      #   library_service_client = Library::V1::LibraryServiceClient.new
       #
       #   # Iterate over all results.
       #   library_service_client.list_strings.each do |element|
@@ -905,17 +874,12 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   Alignment = Google::Example::Library::V1::SomeMessage2::SomeMessage3::Alignment
-      #   Comment = Google::Example::Library::V1::Comment
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #   Stage = Google::Example::Library::V1::Comment::Stage
-      #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client = Library::V1::LibraryServiceClient.new
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   comment = ''
-      #   stage = Stage::UNSET
-      #   alignment = Alignment::CHAR
-      #   comments_element = Comment.new(
+      #   stage = :UNSET
+      #   alignment = :CHAR
+      #   comments_element = Google::Example::Library::V1::Comment.new(
       #     comment: comment,
       #     stage: stage,
       #     alignment: alignment
@@ -947,10 +911,8 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.archived_book_path("[ARCHIVE_PATH]", "[BOOK_ID]")
+      #   library_service_client = Library::V1::LibraryServiceClient.new
+      #   formatted_name = Library::V1::LibraryServiceClient.archived_book_path("[ARCHIVE_PATH]", "[BOOK_ID]")
       #   response = library_service_client.get_book_from_archive(formatted_name)
 
       def get_book_from_archive \
@@ -977,11 +939,9 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
-      #   formatted_alt_book_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client = Library::V1::LibraryServiceClient.new
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   formatted_alt_book_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   response = library_service_client.get_book_from_anywhere(formatted_name, formatted_alt_book_name)
 
       def get_book_from_anywhere \
@@ -1010,10 +970,8 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client = Library::V1::LibraryServiceClient.new
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   index_name = "default index"
       #   index_map_item = ''
       #   index_map = { "default_key" => index_map_item }
@@ -1046,9 +1004,7 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
+      #   library_service_client = Library::V1::LibraryServiceClient.new
       #   library_service_client.stream_shelves.each do |element|
       #     # Process element.
       #   end
@@ -1073,9 +1029,7 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
+      #   library_service_client = Library::V1::LibraryServiceClient.new
       #   name = ''
       #   library_service_client.stream_books(name).each do |element|
       #     # Process element.
@@ -1111,12 +1065,9 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   DiscussBookRequest = Google::Example::Library::V1::DiscussBookRequest
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
+      #   library_service_client = Library::V1::LibraryServiceClient.new
       #   name = ''
-      #   request = DiscussBookRequest.new(name: name)
+      #   request = Google::Example::Library::V1::DiscussBookRequest.new(name: name)
       #   requests = [request]
       #   library_service_client.discuss_book(requests).each do |element|
       #     # Process element.
@@ -1145,12 +1096,9 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   DiscussBookRequest = Google::Example::Library::V1::DiscussBookRequest
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
+      #   library_service_client = Library::V1::LibraryServiceClient.new
       #   name = ''
-      #   request = DiscussBookRequest.new(name: name)
+      #   request = Google::Example::Library::V1::DiscussBookRequest.new(name: name)
       #   requests = [request]
       #   response = library_service_client.monolog_about_book(requests)
 
@@ -1178,9 +1126,7 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
+      #   library_service_client = Library::V1::LibraryServiceClient.new
       #   names_element = ''
       #   names = [names_element]
       #   shelves = []
@@ -1227,10 +1173,8 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_resource = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client = Library::V1::LibraryServiceClient.new
+      #   formatted_resource = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   tag = ''
       #   response = library_service_client.add_tag(formatted_resource, tag)
 
@@ -1261,10 +1205,8 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_resource = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client = Library::V1::LibraryServiceClient.new
+      #   formatted_resource = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #   label = ''
       #   response = library_service_client.add_label(formatted_resource, label)
 
@@ -1291,10 +1233,8 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client = Library::V1::LibraryServiceClient.new
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #
       #   # Register a callback during the method call.
       #   operation = library_service_client.get_big_book(formatted_name) do |op|
@@ -1352,10 +1292,8 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
-      #   formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      #   library_service_client = Library::V1::LibraryServiceClient.new
+      #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       #
       #   # Register a callback during the method call.
       #   operation = library_service_client.get_big_nothing(formatted_name) do |op|
@@ -1465,20 +1403,16 @@ module Library
       # @example
       #   require "library/v1"
       #
-      #   InnerEnum = Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerEnum
-      #   InnerMessage = Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage
-      #   LibraryServiceClient = Library::V1::LibraryServiceClient
-      #
-      #   library_service_client = LibraryServiceClient.new
+      #   library_service_client = Library::V1::LibraryServiceClient.new
       #   required_singular_int32 = 0
       #   required_singular_int64 = 0
       #   required_singular_float = 0.0
       #   required_singular_double = 0.0
       #   required_singular_bool = false
-      #   required_singular_enum = InnerEnum::ZERO
+      #   required_singular_enum = :ZERO
       #   required_singular_string = ''
       #   required_singular_bytes = ''
-      #   required_singular_message = InnerMessage.new
+      #   required_singular_message = Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage.new
       #   required_singular_resource_name = ''
       #   required_singular_resource_name_oneof = ''
       #   required_singular_fixed32 = 0

--- a/src/test/java/com/google/api/codegen/testdata/ruby_smoke_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_smoke_test_library.baseline
@@ -26,16 +26,10 @@ describe "LibraryServiceSmokeTest" do
     end
     project_id = ENV["SMOKE_TEST_PROJECT"].freeze
 
-    Book = Google::Example::Library::V1::Book
-    FieldMask = Google::Protobuf::FieldMask
-    LibraryServiceClient = Library::V1::LibraryServiceClient
-    Rating = Google::Example::Library::V1::Book::Rating
-    UpdateBookRequest = Google::Example::Library::V1::UpdateBookRequest
-
-    library_service_client = LibraryServiceClient.new
-    formatted_name = LibraryServiceClient.book_path("testShelf-" + Time.new.to_i.to_s, project_id)
-    rating = Rating::GOOD
-    book = Book.new(rating: rating)
+    library_service_client = Library::V1::LibraryServiceClient.new
+    formatted_name = Library::V1::LibraryServiceClient.book_path("testShelf-" + Time.new.to_i.to_s, project_id)
+    rating = :GOOD
+    book = Google::Example::Library::V1::Book.new(rating: rating)
     response = library_service_client.update_book(formatted_name, book)
   end
 end

--- a/src/test/java/com/google/api/codegen/testdata/ruby_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_test_library.baseline
@@ -57,20 +57,17 @@ end
 describe Library::V1::LibraryServiceClient do
 
   describe 'create_shelf' do
-    custom_error = CustomTestError.new "Custom test error for LibraryServiceClient#create_shelf."
-
-    LibraryServiceClient = Library::V1::LibraryServiceClient
-    Shelf = Google::Example::Library::V1::Shelf
+    custom_error = CustomTestError.new "Custom test error for Library::V1::LibraryServiceClient#create_shelf."
 
     it 'invokes create_shelf without error' do
       # Create request parameters
-      shelf = Shelf.new
+      shelf = Google::Example::Library::V1::Shelf.new
 
       # Create expected grpc response
       name = "name3373707"
       theme = "theme110327241"
       internal_theme = "internalTheme792518087"
-      expected_response = Shelf.new(
+      expected_response = Google::Example::Library::V1::Shelf.new(
         name: name,
         theme: theme,
         internal_theme: internal_theme
@@ -84,7 +81,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:create_shelf, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         response = client.create_shelf(shelf)
@@ -96,7 +93,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes create_shelf with error' do
       # Create request parameters
-      shelf = Shelf.new
+      shelf = Google::Example::Library::V1::Shelf.new
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -106,7 +103,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:create_shelf, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         err = assert_raises Google::Gax::GaxError do
@@ -120,21 +117,18 @@ describe Library::V1::LibraryServiceClient do
   end
 
   describe 'get_shelf' do
-    custom_error = CustomTestError.new "Custom test error for LibraryServiceClient#get_shelf."
-
-    LibraryServiceClient = Library::V1::LibraryServiceClient
-    Shelf = Google::Example::Library::V1::Shelf
+    custom_error = CustomTestError.new "Custom test error for Library::V1::LibraryServiceClient#get_shelf."
 
     it 'invokes get_shelf without error' do
       # Create request parameters
-      formatted_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
       options_ = ''
 
       # Create expected grpc response
       name_2 = "name2-1052831874"
       theme = "theme110327241"
       internal_theme = "internalTheme792518087"
-      expected_response = Shelf.new(
+      expected_response = Google::Example::Library::V1::Shelf.new(
         name: name_2,
         theme: theme,
         internal_theme: internal_theme
@@ -149,7 +143,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:get_shelf, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         response = client.get_shelf(formatted_name, options_)
@@ -161,7 +155,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_shelf with error' do
       # Create request parameters
-      formatted_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
       options_ = ''
 
       # Mock Grpc layer
@@ -173,7 +167,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:get_shelf, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         err = assert_raises Google::Gax::GaxError do
@@ -187,18 +181,14 @@ describe Library::V1::LibraryServiceClient do
   end
 
   describe 'list_shelves' do
-    custom_error = CustomTestError.new "Custom test error for LibraryServiceClient#list_shelves."
-
-    LibraryServiceClient = Library::V1::LibraryServiceClient
-    ListShelvesResponse = Google::Example::Library::V1::ListShelvesResponse
-    Shelf = Google::Example::Library::V1::Shelf
+    custom_error = CustomTestError.new "Custom test error for Library::V1::LibraryServiceClient#list_shelves."
 
     it 'invokes list_shelves without error' do
       # Create expected grpc response
       next_page_token = ""
-      shelves_element = Shelf.new
+      shelves_element = Google::Example::Library::V1::Shelf.new
       shelves = [shelves_element]
-      expected_response = ListShelvesResponse.new(next_page_token: next_page_token, shelves: shelves)
+      expected_response = Google::Example::Library::V1::ListShelvesResponse.new(next_page_token: next_page_token, shelves: shelves)
 
       # Mock Grpc layer
       mock_method = proc do
@@ -207,7 +197,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:list_shelves, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         response = client.list_shelves
@@ -228,7 +218,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:list_shelves, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         err = assert_raises Google::Gax::GaxError do
@@ -242,14 +232,11 @@ describe Library::V1::LibraryServiceClient do
   end
 
   describe 'delete_shelf' do
-    custom_error = CustomTestError.new "Custom test error for LibraryServiceClient#delete_shelf."
-
-    Empty = Google::Protobuf::Empty
-    LibraryServiceClient = Library::V1::LibraryServiceClient
+    custom_error = CustomTestError.new "Custom test error for Library::V1::LibraryServiceClient#delete_shelf."
 
     it 'invokes delete_shelf without error' do
       # Create request parameters
-      formatted_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -259,7 +246,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:delete_shelf, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         response = client.delete_shelf(formatted_name)
@@ -271,7 +258,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes delete_shelf with error' do
       # Create request parameters
-      formatted_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -281,7 +268,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:delete_shelf, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         err = assert_raises Google::Gax::GaxError do
@@ -295,21 +282,18 @@ describe Library::V1::LibraryServiceClient do
   end
 
   describe 'merge_shelves' do
-    custom_error = CustomTestError.new "Custom test error for LibraryServiceClient#merge_shelves."
-
-    LibraryServiceClient = Library::V1::LibraryServiceClient
-    Shelf = Google::Example::Library::V1::Shelf
+    custom_error = CustomTestError.new "Custom test error for Library::V1::LibraryServiceClient#merge_shelves."
 
     it 'invokes merge_shelves without error' do
       # Create request parameters
-      formatted_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
-      formatted_other_shelf_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
 
       # Create expected grpc response
       name_2 = "name2-1052831874"
       theme = "theme110327241"
       internal_theme = "internalTheme792518087"
-      expected_response = Shelf.new(
+      expected_response = Google::Example::Library::V1::Shelf.new(
         name: name_2,
         theme: theme,
         internal_theme: internal_theme
@@ -324,7 +308,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:merge_shelves, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         response = client.merge_shelves(formatted_name, formatted_other_shelf_name)
@@ -336,8 +320,8 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes merge_shelves with error' do
       # Create request parameters
-      formatted_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
-      formatted_other_shelf_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -348,7 +332,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:merge_shelves, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         err = assert_raises Google::Gax::GaxError do
@@ -362,22 +346,19 @@ describe Library::V1::LibraryServiceClient do
   end
 
   describe 'create_book' do
-    custom_error = CustomTestError.new "Custom test error for LibraryServiceClient#create_book."
-
-    Book = Google::Example::Library::V1::Book
-    LibraryServiceClient = Library::V1::LibraryServiceClient
+    custom_error = CustomTestError.new "Custom test error for Library::V1::LibraryServiceClient#create_book."
 
     it 'invokes create_book without error' do
       # Create request parameters
-      formatted_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
-      book = Book.new
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      book = Google::Example::Library::V1::Book.new
 
       # Create expected grpc response
       name_2 = "name2-1052831874"
       author = "author-1406328437"
       title = "title110371416"
       read = true
-      expected_response = Book.new(
+      expected_response = Google::Example::Library::V1::Book.new(
         name: name_2,
         author: author,
         title: title,
@@ -393,7 +374,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:create_book, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         response = client.create_book(formatted_name, book)
@@ -405,8 +386,8 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes create_book with error' do
       # Create request parameters
-      formatted_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
-      book = Book.new
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
+      book = Google::Example::Library::V1::Book.new
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -417,7 +398,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:create_book, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         err = assert_raises Google::Gax::GaxError do
@@ -431,24 +412,19 @@ describe Library::V1::LibraryServiceClient do
   end
 
   describe 'publish_series' do
-    custom_error = CustomTestError.new "Custom test error for LibraryServiceClient#publish_series."
-
-    LibraryServiceClient = Library::V1::LibraryServiceClient
-    PublishSeriesResponse = Google::Example::Library::V1::PublishSeriesResponse
-    SeriesUuid = Google::Example::Library::V1::SeriesUuid
-    Shelf = Google::Example::Library::V1::Shelf
+    custom_error = CustomTestError.new "Custom test error for Library::V1::LibraryServiceClient#publish_series."
 
     it 'invokes publish_series without error' do
       # Create request parameters
-      shelf = Shelf.new
+      shelf = Google::Example::Library::V1::Shelf.new
       books = []
       series_string = "foobar"
-      series_uuid = SeriesUuid.new(series_string: series_string)
+      series_uuid = Google::Example::Library::V1::SeriesUuid.new(series_string: series_string)
 
       # Create expected grpc response
       book_names_element = "bookNamesElement1491670575"
       book_names = [book_names_element]
-      expected_response = PublishSeriesResponse.new(book_names: book_names)
+      expected_response = Google::Example::Library::V1::PublishSeriesResponse.new(book_names: book_names)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -460,7 +436,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:publish_series, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         response = client.publish_series(
@@ -476,10 +452,10 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes publish_series with error' do
       # Create request parameters
-      shelf = Shelf.new
+      shelf = Google::Example::Library::V1::Shelf.new
       books = []
       series_string = "foobar"
-      series_uuid = SeriesUuid.new(series_string: series_string)
+      series_uuid = Google::Example::Library::V1::SeriesUuid.new(series_string: series_string)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -491,7 +467,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:publish_series, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         err = assert_raises Google::Gax::GaxError do
@@ -509,21 +485,18 @@ describe Library::V1::LibraryServiceClient do
   end
 
   describe 'get_book' do
-    custom_error = CustomTestError.new "Custom test error for LibraryServiceClient#get_book."
-
-    Book = Google::Example::Library::V1::Book
-    LibraryServiceClient = Library::V1::LibraryServiceClient
+    custom_error = CustomTestError.new "Custom test error for Library::V1::LibraryServiceClient#get_book."
 
     it 'invokes get_book without error' do
       # Create request parameters
-      formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
 
       # Create expected grpc response
       name_2 = "name2-1052831874"
       author = "author-1406328437"
       title = "title110371416"
       read = true
-      expected_response = Book.new(
+      expected_response = Google::Example::Library::V1::Book.new(
         name: name_2,
         author: author,
         title: title,
@@ -538,7 +511,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:get_book, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         response = client.get_book(formatted_name)
@@ -550,7 +523,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_book with error' do
       # Create request parameters
-      formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -560,7 +533,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:get_book, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         err = assert_raises Google::Gax::GaxError do
@@ -574,21 +547,17 @@ describe Library::V1::LibraryServiceClient do
   end
 
   describe 'list_books' do
-    custom_error = CustomTestError.new "Custom test error for LibraryServiceClient#list_books."
-
-    Book = Google::Example::Library::V1::Book
-    LibraryServiceClient = Library::V1::LibraryServiceClient
-    ListBooksResponse = Google::Example::Library::V1::ListBooksResponse
+    custom_error = CustomTestError.new "Custom test error for Library::V1::LibraryServiceClient#list_books."
 
     it 'invokes list_books without error' do
       # Create request parameters
-      formatted_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
 
       # Create expected grpc response
       next_page_token = ""
-      books_element = Book.new
+      books_element = Google::Example::Library::V1::Book.new
       books = [books_element]
-      expected_response = ListBooksResponse.new(next_page_token: next_page_token, books: books)
+      expected_response = Google::Example::Library::V1::ListBooksResponse.new(next_page_token: next_page_token, books: books)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -598,7 +567,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:list_books, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         response = client.list_books(formatted_name)
@@ -613,7 +582,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes list_books with error' do
       # Create request parameters
-      formatted_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -623,7 +592,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:list_books, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         err = assert_raises Google::Gax::GaxError do
@@ -637,14 +606,11 @@ describe Library::V1::LibraryServiceClient do
   end
 
   describe 'delete_book' do
-    custom_error = CustomTestError.new "Custom test error for LibraryServiceClient#delete_book."
-
-    Empty = Google::Protobuf::Empty
-    LibraryServiceClient = Library::V1::LibraryServiceClient
+    custom_error = CustomTestError.new "Custom test error for Library::V1::LibraryServiceClient#delete_book."
 
     it 'invokes delete_book without error' do
       # Create request parameters
-      formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -654,7 +620,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:delete_book, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         response = client.delete_book(formatted_name)
@@ -666,7 +632,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes delete_book with error' do
       # Create request parameters
-      formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -676,7 +642,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:delete_book, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         err = assert_raises Google::Gax::GaxError do
@@ -690,22 +656,19 @@ describe Library::V1::LibraryServiceClient do
   end
 
   describe 'update_book' do
-    custom_error = CustomTestError.new "Custom test error for LibraryServiceClient#update_book."
-
-    Book = Google::Example::Library::V1::Book
-    LibraryServiceClient = Library::V1::LibraryServiceClient
+    custom_error = CustomTestError.new "Custom test error for Library::V1::LibraryServiceClient#update_book."
 
     it 'invokes update_book without error' do
       # Create request parameters
-      formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
-      book = Book.new
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      book = Google::Example::Library::V1::Book.new
 
       # Create expected grpc response
       name_2 = "name2-1052831874"
       author = "author-1406328437"
       title = "title110371416"
       read = true
-      expected_response = Book.new(
+      expected_response = Google::Example::Library::V1::Book.new(
         name: name_2,
         author: author,
         title: title,
@@ -721,7 +684,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:update_book, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         response = client.update_book(formatted_name, book)
@@ -733,8 +696,8 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes update_book with error' do
       # Create request parameters
-      formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
-      book = Book.new
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      book = Google::Example::Library::V1::Book.new
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -745,7 +708,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:update_book, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         err = assert_raises Google::Gax::GaxError do
@@ -759,22 +722,19 @@ describe Library::V1::LibraryServiceClient do
   end
 
   describe 'move_book' do
-    custom_error = CustomTestError.new "Custom test error for LibraryServiceClient#move_book."
-
-    Book = Google::Example::Library::V1::Book
-    LibraryServiceClient = Library::V1::LibraryServiceClient
+    custom_error = CustomTestError.new "Custom test error for Library::V1::LibraryServiceClient#move_book."
 
     it 'invokes move_book without error' do
       # Create request parameters
-      formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
-      formatted_other_shelf_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
 
       # Create expected grpc response
       name_2 = "name2-1052831874"
       author = "author-1406328437"
       title = "title110371416"
       read = true
-      expected_response = Book.new(
+      expected_response = Google::Example::Library::V1::Book.new(
         name: name_2,
         author: author,
         title: title,
@@ -790,7 +750,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:move_book, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         response = client.move_book(formatted_name, formatted_other_shelf_name)
@@ -802,8 +762,8 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes move_book with error' do
       # Create request parameters
-      formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
-      formatted_other_shelf_name = LibraryServiceClient.shelf_path("[SHELF_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_other_shelf_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -814,7 +774,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:move_book, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         err = assert_raises Google::Gax::GaxError do
@@ -828,17 +788,14 @@ describe Library::V1::LibraryServiceClient do
   end
 
   describe 'list_strings' do
-    custom_error = CustomTestError.new "Custom test error for LibraryServiceClient#list_strings."
-
-    LibraryServiceClient = Library::V1::LibraryServiceClient
-    ListStringsResponse = Google::Example::Library::V1::ListStringsResponse
+    custom_error = CustomTestError.new "Custom test error for Library::V1::LibraryServiceClient#list_strings."
 
     it 'invokes list_strings without error' do
       # Create expected grpc response
       next_page_token = ""
       strings_element = "stringsElement474465855"
       strings = [strings_element]
-      expected_response = ListStringsResponse.new(next_page_token: next_page_token, strings: strings)
+      expected_response = Google::Example::Library::V1::ListStringsResponse.new(next_page_token: next_page_token, strings: strings)
 
       # Mock Grpc layer
       mock_method = proc do
@@ -847,7 +804,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:list_strings, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         response = client.list_strings
@@ -868,7 +825,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:list_strings, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         err = assert_raises Google::Gax::GaxError do
@@ -882,21 +839,15 @@ describe Library::V1::LibraryServiceClient do
   end
 
   describe 'add_comments' do
-    custom_error = CustomTestError.new "Custom test error for LibraryServiceClient#add_comments."
-
-    Alignment = Google::Example::Library::V1::SomeMessage2::SomeMessage3::Alignment
-    Comment = Google::Example::Library::V1::Comment
-    Empty = Google::Protobuf::Empty
-    LibraryServiceClient = Library::V1::LibraryServiceClient
-    Stage = Google::Example::Library::V1::Comment::Stage
+    custom_error = CustomTestError.new "Custom test error for Library::V1::LibraryServiceClient#add_comments."
 
     it 'invokes add_comments without error' do
       # Create request parameters
-      formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       comment = ''
-      stage = Stage::UNSET
-      alignment = Alignment::CHAR
-      comments_element = Comment.new(
+      stage = :UNSET
+      alignment = :CHAR
+      comments_element = Google::Example::Library::V1::Comment.new(
         comment: comment,
         stage: stage,
         alignment: alignment
@@ -912,7 +863,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:add_comments, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         response = client.add_comments(formatted_name, comments)
@@ -924,11 +875,11 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes add_comments with error' do
       # Create request parameters
-      formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       comment = ''
-      stage = Stage::UNSET
-      alignment = Alignment::CHAR
-      comments_element = Comment.new(
+      stage = :UNSET
+      alignment = :CHAR
+      comments_element = Google::Example::Library::V1::Comment.new(
         comment: comment,
         stage: stage,
         alignment: alignment
@@ -944,7 +895,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:add_comments, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         err = assert_raises Google::Gax::GaxError do
@@ -958,21 +909,18 @@ describe Library::V1::LibraryServiceClient do
   end
 
   describe 'get_book_from_archive' do
-    custom_error = CustomTestError.new "Custom test error for LibraryServiceClient#get_book_from_archive."
-
-    BookFromArchive = Google::Example::Library::V1::BookFromArchive
-    LibraryServiceClient = Library::V1::LibraryServiceClient
+    custom_error = CustomTestError.new "Custom test error for Library::V1::LibraryServiceClient#get_book_from_archive."
 
     it 'invokes get_book_from_archive without error' do
       # Create request parameters
-      formatted_name = LibraryServiceClient.archived_book_path("[ARCHIVE_PATH]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.archived_book_path("[ARCHIVE_PATH]", "[BOOK_ID]")
 
       # Create expected grpc response
       name_2 = "name2-1052831874"
       author = "author-1406328437"
       title = "title110371416"
       read = true
-      expected_response = BookFromArchive.new(
+      expected_response = Google::Example::Library::V1::BookFromArchive.new(
         name: name_2,
         author: author,
         title: title,
@@ -987,7 +935,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:get_book_from_archive, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         response = client.get_book_from_archive(formatted_name)
@@ -999,7 +947,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_book_from_archive with error' do
       # Create request parameters
-      formatted_name = LibraryServiceClient.archived_book_path("[ARCHIVE_PATH]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.archived_book_path("[ARCHIVE_PATH]", "[BOOK_ID]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -1009,7 +957,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:get_book_from_archive, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         err = assert_raises Google::Gax::GaxError do
@@ -1023,22 +971,19 @@ describe Library::V1::LibraryServiceClient do
   end
 
   describe 'get_book_from_anywhere' do
-    custom_error = CustomTestError.new "Custom test error for LibraryServiceClient#get_book_from_anywhere."
-
-    BookFromAnywhere = Google::Example::Library::V1::BookFromAnywhere
-    LibraryServiceClient = Library::V1::LibraryServiceClient
+    custom_error = CustomTestError.new "Custom test error for Library::V1::LibraryServiceClient#get_book_from_anywhere."
 
     it 'invokes get_book_from_anywhere without error' do
       # Create request parameters
-      formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
-      formatted_alt_book_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_alt_book_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
 
       # Create expected grpc response
       name_2 = "name2-1052831874"
       author = "author-1406328437"
       title = "title110371416"
       read = true
-      expected_response = BookFromAnywhere.new(
+      expected_response = Google::Example::Library::V1::BookFromAnywhere.new(
         name: name_2,
         author: author,
         title: title,
@@ -1054,7 +999,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:get_book_from_anywhere, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         response = client.get_book_from_anywhere(formatted_name, formatted_alt_book_name)
@@ -1066,8 +1011,8 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_book_from_anywhere with error' do
       # Create request parameters
-      formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
-      formatted_alt_book_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_alt_book_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -1078,7 +1023,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:get_book_from_anywhere, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         err = assert_raises Google::Gax::GaxError do
@@ -1092,14 +1037,11 @@ describe Library::V1::LibraryServiceClient do
   end
 
   describe 'update_book_index' do
-    custom_error = CustomTestError.new "Custom test error for LibraryServiceClient#update_book_index."
-
-    Empty = Google::Protobuf::Empty
-    LibraryServiceClient = Library::V1::LibraryServiceClient
+    custom_error = CustomTestError.new "Custom test error for Library::V1::LibraryServiceClient#update_book_index."
 
     it 'invokes update_book_index without error' do
       # Create request parameters
-      formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       index_name = "default index"
       index_map_item = ''
       index_map = { "default_key" => index_map_item }
@@ -1114,7 +1056,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:update_book_index, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         response = client.update_book_index(
@@ -1130,7 +1072,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes update_book_index with error' do
       # Create request parameters
-      formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       index_name = "default index"
       index_map_item = ''
       index_map = { "default_key" => index_map_item }
@@ -1145,7 +1087,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:update_book_index, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         err = assert_raises Google::Gax::GaxError do
@@ -1163,18 +1105,14 @@ describe Library::V1::LibraryServiceClient do
   end
 
   describe 'stream_shelves' do
-    custom_error = CustomTestError.new "Custom test error for LibraryServiceClient#stream_shelves."
-
-    LibraryServiceClient = Library::V1::LibraryServiceClient
-    StreamShelvesRequest = Google::Example::Library::V1::StreamShelvesRequest
-    StreamShelvesResponse = Google::Example::Library::V1::StreamShelvesResponse
+    custom_error = CustomTestError.new "Custom test error for Library::V1::LibraryServiceClient#stream_shelves."
 
     it 'invokes stream_shelves without error' do
       # Create request parameters
-      request = StreamShelvesRequest.new
+      request = Google::Example::Library::V1::StreamShelvesRequest.new
 
       # Create expected grpc response
-      expected_response = StreamShelvesResponse.new
+      expected_response = Google::Example::Library::V1::StreamShelvesResponse.new
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -1183,7 +1121,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:stream_shelves, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         response = client.stream_shelves(request)
@@ -1196,7 +1134,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes stream_shelves with error' do
       # Create request parameters
-      request = StreamShelvesRequest.new
+      request = Google::Example::Library::V1::StreamShelvesRequest.new
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -1205,7 +1143,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:stream_shelves, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         err = assert_raises Google::Gax::GaxError do
@@ -1219,23 +1157,19 @@ describe Library::V1::LibraryServiceClient do
   end
 
   describe 'stream_books' do
-    custom_error = CustomTestError.new "Custom test error for LibraryServiceClient#stream_books."
-
-    Book = Google::Example::Library::V1::Book
-    LibraryServiceClient = Library::V1::LibraryServiceClient
-    StreamBooksRequest = Google::Example::Library::V1::StreamBooksRequest
+    custom_error = CustomTestError.new "Custom test error for Library::V1::LibraryServiceClient#stream_books."
 
     it 'invokes stream_books without error' do
       # Create request parameters
       name = ''
-      request = StreamBooksRequest.new(name: name)
+      request = Google::Example::Library::V1::StreamBooksRequest.new(name: name)
 
       # Create expected grpc response
       name_2 = "name2-1052831874"
       author = "author-1406328437"
       title = "title110371416"
       read = true
-      expected_response = Book.new(
+      expected_response = Google::Example::Library::V1::Book.new(
         name: name_2,
         author: author,
         title: title,
@@ -1250,7 +1184,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:stream_books, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         response = client.stream_books(request)
@@ -1264,7 +1198,7 @@ describe Library::V1::LibraryServiceClient do
     it 'invokes stream_books with error' do
       # Create request parameters
       name = ''
-      request = StreamBooksRequest.new(name: name)
+      request = Google::Example::Library::V1::StreamBooksRequest.new(name: name)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -1274,7 +1208,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:stream_books, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         err = assert_raises Google::Gax::GaxError do
@@ -1288,21 +1222,17 @@ describe Library::V1::LibraryServiceClient do
   end
 
   describe 'discuss_book' do
-    custom_error = CustomTestError.new "Custom test error for LibraryServiceClient#discuss_book."
-
-    Comment = Google::Example::Library::V1::Comment
-    DiscussBookRequest = Google::Example::Library::V1::DiscussBookRequest
-    LibraryServiceClient = Library::V1::LibraryServiceClient
+    custom_error = CustomTestError.new "Custom test error for Library::V1::LibraryServiceClient#discuss_book."
 
     it 'invokes discuss_book without error' do
       # Create request parameters
       name = ''
-      request = DiscussBookRequest.new(name: name)
+      request = Google::Example::Library::V1::DiscussBookRequest.new(name: name)
 
       # Create expected grpc response
       user_name = "userName339340927"
       comment = "95"
-      expected_response = Comment.new(user_name: user_name, comment: comment)
+      expected_response = Google::Example::Library::V1::Comment.new(user_name: user_name, comment: comment)
 
       # Mock Grpc layer
       mock_method = proc do |requests|
@@ -1313,7 +1243,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:discuss_book, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         response = client.discuss_book([request])
@@ -1327,7 +1257,7 @@ describe Library::V1::LibraryServiceClient do
     it 'invokes discuss_book with error' do
       # Create request parameters
       name = ''
-      request = DiscussBookRequest.new(name: name)
+      request = Google::Example::Library::V1::DiscussBookRequest.new(name: name)
 
       # Mock Grpc layer
       mock_method = proc do |requests|
@@ -1338,7 +1268,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:discuss_book, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         err = assert_raises Google::Gax::GaxError do
@@ -1352,21 +1282,17 @@ describe Library::V1::LibraryServiceClient do
   end
 
   describe 'monolog_about_book' do
-    custom_error = CustomTestError.new "Custom test error for LibraryServiceClient#monolog_about_book."
-
-    Comment = Google::Example::Library::V1::Comment
-    DiscussBookRequest = Google::Example::Library::V1::DiscussBookRequest
-    LibraryServiceClient = Library::V1::LibraryServiceClient
+    custom_error = CustomTestError.new "Custom test error for Library::V1::LibraryServiceClient#monolog_about_book."
 
     it 'invokes monolog_about_book without error' do
       # Create request parameters
       name = ''
-      request = DiscussBookRequest.new(name: name)
+      request = Google::Example::Library::V1::DiscussBookRequest.new(name: name)
 
       # Create expected grpc response
       user_name = "userName339340927"
       comment = "95"
-      expected_response = Comment.new(user_name: user_name, comment: comment)
+      expected_response = Google::Example::Library::V1::Comment.new(user_name: user_name, comment: comment)
 
       # Mock Grpc layer
       mock_method = proc do |requests|
@@ -1377,7 +1303,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:monolog_about_book, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         response = client.monolog_about_book([request])
@@ -1390,7 +1316,7 @@ describe Library::V1::LibraryServiceClient do
     it 'invokes monolog_about_book with error' do
       # Create request parameters
       name = ''
-      request = DiscussBookRequest.new(name: name)
+      request = Google::Example::Library::V1::DiscussBookRequest.new(name: name)
 
       # Mock Grpc layer
       mock_method = proc do |requests|
@@ -1401,7 +1327,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:monolog_about_book, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         err = assert_raises Google::Gax::GaxError do
@@ -1415,10 +1341,7 @@ describe Library::V1::LibraryServiceClient do
   end
 
   describe 'find_related_books' do
-    custom_error = CustomTestError.new "Custom test error for LibraryServiceClient#find_related_books."
-
-    FindRelatedBooksResponse = Google::Example::Library::V1::FindRelatedBooksResponse
-    LibraryServiceClient = Library::V1::LibraryServiceClient
+    custom_error = CustomTestError.new "Custom test error for Library::V1::LibraryServiceClient#find_related_books."
 
     it 'invokes find_related_books without error' do
       # Create request parameters
@@ -1430,7 +1353,7 @@ describe Library::V1::LibraryServiceClient do
       next_page_token = ""
       names_element_2 = "namesElement21120252792"
       names_2 = [names_element_2]
-      expected_response = FindRelatedBooksResponse.new(next_page_token: next_page_token, names: names_2)
+      expected_response = Google::Example::Library::V1::FindRelatedBooksResponse.new(next_page_token: next_page_token, names: names_2)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -1441,7 +1364,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:find_related_books, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         response = client.find_related_books(names, shelves)
@@ -1469,7 +1392,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:find_related_books, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         err = assert_raises Google::Gax::GaxError do
@@ -1483,18 +1406,15 @@ describe Library::V1::LibraryServiceClient do
   end
 
   describe 'add_tag' do
-    custom_error = CustomTestError.new "Custom test error for LibraryServiceClient#add_tag."
-
-    AddTagResponse = Google::Tagger::V1::AddTagResponse
-    LibraryServiceClient = Library::V1::LibraryServiceClient
+    custom_error = CustomTestError.new "Custom test error for Library::V1::LibraryServiceClient#add_tag."
 
     it 'invokes add_tag without error' do
       # Create request parameters
-      formatted_resource = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_resource = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       tag = ''
 
       # Create expected grpc response
-      expected_response = AddTagResponse.new
+      expected_response = Google::Tagger::V1::AddTagResponse.new
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -1505,7 +1425,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:add_tag, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         response = client.add_tag(formatted_resource, tag)
@@ -1517,7 +1437,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes add_tag with error' do
       # Create request parameters
-      formatted_resource = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_resource = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       tag = ''
 
       # Mock Grpc layer
@@ -1529,7 +1449,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:add_tag, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         err = assert_raises Google::Gax::GaxError do
@@ -1543,18 +1463,15 @@ describe Library::V1::LibraryServiceClient do
   end
 
   describe 'add_label' do
-    custom_error = CustomTestError.new "Custom test error for LibraryServiceClient#add_label."
-
-    AddLabelResponse = Google::Tagger::V1::AddLabelResponse
-    LibraryServiceClient = Library::V1::LibraryServiceClient
+    custom_error = CustomTestError.new "Custom test error for Library::V1::LibraryServiceClient#add_label."
 
     it 'invokes add_label without error' do
       # Create request parameters
-      formatted_resource = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_resource = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       label = ''
 
       # Create expected grpc response
-      expected_response = AddLabelResponse.new
+      expected_response = Google::Tagger::V1::AddLabelResponse.new
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -1565,7 +1482,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:add_label, mock_method)
 
       Google::Tagger::V1::Labeler::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         response = client.add_label(formatted_resource, label)
@@ -1577,7 +1494,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes add_label with error' do
       # Create request parameters
-      formatted_resource = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_resource = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
       label = ''
 
       # Mock Grpc layer
@@ -1589,7 +1506,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:add_label, mock_method)
 
       Google::Tagger::V1::Labeler::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         err = assert_raises Google::Gax::GaxError do
@@ -1603,21 +1520,18 @@ describe Library::V1::LibraryServiceClient do
   end
 
   describe 'get_big_book' do
-    custom_error = CustomTestError.new "Custom test error for LibraryServiceClient#get_big_book."
-
-    Book = Google::Example::Library::V1::Book
-    LibraryServiceClient = Library::V1::LibraryServiceClient
+    custom_error = CustomTestError.new "Custom test error for Library::V1::LibraryServiceClient#get_big_book."
 
     it 'invokes get_big_book without error' do
       # Create request parameters
-      formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
 
       # Create expected grpc response
       name_2 = "name2-1052831874"
       author = "author-1406328437"
       title = "title110371416"
       read = true
-      expected_response = Book.new(
+      expected_response = Google::Example::Library::V1::Book.new(
         name: name_2,
         author: author,
         title: title,
@@ -1639,7 +1553,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:get_big_book, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         response = client.get_big_book(formatted_name)
@@ -1651,11 +1565,11 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_big_book and returns an operation error.' do
       # Create request parameters
-      formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
 
       # Create expected grpc response
       operation_error = Google::Rpc::Status.new(
-        message: 'Operation error for LibraryServiceClient#get_big_book.'
+        message: 'Operation error for Library::V1::LibraryServiceClient#get_big_book.'
       )
       operation = Google::Longrunning::Operation.new(
         name: 'operations/get_big_book_test',
@@ -1671,7 +1585,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:get_big_book, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         response = client.get_big_book(formatted_name)
@@ -1684,7 +1598,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_big_book with error' do
       # Create request parameters
-      formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -1694,7 +1608,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:get_big_book, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         err = assert_raises Google::Gax::GaxError do
@@ -1708,17 +1622,14 @@ describe Library::V1::LibraryServiceClient do
   end
 
   describe 'get_big_nothing' do
-    custom_error = CustomTestError.new "Custom test error for LibraryServiceClient#get_big_nothing."
-
-    Empty = Google::Protobuf::Empty
-    LibraryServiceClient = Library::V1::LibraryServiceClient
+    custom_error = CustomTestError.new "Custom test error for Library::V1::LibraryServiceClient#get_big_nothing."
 
     it 'invokes get_big_nothing without error' do
       # Create request parameters
-      formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
 
       # Create expected grpc response
-      expected_response = Empty.new
+      expected_response = Google::Protobuf::Empty.new
       result = Google::Protobuf::Any.new
       result.pack(expected_response)
       operation = Google::Longrunning::Operation.new(
@@ -1735,7 +1646,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:get_big_nothing, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         response = client.get_big_nothing(formatted_name)
@@ -1747,11 +1658,11 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_big_nothing and returns an operation error.' do
       # Create request parameters
-      formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
 
       # Create expected grpc response
       operation_error = Google::Rpc::Status.new(
-        message: 'Operation error for LibraryServiceClient#get_big_nothing.'
+        message: 'Operation error for Library::V1::LibraryServiceClient#get_big_nothing.'
       )
       operation = Google::Longrunning::Operation.new(
         name: 'operations/get_big_nothing_test',
@@ -1767,7 +1678,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:get_big_nothing, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         response = client.get_big_nothing(formatted_name)
@@ -1780,7 +1691,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes get_big_nothing with error' do
       # Create request parameters
-      formatted_name = LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
+      formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -1790,7 +1701,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:get_big_nothing, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         err = assert_raises Google::Gax::GaxError do
@@ -1804,12 +1715,7 @@ describe Library::V1::LibraryServiceClient do
   end
 
   describe 'test_optional_required_flattening_params' do
-    custom_error = CustomTestError.new "Custom test error for LibraryServiceClient#test_optional_required_flattening_params."
-
-    InnerEnum = Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerEnum
-    InnerMessage = Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage
-    LibraryServiceClient = Library::V1::LibraryServiceClient
-    TestOptionalRequiredFlatteningParamsResponse = Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsResponse
+    custom_error = CustomTestError.new "Custom test error for Library::V1::LibraryServiceClient#test_optional_required_flattening_params."
 
     it 'invokes test_optional_required_flattening_params without error' do
       # Create request parameters
@@ -1818,10 +1724,10 @@ describe Library::V1::LibraryServiceClient do
       required_singular_float = 0.0
       required_singular_double = 0.0
       required_singular_bool = false
-      required_singular_enum = InnerEnum::ZERO
+      required_singular_enum = :ZERO
       required_singular_string = ''
       required_singular_bytes = ''
-      required_singular_message = InnerMessage.new
+      required_singular_message = Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage.new
       required_singular_resource_name = ''
       required_singular_resource_name_oneof = ''
       required_singular_fixed32 = 0
@@ -1842,7 +1748,7 @@ describe Library::V1::LibraryServiceClient do
       required_map = {}
 
       # Create expected grpc response
-      expected_response = TestOptionalRequiredFlatteningParamsResponse.new
+      expected_response = Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsResponse.new
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -1851,7 +1757,7 @@ describe Library::V1::LibraryServiceClient do
         assert_equal(required_singular_float, request.required_singular_float)
         assert_equal(required_singular_double, request.required_singular_double)
         assert_equal(required_singular_bool, request.required_singular_bool)
-        assert_equal(InnerEnum.lookup(required_singular_enum), request.required_singular_enum)
+        assert_equal(required_singular_enum, request.required_singular_enum)
         assert_equal(required_singular_string, request.required_singular_string)
         assert_equal(required_singular_bytes, request.required_singular_bytes)
         assert_equal(required_singular_message, request.required_singular_message)
@@ -1878,7 +1784,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:test_optional_required_flattening_params, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         response = client.test_optional_required_flattening_params(
@@ -1923,10 +1829,10 @@ describe Library::V1::LibraryServiceClient do
       required_singular_float = 0.0
       required_singular_double = 0.0
       required_singular_bool = false
-      required_singular_enum = InnerEnum::ZERO
+      required_singular_enum = :ZERO
       required_singular_string = ''
       required_singular_bytes = ''
-      required_singular_message = InnerMessage.new
+      required_singular_message = Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage.new
       required_singular_resource_name = ''
       required_singular_resource_name_oneof = ''
       required_singular_fixed32 = 0
@@ -1953,7 +1859,7 @@ describe Library::V1::LibraryServiceClient do
         assert_equal(required_singular_float, request.required_singular_float)
         assert_equal(required_singular_double, request.required_singular_double)
         assert_equal(required_singular_bool, request.required_singular_bool)
-        assert_equal(InnerEnum.lookup(required_singular_enum), request.required_singular_enum)
+        assert_equal(required_singular_enum, request.required_singular_enum)
         assert_equal(required_singular_string, request.required_singular_string)
         assert_equal(required_singular_bytes, request.required_singular_bytes)
         assert_equal(required_singular_message, request.required_singular_message)
@@ -1980,7 +1886,7 @@ describe Library::V1::LibraryServiceClient do
       mock_stub = MockGrpcClientStub.new(:test_optional_required_flattening_params, mock_method)
 
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = LibraryServiceClient.new
+        client = Library::V1::LibraryServiceClient.new
 
         # Call method
         err = assert_raises Google::Gax::GaxError do

--- a/src/test/java/com/google/api/codegen/transformer/ruby/RubyModelTypeNameConverterTest.java
+++ b/src/test/java/com/google/api/codegen/transformer/ruby/RubyModelTypeNameConverterTest.java
@@ -38,6 +38,6 @@ public class RubyModelTypeNameConverterTest {
             converter
                 .getEnumValue(type, value)
                 .getValueAndSaveTypeNicknameIn(new RubyTypeTable(packageName)))
-        .isEqualTo("Rating::GOOD");
+        .isEqualTo(":GOOD");
   }
 }


### PR DESCRIPTION
Often, when getting reviews internally and externally we get the feedback that aliasing in the method samples were weird and unidiomatic. This makes it such that samples and tests simply use fully qualified types. 

Note: Enums are not using fully qualified types. Rather they are just using their ruby symbol. Based on [protobuf#enum](https://developers.google.com/protocol-buffers/docs/reference/ruby-generated#enum) reference for ruby.