### PR TITLE
Specify HTTP client when building service 

### DIFF
--- a/src/main/java/com/google/api/codegen/discovery/transformer/py/PythonSampleMethodToViewTransformer.java
+++ b/src/main/java/com/google/api/codegen/discovery/transformer/py/PythonSampleMethodToViewTransformer.java
@@ -117,6 +117,7 @@ public class PythonSampleMethodToViewTransformer implements SampleMethodToViewTr
     discoveryBuildParams.add(String.format("'%s'", config.apiVersion()));
     switch (config.authType()) {
       case NONE:
+        discoveryBuildParams.add("http=httplib2.Http(timeout=60)");
         break;
       case API_KEY:
         discoveryBuildParams.add("developerKey=" + credentialsVarName);

--- a/src/main/resources/com/google/api/codegen/py/sample.snip
+++ b/src/main/resources/com/google/api/codegen/py/sample.snip
@@ -24,6 +24,9 @@
         from pprint import pprint
     @end
 
+    @if class.auth.type == "NONE"
+        import httplib2
+    @end
     from googleapiclient import discovery
     @if class.auth.type == "APPLICATION_DEFAULT_CREDENTIALS"
         from oauth2client.client import GoogleCredentials

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_foo.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/py/py_foo.v1.json.baseline
@@ -10,9 +10,10 @@ BEFORE RUNNING:
 """
 from pprint import pprint
 
+import httplib2
 from googleapiclient import discovery
 
-service = discovery.build('foo', 'v1', discoveryServiceUrl='localhost:8080/$discovery/foo?version=v1')
+service = discovery.build('foo', 'v1', http=httplib2.Http(timeout=60), discoveryServiceUrl='localhost:8080/$discovery/foo?version=v1')
 
 request = service.baz().get()
 response = request.execute()


### PR DESCRIPTION
If a HTTP client is not passed to `build`, the Google API Python client
will create a default one and attempt to authenticate it. This causes
failures in environments where ADC auth is not available (Travis).

In any case, it's not useful to access any auth code in the mock tests.
This commit removes that possibility.