### PR TITLE
Java: Separating RPC from grpc in UnaryCallable

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTransformer.java
@@ -440,7 +440,7 @@ public class JavaGapicSurfaceTransformer implements ModelToViewTransformer {
     ModelTypeTable typeTable = context.getModelTypeTable();
     typeTable.saveNicknameFor("com.google.api.core.BetaApi");
     typeTable.saveNicknameFor("com.google.api.gax.grpc.ChannelAndExecutor");
-    typeTable.saveNicknameFor("com.google.api.gax.grpc.UnaryCallable");
+    typeTable.saveNicknameFor("com.google.api.gax.grpc.UnaryGrpcCallable");
     typeTable.saveNicknameFor("com.google.api.pathtemplate.PathTemplate");
     typeTable.saveNicknameFor("io.grpc.ManagedChannel");
     typeTable.saveNicknameFor("java.io.Closeable");
@@ -496,7 +496,7 @@ public class JavaGapicSurfaceTransformer implements ModelToViewTransformer {
       typeTable.saveNicknameFor("com.google.api.gax.grpc.PagedCallSettings");
       typeTable.saveNicknameFor("com.google.api.gax.grpc.PagedListDescriptor");
       typeTable.saveNicknameFor("com.google.api.gax.grpc.PagedListResponseFactory");
-      typeTable.saveNicknameFor("com.google.api.gax.grpc.UnaryCallable");
+      typeTable.saveNicknameFor("com.google.api.gax.grpc.UnaryGrpcCallable");
     }
     if (interfaceConfig.hasBatchingMethods()) {
       typeTable.saveNicknameFor("com.google.api.gax.batching.BatchingSettings");

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTransformer.java
@@ -471,8 +471,8 @@ public class JavaGapicSurfaceTransformer implements ModelToViewTransformer {
     typeTable.saveNicknameFor("com.google.api.gax.grpc.ExecutorProvider");
     typeTable.saveNicknameFor("com.google.api.gax.grpc.InstantiatingChannelProvider");
     typeTable.saveNicknameFor("com.google.api.gax.grpc.InstantiatingExecutorProvider");
-    typeTable.saveNicknameFor("com.google.api.gax.grpc.SimpleCallSettings");
-    typeTable.saveNicknameFor("com.google.api.gax.grpc.UnaryCallSettings");
+    typeTable.saveNicknameFor("com.google.api.gax.grpc.SimpleGrpcCallSettings");
+    typeTable.saveNicknameFor("com.google.api.gax.grpc.UnaryGrpcCallSettings");
     typeTable.saveNicknameFor("com.google.api.gax.retrying.RetrySettings");
     typeTable.saveNicknameFor("com.google.auth.Credentials");
     typeTable.saveNicknameFor("com.google.common.collect.ImmutableList");
@@ -493,7 +493,7 @@ public class JavaGapicSurfaceTransformer implements ModelToViewTransformer {
       typeTable.saveNicknameFor("com.google.api.core.ApiFuture");
       typeTable.saveNicknameFor("com.google.api.gax.grpc.CallContext");
       typeTable.saveNicknameFor("com.google.api.gax.grpc.PageContext");
-      typeTable.saveNicknameFor("com.google.api.gax.grpc.PagedCallSettings");
+      typeTable.saveNicknameFor("com.google.api.gax.grpc.PagedGrpcCallSettings");
       typeTable.saveNicknameFor("com.google.api.gax.grpc.PagedListDescriptor");
       typeTable.saveNicknameFor("com.google.api.gax.grpc.PagedListResponseFactory");
       typeTable.saveNicknameFor("com.google.api.gax.grpc.UnaryGrpcCallable");
@@ -505,7 +505,7 @@ public class JavaGapicSurfaceTransformer implements ModelToViewTransformer {
       typeTable.saveNicknameFor("com.google.api.gax.batching.FlowControlSettings");
       typeTable.saveNicknameFor("com.google.api.gax.batching.PartitionKey");
       typeTable.saveNicknameFor("com.google.api.gax.batching.RequestBuilder");
-      typeTable.saveNicknameFor("com.google.api.gax.grpc.BatchingCallSettings");
+      typeTable.saveNicknameFor("com.google.api.gax.grpc.BatchingGrpcCallSettings");
       typeTable.saveNicknameFor("com.google.api.gax.grpc.BatchedRequestIssuer");
       typeTable.saveNicknameFor("com.google.api.gax.grpc.BatchingDescriptor");
       typeTable.saveNicknameFor("com.google.api.gax.grpc.RequestIssuer");

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceNamer.java
@@ -186,7 +186,7 @@ public class JavaSurfaceNamer extends SurfaceNamer {
   public String getApiCallableTypeName(ServiceMethodType serviceMethodType) {
     switch (serviceMethodType) {
       case UnaryMethod:
-        return "UnaryCallable";
+        return "UnaryGrpcCallable";
       case GrpcStreamingMethod:
         return "StreamingCallable";
       case LongRunningMethod:

--- a/src/main/resources/com/google/api/codegen/java/main.snip
+++ b/src/main/resources/com/google/api/codegen/java/main.snip
@@ -237,7 +237,7 @@
         this.{@apiCallable.name} = UnaryCallable.create(settings.{@apiCallable.settingsFunctionName}(), this.channel, this.executor);
       @case "PagedApiCallable"
         this.{@apiCallable.name} =
-            UnaryCallable.createPagedVariant(settings.{@apiCallable.settingsFunctionName}(), this.channel, this.executor);
+            UnaryGrpcCallable.createPagedVariant(settings.{@apiCallable.settingsFunctionName}(), this.channel, this.executor);
       @case "BatchingApiCallable"
         this.{@apiCallable.name} = UnaryCallable.create(settings.{@apiCallable.settingsFunctionName}(), this.channel, this.executor);
       @case "StreamingApiCallable"

--- a/src/main/resources/com/google/api/codegen/java/main.snip
+++ b/src/main/resources/com/google/api/codegen/java/main.snip
@@ -234,16 +234,16 @@
     @join apiCallable : xapiClass.apiCallableMembers
       @switch apiCallable.type
       @case "SimpleApiCallable"
-        this.{@apiCallable.name} = UnaryCallable.create(settings.{@apiCallable.settingsFunctionName}(), this.channel, this.executor);
+        this.{@apiCallable.name} = UnaryGrpcCallable.create(settings.{@apiCallable.settingsFunctionName}(), this.channel, this.executor);
       @case "PagedApiCallable"
         this.{@apiCallable.name} =
             UnaryGrpcCallable.createPagedVariant(settings.{@apiCallable.settingsFunctionName}(), this.channel, this.executor);
       @case "BatchingApiCallable"
-        this.{@apiCallable.name} = UnaryCallable.create(settings.{@apiCallable.settingsFunctionName}(), this.channel, this.executor);
+        this.{@apiCallable.name} = UnaryGrpcCallable.create(settings.{@apiCallable.settingsFunctionName}(), this.channel, this.executor);
       @case "StreamingApiCallable"
         this.{@apiCallable.name} = StreamingCallable.create(settings.{@apiCallable.settingsFunctionName}(), this.channel);
       @case "InitialOperationApiCallable"
-        this.{@apiCallable.name} = UnaryCallable.create(settings.{@apiCallable.settingsFunctionName}().getInitialCallSettings(), this.channel, this.executor);
+        this.{@apiCallable.name} = UnaryGrpcCallable.create(settings.{@apiCallable.settingsFunctionName}().getInitialCallSettings(), this.channel, this.executor);
       @case "OperationApiCallable"
         this.{@apiCallable.name} = OperationCallable.create(settings.{@apiCallable.settingsFunctionName}(),\
             this.channel, this.executor, this.operationsClient);
@@ -438,7 +438,7 @@
     {@apiMethod.releaseLevelAnnotation}
 
   @end
-  {@apiMethod.visibility} final UnaryCallable<{@apiMethod.serviceRequestTypeName}, \
+  {@apiMethod.visibility} final UnaryGrpcCallable<{@apiMethod.serviceRequestTypeName}, \
       {@apiMethod.responseTypeName}> {@apiMethod.name}() {
     return {@apiMethod.callableMethod.callableName};
   }

--- a/src/main/resources/com/google/api/codegen/java/settings.snip
+++ b/src/main/resources/com/google/api/codegen/java/settings.snip
@@ -324,7 +324,7 @@
         new PagedListResponseFactory<{@factory.requestTypeName}, {@factory.responseTypeName}, {@factory.pagedListResponseTypeName}>() {
           @@Override
           public ApiFuture<{@factory.pagedListResponseTypeName}> getFuturePagedResponse(
-              UnaryCallable<{@factory.requestTypeName}, {@factory.responseTypeName}> callable,
+              UnaryGrpcCallable<{@factory.requestTypeName}, {@factory.responseTypeName}> callable,
               {@factory.requestTypeName} request,
               CallContext context,
               ApiFuture<{@factory.responseTypeName}> futureResponse) {

--- a/src/main/resources/com/google/api/codegen/java/settings.snip
+++ b/src/main/resources/com/google/api/codegen/java/settings.snip
@@ -192,14 +192,14 @@
   @join settings : xsettingsClass.callSettings
     @switch settings.type
     @case "SimpleApiCallable"
-      private final SimpleCallSettings<{@settings.requestTypeName}, \
+      private final SimpleGrpcCallSettings<{@settings.requestTypeName}, \
           {@settings.responseTypeName}> {@settings.memberName};
     @case "PagedApiCallable"
-      private final PagedCallSettings<{@settings.requestTypeName}, \
+      private final PagedGrpcCallSettings<{@settings.requestTypeName}, \
           {@settings.responseTypeName}, \
           {@settings.pagedListResponseTypeName}> {@settings.memberName};
     @case "BatchingApiCallable"
-      private final BatchingCallSettings<{@settings.requestTypeName}, \
+      private final BatchingGrpcCallSettings<{@settings.requestTypeName}, \
           {@settings.responseTypeName}> {@settings.memberName};
     @case "StreamingApiCallable"
       private final StreamingCallSettings<{@settings.requestTypeName}, \
@@ -221,18 +221,18 @@
      */
     @switch settings.type
     @case "SimpleApiCallable"
-        public SimpleCallSettings<{@settings.requestTypeName}, \
+        public SimpleGrpcCallSettings<{@settings.requestTypeName}, \
             {@settings.responseTypeName}> {@settings.settingsGetFunction}() {
           return {@settings.memberName};
        }
     @case "PagedApiCallable"
-      public PagedCallSettings<{@settings.requestTypeName}, \
+      public PagedGrpcCallSettings<{@settings.requestTypeName}, \
           {@settings.responseTypeName}, \
           {@settings.pagedListResponseTypeName}> {@settings.settingsGetFunction}() {
         return {@settings.memberName};
       }
     @case "BatchingApiCallable"
-      public BatchingCallSettings<{@settings.requestTypeName}, \
+      public BatchingGrpcCallSettings<{@settings.requestTypeName}, \
           {@settings.responseTypeName}> {@settings.settingsGetFunction}() {
         return {@settings.memberName};
       }
@@ -428,7 +428,7 @@
    * Builder for {@xsettingsClass.name}.
    */
   public static class Builder extends ClientSettings.Builder {
-    private final ImmutableList<UnaryCallSettings.Builder> unaryMethodSettingsBuilders;
+    private final ImmutableList<UnaryGrpcCallSettings.Builder> unaryMethodSettingsBuilders;
 
     {@builderMembers(xsettingsClass)}
 
@@ -444,14 +444,14 @@
   @join settings : xsettingsClass.callSettings
     @switch settings.type.toString
     @case "SimpleApiCallable"
-      private final SimpleCallSettings.Builder<{@settings.requestTypeName}, \
+      private final SimpleGrpcCallSettings.Builder<{@settings.requestTypeName}, \
           {@settings.responseTypeName}> {@settings.memberName};
     @case "PagedApiCallable"
-      private final PagedCallSettings.Builder<{@settings.requestTypeName}, \
+      private final PagedGrpcCallSettings.Builder<{@settings.requestTypeName}, \
           {@settings.responseTypeName}, \
           {@settings.pagedListResponseTypeName}> {@settings.memberName};
     @case "BatchingApiCallable"
-      private final BatchingCallSettings.Builder<{@settings.requestTypeName}, \
+      private final BatchingGrpcCallSettings.Builder<{@settings.requestTypeName}, \
           {@settings.responseTypeName}> {@settings.memberName};
     @case "StreamingApiCallable"
       private final StreamingCallSettings.Builder<{@settings.requestTypeName}, \
@@ -515,13 +515,13 @@
     @join settings : xsettingsClass.callSettings
       @switch settings.type.toString
       @case "SimpleApiCallable"
-        {@settings.memberName} = SimpleCallSettings.newBuilder({@settings.grpcMethodConstant});
+        {@settings.memberName} = SimpleGrpcCallSettings.newBuilder({@settings.grpcMethodConstant});
       @case "PagedApiCallable"
-        {@settings.memberName} = PagedCallSettings.newBuilder(
+        {@settings.memberName} = PagedGrpcCallSettings.newBuilder(
             {@settings.grpcMethodConstant},
             {@settings.pagedListResponseFactoryName});
       @case "BatchingApiCallable"
-        {@settings.memberName} = BatchingCallSettings.newBuilder(
+        {@settings.memberName} = BatchingGrpcCallSettings.newBuilder(
             {@settings.grpcMethodConstant},
             {@settings.batchingDescriptorName})
                 .setBatchingSettingsBuilder(BatchingSettings.newBuilder());
@@ -540,7 +540,7 @@
       @end
       {@BREAK}
     @end
-    unaryMethodSettingsBuilders = ImmutableList.<UnaryCallSettings.Builder>of(
+    unaryMethodSettingsBuilders = ImmutableList.<UnaryGrpcCallSettings.Builder>of(
         @join settings : xsettingsClass.unaryCallSettings vertical on ",".add(BREAK)
           {@settings.memberName}
         @end
@@ -591,7 +591,7 @@
       {@settings.memberName} = settings.{@settings.memberName}.toBuilder();
     @end
 
-    unaryMethodSettingsBuilders = ImmutableList.<UnaryCallSettings.Builder>of(
+    unaryMethodSettingsBuilders = ImmutableList.<UnaryGrpcCallSettings.Builder>of(
         @join settings : xsettingsClass.unaryCallSettings vertical on ",".add(BREAK)
           {@settings.memberName}
         @end
@@ -619,7 +619,7 @@
    *
    * Note: This method does not support applying settings to streaming methods.
    */
-  public Builder applyToAllUnaryMethods(UnaryCallSettings.Builder unaryCallSettings) throws Exception {
+  public Builder applyToAllUnaryMethods(UnaryGrpcCallSettings.Builder unaryCallSettings) throws Exception {
     super.applyToAllUnaryMethods(unaryMethodSettingsBuilders, unaryCallSettings);
     return this;
   }
@@ -630,17 +630,17 @@
      */
     @switch settings.type
     @case "SimpleApiCallable"
-      public SimpleCallSettings.Builder<{@settings.requestTypeName}, \
+      public SimpleGrpcCallSettings.Builder<{@settings.requestTypeName}, \
           {@settings.responseTypeName}> {@settings.settingsGetFunction}() {
         return {@settings.memberName};
       }
     @case "PagedApiCallable"
-      public PagedCallSettings.Builder<{@settings.requestTypeName}, \
+      public PagedGrpcCallSettings.Builder<{@settings.requestTypeName}, \
           {@settings.responseTypeName}, {@settings.pagedListResponseTypeName}> {@settings.settingsGetFunction}() {
         return {@settings.memberName};
       }
     @case "BatchingApiCallable"
-      public BatchingCallSettings.Builder<{@settings.requestTypeName}, \
+      public BatchingGrpcCallSettings.Builder<{@settings.requestTypeName}, \
           {@settings.responseTypeName}> {@settings.settingsGetFunction}() {
         return {@settings.memberName};
       }

--- a/src/test/java/com/google/api/codegen/testdata/java_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_main_library.baseline
@@ -23,7 +23,7 @@ import com.google.api.gax.grpc.FixedExecutorProvider;
 import com.google.api.gax.grpc.OperationCallable;
 import com.google.api.gax.grpc.OperationFuture;
 import com.google.api.gax.grpc.StreamingCallable;
-import com.google.api.gax.grpc.UnaryCallable;
+import com.google.api.gax.grpc.UnaryGrpcCallable;
 import com.google.api.pathtemplate.PathTemplate;
 import com.google.api.resourcenames.ResourceName;
 import com.google.example.library.v1.AddCommentsRequest;
@@ -170,39 +170,39 @@ public class LibraryClient implements AutoCloseable {
   private final OperationsClient operationsClient;
   private final List<AutoCloseable> closeables = new ArrayList<>();
 
-  private final UnaryCallable<CreateShelfRequest, Shelf> createShelfCallable;
-  private final UnaryCallable<GetShelfRequest, Shelf> getShelfCallable;
-  private final UnaryCallable<ListShelvesRequest, ListShelvesResponse> listShelvesCallable;
-  private final UnaryCallable<ListShelvesRequest, ListShelvesPagedResponse> listShelvesPagedCallable;
-  private final UnaryCallable<DeleteShelfRequest, Empty> deleteShelfCallable;
-  private final UnaryCallable<MergeShelvesRequest, Shelf> mergeShelvesCallable;
-  private final UnaryCallable<CreateBookRequest, Book> createBookCallable;
-  private final UnaryCallable<PublishSeriesRequest, PublishSeriesResponse> publishSeriesCallable;
-  private final UnaryCallable<GetBookRequest, Book> getBookCallable;
-  private final UnaryCallable<ListBooksRequest, ListBooksResponse> listBooksCallable;
-  private final UnaryCallable<ListBooksRequest, ListBooksPagedResponse> listBooksPagedCallable;
-  private final UnaryCallable<DeleteBookRequest, Empty> deleteBookCallable;
-  private final UnaryCallable<UpdateBookRequest, Book> updateBookCallable;
-  private final UnaryCallable<MoveBookRequest, Book> moveBookCallable;
-  private final UnaryCallable<ListStringsRequest, ListStringsResponse> listStringsCallable;
-  private final UnaryCallable<ListStringsRequest, ListStringsPagedResponse> listStringsPagedCallable;
-  private final UnaryCallable<AddCommentsRequest, Empty> addCommentsCallable;
-  private final UnaryCallable<GetBookFromArchiveRequest, BookFromArchive> getBookFromArchiveCallable;
-  private final UnaryCallable<GetBookFromAnywhereRequest, BookFromAnywhere> getBookFromAnywhereCallable;
-  private final UnaryCallable<UpdateBookIndexRequest, Empty> updateBookIndexCallable;
+  private final UnaryGrpcCallable<CreateShelfRequest, Shelf> createShelfCallable;
+  private final UnaryGrpcCallable<GetShelfRequest, Shelf> getShelfCallable;
+  private final UnaryGrpcCallable<ListShelvesRequest, ListShelvesResponse> listShelvesCallable;
+  private final UnaryGrpcCallable<ListShelvesRequest, ListShelvesPagedResponse> listShelvesPagedCallable;
+  private final UnaryGrpcCallable<DeleteShelfRequest, Empty> deleteShelfCallable;
+  private final UnaryGrpcCallable<MergeShelvesRequest, Shelf> mergeShelvesCallable;
+  private final UnaryGrpcCallable<CreateBookRequest, Book> createBookCallable;
+  private final UnaryGrpcCallable<PublishSeriesRequest, PublishSeriesResponse> publishSeriesCallable;
+  private final UnaryGrpcCallable<GetBookRequest, Book> getBookCallable;
+  private final UnaryGrpcCallable<ListBooksRequest, ListBooksResponse> listBooksCallable;
+  private final UnaryGrpcCallable<ListBooksRequest, ListBooksPagedResponse> listBooksPagedCallable;
+  private final UnaryGrpcCallable<DeleteBookRequest, Empty> deleteBookCallable;
+  private final UnaryGrpcCallable<UpdateBookRequest, Book> updateBookCallable;
+  private final UnaryGrpcCallable<MoveBookRequest, Book> moveBookCallable;
+  private final UnaryGrpcCallable<ListStringsRequest, ListStringsResponse> listStringsCallable;
+  private final UnaryGrpcCallable<ListStringsRequest, ListStringsPagedResponse> listStringsPagedCallable;
+  private final UnaryGrpcCallable<AddCommentsRequest, Empty> addCommentsCallable;
+  private final UnaryGrpcCallable<GetBookFromArchiveRequest, BookFromArchive> getBookFromArchiveCallable;
+  private final UnaryGrpcCallable<GetBookFromAnywhereRequest, BookFromAnywhere> getBookFromAnywhereCallable;
+  private final UnaryGrpcCallable<UpdateBookIndexRequest, Empty> updateBookIndexCallable;
   private final StreamingCallable<StreamShelvesRequest, StreamShelvesResponse> streamShelvesCallable;
   private final StreamingCallable<StreamBooksRequest, Book> streamBooksCallable;
   private final StreamingCallable<DiscussBookRequest, Comment> discussBookCallable;
   private final StreamingCallable<DiscussBookRequest, Comment> monologAboutBookCallable;
-  private final UnaryCallable<FindRelatedBooksRequest, FindRelatedBooksResponse> findRelatedBooksCallable;
-  private final UnaryCallable<FindRelatedBooksRequest, FindRelatedBooksPagedResponse> findRelatedBooksPagedCallable;
-  private final UnaryCallable<AddTagRequest, AddTagResponse> addTagCallable;
-  private final UnaryCallable<AddLabelRequest, AddLabelResponse> addLabelCallable;
-  private final UnaryCallable<GetBookRequest, Operation> getBigBookCallable;
+  private final UnaryGrpcCallable<FindRelatedBooksRequest, FindRelatedBooksResponse> findRelatedBooksCallable;
+  private final UnaryGrpcCallable<FindRelatedBooksRequest, FindRelatedBooksPagedResponse> findRelatedBooksPagedCallable;
+  private final UnaryGrpcCallable<AddTagRequest, AddTagResponse> addTagCallable;
+  private final UnaryGrpcCallable<AddLabelRequest, AddLabelResponse> addLabelCallable;
+  private final UnaryGrpcCallable<GetBookRequest, Operation> getBigBookCallable;
   private final OperationCallable<GetBookRequest, Book> getBigBookOperationCallable;
-  private final UnaryCallable<GetBookRequest, Operation> getBigNothingCallable;
+  private final UnaryGrpcCallable<GetBookRequest, Operation> getBigNothingCallable;
   private final OperationCallable<GetBookRequest, Empty> getBigNothingOperationCallable;
-  private final UnaryCallable<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsCallable;
+  private final UnaryGrpcCallable<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsCallable;
 
 
 
@@ -242,43 +242,43 @@ public class LibraryClient implements AutoCloseable {
             .build();
     this.operationsClient = OperationsClient.create(operationsSettings);
 
-    this.createShelfCallable = UnaryCallable.create(settings.createShelfSettings(), this.channel, this.executor);
-    this.getShelfCallable = UnaryCallable.create(settings.getShelfSettings(), this.channel, this.executor);
-    this.listShelvesCallable = UnaryCallable.create(settings.listShelvesSettings(), this.channel, this.executor);
+    this.createShelfCallable = UnaryGrpcCallable.create(settings.createShelfSettings(), this.channel, this.executor);
+    this.getShelfCallable = UnaryGrpcCallable.create(settings.getShelfSettings(), this.channel, this.executor);
+    this.listShelvesCallable = UnaryGrpcCallable.create(settings.listShelvesSettings(), this.channel, this.executor);
     this.listShelvesPagedCallable =
-        UnaryCallable.createPagedVariant(settings.listShelvesSettings(), this.channel, this.executor);
-    this.deleteShelfCallable = UnaryCallable.create(settings.deleteShelfSettings(), this.channel, this.executor);
-    this.mergeShelvesCallable = UnaryCallable.create(settings.mergeShelvesSettings(), this.channel, this.executor);
-    this.createBookCallable = UnaryCallable.create(settings.createBookSettings(), this.channel, this.executor);
-    this.publishSeriesCallable = UnaryCallable.create(settings.publishSeriesSettings(), this.channel, this.executor);
-    this.getBookCallable = UnaryCallable.create(settings.getBookSettings(), this.channel, this.executor);
-    this.listBooksCallable = UnaryCallable.create(settings.listBooksSettings(), this.channel, this.executor);
+        UnaryGrpcCallable.createPagedVariant(settings.listShelvesSettings(), this.channel, this.executor);
+    this.deleteShelfCallable = UnaryGrpcCallable.create(settings.deleteShelfSettings(), this.channel, this.executor);
+    this.mergeShelvesCallable = UnaryGrpcCallable.create(settings.mergeShelvesSettings(), this.channel, this.executor);
+    this.createBookCallable = UnaryGrpcCallable.create(settings.createBookSettings(), this.channel, this.executor);
+    this.publishSeriesCallable = UnaryGrpcCallable.create(settings.publishSeriesSettings(), this.channel, this.executor);
+    this.getBookCallable = UnaryGrpcCallable.create(settings.getBookSettings(), this.channel, this.executor);
+    this.listBooksCallable = UnaryGrpcCallable.create(settings.listBooksSettings(), this.channel, this.executor);
     this.listBooksPagedCallable =
-        UnaryCallable.createPagedVariant(settings.listBooksSettings(), this.channel, this.executor);
-    this.deleteBookCallable = UnaryCallable.create(settings.deleteBookSettings(), this.channel, this.executor);
-    this.updateBookCallable = UnaryCallable.create(settings.updateBookSettings(), this.channel, this.executor);
-    this.moveBookCallable = UnaryCallable.create(settings.moveBookSettings(), this.channel, this.executor);
-    this.listStringsCallable = UnaryCallable.create(settings.listStringsSettings(), this.channel, this.executor);
+        UnaryGrpcCallable.createPagedVariant(settings.listBooksSettings(), this.channel, this.executor);
+    this.deleteBookCallable = UnaryGrpcCallable.create(settings.deleteBookSettings(), this.channel, this.executor);
+    this.updateBookCallable = UnaryGrpcCallable.create(settings.updateBookSettings(), this.channel, this.executor);
+    this.moveBookCallable = UnaryGrpcCallable.create(settings.moveBookSettings(), this.channel, this.executor);
+    this.listStringsCallable = UnaryGrpcCallable.create(settings.listStringsSettings(), this.channel, this.executor);
     this.listStringsPagedCallable =
-        UnaryCallable.createPagedVariant(settings.listStringsSettings(), this.channel, this.executor);
-    this.addCommentsCallable = UnaryCallable.create(settings.addCommentsSettings(), this.channel, this.executor);
-    this.getBookFromArchiveCallable = UnaryCallable.create(settings.getBookFromArchiveSettings(), this.channel, this.executor);
-    this.getBookFromAnywhereCallable = UnaryCallable.create(settings.getBookFromAnywhereSettings(), this.channel, this.executor);
-    this.updateBookIndexCallable = UnaryCallable.create(settings.updateBookIndexSettings(), this.channel, this.executor);
+        UnaryGrpcCallable.createPagedVariant(settings.listStringsSettings(), this.channel, this.executor);
+    this.addCommentsCallable = UnaryGrpcCallable.create(settings.addCommentsSettings(), this.channel, this.executor);
+    this.getBookFromArchiveCallable = UnaryGrpcCallable.create(settings.getBookFromArchiveSettings(), this.channel, this.executor);
+    this.getBookFromAnywhereCallable = UnaryGrpcCallable.create(settings.getBookFromAnywhereSettings(), this.channel, this.executor);
+    this.updateBookIndexCallable = UnaryGrpcCallable.create(settings.updateBookIndexSettings(), this.channel, this.executor);
     this.streamShelvesCallable = StreamingCallable.create(settings.streamShelvesSettings(), this.channel);
     this.streamBooksCallable = StreamingCallable.create(settings.streamBooksSettings(), this.channel);
     this.discussBookCallable = StreamingCallable.create(settings.discussBookSettings(), this.channel);
     this.monologAboutBookCallable = StreamingCallable.create(settings.monologAboutBookSettings(), this.channel);
-    this.findRelatedBooksCallable = UnaryCallable.create(settings.findRelatedBooksSettings(), this.channel, this.executor);
+    this.findRelatedBooksCallable = UnaryGrpcCallable.create(settings.findRelatedBooksSettings(), this.channel, this.executor);
     this.findRelatedBooksPagedCallable =
-        UnaryCallable.createPagedVariant(settings.findRelatedBooksSettings(), this.channel, this.executor);
-    this.addTagCallable = UnaryCallable.create(settings.addTagSettings(), this.channel, this.executor);
-    this.addLabelCallable = UnaryCallable.create(settings.addLabelSettings(), this.channel, this.executor);
-    this.getBigBookCallable = UnaryCallable.create(settings.getBigBookSettings().getInitialCallSettings(), this.channel, this.executor);
+        UnaryGrpcCallable.createPagedVariant(settings.findRelatedBooksSettings(), this.channel, this.executor);
+    this.addTagCallable = UnaryGrpcCallable.create(settings.addTagSettings(), this.channel, this.executor);
+    this.addLabelCallable = UnaryGrpcCallable.create(settings.addLabelSettings(), this.channel, this.executor);
+    this.getBigBookCallable = UnaryGrpcCallable.create(settings.getBigBookSettings().getInitialCallSettings(), this.channel, this.executor);
     this.getBigBookOperationCallable = OperationCallable.create(settings.getBigBookSettings(),this.channel, this.executor, this.operationsClient);
-    this.getBigNothingCallable = UnaryCallable.create(settings.getBigNothingSettings().getInitialCallSettings(), this.channel, this.executor);
+    this.getBigNothingCallable = UnaryGrpcCallable.create(settings.getBigNothingSettings().getInitialCallSettings(), this.channel, this.executor);
     this.getBigNothingOperationCallable = OperationCallable.create(settings.getBigNothingSettings(),this.channel, this.executor, this.operationsClient);
-    this.testOptionalRequiredFlatteningParamsCallable = UnaryCallable.create(settings.testOptionalRequiredFlatteningParamsSettings(), this.channel, this.executor);
+    this.testOptionalRequiredFlatteningParamsCallable = UnaryGrpcCallable.create(settings.testOptionalRequiredFlatteningParamsSettings(), this.channel, this.executor);
 
     if (settings.getChannelProvider().shouldAutoClose()) {
       closeables.add(
@@ -378,7 +378,7 @@ public class LibraryClient implements AutoCloseable {
    * }
    * </code></pre>
    */
-  public final UnaryCallable<CreateShelfRequest, Shelf> createShelfCallable() {
+  public final UnaryGrpcCallable<CreateShelfRequest, Shelf> createShelfCallable() {
     return createShelfCallable;
   }
 
@@ -506,7 +506,7 @@ public class LibraryClient implements AutoCloseable {
    * }
    * </code></pre>
    */
-  public final UnaryCallable<GetShelfRequest, Shelf> getShelfCallable() {
+  public final UnaryGrpcCallable<GetShelfRequest, Shelf> getShelfCallable() {
     return getShelfCallable;
   }
 
@@ -571,7 +571,7 @@ public class LibraryClient implements AutoCloseable {
    * }
    * </code></pre>
    */
-  public final UnaryCallable<ListShelvesRequest, ListShelvesPagedResponse> listShelvesPagedCallable() {
+  public final UnaryGrpcCallable<ListShelvesRequest, ListShelvesPagedResponse> listShelvesPagedCallable() {
     return listShelvesPagedCallable;
   }
 
@@ -598,7 +598,7 @@ public class LibraryClient implements AutoCloseable {
    * }
    * </code></pre>
    */
-  public final UnaryCallable<ListShelvesRequest, ListShelvesResponse> listShelvesCallable() {
+  public final UnaryGrpcCallable<ListShelvesRequest, ListShelvesResponse> listShelvesCallable() {
     return listShelvesCallable;
   }
 
@@ -665,7 +665,7 @@ public class LibraryClient implements AutoCloseable {
    * }
    * </code></pre>
    */
-  public final UnaryCallable<DeleteShelfRequest, Empty> deleteShelfCallable() {
+  public final UnaryGrpcCallable<DeleteShelfRequest, Empty> deleteShelfCallable() {
     return deleteShelfCallable;
   }
 
@@ -745,7 +745,7 @@ public class LibraryClient implements AutoCloseable {
    * }
    * </code></pre>
    */
-  public final UnaryCallable<MergeShelvesRequest, Shelf> mergeShelvesCallable() {
+  public final UnaryGrpcCallable<MergeShelvesRequest, Shelf> mergeShelvesCallable() {
     return mergeShelvesCallable;
   }
 
@@ -819,7 +819,7 @@ public class LibraryClient implements AutoCloseable {
    * }
    * </code></pre>
    */
-  public final UnaryCallable<CreateBookRequest, Book> createBookCallable() {
+  public final UnaryGrpcCallable<CreateBookRequest, Book> createBookCallable() {
     return createBookCallable;
   }
 
@@ -912,7 +912,7 @@ public class LibraryClient implements AutoCloseable {
    * }
    * </code></pre>
    */
-  public final UnaryCallable<PublishSeriesRequest, PublishSeriesResponse> publishSeriesCallable() {
+  public final UnaryGrpcCallable<PublishSeriesRequest, PublishSeriesResponse> publishSeriesCallable() {
     return publishSeriesCallable;
   }
 
@@ -979,7 +979,7 @@ public class LibraryClient implements AutoCloseable {
    * }
    * </code></pre>
    */
-  public final UnaryCallable<GetBookRequest, Book> getBookCallable() {
+  public final UnaryGrpcCallable<GetBookRequest, Book> getBookCallable() {
     return getBookCallable;
   }
 
@@ -1055,7 +1055,7 @@ public class LibraryClient implements AutoCloseable {
    * }
    * </code></pre>
    */
-  public final UnaryCallable<ListBooksRequest, ListBooksPagedResponse> listBooksPagedCallable() {
+  public final UnaryGrpcCallable<ListBooksRequest, ListBooksPagedResponse> listBooksPagedCallable() {
     return listBooksPagedCallable;
   }
 
@@ -1085,7 +1085,7 @@ public class LibraryClient implements AutoCloseable {
    * }
    * </code></pre>
    */
-  public final UnaryCallable<ListBooksRequest, ListBooksResponse> listBooksCallable() {
+  public final UnaryGrpcCallable<ListBooksRequest, ListBooksResponse> listBooksCallable() {
     return listBooksCallable;
   }
 
@@ -1152,7 +1152,7 @@ public class LibraryClient implements AutoCloseable {
    * }
    * </code></pre>
    */
-  public final UnaryCallable<DeleteBookRequest, Empty> deleteBookCallable() {
+  public final UnaryGrpcCallable<DeleteBookRequest, Empty> deleteBookCallable() {
     return deleteBookCallable;
   }
 
@@ -1259,7 +1259,7 @@ public class LibraryClient implements AutoCloseable {
    * }
    * </code></pre>
    */
-  public final UnaryCallable<UpdateBookRequest, Book> updateBookCallable() {
+  public final UnaryGrpcCallable<UpdateBookRequest, Book> updateBookCallable() {
     return updateBookCallable;
   }
 
@@ -1333,7 +1333,7 @@ public class LibraryClient implements AutoCloseable {
    * }
    * </code></pre>
    */
-  public final UnaryCallable<MoveBookRequest, Book> moveBookCallable() {
+  public final UnaryGrpcCallable<MoveBookRequest, Book> moveBookCallable() {
     return moveBookCallable;
   }
 
@@ -1423,7 +1423,7 @@ public class LibraryClient implements AutoCloseable {
    * }
    * </code></pre>
    */
-  public final UnaryCallable<ListStringsRequest, ListStringsPagedResponse> listStringsPagedCallable() {
+  public final UnaryGrpcCallable<ListStringsRequest, ListStringsPagedResponse> listStringsPagedCallable() {
     return listStringsPagedCallable;
   }
 
@@ -1450,7 +1450,7 @@ public class LibraryClient implements AutoCloseable {
    * }
    * </code></pre>
    */
-  public final UnaryCallable<ListStringsRequest, ListStringsResponse> listStringsCallable() {
+  public final UnaryGrpcCallable<ListStringsRequest, ListStringsResponse> listStringsCallable() {
     return listStringsCallable;
   }
 
@@ -1548,7 +1548,7 @@ public class LibraryClient implements AutoCloseable {
    * }
    * </code></pre>
    */
-  public final UnaryCallable<AddCommentsRequest, Empty> addCommentsCallable() {
+  public final UnaryGrpcCallable<AddCommentsRequest, Empty> addCommentsCallable() {
     return addCommentsCallable;
   }
 
@@ -1615,7 +1615,7 @@ public class LibraryClient implements AutoCloseable {
    * }
    * </code></pre>
    */
-  public final UnaryCallable<GetBookFromArchiveRequest, BookFromArchive> getBookFromArchiveCallable() {
+  public final UnaryGrpcCallable<GetBookFromArchiveRequest, BookFromArchive> getBookFromArchiveCallable() {
     return getBookFromArchiveCallable;
   }
 
@@ -1690,7 +1690,7 @@ public class LibraryClient implements AutoCloseable {
    * }
    * </code></pre>
    */
-  public final UnaryCallable<GetBookFromAnywhereRequest, BookFromAnywhere> getBookFromAnywhereCallable() {
+  public final UnaryGrpcCallable<GetBookFromAnywhereRequest, BookFromAnywhere> getBookFromAnywhereCallable() {
     return getBookFromAnywhereCallable;
   }
 
@@ -1777,7 +1777,7 @@ public class LibraryClient implements AutoCloseable {
    * }
    * </code></pre>
    */
-  public final UnaryCallable<UpdateBookIndexRequest, Empty> updateBookIndexCallable() {
+  public final UnaryGrpcCallable<UpdateBookIndexRequest, Empty> updateBookIndexCallable() {
     return updateBookIndexCallable;
   }
 
@@ -2015,7 +2015,7 @@ public class LibraryClient implements AutoCloseable {
    * }
    * </code></pre>
    */
-  public final UnaryCallable<FindRelatedBooksRequest, FindRelatedBooksPagedResponse> findRelatedBooksPagedCallable() {
+  public final UnaryGrpcCallable<FindRelatedBooksRequest, FindRelatedBooksPagedResponse> findRelatedBooksPagedCallable() {
     return findRelatedBooksPagedCallable;
   }
 
@@ -2048,7 +2048,7 @@ public class LibraryClient implements AutoCloseable {
    * }
    * </code></pre>
    */
-  public final UnaryCallable<FindRelatedBooksRequest, FindRelatedBooksResponse> findRelatedBooksCallable() {
+  public final UnaryGrpcCallable<FindRelatedBooksRequest, FindRelatedBooksResponse> findRelatedBooksCallable() {
     return findRelatedBooksCallable;
   }
 
@@ -2124,7 +2124,7 @@ public class LibraryClient implements AutoCloseable {
    * }
    * </code></pre>
    */
-  public final UnaryCallable<AddTagRequest, AddTagResponse> addTagCallable() {
+  public final UnaryGrpcCallable<AddTagRequest, AddTagResponse> addTagCallable() {
     return addTagCallable;
   }
 
@@ -2203,7 +2203,7 @@ public class LibraryClient implements AutoCloseable {
    * </code></pre>
    */
   @Deprecated
-  /* package-private */ final UnaryCallable<AddLabelRequest, AddLabelResponse> addLabelCallable() {
+  /* package-private */ final UnaryGrpcCallable<AddLabelRequest, AddLabelResponse> addLabelCallable() {
     return addLabelCallable;
   }
 
@@ -2291,7 +2291,7 @@ public class LibraryClient implements AutoCloseable {
    * }
    * </code></pre>
    */
-  public final UnaryCallable<GetBookRequest, Operation> getBigBookCallable() {
+  public final UnaryGrpcCallable<GetBookRequest, Operation> getBigBookCallable() {
     return getBigBookCallable;
   }
 
@@ -2379,7 +2379,7 @@ public class LibraryClient implements AutoCloseable {
    * }
    * </code></pre>
    */
-  public final UnaryCallable<GetBookRequest, Operation> getBigNothingCallable() {
+  public final UnaryGrpcCallable<GetBookRequest, Operation> getBigNothingCallable() {
     return getBigNothingCallable;
   }
 
@@ -2731,7 +2731,7 @@ public class LibraryClient implements AutoCloseable {
    * }
    * </code></pre>
    */
-  public final UnaryCallable<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsCallable() {
+  public final UnaryGrpcCallable<TestOptionalRequiredFlatteningParamsRequest, TestOptionalRequiredFlatteningParamsResponse> testOptionalRequiredFlatteningParamsCallable() {
     return testOptionalRequiredFlatteningParamsCallable;
   }
 

--- a/src/test/java/com/google/api/codegen/testdata/java_main_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_main_no_path_templates.baseline
@@ -18,7 +18,7 @@ package com.google.gcloud.example;
 
 import com.google.api.core.BetaApi;
 import com.google.api.gax.grpc.ChannelAndExecutor;
-import com.google.api.gax.grpc.UnaryCallable;
+import com.google.api.gax.grpc.UnaryGrpcCallable;
 import com.google.api.pathtemplate.PathTemplate;
 import com.google.example.noPathTemplates.v1.IncrementRequest;
 import com.google.protobuf.Empty;
@@ -94,7 +94,7 @@ public class NoTemplatesApiServiceClient implements AutoCloseable {
   private final ManagedChannel channel;
   private final List<AutoCloseable> closeables = new ArrayList<>();
 
-  private final UnaryCallable<IncrementRequest, Empty> incrementCallable;
+  private final UnaryGrpcCallable<IncrementRequest, Empty> incrementCallable;
 
 
 
@@ -120,7 +120,7 @@ public class NoTemplatesApiServiceClient implements AutoCloseable {
     this.channel = channelAndExecutor.getChannel();
 
 
-    this.incrementCallable = UnaryCallable.create(settings.incrementSettings(), this.channel, this.executor);
+    this.incrementCallable = UnaryGrpcCallable.create(settings.incrementSettings(), this.channel, this.executor);
 
     if (settings.getChannelProvider().shouldAutoClose()) {
       closeables.add(
@@ -190,7 +190,7 @@ public class NoTemplatesApiServiceClient implements AutoCloseable {
    * }
    * </code></pre>
    */
-  public final UnaryCallable<IncrementRequest, Empty> incrementCallable() {
+  public final UnaryGrpcCallable<IncrementRequest, Empty> incrementCallable() {
     return incrementCallable;
   }
 

--- a/src/test/java/com/google/api/codegen/testdata/java_settings_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_settings_library.baseline
@@ -29,7 +29,7 @@ import com.google.api.gax.core.GoogleCredentialsProvider;
 import com.google.api.gax.core.PropertiesProvider;
 import com.google.api.gax.grpc.ApiExceptions;
 import com.google.api.gax.grpc.BatchedRequestIssuer;
-import com.google.api.gax.grpc.BatchingCallSettings;
+import com.google.api.gax.grpc.BatchingGrpcCallSettings;
 import com.google.api.gax.grpc.BatchingDescriptor;
 import com.google.api.gax.grpc.CallContext;
 import com.google.api.gax.grpc.ChannelProvider;
@@ -39,14 +39,14 @@ import com.google.api.gax.grpc.InstantiatingChannelProvider;
 import com.google.api.gax.grpc.InstantiatingExecutorProvider;
 import com.google.api.gax.grpc.OperationCallSettings;
 import com.google.api.gax.grpc.PageContext;
-import com.google.api.gax.grpc.PagedCallSettings;
+import com.google.api.gax.grpc.PagedGrpcCallSettings;
 import com.google.api.gax.grpc.PagedListDescriptor;
 import com.google.api.gax.grpc.PagedListResponseFactory;
 import com.google.api.gax.grpc.RequestIssuer;
 import com.google.api.gax.grpc.SimpleCallSettings;
 import com.google.api.gax.grpc.StreamingCallSettings;
-import com.google.api.gax.grpc.UnaryCallSettings;
-import com.google.api.gax.grpc.UnaryCallable;
+import com.google.api.gax.grpc.UnaryGrpcCallSettings;
+import com.google.api.gax.grpc.UnaryGrpcCallable;
 import com.google.api.gax.retrying.RetrySettings;
 import com.google.auth.Credentials;
 import com.google.common.collect.ImmutableList;
@@ -320,18 +320,18 @@ public class LibrarySettings extends ClientSettings {
 
   private final SimpleCallSettings<CreateShelfRequest, Shelf> createShelfSettings;
   private final SimpleCallSettings<GetShelfRequest, Shelf> getShelfSettings;
-  private final PagedCallSettings<ListShelvesRequest, ListShelvesResponse, ListShelvesPagedResponse> listShelvesSettings;
+  private final PagedGrpcCallSettings<ListShelvesRequest, ListShelvesResponse, ListShelvesPagedResponse> listShelvesSettings;
   private final SimpleCallSettings<DeleteShelfRequest, Empty> deleteShelfSettings;
   private final SimpleCallSettings<MergeShelvesRequest, Shelf> mergeShelvesSettings;
   private final SimpleCallSettings<CreateBookRequest, Book> createBookSettings;
-  private final BatchingCallSettings<PublishSeriesRequest, PublishSeriesResponse> publishSeriesSettings;
+  private final BatchingGrpcCallSettings<PublishSeriesRequest, PublishSeriesResponse> publishSeriesSettings;
   private final SimpleCallSettings<GetBookRequest, Book> getBookSettings;
-  private final PagedCallSettings<ListBooksRequest, ListBooksResponse, ListBooksPagedResponse> listBooksSettings;
+  private final PagedGrpcCallSettings<ListBooksRequest, ListBooksResponse, ListBooksPagedResponse> listBooksSettings;
   private final SimpleCallSettings<DeleteBookRequest, Empty> deleteBookSettings;
   private final SimpleCallSettings<UpdateBookRequest, Book> updateBookSettings;
   private final SimpleCallSettings<MoveBookRequest, Book> moveBookSettings;
-  private final PagedCallSettings<ListStringsRequest, ListStringsResponse, ListStringsPagedResponse> listStringsSettings;
-  private final BatchingCallSettings<AddCommentsRequest, Empty> addCommentsSettings;
+  private final PagedGrpcCallSettings<ListStringsRequest, ListStringsResponse, ListStringsPagedResponse> listStringsSettings;
+  private final BatchingGrpcCallSettings<AddCommentsRequest, Empty> addCommentsSettings;
   private final SimpleCallSettings<GetBookFromArchiveRequest, BookFromArchive> getBookFromArchiveSettings;
   private final SimpleCallSettings<GetBookFromAnywhereRequest, BookFromAnywhere> getBookFromAnywhereSettings;
   private final SimpleCallSettings<UpdateBookIndexRequest, Empty> updateBookIndexSettings;
@@ -339,7 +339,7 @@ public class LibrarySettings extends ClientSettings {
   private final StreamingCallSettings<StreamBooksRequest, Book> streamBooksSettings;
   private final StreamingCallSettings<DiscussBookRequest, Comment> discussBookSettings;
   private final StreamingCallSettings<DiscussBookRequest, Comment> monologAboutBookSettings;
-  private final PagedCallSettings<FindRelatedBooksRequest, FindRelatedBooksResponse, FindRelatedBooksPagedResponse> findRelatedBooksSettings;
+  private final PagedGrpcCallSettings<FindRelatedBooksRequest, FindRelatedBooksResponse, FindRelatedBooksPagedResponse> findRelatedBooksSettings;
   private final SimpleCallSettings<AddTagRequest, AddTagResponse> addTagSettings;
   private final SimpleCallSettings<AddLabelRequest, AddLabelResponse> addLabelSettings;
   private final OperationCallSettings<GetBookRequest, Book> getBigBookSettings;
@@ -363,7 +363,7 @@ public class LibrarySettings extends ClientSettings {
   /**
    * Returns the object with the settings used for calls to listShelves.
    */
-  public PagedCallSettings<ListShelvesRequest, ListShelvesResponse, ListShelvesPagedResponse> listShelvesSettings() {
+  public PagedGrpcCallSettings<ListShelvesRequest, ListShelvesResponse, ListShelvesPagedResponse> listShelvesSettings() {
     return listShelvesSettings;
   }
 
@@ -391,7 +391,7 @@ public class LibrarySettings extends ClientSettings {
   /**
    * Returns the object with the settings used for calls to publishSeries.
    */
-  public BatchingCallSettings<PublishSeriesRequest, PublishSeriesResponse> publishSeriesSettings() {
+  public BatchingGrpcCallSettings<PublishSeriesRequest, PublishSeriesResponse> publishSeriesSettings() {
     return publishSeriesSettings;
   }
 
@@ -405,7 +405,7 @@ public class LibrarySettings extends ClientSettings {
   /**
    * Returns the object with the settings used for calls to listBooks.
    */
-  public PagedCallSettings<ListBooksRequest, ListBooksResponse, ListBooksPagedResponse> listBooksSettings() {
+  public PagedGrpcCallSettings<ListBooksRequest, ListBooksResponse, ListBooksPagedResponse> listBooksSettings() {
     return listBooksSettings;
   }
 
@@ -433,14 +433,14 @@ public class LibrarySettings extends ClientSettings {
   /**
    * Returns the object with the settings used for calls to listStrings.
    */
-  public PagedCallSettings<ListStringsRequest, ListStringsResponse, ListStringsPagedResponse> listStringsSettings() {
+  public PagedGrpcCallSettings<ListStringsRequest, ListStringsResponse, ListStringsPagedResponse> listStringsSettings() {
     return listStringsSettings;
   }
 
   /**
    * Returns the object with the settings used for calls to addComments.
    */
-  public BatchingCallSettings<AddCommentsRequest, Empty> addCommentsSettings() {
+  public BatchingGrpcCallSettings<AddCommentsRequest, Empty> addCommentsSettings() {
     return addCommentsSettings;
   }
 
@@ -496,7 +496,7 @@ public class LibrarySettings extends ClientSettings {
   /**
    * Returns the object with the settings used for calls to findRelatedBooks.
    */
-  public PagedCallSettings<FindRelatedBooksRequest, FindRelatedBooksResponse, FindRelatedBooksPagedResponse> findRelatedBooksSettings() {
+  public PagedGrpcCallSettings<FindRelatedBooksRequest, FindRelatedBooksResponse, FindRelatedBooksPagedResponse> findRelatedBooksSettings() {
     return findRelatedBooksSettings;
   }
 
@@ -776,7 +776,7 @@ public class LibrarySettings extends ClientSettings {
       new PagedListResponseFactory<ListShelvesRequest, ListShelvesResponse, ListShelvesPagedResponse>() {
         @Override
         public ApiFuture<ListShelvesPagedResponse> getFuturePagedResponse(
-            UnaryCallable<ListShelvesRequest, ListShelvesResponse> callable,
+            UnaryGrpcCallable<ListShelvesRequest, ListShelvesResponse> callable,
             ListShelvesRequest request,
             CallContext context,
             ApiFuture<ListShelvesResponse> futureResponse) {
@@ -790,7 +790,7 @@ public class LibrarySettings extends ClientSettings {
       new PagedListResponseFactory<ListBooksRequest, ListBooksResponse, ListBooksPagedResponse>() {
         @Override
         public ApiFuture<ListBooksPagedResponse> getFuturePagedResponse(
-            UnaryCallable<ListBooksRequest, ListBooksResponse> callable,
+            UnaryGrpcCallable<ListBooksRequest, ListBooksResponse> callable,
             ListBooksRequest request,
             CallContext context,
             ApiFuture<ListBooksResponse> futureResponse) {
@@ -804,7 +804,7 @@ public class LibrarySettings extends ClientSettings {
       new PagedListResponseFactory<ListStringsRequest, ListStringsResponse, ListStringsPagedResponse>() {
         @Override
         public ApiFuture<ListStringsPagedResponse> getFuturePagedResponse(
-            UnaryCallable<ListStringsRequest, ListStringsResponse> callable,
+            UnaryGrpcCallable<ListStringsRequest, ListStringsResponse> callable,
             ListStringsRequest request,
             CallContext context,
             ApiFuture<ListStringsResponse> futureResponse) {
@@ -818,7 +818,7 @@ public class LibrarySettings extends ClientSettings {
       new PagedListResponseFactory<FindRelatedBooksRequest, FindRelatedBooksResponse, FindRelatedBooksPagedResponse>() {
         @Override
         public ApiFuture<FindRelatedBooksPagedResponse> getFuturePagedResponse(
-            UnaryCallable<FindRelatedBooksRequest, FindRelatedBooksResponse> callable,
+            UnaryGrpcCallable<FindRelatedBooksRequest, FindRelatedBooksResponse> callable,
             FindRelatedBooksRequest request,
             CallContext context,
             ApiFuture<FindRelatedBooksResponse> futureResponse) {
@@ -954,22 +954,22 @@ public class LibrarySettings extends ClientSettings {
    * Builder for LibrarySettings.
    */
   public static class Builder extends ClientSettings.Builder {
-    private final ImmutableList<UnaryCallSettings.Builder> unaryMethodSettingsBuilders;
+    private final ImmutableList<UnaryGrpcCallSettings.Builder> unaryMethodSettingsBuilders;
 
     private final SimpleCallSettings.Builder<CreateShelfRequest, Shelf> createShelfSettings;
     private final SimpleCallSettings.Builder<GetShelfRequest, Shelf> getShelfSettings;
-    private final PagedCallSettings.Builder<ListShelvesRequest, ListShelvesResponse, ListShelvesPagedResponse> listShelvesSettings;
+    private final PagedGrpcCallSettings.Builder<ListShelvesRequest, ListShelvesResponse, ListShelvesPagedResponse> listShelvesSettings;
     private final SimpleCallSettings.Builder<DeleteShelfRequest, Empty> deleteShelfSettings;
     private final SimpleCallSettings.Builder<MergeShelvesRequest, Shelf> mergeShelvesSettings;
     private final SimpleCallSettings.Builder<CreateBookRequest, Book> createBookSettings;
-    private final BatchingCallSettings.Builder<PublishSeriesRequest, PublishSeriesResponse> publishSeriesSettings;
+    private final BatchingGrpcCallSettings.Builder<PublishSeriesRequest, PublishSeriesResponse> publishSeriesSettings;
     private final SimpleCallSettings.Builder<GetBookRequest, Book> getBookSettings;
-    private final PagedCallSettings.Builder<ListBooksRequest, ListBooksResponse, ListBooksPagedResponse> listBooksSettings;
+    private final PagedGrpcCallSettings.Builder<ListBooksRequest, ListBooksResponse, ListBooksPagedResponse> listBooksSettings;
     private final SimpleCallSettings.Builder<DeleteBookRequest, Empty> deleteBookSettings;
     private final SimpleCallSettings.Builder<UpdateBookRequest, Book> updateBookSettings;
     private final SimpleCallSettings.Builder<MoveBookRequest, Book> moveBookSettings;
-    private final PagedCallSettings.Builder<ListStringsRequest, ListStringsResponse, ListStringsPagedResponse> listStringsSettings;
-    private final BatchingCallSettings.Builder<AddCommentsRequest, Empty> addCommentsSettings;
+    private final PagedGrpcCallSettings.Builder<ListStringsRequest, ListStringsResponse, ListStringsPagedResponse> listStringsSettings;
+    private final BatchingGrpcCallSettings.Builder<AddCommentsRequest, Empty> addCommentsSettings;
     private final SimpleCallSettings.Builder<GetBookFromArchiveRequest, BookFromArchive> getBookFromArchiveSettings;
     private final SimpleCallSettings.Builder<GetBookFromAnywhereRequest, BookFromAnywhere> getBookFromAnywhereSettings;
     private final SimpleCallSettings.Builder<UpdateBookIndexRequest, Empty> updateBookIndexSettings;
@@ -977,7 +977,7 @@ public class LibrarySettings extends ClientSettings {
     private final StreamingCallSettings.Builder<StreamBooksRequest, Book> streamBooksSettings;
     private final StreamingCallSettings.Builder<DiscussBookRequest, Comment> discussBookSettings;
     private final StreamingCallSettings.Builder<DiscussBookRequest, Comment> monologAboutBookSettings;
-    private final PagedCallSettings.Builder<FindRelatedBooksRequest, FindRelatedBooksResponse, FindRelatedBooksPagedResponse> findRelatedBooksSettings;
+    private final PagedGrpcCallSettings.Builder<FindRelatedBooksRequest, FindRelatedBooksResponse, FindRelatedBooksPagedResponse> findRelatedBooksSettings;
     private final SimpleCallSettings.Builder<AddTagRequest, AddTagResponse> addTagSettings;
     private final SimpleCallSettings.Builder<AddLabelRequest, AddLabelResponse> addLabelSettings;
     private final OperationCallSettings.Builder<GetBookRequest, Book> getBigBookSettings;
@@ -1021,7 +1021,7 @@ public class LibrarySettings extends ClientSettings {
 
       getShelfSettings = SimpleCallSettings.newBuilder(METHOD_GET_SHELF);
 
-      listShelvesSettings = PagedCallSettings.newBuilder(
+      listShelvesSettings = PagedGrpcCallSettings.newBuilder(
           METHOD_LIST_SHELVES,
           LIST_SHELVES_PAGE_STR_FACT);
 
@@ -1031,14 +1031,14 @@ public class LibrarySettings extends ClientSettings {
 
       createBookSettings = SimpleCallSettings.newBuilder(METHOD_CREATE_BOOK);
 
-      publishSeriesSettings = BatchingCallSettings.newBuilder(
+      publishSeriesSettings = BatchingGrpcCallSettings.newBuilder(
           METHOD_PUBLISH_SERIES,
           PUBLISH_SERIES_BATCHING_DESC)
               .setBatchingSettingsBuilder(BatchingSettings.newBuilder());
 
       getBookSettings = SimpleCallSettings.newBuilder(METHOD_GET_BOOK);
 
-      listBooksSettings = PagedCallSettings.newBuilder(
+      listBooksSettings = PagedGrpcCallSettings.newBuilder(
           METHOD_LIST_BOOKS,
           LIST_BOOKS_PAGE_STR_FACT);
 
@@ -1048,11 +1048,11 @@ public class LibrarySettings extends ClientSettings {
 
       moveBookSettings = SimpleCallSettings.newBuilder(METHOD_MOVE_BOOK);
 
-      listStringsSettings = PagedCallSettings.newBuilder(
+      listStringsSettings = PagedGrpcCallSettings.newBuilder(
           METHOD_LIST_STRINGS,
           LIST_STRINGS_PAGE_STR_FACT);
 
-      addCommentsSettings = BatchingCallSettings.newBuilder(
+      addCommentsSettings = BatchingGrpcCallSettings.newBuilder(
           METHOD_ADD_COMMENTS,
           ADD_COMMENTS_BATCHING_DESC)
               .setBatchingSettingsBuilder(BatchingSettings.newBuilder());
@@ -1071,7 +1071,7 @@ public class LibrarySettings extends ClientSettings {
 
       monologAboutBookSettings = StreamingCallSettings.newBuilder(METHOD_MONOLOG_ABOUT_BOOK);
 
-      findRelatedBooksSettings = PagedCallSettings.newBuilder(
+      findRelatedBooksSettings = PagedGrpcCallSettings.newBuilder(
           METHOD_FIND_RELATED_BOOKS,
           FIND_RELATED_BOOKS_PAGE_STR_FACT);
 
@@ -1092,7 +1092,7 @@ public class LibrarySettings extends ClientSettings {
 
       testOptionalRequiredFlatteningParamsSettings = SimpleCallSettings.newBuilder(METHOD_TEST_OPTIONAL_REQUIRED_FLATTENING_PARAMS);
 
-      unaryMethodSettingsBuilders = ImmutableList.<UnaryCallSettings.Builder>of(
+      unaryMethodSettingsBuilders = ImmutableList.<UnaryGrpcCallSettings.Builder>of(
           createShelfSettings,
           getShelfSettings,
           listShelvesSettings,
@@ -1260,7 +1260,7 @@ public class LibrarySettings extends ClientSettings {
       getBigNothingSettings = settings.getBigNothingSettings.toBuilder();
       testOptionalRequiredFlatteningParamsSettings = settings.testOptionalRequiredFlatteningParamsSettings.toBuilder();
 
-      unaryMethodSettingsBuilders = ImmutableList.<UnaryCallSettings.Builder>of(
+      unaryMethodSettingsBuilders = ImmutableList.<UnaryGrpcCallSettings.Builder>of(
           createShelfSettings,
           getShelfSettings,
           listShelvesSettings,
@@ -1304,7 +1304,7 @@ public class LibrarySettings extends ClientSettings {
      *
      * Note: This method does not support applying settings to streaming methods.
      */
-    public Builder applyToAllUnaryMethods(UnaryCallSettings.Builder unaryCallSettings) throws Exception {
+    public Builder applyToAllUnaryMethods(UnaryGrpcCallSettings.Builder unaryCallSettings) throws Exception {
       super.applyToAllUnaryMethods(unaryMethodSettingsBuilders, unaryCallSettings);
       return this;
     }
@@ -1326,7 +1326,7 @@ public class LibrarySettings extends ClientSettings {
     /**
      * Returns the builder for the settings used for calls to listShelves.
      */
-    public PagedCallSettings.Builder<ListShelvesRequest, ListShelvesResponse, ListShelvesPagedResponse> listShelvesSettings() {
+    public PagedGrpcCallSettings.Builder<ListShelvesRequest, ListShelvesResponse, ListShelvesPagedResponse> listShelvesSettings() {
       return listShelvesSettings;
     }
 
@@ -1354,7 +1354,7 @@ public class LibrarySettings extends ClientSettings {
     /**
      * Returns the builder for the settings used for calls to publishSeries.
      */
-    public BatchingCallSettings.Builder<PublishSeriesRequest, PublishSeriesResponse> publishSeriesSettings() {
+    public BatchingGrpcCallSettings.Builder<PublishSeriesRequest, PublishSeriesResponse> publishSeriesSettings() {
       return publishSeriesSettings;
     }
 
@@ -1368,7 +1368,7 @@ public class LibrarySettings extends ClientSettings {
     /**
      * Returns the builder for the settings used for calls to listBooks.
      */
-    public PagedCallSettings.Builder<ListBooksRequest, ListBooksResponse, ListBooksPagedResponse> listBooksSettings() {
+    public PagedGrpcCallSettings.Builder<ListBooksRequest, ListBooksResponse, ListBooksPagedResponse> listBooksSettings() {
       return listBooksSettings;
     }
 
@@ -1396,14 +1396,14 @@ public class LibrarySettings extends ClientSettings {
     /**
      * Returns the builder for the settings used for calls to listStrings.
      */
-    public PagedCallSettings.Builder<ListStringsRequest, ListStringsResponse, ListStringsPagedResponse> listStringsSettings() {
+    public PagedGrpcCallSettings.Builder<ListStringsRequest, ListStringsResponse, ListStringsPagedResponse> listStringsSettings() {
       return listStringsSettings;
     }
 
     /**
      * Returns the builder for the settings used for calls to addComments.
      */
-    public BatchingCallSettings.Builder<AddCommentsRequest, Empty> addCommentsSettings() {
+    public BatchingGrpcCallSettings.Builder<AddCommentsRequest, Empty> addCommentsSettings() {
       return addCommentsSettings;
     }
 
@@ -1459,7 +1459,7 @@ public class LibrarySettings extends ClientSettings {
     /**
      * Returns the builder for the settings used for calls to findRelatedBooks.
      */
-    public PagedCallSettings.Builder<FindRelatedBooksRequest, FindRelatedBooksResponse, FindRelatedBooksPagedResponse> findRelatedBooksSettings() {
+    public PagedGrpcCallSettings.Builder<FindRelatedBooksRequest, FindRelatedBooksResponse, FindRelatedBooksPagedResponse> findRelatedBooksSettings() {
       return findRelatedBooksSettings;
     }
 

--- a/src/test/java/com/google/api/codegen/testdata/java_settings_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_settings_no_path_templates.baseline
@@ -27,7 +27,7 @@ import com.google.api.gax.grpc.ExecutorProvider;
 import com.google.api.gax.grpc.InstantiatingChannelProvider;
 import com.google.api.gax.grpc.InstantiatingExecutorProvider;
 import com.google.api.gax.grpc.SimpleCallSettings;
-import com.google.api.gax.grpc.UnaryCallSettings;
+import com.google.api.gax.grpc.UnaryGrpcCallSettings;
 import com.google.api.gax.retrying.RetrySettings;
 import com.google.auth.Credentials;
 import com.google.common.collect.ImmutableList;
@@ -147,7 +147,7 @@ public class NoTemplatesApiServiceSettings extends ClientSettings {
    * Builder for NoTemplatesApiServiceSettings.
    */
   public static class Builder extends ClientSettings.Builder {
-    private final ImmutableList<UnaryCallSettings.Builder> unaryMethodSettingsBuilders;
+    private final ImmutableList<UnaryGrpcCallSettings.Builder> unaryMethodSettingsBuilders;
 
     private final SimpleCallSettings.Builder<IncrementRequest, Empty> incrementSettings;
 
@@ -171,7 +171,7 @@ public class NoTemplatesApiServiceSettings extends ClientSettings {
 
       incrementSettings = SimpleCallSettings.newBuilder(METHOD_INCREMENT);
 
-      unaryMethodSettingsBuilders = ImmutableList.<UnaryCallSettings.Builder>of(
+      unaryMethodSettingsBuilders = ImmutableList.<UnaryGrpcCallSettings.Builder>of(
           incrementSettings
       );
     }
@@ -191,7 +191,7 @@ public class NoTemplatesApiServiceSettings extends ClientSettings {
 
       incrementSettings = settings.incrementSettings.toBuilder();
 
-      unaryMethodSettingsBuilders = ImmutableList.<UnaryCallSettings.Builder>of(
+      unaryMethodSettingsBuilders = ImmutableList.<UnaryGrpcCallSettings.Builder>of(
           incrementSettings
       );
     }
@@ -215,7 +215,7 @@ public class NoTemplatesApiServiceSettings extends ClientSettings {
      *
      * Note: This method does not support applying settings to streaming methods.
      */
-    public Builder applyToAllUnaryMethods(UnaryCallSettings.Builder unaryCallSettings) throws Exception {
+    public Builder applyToAllUnaryMethods(UnaryGrpcCallSettings.Builder unaryCallSettings) throws Exception {
       super.applyToAllUnaryMethods(unaryMethodSettingsBuilders, unaryCallSettings);
       return this;
     }


### PR DESCRIPTION
As part of introducing a REST alternative to grpc in gax-java, this pull request abstracts the UnaryCallable class into a interface to be shared by a UnaryGrpcCallable and UnaryRestCallable implementation.

See https://github.com/googleapis/gax-java/pull/308 for affected code in gax-java.