### PR TITLE
Add `updateAndPushDocs` task

### DIFF
--- a/src/main/resources/com/google/api/codegen/metadatagen/java/grpc/build.gradle.snip
+++ b/src/main/resources/com/google/api/codegen/metadatagen/java/grpc/build.gradle.snip
@@ -129,7 +129,8 @@
     }
   }
 
-  task createApiDocsRedirect {
+  // Regenerates the gh-pages branch under tmp_gh-pages
+  task updateDocs {
     dependsOn 'copyFilesToGhPages'
     doLast {
       def outputContent = new File(projectDir.getAbsolutePath() + '/templates/apidocs_index.html.template').text
@@ -150,14 +151,9 @@
     }
   }
 
-  // Regenerates the gh-pages branch under tmp_gh-pages
-  task updateDocs {
-    dependsOn 'createApiDocsRedirect'
-  }
-
   // Regenerates and push the gh-pages branch under tmp_gh-pages
   task updateAndPushDocs {
-    dependsOn 'createApiDocsRedirect'
+    dependsOn 'updateDocs'
     doLast {
       exec {
         workingDir javaDocRoot

--- a/src/main/resources/com/google/api/codegen/metadatagen/java/grpc/build.gradle.snip
+++ b/src/main/resources/com/google/api/codegen/metadatagen/java/grpc/build.gradle.snip
@@ -150,9 +150,21 @@
     }
   }
 
-  // Regenerates the gh-pages branch under tmp_gh-pages, which must be committed separately
-  task updateDocsWithCurrentVersion {
+  // Regenerates the gh-pages branch under tmp_gh-pages
+  task updateDocs {
     dependsOn 'createApiDocsRedirect'
+  }
+
+  // Regenerates and push the gh-pages branch under tmp_gh-pages
+  task updateAndPushDocs {
+    dependsOn 'createApiDocsRedirect'
+    doLast {
+      exec {
+        workingDir javaDocRoot
+        commandLine 'git', 'push'
+        println "New docs have been pushed to Github for ${packageName} ${project.version}"
+      }
+    }
   }
 
 @end

--- a/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/java_common_protos.baseline
+++ b/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/java_common_protos.baseline
@@ -335,7 +335,8 @@ task copyFilesToGhPages {
   }
 }
 
-task createApiDocsRedirect {
+// Regenerates the gh-pages branch under tmp_gh-pages
+task updateDocs {
   dependsOn 'copyFilesToGhPages'
   doLast {
     def outputContent = new File(projectDir.getAbsolutePath() + '/templates/apidocs_index.html.template').text
@@ -356,14 +357,9 @@ task createApiDocsRedirect {
   }
 }
 
-// Regenerates the gh-pages branch under tmp_gh-pages
-task updateDocs {
-  dependsOn 'createApiDocsRedirect'
-}
-
 // Regenerates and push the gh-pages branch under tmp_gh-pages
 task updateAndPushDocs {
-  dependsOn 'createApiDocsRedirect'
+  dependsOn 'updateDocs'
   doLast {
     exec {
       workingDir javaDocRoot

--- a/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/java_common_protos.baseline
+++ b/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/java_common_protos.baseline
@@ -356,8 +356,20 @@ task createApiDocsRedirect {
   }
 }
 
-// Regenerates the gh-pages branch under tmp_gh-pages, which must be committed separately
-task updateDocsWithCurrentVersion {
+// Regenerates the gh-pages branch under tmp_gh-pages
+task updateDocs {
   dependsOn 'createApiDocsRedirect'
+}
+
+// Regenerates and push the gh-pages branch under tmp_gh-pages
+task updateAndPushDocs {
+  dependsOn 'createApiDocsRedirect'
+  doLast {
+    exec {
+      workingDir javaDocRoot
+      commandLine 'git', 'push'
+      println "New docs have been pushed to Github for ${packageName} ${project.version}"
+    }
+  }
 }
 

--- a/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/java_grpc_stubs.baseline
+++ b/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/java_grpc_stubs.baseline
@@ -357,8 +357,20 @@ task createApiDocsRedirect {
   }
 }
 
-// Regenerates the gh-pages branch under tmp_gh-pages, which must be committed separately
-task updateDocsWithCurrentVersion {
+// Regenerates the gh-pages branch under tmp_gh-pages
+task updateDocs {
   dependsOn 'createApiDocsRedirect'
+}
+
+// Regenerates and push the gh-pages branch under tmp_gh-pages
+task updateAndPushDocs {
+  dependsOn 'createApiDocsRedirect'
+  doLast {
+    exec {
+      workingDir javaDocRoot
+      commandLine 'git', 'push'
+      println "New docs have been pushed to Github for ${packageName} ${project.version}"
+    }
+  }
 }
 

--- a/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/java_grpc_stubs.baseline
+++ b/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/java_grpc_stubs.baseline
@@ -336,7 +336,8 @@ task copyFilesToGhPages {
   }
 }
 
-task createApiDocsRedirect {
+// Regenerates the gh-pages branch under tmp_gh-pages
+task updateDocs {
   dependsOn 'copyFilesToGhPages'
   doLast {
     def outputContent = new File(projectDir.getAbsolutePath() + '/templates/apidocs_index.html.template').text
@@ -357,14 +358,9 @@ task createApiDocsRedirect {
   }
 }
 
-// Regenerates the gh-pages branch under tmp_gh-pages
-task updateDocs {
-  dependsOn 'createApiDocsRedirect'
-}
-
 // Regenerates and push the gh-pages branch under tmp_gh-pages
 task updateAndPushDocs {
-  dependsOn 'createApiDocsRedirect'
+  dependsOn 'updateDocs'
   doLast {
     exec {
       workingDir javaDocRoot

--- a/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/java_library.baseline
@@ -358,8 +358,20 @@ task createApiDocsRedirect {
   }
 }
 
-// Regenerates the gh-pages branch under tmp_gh-pages, which must be committed separately
-task updateDocsWithCurrentVersion {
+// Regenerates the gh-pages branch under tmp_gh-pages
+task updateDocs {
   dependsOn 'createApiDocsRedirect'
+}
+
+// Regenerates and push the gh-pages branch under tmp_gh-pages
+task updateAndPushDocs {
+  dependsOn 'createApiDocsRedirect'
+  doLast {
+    exec {
+      workingDir javaDocRoot
+      commandLine 'git', 'push'
+      println "New docs have been pushed to Github for ${packageName} ${project.version}"
+    }
+  }
 }
 

--- a/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/grpcmetadatagen/testdata/java_library.baseline
@@ -337,7 +337,8 @@ task copyFilesToGhPages {
   }
 }
 
-task createApiDocsRedirect {
+// Regenerates the gh-pages branch under tmp_gh-pages
+task updateDocs {
   dependsOn 'copyFilesToGhPages'
   doLast {
     def outputContent = new File(projectDir.getAbsolutePath() + '/templates/apidocs_index.html.template').text
@@ -358,14 +359,9 @@ task createApiDocsRedirect {
   }
 }
 
-// Regenerates the gh-pages branch under tmp_gh-pages
-task updateDocs {
-  dependsOn 'createApiDocsRedirect'
-}
-
 // Regenerates and push the gh-pages branch under tmp_gh-pages
 task updateAndPushDocs {
-  dependsOn 'createApiDocsRedirect'
+  dependsOn 'updateDocs'
   doLast {
     exec {
       workingDir javaDocRoot


### PR DESCRIPTION
After this PR the producer only needs to execute
```
./gradlew updateAndPushDocs
```
from the java root directory in api-client-staging. This command will automatically update and push all the javadocs into Github.io

If you don't want the automatic push, you can still run:
```
./gradlew updateDocs
```

This command will only update and commit the docs so you can push them manually.