### PR TITLE
Add a command line option for a Ruby names file

### DIFF
--- a/src/main/java/com/google/api/codegen/DiscoveryFragmentGeneratorApi.java
+++ b/src/main/java/com/google/api/codegen/DiscoveryFragmentGeneratorApi.java
@@ -83,6 +83,9 @@ public class DiscoveryFragmentGeneratorApi {
           "An @-delimited map of language to auth instructions URL: lang:URL@lang:URL@...",
           "");
 
+  public static final Option<String> RUBY_NAMES_FILE =
+      ToolOptions.createOption(String.class, "ruby_names_file", "A Ruby names file.", "");
+
   private final ToolOptions options;
   private final String dataPath;
 
@@ -133,9 +136,11 @@ public class DiscoveryFragmentGeneratorApi {
     ApiaryConfig apiaryConfig = discovery.getConfig();
     apiaryConfig.setAuthInstructionsUrl(parseAuthInstructionsUrl(authInstructions, id));
 
+    File rubyNamesFile = new File(options.get(RUBY_NAMES_FILE));
+
     DiscoveryProviderFactory providerFactory = createProviderFactory(factory);
     DiscoveryProvider provider =
-        providerFactory.create(discovery.getService(), apiaryConfig, overrides, id);
+        providerFactory.create(discovery.getService(), apiaryConfig, overrides, rubyNamesFile, id);
 
     for (Api api : discovery.getService().getApisList()) {
       for (Method method : api.getMethodsList()) {

--- a/src/main/java/com/google/api/codegen/DiscoveryFragmentGeneratorTool.java
+++ b/src/main/java/com/google/api/codegen/DiscoveryFragmentGeneratorTool.java
@@ -69,6 +69,13 @@ public class DiscoveryFragmentGeneratorTool {
             .hasArg()
             .argName("AUTH-INSTRUCTIONS")
             .build());
+    options.addOption(
+        Option.builder()
+            .longOpt("ruby_names_file")
+            .desc("A Ruby names file.")
+            .hasArg()
+            .argName("RUBY-NAMES-FILE")
+            .build());
 
     CommandLine cl = (new DefaultParser()).parse(options, args);
     if (cl.hasOption("help")) {
@@ -81,24 +88,27 @@ public class DiscoveryFragmentGeneratorTool {
         cl.getOptionValues("gapic_yaml"),
         cl.getOptionValue("overrides", ""),
         cl.getOptionValue("output", ""),
-        cl.getOptionValue("auth_instructions", ""));
+        cl.getOptionValue("auth_instructions", ""),
+        cl.getOptionValue("ruby_names_file", ""));
   }
 
   private static void generate(
       String discoveryDoc,
       String[] generatorConfigs,
-      String overridesFile,
+      String overrideFiles,
       String outputDirectory,
-      String authInstructions)
+      String authInstructions,
+      String rubyNamesFile)
       throws Exception {
 
     ToolOptions options = ToolOptions.create();
     options.set(DiscoveryFragmentGeneratorApi.DISCOVERY_DOC, discoveryDoc);
     options.set(
         DiscoveryFragmentGeneratorApi.GENERATOR_CONFIG_FILES, Arrays.asList(generatorConfigs));
-    options.set(DiscoveryFragmentGeneratorApi.OVERRIDE_FILES, overridesFile);
+    options.set(DiscoveryFragmentGeneratorApi.OVERRIDE_FILES, overrideFiles);
     options.set(DiscoveryFragmentGeneratorApi.OUTPUT_FILE, outputDirectory);
     options.set(DiscoveryFragmentGeneratorApi.AUTH_INSTRUCTIONS_URL, authInstructions);
+    options.set(DiscoveryFragmentGeneratorApi.RUBY_NAMES_FILE, rubyNamesFile);
     DiscoveryFragmentGeneratorApi generator = new DiscoveryFragmentGeneratorApi(options);
     generator.run();
   }

--- a/src/main/java/com/google/api/codegen/discovery/DiscoveryProviderFactory.java
+++ b/src/main/java/com/google/api/codegen/discovery/DiscoveryProviderFactory.java
@@ -17,11 +17,15 @@ package com.google.api.codegen.discovery;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.api.Service;
 import com.google.api.codegen.ApiaryConfig;
+import java.io.File;
 import java.util.List;
 
 /** A factory for DiscoveryProviders which perform code generation. */
 public interface DiscoveryProviderFactory {
-  /** Create the provider from the given service, apiaryConfig, sampleConfigOverrides, and id. */
   DiscoveryProvider create(
-      Service service, ApiaryConfig apiaryConfig, List<JsonNode> sampleConfigOverrides, String id);
+      Service service,
+      ApiaryConfig apiaryConfig,
+      List<JsonNode> sampleConfigOverrides,
+      File rubyNamesFile,
+      String id);
 }

--- a/src/main/java/com/google/api/codegen/discovery/MainDiscoveryProviderFactory.java
+++ b/src/main/java/com/google/api/codegen/discovery/MainDiscoveryProviderFactory.java
@@ -39,6 +39,7 @@ import com.google.api.codegen.rendering.CommonSnippetSetRunner;
 import com.google.api.codegen.util.CommonRenderingUtil;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -81,11 +82,14 @@ public class MainDiscoveryProviderFactory implements DiscoveryProviderFactory {
           .put(NODEJS, NodeJSTypeNameGenerator.class)
           .put(PHP, PhpTypeNameGenerator.class)
           .put(PYTHON, PythonTypeNameGenerator.class)
-          .put(RUBY, RubyTypeNameGenerator.class)
           .build();
 
   public static DiscoveryProvider defaultCreate(
-      Service service, ApiaryConfig apiaryConfig, List<JsonNode> sampleConfigOverrides, String id) {
+      Service service,
+      ApiaryConfig apiaryConfig,
+      List<JsonNode> sampleConfigOverrides,
+      File rubyNamesFile,
+      String id) {
     // Use nodes corresponding to language pattern fields matching current language.
     List<JsonNode> overrides = new ArrayList<JsonNode>();
     // Sort patterns to ensure deterministic ordering of overrides
@@ -103,7 +107,11 @@ public class MainDiscoveryProviderFactory implements DiscoveryProviderFactory {
     TypeNameGenerator typeNameGenerator = null;
     try {
       sampleMethodToViewTransformer = SAMPLE_METHOD_TO_VIEW_TRANSFORMER_MAP.get(id).newInstance();
-      typeNameGenerator = TYPE_NAME_GENERATOR_MAP.get(id).newInstance();
+      if (id.equals(RUBY)) {
+        typeNameGenerator = new RubyTypeNameGenerator(rubyNamesFile);
+      } else {
+        typeNameGenerator = TYPE_NAME_GENERATOR_MAP.get(id).newInstance();
+      }
     } catch (InstantiationException | IllegalAccessException e) {
       throw new RuntimeException(e);
     }
@@ -130,7 +138,11 @@ public class MainDiscoveryProviderFactory implements DiscoveryProviderFactory {
 
   @Override
   public DiscoveryProvider create(
-      Service service, ApiaryConfig apiaryConfig, List<JsonNode> sampleConfigOverrides, String id) {
-    return defaultCreate(service, apiaryConfig, sampleConfigOverrides, id);
+      Service service,
+      ApiaryConfig apiaryConfig,
+      List<JsonNode> sampleConfigOverrides,
+      File rubyNamesFile,
+      String id) {
+    return defaultCreate(service, apiaryConfig, sampleConfigOverrides, rubyNamesFile, id);
   }
 }

--- a/src/main/java/com/google/api/codegen/discovery/config/ruby/RubyTypeNameGenerator.java
+++ b/src/main/java/com/google/api/codegen/discovery/config/ruby/RubyTypeNameGenerator.java
@@ -17,12 +17,14 @@ package com.google.api.codegen.discovery.config.ruby;
 import com.google.api.codegen.discovery.config.TypeNameGenerator;
 import com.google.api.codegen.ruby.RubyApiaryNameMap;
 import com.google.api.codegen.util.Name;
+import com.google.common.base.Charsets;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Files;
 import com.google.common.io.Resources;
+import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import org.yaml.snakeyaml.Yaml;
@@ -32,20 +34,24 @@ public class RubyTypeNameGenerator extends TypeNameGenerator {
   private String apiName;
   private final ImmutableMap<String, String> NAME_MAP;
 
-  public RubyTypeNameGenerator() {
+  public RubyTypeNameGenerator(File rubyNamesFile) {
     try {
-      NAME_MAP = getMethodNameMap();
+      NAME_MAP = getMethodNameMap(rubyNamesFile);
     } catch (IOException e) {
       throw new IllegalStateException(e);
     }
   }
 
   @SuppressWarnings("unchecked")
-  private ImmutableMap<String, String> getMethodNameMap() throws IOException {
-    String data =
-        Resources.toString(
-            Resources.getResource(RubyApiaryNameMap.class, "apiary_names.yaml"),
-            StandardCharsets.UTF_8);
+  private ImmutableMap<String, String> getMethodNameMap(File rubyNamesFile) throws IOException {
+    String data;
+    if (rubyNamesFile != null) {
+      data = Files.toString(rubyNamesFile, Charsets.UTF_8);
+    } else {
+      data =
+          Resources.toString(
+              Resources.getResource(RubyApiaryNameMap.class, "apiary_names.yaml"), Charsets.UTF_8);
+    }
     // Unchecked cast here.
     return ImmutableMap.copyOf((Map<String, String>) (new Yaml().load(data)));
   }

--- a/src/test/java/com/google/api/codegen/DiscoveryGeneratorTestBase.java
+++ b/src/test/java/com/google/api/codegen/DiscoveryGeneratorTestBase.java
@@ -109,7 +109,7 @@ public abstract class DiscoveryGeneratorTestBase extends ConfigBaselineTestCase 
     }
     DiscoveryProvider provider =
         MainDiscoveryProviderFactory.defaultCreate(
-            discoveryImporter.getService(), discoveryImporter.getConfig(), overrides, id);
+            discoveryImporter.getService(), discoveryImporter.getConfig(), overrides, null, id);
 
     Doc output = Doc.EMPTY;
     for (Api api : discoveryImporter.getService().getApisList()) {


### PR DESCRIPTION
This option allows a custom Ruby names file to be passed to the sample
generator. It's intended purpose is to make generation of samples for
the mock tests easier.