### PR TITLE
Fix print for map resources in Ruby

### DIFF
--- a/src/main/resources/com/google/api/codegen/ruby/sample.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/sample.snip
@@ -113,7 +113,7 @@
     @if class.pageStreaming.isResourceMap
       {@class.pageStreaming.pageVarName}.each do |{@class.pageStreaming.resourceKeyVarName}, {@class.pageStreaming.resourceValueVarName}|
         @# TODO: Change code below to process each ({@class.pageStreaming.resourceKeyVarName}, {@class.pageStreaming.resourceValueVarName}) pair:
-        puts String({@class.pageStreaming.resourceKeyVarName} << " => " << {@class.pageStreaming.resourceValueVarName}.to_json
+        puts String({@class.pageStreaming.resourceKeyVarName}) + " => " + {@class.pageStreaming.resourceValueVarName}.to_json
       end
     @else
       # We don't handle non-repeated page streaming resources separately in Ruby

--- a/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_compute.v1.json.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/discoveries/ruby/ruby_compute.v1.json.baseline
@@ -31,7 +31,7 @@ end
 
 items.each do |name, addresses_scoped_list|
   # TODO: Change code below to process each (name, addresses_scoped_list) pair:
-  puts String(name << " => " << addresses_scoped_list.to_json
+  puts String(name) + " => " + addresses_scoped_list.to_json
 end
 # BEFORE RUNNING:
 # ---------------
@@ -210,7 +210,7 @@ end
 
 items.each do |name, autoscalers_scoped_list|
   # TODO: Change code below to process each (name, autoscalers_scoped_list) pair:
-  puts String(name << " => " << autoscalers_scoped_list.to_json
+  puts String(name) + " => " + autoscalers_scoped_list.to_json
 end
 # BEFORE RUNNING:
 # ---------------
@@ -466,7 +466,7 @@ end
 
 items.each do |name, backend_services_scoped_list|
   # TODO: Change code below to process each (name, backend_services_scoped_list) pair:
-  puts String(name << " => " << backend_services_scoped_list.to_json
+  puts String(name) + " => " + backend_services_scoped_list.to_json
 end
 # BEFORE RUNNING:
 # ---------------
@@ -742,7 +742,7 @@ end
 
 items.each do |name, disk_types_scoped_list|
   # TODO: Change code below to process each (name, disk_types_scoped_list) pair:
-  puts String(name << " => " << disk_types_scoped_list.to_json
+  puts String(name) + " => " + disk_types_scoped_list.to_json
 end
 # BEFORE RUNNING:
 # ---------------
@@ -849,7 +849,7 @@ end
 
 items.each do |name, disks_scoped_list|
   # TODO: Change code below to process each (name, disks_scoped_list) pair:
-  puts String(name << " => " << disks_scoped_list.to_json
+  puts String(name) + " => " + disks_scoped_list.to_json
 end
 # BEFORE RUNNING:
 # ---------------
@@ -1313,7 +1313,7 @@ end
 
 items.each do |name, forwarding_rules_scoped_list|
   # TODO: Change code below to process each (name, forwarding_rules_scoped_list) pair:
-  puts String(name << " => " << forwarding_rules_scoped_list.to_json
+  puts String(name) + " => " + forwarding_rules_scoped_list.to_json
 end
 # BEFORE RUNNING:
 # ---------------
@@ -1833,7 +1833,7 @@ end
 
 items.each do |name, operations_scoped_list|
   # TODO: Change code below to process each (name, operations_scoped_list) pair:
-  puts String(name << " => " << operations_scoped_list.to_json
+  puts String(name) + " => " + operations_scoped_list.to_json
 end
 # BEFORE RUNNING:
 # ---------------
@@ -2826,7 +2826,7 @@ end
 
 items.each do |name, instance_group_managers_scoped_list|
   # TODO: Change code below to process each (name, instance_group_managers_scoped_list) pair:
-  puts String(name << " => " << instance_group_managers_scoped_list.to_json
+  puts String(name) + " => " + instance_group_managers_scoped_list.to_json
 end
 # BEFORE RUNNING:
 # ---------------
@@ -3277,7 +3277,7 @@ end
 
 items.each do |name, instance_groups_scoped_list|
   # TODO: Change code below to process each (name, instance_groups_scoped_list) pair:
-  puts String(name << " => " << instance_groups_scoped_list.to_json
+  puts String(name) + " => " + instance_groups_scoped_list.to_json
 end
 # BEFORE RUNNING:
 # ---------------
@@ -3752,7 +3752,7 @@ end
 
 items.each do |name, instances_scoped_list|
   # TODO: Change code below to process each (name, instances_scoped_list) pair:
-  puts String(name << " => " << instances_scoped_list.to_json
+  puts String(name) + " => " + instances_scoped_list.to_json
 end
 # BEFORE RUNNING:
 # ---------------
@@ -4504,7 +4504,7 @@ end
 
 items.each do |name, machine_types_scoped_list|
   # TODO: Change code below to process each (name, machine_types_scoped_list) pair:
-  puts String(name << " => " << machine_types_scoped_list.to_json
+  puts String(name) + " => " + machine_types_scoped_list.to_json
 end
 # BEFORE RUNNING:
 # ---------------
@@ -6167,7 +6167,7 @@ end
 
 items.each do |name, routers_scoped_list|
   # TODO: Change code below to process each (name, routers_scoped_list) pair:
-  puts String(name << " => " << routers_scoped_list.to_json
+  puts String(name) + " => " + routers_scoped_list.to_json
 end
 # BEFORE RUNNING:
 # ---------------
@@ -6867,7 +6867,7 @@ end
 
 items.each do |name, subnetworks_scoped_list|
   # TODO: Change code below to process each (name, subnetworks_scoped_list) pair:
-  puts String(name << " => " << subnetworks_scoped_list.to_json
+  puts String(name) + " => " + subnetworks_scoped_list.to_json
 end
 # BEFORE RUNNING:
 # ---------------
@@ -7459,7 +7459,7 @@ end
 
 items.each do |name, target_instances_scoped_list|
   # TODO: Change code below to process each (name, target_instances_scoped_list) pair:
-  puts String(name << " => " << target_instances_scoped_list.to_json
+  puts String(name) + " => " + target_instances_scoped_list.to_json
 end
 # BEFORE RUNNING:
 # ---------------
@@ -7716,7 +7716,7 @@ end
 
 items.each do |name, target_pools_scoped_list|
   # TODO: Change code below to process each (name, target_pools_scoped_list) pair:
-  puts String(name << " => " << target_pools_scoped_list.to_json
+  puts String(name) + " => " + target_pools_scoped_list.to_json
 end
 # BEFORE RUNNING:
 # ---------------
@@ -8292,7 +8292,7 @@ end
 
 items.each do |name, target_vpn_gateways_scoped_list|
   # TODO: Change code below to process each (name, target_vpn_gateways_scoped_list) pair:
-  puts String(name << " => " << target_vpn_gateways_scoped_list.to_json
+  puts String(name) + " => " + target_vpn_gateways_scoped_list.to_json
 end
 # BEFORE RUNNING:
 # ---------------
@@ -8750,7 +8750,7 @@ end
 
 items.each do |name, vpn_tunnels_scoped_list|
   # TODO: Change code below to process each (name, vpn_tunnels_scoped_list) pair:
-  puts String(name << " => " << vpn_tunnels_scoped_list.to_json
+  puts String(name) + " => " + vpn_tunnels_scoped_list.to_json
 end
 # BEFORE RUNNING:
 # ---------------


### PR DESCRIPTION
Also fix a missing ')' bug.
The '<<' was changed to '+' because the key string is immutable.