### PR TITLE
Use absolute path in build.gradle

### DIFF
--- a/src/main/resources/com/google/api/codegen/metadatagen/java/grpc/build.gradle.snip
+++ b/src/main/resources/com/google/api/codegen/metadatagen/java/grpc/build.gradle.snip
@@ -24,6 +24,7 @@
 
   ext {
     packageName = '{@metadata.identifier}'
+    javaDocRoot = projectDir.getAbsolutePath() + '/tmp_gh-pages'
   }
 
   sourceSets {
@@ -106,8 +107,9 @@
   }
 
   task checkOutGhPages << {
-    if (!new File('tmp_gh-pages').exists()) {
+    if (!new File(javaDocRoot).exists()) {
       exec {
+        workingDir projectDir
         commandLine 'git', 'clone', '--branch', 'gh-pages',
             '--single-branch', 'git@@github.com:googleapis/googleapis.git', 'tmp_gh-pages'
       }
@@ -118,7 +120,7 @@
     dependsOn 'checkOutGhPages'
     dependsOn 'javadoc'
     doLast {
-      def newSiteDirPath = "tmp_gh-pages/java/${packageName}/${project.version}/apidocs/"
+      def newSiteDirPath = javaDocRoot + "/java/${packageName}/${project.version}/apidocs/"
       new File(newSiteDirPath).mkdirs()
       copy {
         from 'build/docs/javadoc'
@@ -130,17 +132,17 @@
   task createApiDocsRedirect {
     dependsOn 'copyFilesToGhPages'
     doLast {
-      def outputContent = new File('templates/apidocs_index.html.template').text
+      def outputContent = new File(projectDir.getAbsolutePath() + '/templates/apidocs_index.html.template').text
       outputContent = outputContent.replace('{{siteVersion}}', project.version)
       outputContent = outputContent.replace('{{packageName}}', packageName)
-      new File("tmp_gh-pages/java/${packageName}/apidocs").mkdirs()
-      new File("tmp_gh-pages/java/${packageName}/apidocs/index.html").write(outputContent)
+      new File(javaDocRoot + "/java/${packageName}/apidocs").mkdirs()
+      new File(javaDocRoot + "/java/${packageName}/apidocs/index.html").write(outputContent)
       exec {
-        workingDir 'tmp_gh-pages/'
+        workingDir javaDocRoot
         commandLine 'git', 'add', '.'
       }
       exec {
-        workingDir 'tmp_gh-pages/'
+        workingDir javaDocRoot
         commandLine 'git', 'commit', '-m', "Regenerating docs for ${packageName} ${project.version}"
       }
       println 'New docs have been generated under tmp_gh-pages and have been committed;'

--- a/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/java_common_protos.baseline
+++ b/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/java_common_protos.baseline
@@ -230,6 +230,7 @@ dependencies {
 
 ext {
   packageName = 'proto-google-common-protos'
+  javaDocRoot = projectDir.getAbsolutePath() + '/tmp_gh-pages'
 }
 
 sourceSets {
@@ -312,8 +313,9 @@ if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')
 }
 
 task checkOutGhPages << {
-  if (!new File('tmp_gh-pages').exists()) {
+  if (!new File(javaDocRoot).exists()) {
     exec {
+      workingDir projectDir
       commandLine 'git', 'clone', '--branch', 'gh-pages',
           '--single-branch', 'git@github.com:googleapis/googleapis.git', 'tmp_gh-pages'
     }
@@ -324,7 +326,7 @@ task copyFilesToGhPages {
   dependsOn 'checkOutGhPages'
   dependsOn 'javadoc'
   doLast {
-    def newSiteDirPath = "tmp_gh-pages/java/${packageName}/${project.version}/apidocs/"
+    def newSiteDirPath = javaDocRoot + "/java/${packageName}/${project.version}/apidocs/"
     new File(newSiteDirPath).mkdirs()
     copy {
       from 'build/docs/javadoc'
@@ -336,17 +338,17 @@ task copyFilesToGhPages {
 task createApiDocsRedirect {
   dependsOn 'copyFilesToGhPages'
   doLast {
-    def outputContent = new File('templates/apidocs_index.html.template').text
+    def outputContent = new File(projectDir.getAbsolutePath() + '/templates/apidocs_index.html.template').text
     outputContent = outputContent.replace('{{siteVersion}}', project.version)
     outputContent = outputContent.replace('{{packageName}}', packageName)
-    new File("tmp_gh-pages/java/${packageName}/apidocs").mkdirs()
-    new File("tmp_gh-pages/java/${packageName}/apidocs/index.html").write(outputContent)
+    new File(javaDocRoot + "/java/${packageName}/apidocs").mkdirs()
+    new File(javaDocRoot + "/java/${packageName}/apidocs/index.html").write(outputContent)
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'add', '.'
     }
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'commit', '-m', "Regenerating docs for ${packageName} ${project.version}"
     }
     println 'New docs have been generated under tmp_gh-pages and have been committed;'

--- a/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/java_grpc_stubs.baseline
+++ b/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/java_grpc_stubs.baseline
@@ -231,6 +231,7 @@ dependencies {
 
 ext {
   packageName = 'grpc-google-cloud-library-v1'
+  javaDocRoot = projectDir.getAbsolutePath() + '/tmp_gh-pages'
 }
 
 sourceSets {
@@ -313,8 +314,9 @@ if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')
 }
 
 task checkOutGhPages << {
-  if (!new File('tmp_gh-pages').exists()) {
+  if (!new File(javaDocRoot).exists()) {
     exec {
+      workingDir projectDir
       commandLine 'git', 'clone', '--branch', 'gh-pages',
           '--single-branch', 'git@github.com:googleapis/googleapis.git', 'tmp_gh-pages'
     }
@@ -325,7 +327,7 @@ task copyFilesToGhPages {
   dependsOn 'checkOutGhPages'
   dependsOn 'javadoc'
   doLast {
-    def newSiteDirPath = "tmp_gh-pages/java/${packageName}/${project.version}/apidocs/"
+    def newSiteDirPath = javaDocRoot + "/java/${packageName}/${project.version}/apidocs/"
     new File(newSiteDirPath).mkdirs()
     copy {
       from 'build/docs/javadoc'
@@ -337,17 +339,17 @@ task copyFilesToGhPages {
 task createApiDocsRedirect {
   dependsOn 'copyFilesToGhPages'
   doLast {
-    def outputContent = new File('templates/apidocs_index.html.template').text
+    def outputContent = new File(projectDir.getAbsolutePath() + '/templates/apidocs_index.html.template').text
     outputContent = outputContent.replace('{{siteVersion}}', project.version)
     outputContent = outputContent.replace('{{packageName}}', packageName)
-    new File("tmp_gh-pages/java/${packageName}/apidocs").mkdirs()
-    new File("tmp_gh-pages/java/${packageName}/apidocs/index.html").write(outputContent)
+    new File(javaDocRoot + "/java/${packageName}/apidocs").mkdirs()
+    new File(javaDocRoot + "/java/${packageName}/apidocs/index.html").write(outputContent)
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'add', '.'
     }
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'commit', '-m', "Regenerating docs for ${packageName} ${project.version}"
     }
     println 'New docs have been generated under tmp_gh-pages and have been committed;'

--- a/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/java_library.baseline
@@ -232,6 +232,7 @@ dependencies {
 
 ext {
   packageName = 'proto-google-cloud-library-v1'
+  javaDocRoot = projectDir.getAbsolutePath() + '/tmp_gh-pages'
 }
 
 sourceSets {
@@ -314,8 +315,9 @@ if (project.hasProperty('ossrhUsername') && project.hasProperty('ossrhPassword')
 }
 
 task checkOutGhPages << {
-  if (!new File('tmp_gh-pages').exists()) {
+  if (!new File(javaDocRoot).exists()) {
     exec {
+      workingDir projectDir
       commandLine 'git', 'clone', '--branch', 'gh-pages',
           '--single-branch', 'git@github.com:googleapis/googleapis.git', 'tmp_gh-pages'
     }
@@ -326,7 +328,7 @@ task copyFilesToGhPages {
   dependsOn 'checkOutGhPages'
   dependsOn 'javadoc'
   doLast {
-    def newSiteDirPath = "tmp_gh-pages/java/${packageName}/${project.version}/apidocs/"
+    def newSiteDirPath = javaDocRoot + "/java/${packageName}/${project.version}/apidocs/"
     new File(newSiteDirPath).mkdirs()
     copy {
       from 'build/docs/javadoc'
@@ -338,17 +340,17 @@ task copyFilesToGhPages {
 task createApiDocsRedirect {
   dependsOn 'copyFilesToGhPages'
   doLast {
-    def outputContent = new File('templates/apidocs_index.html.template').text
+    def outputContent = new File(projectDir.getAbsolutePath() + '/templates/apidocs_index.html.template').text
     outputContent = outputContent.replace('{{siteVersion}}', project.version)
     outputContent = outputContent.replace('{{packageName}}', packageName)
-    new File("tmp_gh-pages/java/${packageName}/apidocs").mkdirs()
-    new File("tmp_gh-pages/java/${packageName}/apidocs/index.html").write(outputContent)
+    new File(javaDocRoot + "/java/${packageName}/apidocs").mkdirs()
+    new File(javaDocRoot + "/java/${packageName}/apidocs/index.html").write(outputContent)
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'add', '.'
     }
     exec {
-      workingDir 'tmp_gh-pages/'
+      workingDir javaDocRoot
       commandLine 'git', 'commit', '-m', "Regenerating docs for ${packageName} ${project.version}"
     }
     println 'New docs have been generated under tmp_gh-pages and have been committed;'


### PR DESCRIPTION
Relative paths do not work well in the new api-client-staging structure since it depends on the directory of execution. Switching to use absolute path with `projectDir` solves this problem.

I will update the api-client-staging PR once the CI is fixed