### PR TITLE
Change media body from an object to a string

### DIFF
--- a/src/main/resources/com/google/api/codegen/nodejs/sample.snip
+++ b/src/main/resources/com/google/api/codegen/nodejs/sample.snip
@@ -83,7 +83,7 @@
         // TODO: Add desired media content for upload. See
         // https://github.com/google/google-api-nodejs-client#media-uploads
         mimeType: '',  // See https://www.w3.org/Protocols/rfc1341/4_Content-Type.html
-        body: {},
+        body: '',
       },
 
     @end

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_bigquery.v2.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_bigquery.v2.json.baseline
@@ -528,7 +528,7 @@ authorize(function(authClient) {
       // TODO: Add desired media content for upload. See
       // https://github.com/google/google-api-nodejs-client#media-uploads
       mimeType: '',  // See https://www.w3.org/Protocols/rfc1341/4_Content-Type.html
-      body: {},
+      body: '',
     },
 
     auth: authClient,

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_dfareporting.v2.6.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_dfareporting.v2.6.json.baseline
@@ -2605,7 +2605,7 @@ authorize(function(authClient) {
       // TODO: Add desired media content for upload. See
       // https://github.com/google/google-api-nodejs-client#media-uploads
       mimeType: '',  // See https://www.w3.org/Protocols/rfc1341/4_Content-Type.html
-      body: {},
+      body: '',
     },
 
     auth: authClient,

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_storage.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/nodejs/nodejs_storage.v1.json.baseline
@@ -1620,7 +1620,7 @@ authorize(function(authClient) {
       // TODO: Add desired media content for upload. See
       // https://github.com/google/google-api-nodejs-client#media-uploads
       mimeType: '',  // See https://www.w3.org/Protocols/rfc1341/4_Content-Type.html
-      body: {},
+      body: '',
     },
 
     auth: authClient,


### PR DESCRIPTION
Samples fail before sending a request if the media body is an object.