### PR TITLE
go: use time.UnixNano instead of testutil.UIDSpace

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/go/GoSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/go/GoSurfaceNamer.java
@@ -373,6 +373,7 @@ public class GoSurfaceNamer extends SurfaceNamer {
 
   @Override
   public String injectRandomStringGeneratorCode(String randomString) {
-    return randomString.replace(InitFieldConfig.RANDOM_TOKEN, "\" + uidSpace.New() + \"");
+    return randomString.replace(
+        InitFieldConfig.RANDOM_TOKEN, "\" + strconv.FormatInt(time.Now().UnixNano(), 10) + \"");
   }
 }

--- a/src/main/resources/com/google/api/codegen/go/smoke.snip
+++ b/src/main/resources/com/google/api/codegen/go/smoke.snip
@@ -11,7 +11,9 @@
   )
 
   import (
+    "strconv"
     "testing"
+    "time"
 
     "cloud.google.com/go/internal/testutil"
     "golang.org/x/net/context"
@@ -20,6 +22,8 @@
   )
 
   var _ = iterator.Done
+  var _ = strconv.FormatUint
+  var _ = time.Now
 
   func {@view.name}(t *testing.T) {
     if testing.Short() {
@@ -32,8 +36,7 @@
     }
 
     projectId := testutil.ProjID()
-    uidSpace := testutil.NewUIDSpace("{@view.name}")
-    _, _ = projectId, uidSpace
+    _ = projectId
 
     c, err := {@view.method.serviceConstructorName}(ctx, option.WithTokenSource(ts))
     if err != nil {

--- a/src/test/java/com/google/api/codegen/testdata/go_smoke_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_smoke_library.baseline
@@ -22,7 +22,9 @@ import (
 )
 
 import (
+  "strconv"
   "testing"
+  "time"
 
   "cloud.google.com/go/internal/testutil"
   "golang.org/x/net/context"
@@ -31,6 +33,8 @@ import (
 )
 
 var _ = iterator.Done
+var _ = strconv.FormatUint
+var _ = time.Now
 
 func TestLibraryServiceSmoke(t *testing.T) {
   if testing.Short() {
@@ -43,15 +47,14 @@ func TestLibraryServiceSmoke(t *testing.T) {
   }
 
   projectId := testutil.ProjID()
-  uidSpace := testutil.NewUIDSpace("TestLibraryServiceSmoke")
-  _, _ = projectId, uidSpace
+  _ = projectId
 
   c, err := NewClient(ctx, option.WithTokenSource(ts))
   if err != nil {
     t.Fatal(err)
   }
 
-  var formattedName string = LibraryBookPath("testShelf-" + uidSpace.New() + "", projectId)
+  var formattedName string = LibraryBookPath("testShelf-" + strconv.FormatInt(time.Now().UnixNano(), 10) + "", projectId)
   var rating librarypb.Book_Rating = librarypb.Book_GOOD
   var book = &librarypb.Book{
       Rating: rating,


### PR DESCRIPTION
Since generated code should be testable from api-client-staging repo,
we want to reduce dependency on other cloud.google.com/go packages,
especially internal ones.

Clients will still depend on testutil for ProjID and TokenSource.
This is OK, since they can be easily reimplemented in google-client-staging
repo itself.