### PR TITLE
PHP streaming retry and exception tests

### DIFF
--- a/src/main/java/com/google/api/codegen/GapicContext.java
+++ b/src/main/java/com/google/api/codegen/GapicContext.java
@@ -117,6 +117,14 @@ public class GapicContext extends CodegenContext {
     return !method.getRequestStreaming() && !method.getResponseStreaming();
   }
 
+  /**
+   * Returns true when the method supports retrying. By default, all supported methods support
+   * retrying. TODO: when isSupported is removed, this should return true.
+   */
+  public boolean isRetryingSupported(Method method) {
+    return isSupported(method);
+  }
+
   /** Returns a list of RPC methods supported by the context. */
   public List<Method> getSupportedMethods(Interface apiInterface) {
     List<Method> simples = new ArrayList<>(apiInterface.getMethods().size());

--- a/src/main/java/com/google/api/codegen/clientconfig/php/PhpClientConfigGapicContext.java
+++ b/src/main/java/com/google/api/codegen/clientconfig/php/PhpClientConfigGapicContext.java
@@ -1,0 +1,33 @@
+/* Copyright 2016 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.clientconfig.php;
+
+import com.google.api.codegen.clientconfig.ClientConfigGapicContext;
+import com.google.api.codegen.config.GapicProductConfig;
+import com.google.api.tools.framework.model.Method;
+import com.google.api.tools.framework.model.Model;
+
+public class PhpClientConfigGapicContext extends ClientConfigGapicContext {
+
+  /** Constructs the client config codegen context. */
+  public PhpClientConfigGapicContext(Model model, GapicProductConfig config) {
+    super(model, config);
+  }
+
+  @Override
+  public boolean isRetryingSupported(Method method) {
+    return isSupported(method) && !method.getRequestStreaming() && !method.getResponseStreaming();
+  }
+}

--- a/src/main/java/com/google/api/codegen/gapic/MainGapicProviderFactory.java
+++ b/src/main/java/com/google/api/codegen/gapic/MainGapicProviderFactory.java
@@ -19,6 +19,7 @@ import com.google.api.codegen.ProtoFileView;
 import com.google.api.codegen.SnippetSetRunner;
 import com.google.api.codegen.clientconfig.ClientConfigGapicContext;
 import com.google.api.codegen.clientconfig.ClientConfigSnippetSetRunner;
+import com.google.api.codegen.clientconfig.php.PhpClientConfigGapicContext;
 import com.google.api.codegen.config.GapicProductConfig;
 import com.google.api.codegen.config.PackageMetadataConfig;
 import com.google.api.codegen.nodejs.NodeJSCodePathMapper;
@@ -260,7 +261,7 @@ public class MainGapicProviderFactory
             CommonGapicProvider.<Interface>newBuilder()
                 .setModel(model)
                 .setView(new InterfaceView())
-                .setContext(new ClientConfigGapicContext(model, productConfig))
+                .setContext(new PhpClientConfigGapicContext(model, productConfig))
                 .setSnippetSetRunner(
                     new ClientConfigSnippetSetRunner<Interface>(
                         SnippetSetRunner.SNIPPET_RESOURCE_ROOT))

--- a/src/main/resources/com/google/api/codegen/clientconfig/json.snip
+++ b/src/main/resources/com/google/api/codegen/clientconfig/json.snip
@@ -88,12 +88,12 @@
                 retryCodesName = methodConfig.getRetryCodesConfigName, \
                 retryParamsName = methodConfig.getRetrySettingsConfigName
             "{@method.getSimpleName}": {
-              @if or(and(retryCodesName, retryParamsName), isBatching)
+              @if or(and(and(retryCodesName, retryParamsName), context.isRetryingSupported(method)), isBatching)
                 "timeout_millis": {@timeout},
               @else
                 "timeout_millis": {@timeout}
               @end
-              @if and(retryCodesName, retryParamsName)
+              @if and(and(retryCodesName, retryParamsName), context.isRetryingSupported(method))
                   "retry_codes_name": "{@retryCodesName}",
                   @if isBatching
                       "retry_params_name": "{@retryParamsName}",

--- a/src/main/resources/com/google/api/codegen/php/test.snip
+++ b/src/main/resources/com/google/api/codegen/php/test.snip
@@ -134,7 +134,7 @@
         $this->assertTrue($grpcStub->isExhausted());
 
         $status = new stdClass();
-        $status->code = Grpc\STATUS_INTERNAL;
+        $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
         $grpcStub->addResponse(null, $status);
 
@@ -152,6 +152,8 @@
             $this->assertEquals($status->details, $ex->getMessage());
         }
 
+        // Call getReceivedCalls to ensure the stub is exhausted
+        $grpcStub->getReceivedCalls();
         $this->assertTrue($grpcStub->isExhausted());
     }
 @end
@@ -253,7 +255,7 @@
         $grpcStub->addResponse($incompleteOperation);
 
         $status = new stdClass();
-        $status->code = Grpc\STATUS_INTERNAL;
+        $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
         $operationsStub->addResponse(null, $status);
 
@@ -278,6 +280,9 @@
             $this->assertEquals($status->details, $ex->getMessage());
         }
 
+        // Call getReceivedCalls to ensure the stubs are exhausted
+        $grpcStub->getReceivedCalls();
+        $operationsStub->getReceivedCalls();
         $this->assertTrue($grpcStub->isExhausted());
         $this->assertTrue($operationsStub->isExhausted());
     }

--- a/src/test/java/com/google/api/codegen/testdata/php_json_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php_json_library.baseline
@@ -119,24 +119,16 @@
           "retry_params_name": "default"
         },
         "StreamShelves": {
-          "timeout_millis": 30000,
-          "retry_codes_name": "idempotent",
-          "retry_params_name": "default"
+          "timeout_millis": 30000
         },
         "StreamBooks": {
-          "timeout_millis": 30000,
-          "retry_codes_name": "idempotent",
-          "retry_params_name": "default"
+          "timeout_millis": 30000
         },
         "DiscussBook": {
-          "timeout_millis": 30000,
-          "retry_codes_name": "non_idempotent",
-          "retry_params_name": "default"
+          "timeout_millis": 30000
         },
         "MonologAboutBook": {
-          "timeout_millis": 30000,
-          "retry_codes_name": "non_idempotent",
-          "retry_params_name": "default"
+          "timeout_millis": 30000
         },
         "FindRelatedBooks": {
           "timeout_millis": 3000,

--- a/src/test/java/com/google/api/codegen/testdata/php_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php_test_library.baseline
@@ -167,7 +167,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($grpcStub->isExhausted());
 
         $status = new stdClass();
-        $status->code = Grpc\STATUS_INTERNAL;
+        $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
         $grpcStub->addResponse(null, $status);
 
@@ -183,6 +183,8 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->assertEquals($status->details, $ex->getMessage());
         }
 
+        // Call getReceivedCalls to ensure the stub is exhausted
+        $grpcStub->getReceivedCalls();
         $this->assertTrue($grpcStub->isExhausted());
     }
 
@@ -235,7 +237,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($grpcStub->isExhausted());
 
         $status = new stdClass();
-        $status->code = Grpc\STATUS_INTERNAL;
+        $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
         $grpcStub->addResponse(null, $status);
 
@@ -252,6 +254,8 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->assertEquals($status->details, $ex->getMessage());
         }
 
+        // Call getReceivedCalls to ensure the stub is exhausted
+        $grpcStub->getReceivedCalls();
         $this->assertTrue($grpcStub->isExhausted());
     }
 
@@ -302,7 +306,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($grpcStub->isExhausted());
 
         $status = new stdClass();
-        $status->code = Grpc\STATUS_INTERNAL;
+        $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
         $grpcStub->addResponse(null, $status);
 
@@ -315,6 +319,8 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->assertEquals($status->details, $ex->getMessage());
         }
 
+        // Call getReceivedCalls to ensure the stub is exhausted
+        $grpcStub->getReceivedCalls();
         $this->assertTrue($grpcStub->isExhausted());
     }
 
@@ -358,7 +364,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($grpcStub->isExhausted());
 
         $status = new stdClass();
-        $status->code = Grpc\STATUS_INTERNAL;
+        $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
         $grpcStub->addResponse(null, $status);
 
@@ -374,6 +380,8 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->assertEquals($status->details, $ex->getMessage());
         }
 
+        // Call getReceivedCalls to ensure the stub is exhausted
+        $grpcStub->getReceivedCalls();
         $this->assertTrue($grpcStub->isExhausted());
     }
 
@@ -426,7 +434,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($grpcStub->isExhausted());
 
         $status = new stdClass();
-        $status->code = Grpc\STATUS_INTERNAL;
+        $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
         $grpcStub->addResponse(null, $status);
 
@@ -443,6 +451,8 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->assertEquals($status->details, $ex->getMessage());
         }
 
+        // Call getReceivedCalls to ensure the stub is exhausted
+        $grpcStub->getReceivedCalls();
         $this->assertTrue($grpcStub->isExhausted());
     }
 
@@ -497,7 +507,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($grpcStub->isExhausted());
 
         $status = new stdClass();
-        $status->code = Grpc\STATUS_INTERNAL;
+        $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
         $grpcStub->addResponse(null, $status);
 
@@ -514,6 +524,8 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->assertEquals($status->details, $ex->getMessage());
         }
 
+        // Call getReceivedCalls to ensure the stub is exhausted
+        $grpcStub->getReceivedCalls();
         $this->assertTrue($grpcStub->isExhausted());
     }
 
@@ -569,7 +581,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($grpcStub->isExhausted());
 
         $status = new stdClass();
-        $status->code = Grpc\STATUS_INTERNAL;
+        $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
         $grpcStub->addResponse(null, $status);
 
@@ -589,6 +601,8 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->assertEquals($status->details, $ex->getMessage());
         }
 
+        // Call getReceivedCalls to ensure the stub is exhausted
+        $grpcStub->getReceivedCalls();
         $this->assertTrue($grpcStub->isExhausted());
     }
 
@@ -641,7 +655,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($grpcStub->isExhausted());
 
         $status = new stdClass();
-        $status->code = Grpc\STATUS_INTERNAL;
+        $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
         $grpcStub->addResponse(null, $status);
 
@@ -657,6 +671,8 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->assertEquals($status->details, $ex->getMessage());
         }
 
+        // Call getReceivedCalls to ensure the stub is exhausted
+        $grpcStub->getReceivedCalls();
         $this->assertTrue($grpcStub->isExhausted());
     }
 
@@ -711,7 +727,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($grpcStub->isExhausted());
 
         $status = new stdClass();
-        $status->code = Grpc\STATUS_INTERNAL;
+        $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
         $grpcStub->addResponse(null, $status);
 
@@ -727,6 +743,8 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->assertEquals($status->details, $ex->getMessage());
         }
 
+        // Call getReceivedCalls to ensure the stub is exhausted
+        $grpcStub->getReceivedCalls();
         $this->assertTrue($grpcStub->isExhausted());
     }
 
@@ -770,7 +788,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($grpcStub->isExhausted());
 
         $status = new stdClass();
-        $status->code = Grpc\STATUS_INTERNAL;
+        $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
         $grpcStub->addResponse(null, $status);
 
@@ -786,6 +804,8 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->assertEquals($status->details, $ex->getMessage());
         }
 
+        // Call getReceivedCalls to ensure the stub is exhausted
+        $grpcStub->getReceivedCalls();
         $this->assertTrue($grpcStub->isExhausted());
     }
 
@@ -840,7 +860,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($grpcStub->isExhausted());
 
         $status = new stdClass();
-        $status->code = Grpc\STATUS_INTERNAL;
+        $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
         $grpcStub->addResponse(null, $status);
 
@@ -857,6 +877,8 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->assertEquals($status->details, $ex->getMessage());
         }
 
+        // Call getReceivedCalls to ensure the stub is exhausted
+        $grpcStub->getReceivedCalls();
         $this->assertTrue($grpcStub->isExhausted());
     }
 
@@ -911,7 +933,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($grpcStub->isExhausted());
 
         $status = new stdClass();
-        $status->code = Grpc\STATUS_INTERNAL;
+        $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
         $grpcStub->addResponse(null, $status);
 
@@ -928,6 +950,8 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->assertEquals($status->details, $ex->getMessage());
         }
 
+        // Call getReceivedCalls to ensure the stub is exhausted
+        $grpcStub->getReceivedCalls();
         $this->assertTrue($grpcStub->isExhausted());
     }
 
@@ -978,7 +1002,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($grpcStub->isExhausted());
 
         $status = new stdClass();
-        $status->code = Grpc\STATUS_INTERNAL;
+        $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
         $grpcStub->addResponse(null, $status);
 
@@ -991,6 +1015,8 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->assertEquals($status->details, $ex->getMessage());
         }
 
+        // Call getReceivedCalls to ensure the stub is exhausted
+        $grpcStub->getReceivedCalls();
         $this->assertTrue($grpcStub->isExhausted());
     }
 
@@ -1043,7 +1069,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($grpcStub->isExhausted());
 
         $status = new stdClass();
-        $status->code = Grpc\STATUS_INTERNAL;
+        $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
         $grpcStub->addResponse(null, $status);
 
@@ -1067,6 +1093,8 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->assertEquals($status->details, $ex->getMessage());
         }
 
+        // Call getReceivedCalls to ensure the stub is exhausted
+        $grpcStub->getReceivedCalls();
         $this->assertTrue($grpcStub->isExhausted());
     }
 
@@ -1119,7 +1147,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($grpcStub->isExhausted());
 
         $status = new stdClass();
-        $status->code = Grpc\STATUS_INTERNAL;
+        $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
         $grpcStub->addResponse(null, $status);
 
@@ -1135,6 +1163,8 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->assertEquals($status->details, $ex->getMessage());
         }
 
+        // Call getReceivedCalls to ensure the stub is exhausted
+        $grpcStub->getReceivedCalls();
         $this->assertTrue($grpcStub->isExhausted());
     }
 
@@ -1189,7 +1219,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($grpcStub->isExhausted());
 
         $status = new stdClass();
-        $status->code = Grpc\STATUS_INTERNAL;
+        $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
         $grpcStub->addResponse(null, $status);
 
@@ -1206,6 +1236,8 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->assertEquals($status->details, $ex->getMessage());
         }
 
+        // Call getReceivedCalls to ensure the stub is exhausted
+        $grpcStub->getReceivedCalls();
         $this->assertTrue($grpcStub->isExhausted());
     }
 
@@ -1254,7 +1286,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($grpcStub->isExhausted());
 
         $status = new stdClass();
-        $status->code = Grpc\STATUS_INTERNAL;
+        $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
         $grpcStub->addResponse(null, $status);
 
@@ -1273,6 +1305,8 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->assertEquals($status->details, $ex->getMessage());
         }
 
+        // Call getReceivedCalls to ensure the stub is exhausted
+        $grpcStub->getReceivedCalls();
         $this->assertTrue($grpcStub->isExhausted());
     }
 
@@ -1330,7 +1364,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($grpcStub->isExhausted());
 
         $status = new stdClass();
-        $status->code = Grpc\STATUS_INTERNAL;
+        $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
         $grpcStub->addResponse(null, $status);
 
@@ -1348,6 +1382,8 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->assertEquals($status->details, $ex->getMessage());
         }
 
+        // Call getReceivedCalls to ensure the stub is exhausted
+        $grpcStub->getReceivedCalls();
         $this->assertTrue($grpcStub->isExhausted());
     }
 
@@ -1394,7 +1430,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($grpcStub->isExhausted());
 
         $status = new stdClass();
-        $status->code = Grpc\STATUS_INTERNAL;
+        $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
         $grpcStub->addResponse(null, $status);
 
@@ -1411,6 +1447,8 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->assertEquals($status->details, $ex->getMessage());
         }
 
+        // Call getReceivedCalls to ensure the stub is exhausted
+        $grpcStub->getReceivedCalls();
         $this->assertTrue($grpcStub->isExhausted());
     }
 
@@ -1457,7 +1495,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($grpcStub->isExhausted());
 
         $status = new stdClass();
-        $status->code = Grpc\STATUS_INTERNAL;
+        $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
         $grpcStub->addResponse(null, $status);
 
@@ -1474,6 +1512,8 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->assertEquals($status->details, $ex->getMessage());
         }
 
+        // Call getReceivedCalls to ensure the stub is exhausted
+        $grpcStub->getReceivedCalls();
         $this->assertTrue($grpcStub->isExhausted());
     }
 
@@ -1580,7 +1620,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $grpcStub->addResponse($incompleteOperation);
 
         $status = new stdClass();
-        $status->code = Grpc\STATUS_INTERNAL;
+        $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
         $operationsStub->addResponse(null, $status);
 
@@ -1603,6 +1643,9 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->assertEquals($status->details, $ex->getMessage());
         }
 
+        // Call getReceivedCalls to ensure the stubs are exhausted
+        $grpcStub->getReceivedCalls();
+        $operationsStub->getReceivedCalls();
         $this->assertTrue($grpcStub->isExhausted());
         $this->assertTrue($operationsStub->isExhausted());
     }
@@ -1702,7 +1745,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $grpcStub->addResponse($incompleteOperation);
 
         $status = new stdClass();
-        $status->code = Grpc\STATUS_INTERNAL;
+        $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
         $operationsStub->addResponse(null, $status);
 
@@ -1725,6 +1768,9 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->assertEquals($status->details, $ex->getMessage());
         }
 
+        // Call getReceivedCalls to ensure the stubs are exhausted
+        $grpcStub->getReceivedCalls();
+        $operationsStub->getReceivedCalls();
         $this->assertTrue($grpcStub->isExhausted());
         $this->assertTrue($operationsStub->isExhausted());
     }
@@ -1822,7 +1868,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($grpcStub->isExhausted());
 
         $status = new stdClass();
-        $status->code = Grpc\STATUS_INTERNAL;
+        $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
         $grpcStub->addResponse(null, $status);
 
@@ -1864,6 +1910,8 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->assertEquals($status->details, $ex->getMessage());
         }
 
+        // Call getReceivedCalls to ensure the stub is exhausted
+        $grpcStub->getReceivedCalls();
         $this->assertTrue($grpcStub->isExhausted());
     }
 


### PR DESCRIPTION
This PR:
- Removes retry settings from PHP streaming methods. Retrying does not make sense in that context, and GAX prevents the use of retry settings for streaming methods in PHP
- Changes from INTERNAL errors to DATA_LOSS errors, because some methods are configured to retry on INTERNAL errors(!)
- Call getReceivedCalls in exception tests so that the stub will be exhausted