### PR TITLE
Ruby: Use native hash to protobuf coercion

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/GrpcElementDocTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/GrpcElementDocTransformer.java
@@ -65,7 +65,7 @@ public class GrpcElementDocTransformer {
     for (Field field : fields) {
       SimpleParamDocView.Builder doc = SimpleParamDocView.newBuilder();
       doc.paramName(namer.getFieldKey(field));
-      doc.typeName(namer.getParamTypeName(typeTable, field.getType()));
+      doc.typeName(namer.getMessagePropertyTypeName(typeTable, field.getType()));
       doc.lines(namer.getDocLines(field));
       propertyDocs.add(doc.build());
     }

--- a/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
@@ -133,9 +133,18 @@ public class InitCodeTransformer {
         enumTypeName = methodContext.getTypeTable().getNicknameFor(fieldType);
       }
 
+      String messageTypeName = null;
+      if (fieldType.isMessage() && !fieldType.isRepeated()) {
+        messageTypeName = methodContext.getTypeTable().getFullNameFor(fieldType);
+      }
+
       assertViews.add(
           createAssertView(
-              expectedValueIdentifier, expectedTransformFunction, getterMethod, enumTypeName));
+              expectedValueIdentifier,
+              expectedTransformFunction,
+              getterMethod,
+              enumTypeName,
+              messageTypeName));
     }
     return assertViews;
   }
@@ -161,12 +170,17 @@ public class InitCodeTransformer {
   }
 
   private ClientTestAssertView createAssertView(
-      String expected, String expectedTransformFunction, String actual, String enumTypeName) {
+      String expected,
+      String expectedTransformFunction,
+      String actual,
+      String enumTypeName,
+      String messageTypeName) {
     return ClientTestAssertView.newBuilder()
         .expectedValueIdentifier(expected)
         .expectedValueTransformFunction(expectedTransformFunction)
         .actualValueGetter(actual)
         .enumTypeName(enumTypeName)
+        .messageTypeName(messageTypeName)
         .build();
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
@@ -695,6 +695,11 @@ public class SurfaceNamer extends NameFormatterDelegator {
     return getNotImplementedString("SurfaceNamer.getParamTypeName");
   }
 
+  /** The type name for the message property */
+  public String getMessagePropertyTypeName(ModelTypeTable typeTable, TypeRef type) {
+    return getParamTypeName(typeTable, type);
+  }
+
   /** The type name for retry settings. */
   public String getRetrySettingsTypeName() {
     return getNotImplementedString("SurfaceNamer.getRetrySettingsClassName");

--- a/src/main/java/com/google/api/codegen/transformer/TestCaseTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/TestCaseTransformer.java
@@ -60,6 +60,8 @@ public class TestCaseTransformer {
 
     String clientMethodName;
     String responseTypeName;
+    String fullyQualifiedResponseTypeName =
+        methodContext.getTypeTable().getFullNameFor(method.getOutputType());
     if (methodConfig.isPageStreaming()) {
       clientMethodName = namer.getApiMethodName(method, methodConfig.getVisibility());
       responseTypeName =
@@ -73,6 +75,10 @@ public class TestCaseTransformer {
           methodContext
               .getTypeTable()
               .getAndSaveNicknameFor(methodConfig.getLongRunningConfig().getReturnType());
+      fullyQualifiedResponseTypeName =
+          methodContext
+              .getTypeTable()
+              .getFullNameFor(methodConfig.getLongRunningConfig().getReturnType());
     } else if (clientMethodType == ClientMethodType.CallableMethod) {
       clientMethodName = namer.getCallableMethodName(method);
       responseTypeName = methodContext.getTypeTable().getAndSaveNicknameFor(method.getOutputType());
@@ -104,6 +110,9 @@ public class TestCaseTransformer {
         .pageStreamingResponseViews(createPageStreamingResponseViews(methodContext))
         .requestTypeName(methodContext.getTypeTable().getAndSaveNicknameFor(method.getInputType()))
         .responseTypeName(responseTypeName)
+        .fullyQualifiedRequestTypeName(
+            methodContext.getTypeTable().getFullNameFor(method.getInputType()))
+        .fullyQualifiedResponseTypeName(fullyQualifiedResponseTypeName)
         .serviceConstructorName(
             namer.getApiWrapperClassConstructorName(methodContext.getInterface()))
         .fullyQualifiedServiceClassName(

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubyApiMethodParamTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubyApiMethodParamTransformer.java
@@ -113,6 +113,13 @@ public class RubyApiMethodParamTransformer implements ApiMethodParamTransformer 
             "resources in a page.");
       } else {
         docLines.addAll(namer.getDocLines(field));
+        if (field.getType().isMessage()) {
+          docLines.add(
+              String.format(
+                  "A hash of the same form as `%s`",
+                  context.getTypeTable().getFullNameFor(field.getType())));
+          docLines.add("can also be provided.");
+        }
       }
       paramDoc.lines(docLines.build());
       docs.add(paramDoc.build());

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubyApiMethodParamTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubyApiMethodParamTransformer.java
@@ -113,11 +113,20 @@ public class RubyApiMethodParamTransformer implements ApiMethodParamTransformer 
             "resources in a page.");
       } else {
         docLines.addAll(namer.getDocLines(field));
-        if (field.getType().isMessage()) {
-          docLines.add(
-              String.format(
-                  "A hash of the same form as `%s`",
-                  context.getTypeTable().getFullNameFor(field.getType())));
+        boolean isMessageField = field.getType().isMessage() && !field.getType().isMap();
+        boolean isMapContainingMessage =
+            field.getType().isMap() && field.getType().getMapValueField().getType().isMessage();
+        if (isMessageField || isMapContainingMessage) {
+          String messageType;
+          if (isMapContainingMessage) {
+            messageType =
+                context
+                    .getTypeTable()
+                    .getFullNameForElementType(field.getType().getMapValueField().getType());
+          } else {
+            messageType = context.getTypeTable().getFullNameForElementType(field.getType());
+          }
+          docLines.add(String.format("A hash of the same form as `%s`", messageType));
           docLines.add("can also be provided.");
         }
       }

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubyModelTypeNameConverter.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubyModelTypeNameConverter.java
@@ -134,7 +134,7 @@ public class RubyModelTypeNameConverter implements ModelTypeNameConverter {
     }
     if (type.isMessage()) {
       TypeName typeName = getTypeName(type);
-      return TypedValue.create(typeName, typeName.getFullName() + ".new");
+      return TypedValue.create(typeName, "{}");
     }
     if (type.isEnum()) {
       return getEnumValue(type, type.getEnumType().getValues().get(0));

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubySurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubySurfaceNamer.java
@@ -106,6 +106,39 @@ public class RubySurfaceNamer extends SurfaceNamer {
     if (type.isMap()) {
       String keyTypeName = typeTable.getFullNameForElementType(type.getMapKeyField().getType());
       String valueTypeName = typeTable.getFullNameForElementType(type.getMapValueField().getType());
+      if (type.getMapValueField().getType().isMessage()) {
+        valueTypeName += " | Hash";
+      }
+      return new TypeName(
+              typeTable.getFullNameFor(type),
+              typeTable.getNicknameFor(type),
+              "%s{%i => %i}",
+              new TypeName(keyTypeName),
+              new TypeName(valueTypeName))
+          .getFullName();
+    }
+
+    String elementTypeName = typeTable.getFullNameForElementType(type);
+    if (type.isMessage()) {
+      elementTypeName += " | Hash";
+    }
+    if (type.isRepeated()) {
+      return new TypeName(
+              typeTable.getFullNameFor(type),
+              typeTable.getNicknameFor(type),
+              "%s<%i>",
+              new TypeName(elementTypeName))
+          .getFullName();
+    }
+
+    return elementTypeName;
+  }
+
+  /** The type name for the message property */
+  public String getMessagePropertyTypeName(ModelTypeTable typeTable, TypeRef type) {
+    if (type.isMap()) {
+      String keyTypeName = typeTable.getFullNameForElementType(type.getMapKeyField().getType());
+      String valueTypeName = typeTable.getFullNameForElementType(type.getMapValueField().getType());
       return new TypeName(
               typeTable.getFullNameFor(type),
               typeTable.getNicknameFor(type),

--- a/src/main/java/com/google/api/codegen/viewmodel/testing/ClientTestAssertView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/testing/ClientTestAssertView.java
@@ -32,12 +32,22 @@ public abstract class ClientTestAssertView {
   @Nullable
   public abstract String enumTypeName();
 
+  // Message type name is needed for ruby since the value of the init code is in the form of a hash
+  // and will need to be converted to its message type in order to compare with what is in the
+  // request.
+  @Nullable
+  public abstract String messageTypeName();
+
   public boolean hasExpectedValueTransformFunction() {
     return expectedValueTransformFunction() != null;
   }
 
   public boolean hasEnumTypeName() {
     return enumTypeName() != null;
+  }
+
+  public boolean hasMessageTypeName() {
+    return messageTypeName() != null;
   }
 
   public static Builder newBuilder() {
@@ -53,6 +63,8 @@ public abstract class ClientTestAssertView {
     public abstract Builder expectedValueTransformFunction(String val);
 
     public abstract Builder enumTypeName(String val);
+
+    public abstract Builder messageTypeName(String val);
 
     public abstract ClientTestAssertView build();
   }

--- a/src/main/java/com/google/api/codegen/viewmodel/testing/TestCaseView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/testing/TestCaseView.java
@@ -37,6 +37,10 @@ public abstract class TestCaseView {
 
   public abstract String responseTypeName();
 
+  public abstract String fullyQualifiedRequestTypeName();
+
+  public abstract String fullyQualifiedResponseTypeName();
+
   public abstract List<PageStreamingResponseView> pageStreamingResponseViews();
 
   public abstract String name();
@@ -91,6 +95,10 @@ public abstract class TestCaseView {
     public abstract Builder requestTypeName(String val);
 
     public abstract Builder responseTypeName(String val);
+
+    public abstract Builder fullyQualifiedRequestTypeName(String val);
+
+    public abstract Builder fullyQualifiedResponseTypeName(String val);
 
     public abstract Builder pageStreamingResponseViews(List<PageStreamingResponseView> val);
 

--- a/src/main/resources/com/google/api/codegen/ruby/initcode.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/initcode.snip
@@ -18,7 +18,7 @@
 @private initLineStructure(line)
   @switch line.fieldSettings.size.toString
   @case "0"
-    {@line.identifier} = {@line.fullyQualifiedTypeName}.new
+    {@line.identifier} = {}
   @case "1"
     {@singleLineInitStructure(line)}
   @case "2"
@@ -29,13 +29,13 @@
 @end
 
 @private singleLineInitStructure(line)
-    {@line.identifier} = {@line.fullyQualifiedTypeName}.new({@structureFieldsList(line.fieldSettings)})
+    {@line.identifier} = { {@structureFieldsList(line.fieldSettings)} }
 @end
 
 @private multiLineInitStructure(line)
-  {@line.identifier} = {@line.fullyQualifiedTypeName}.new(
+  {@line.identifier} = {
     {@multilineStructureFieldsList(line.fieldSettings)}
-  )
+  }
 @end
 
 @private structureFieldsList(fieldSettings)

--- a/src/main/resources/com/google/api/codegen/ruby/main.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/main.snip
@@ -323,7 +323,7 @@
     @if apiMethod.hasRequestParameters
       def {@apiMethod.name} @\
           {@paramList(apiMethod.methodParams)}
-        req = {@apiMethod.requestTypeName}.new({
+        req = {
           @if apiMethod.requiredRequestObjectParams
             @if apiMethod.optionalRequestObjectParamsNoPageToken
               {@namedParameters(apiMethod.requiredRequestObjectParams)},
@@ -334,7 +334,8 @@
           @else
             {@namedParameters(apiMethod.optionalRequestObjectParamsNoPageToken)}
           @end
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, {@apiMethod.requestTypeName})
         {@makeApiCall(apiMethod)}
       end
     @else

--- a/src/main/resources/com/google/api/codegen/ruby/test.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/test.snip
@@ -119,6 +119,7 @@
     @if test.hasReturnValue
       @# Create expected grpc response
       {@initCode(test.mockResponse.initCode)}
+      expected_response = Google::Gax::to_proto(expected_response, {@test.fullyQualifiedResponseTypeName})
     @end
 
     @# Mock Grpc layer
@@ -150,6 +151,7 @@
     @end
     @# Create expected grpc response
     {@initCode(test.mockResponse.initCode)}
+    expected_response = Google::Gax::to_proto(expected_response, {@test.fullyQualifiedResponseTypeName})
 
     @# Mock Grpc layer
     {@mockUnaryRequest(test)}
@@ -181,6 +183,7 @@
     @end
     @# Create expected grpc response
     {@initCode(test.mockResponse.initCode)}
+    expected_response = Google::Gax::to_proto(expected_response, {@test.fullyQualifiedResponseTypeName})
     result = Google::Protobuf::Any.new
     result.pack(expected_response)
     operation = Google::Longrunning::Operation.new(
@@ -246,6 +249,7 @@
     @end
     @# Create expected grpc response
     {@initCode(test.mockResponse.initCode)}
+    expected_response = Google::Gax::to_proto(expected_response, {@test.fullyQualifiedResponseTypeName})
 
     @# Mock Grpc layer
     {@mockServerStreamingRequest(test)}
@@ -272,6 +276,7 @@
 
       @# Create expected grpc response
       {@initCode(test.mockResponse.initCode)}
+      expected_response = Google::Gax::to_proto(expected_response, {@test.fullyQualifiedResponseTypeName})
     @end
 
     @# Mock Grpc layer
@@ -301,6 +306,7 @@
 
     @# Create expected grpc response
     {@initCode(test.mockResponse.initCode)}
+    expected_response = Google::Gax::to_proto(expected_response, {@test.fullyQualifiedResponseTypeName})
 
     @# Mock Grpc layer
     {@mockBidiStreamingRequest(test)}
@@ -450,15 +456,20 @@
 @end
 
 @private requestAsserts(test)
-   @join assert : test.asserts
-     assert_equal(\
-       {@expectedValue(assert)}, \
-       request.{@assert.actualValueGetter})
-   @end
+  assert_instance_of({@test.fullyQualifiedRequestTypeName}, request)
+  @join assert : test.asserts
+    assert_equal(\
+      {@expectedValue(assert)}, \
+      request.{@assert.actualValueGetter})
+  @end
 @end
 
 @private expectedValue(assert)
-  {@assert.expectedValueIdentifier}
+  @if assert.hasMessageTypeName
+    Google::Gax::to_proto({@assert.expectedValueIdentifier}, {@assert.messageTypeName})
+  @else
+    {@assert.expectedValueIdentifier}
+  @end
 @end
 
 @private methodCallWithResponse(test)

--- a/src/test/java/com/google/api/codegen/testdata/ruby_README_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_README_library.baseline
@@ -25,7 +25,7 @@ require "library/v1"
 library_service_client = Library::V1::LibraryServiceClient.new
 formatted_name = Library::V1::LibraryServiceClient.book_path("testShelf-" + Time.new.to_i.to_s, project_id)
 rating = :GOOD
-book = Google::Example::Library::V1::Book.new(rating: rating)
+book = { rating: rating }
 response = library_service_client.update_book(formatted_name, book)
 ```
 

--- a/src/test/java/com/google/api/codegen/testdata/ruby_doc_README_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_doc_README_library.baseline
@@ -25,7 +25,7 @@ require "library/v1"
 library_service_client = Library::V1::LibraryServiceClient.new
 formatted_name = Library::V1::LibraryServiceClient.book_path("testShelf-" + Time.new.to_i.to_s, project_id)
 rating = :GOOD
-book = Google::Example::Library::V1::Book.new(rating: rating)
+book = { rating: rating }
 response = library_service_client.update_book(formatted_name, book)
 ```
 

--- a/src/test/java/com/google/api/codegen/testdata/ruby_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_doc_main_library.baseline
@@ -622,7 +622,7 @@ module Library
       #   can also be provided.
       # @param books [Array<Google::Example::Library::V1::Book | Hash>]
       #   The books to publish in the series.
-      #   A hash of the same form as `Array`
+      #   A hash of the same form as `Google::Example::Library::V1::Book`
       #   can also be provided.
       # @param series_uuid [Google::Example::Library::V1::SeriesUuid | Hash]
       #   Uniquely identifies the series to the publishing house.
@@ -899,7 +899,7 @@ module Library
       #
       # @param name [String]
       # @param comments [Array<Google::Example::Library::V1::Comment | Hash>]
-      #   A hash of the same form as `Array`
+      #   A hash of the same form as `Google::Example::Library::V1::Comment`
       #   can also be provided.
       # @param options [Google::Gax::CallOptions]
       #   Overrides the default settings for this call, e.g, timeout,
@@ -1000,8 +1000,6 @@ module Library
       #   The name of the index for the book
       # @param index_map [Hash{String => String}]
       #   The index to update the book with
-      #   A hash of the same form as `Hash`
-      #   can also be provided.
       # @param options [Google::Gax::CallOptions]
       #   Overrides the default settings for this call, e.g, timeout,
       #   retries, etc.
@@ -1411,15 +1409,13 @@ module Library
       # @param required_repeated_string [Array<String>]
       # @param required_repeated_bytes [Array<String>]
       # @param required_repeated_message [Array<Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage | Hash>]
-      #   A hash of the same form as `Array`
+      #   A hash of the same form as `Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage`
       #   can also be provided.
       # @param required_repeated_resource_name [Array<String>]
       # @param required_repeated_resource_name_oneof [Array<String>]
       # @param required_repeated_fixed32 [Array<Integer>]
       # @param required_repeated_fixed64 [Array<Integer>]
       # @param required_map [Hash{Integer => String}]
-      #   A hash of the same form as `Hash`
-      #   can also be provided.
       # @param optional_singular_int32 [Integer]
       # @param optional_singular_int64 [Integer]
       # @param optional_singular_float [Float]
@@ -1444,15 +1440,13 @@ module Library
       # @param optional_repeated_string [Array<String>]
       # @param optional_repeated_bytes [Array<String>]
       # @param optional_repeated_message [Array<Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage | Hash>]
-      #   A hash of the same form as `Array`
+      #   A hash of the same form as `Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage`
       #   can also be provided.
       # @param optional_repeated_resource_name [Array<String>]
       # @param optional_repeated_resource_name_oneof [Array<String>]
       # @param optional_repeated_fixed32 [Array<Integer>]
       # @param optional_repeated_fixed64 [Array<Integer>]
       # @param optional_map [Hash{Integer => String}]
-      #   A hash of the same form as `Hash`
-      #   can also be provided.
       # @param options [Google::Gax::CallOptions]
       #   Overrides the default settings for this call, e.g, timeout,
       #   retries, etc.

--- a/src/test/java/com/google/api/codegen/testdata/ruby_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_doc_main_library.baseline
@@ -420,8 +420,10 @@ module Library
       # Creates a shelf, and returns the new Shelf.
       # RPC method comment may include special characters: <>&"+'@.
       #
-      # @param shelf [Google::Example::Library::V1::Shelf]
+      # @param shelf [Google::Example::Library::V1::Shelf | Hash]
       #   The shelf to create.
+      #   A hash of the same form as `Google::Example::Library::V1::Shelf`
+      #   can also be provided.
       # @param options [Google::Gax::CallOptions]
       #   Overrides the default settings for this call, e.g, timeout,
       #   retries, etc.
@@ -450,9 +452,13 @@ module Library
       #   The name of the shelf to retrieve.
       # @param options_ [String]
       #   To test 'options' parameter name conflict.
-      # @param message [Google::Example::Library::V1::SomeMessage]
+      # @param message [Google::Example::Library::V1::SomeMessage | Hash]
       #   Field to verify that message-type query parameter gets flattened.
-      # @param string_builder [Google::Example::Library::V1::StringBuilder]
+      #   A hash of the same form as `Google::Example::Library::V1::SomeMessage`
+      #   can also be provided.
+      # @param string_builder [Google::Example::Library::V1::StringBuilder | Hash]
+      #   A hash of the same form as `Google::Example::Library::V1::StringBuilder`
+      #   can also be provided.
       # @param options [Google::Gax::CallOptions]
       #   Overrides the default settings for this call, e.g, timeout,
       #   retries, etc.
@@ -579,8 +585,10 @@ module Library
       #
       # @param name [String]
       #   The name of the shelf in which the book is created.
-      # @param book [Google::Example::Library::V1::Book]
+      # @param book [Google::Example::Library::V1::Book | Hash]
       #   The book to create.
+      #   A hash of the same form as `Google::Example::Library::V1::Book`
+      #   can also be provided.
       # @param options [Google::Gax::CallOptions]
       #   Overrides the default settings for this call, e.g, timeout,
       #   retries, etc.
@@ -608,12 +616,18 @@ module Library
 
       # Creates a series of books.
       #
-      # @param shelf [Google::Example::Library::V1::Shelf]
+      # @param shelf [Google::Example::Library::V1::Shelf | Hash]
       #   The shelf in which the series is created.
-      # @param books [Array<Google::Example::Library::V1::Book>]
+      #   A hash of the same form as `Google::Example::Library::V1::Shelf`
+      #   can also be provided.
+      # @param books [Array<Google::Example::Library::V1::Book | Hash>]
       #   The books to publish in the series.
-      # @param series_uuid [Google::Example::Library::V1::SeriesUuid]
+      #   A hash of the same form as `Array`
+      #   can also be provided.
+      # @param series_uuid [Google::Example::Library::V1::SeriesUuid | Hash]
       #   Uniquely identifies the series to the publishing house.
+      #   A hash of the same form as `Google::Example::Library::V1::SeriesUuid`
+      #   can also be provided.
       # @param edition [Integer]
       #   The edition of the series
       # @param review_copy [true, false]
@@ -761,12 +775,18 @@ module Library
       #
       # @param name [String]
       #   The name of the book to update.
-      # @param book [Google::Example::Library::V1::Book]
+      # @param book [Google::Example::Library::V1::Book | Hash]
       #   The book to update with.
-      # @param update_mask [Google::Protobuf::FieldMask]
+      #   A hash of the same form as `Google::Example::Library::V1::Book`
+      #   can also be provided.
+      # @param update_mask [Google::Protobuf::FieldMask | Hash]
       #   A field mask to apply, rendered as an HTTP parameter.
-      # @param physical_mask [Google::Example::Library::V1::FieldMask]
+      #   A hash of the same form as `Google::Protobuf::FieldMask`
+      #   can also be provided.
+      # @param physical_mask [Google::Example::Library::V1::FieldMask | Hash]
       #   To test Python import clash resolution.
+      #   A hash of the same form as `Google::Example::Library::V1::FieldMask`
+      #   can also be provided.
       # @param options [Google::Gax::CallOptions]
       #   Overrides the default settings for this call, e.g, timeout,
       #   retries, etc.
@@ -878,7 +898,9 @@ module Library
       # Adds comments to a book
       #
       # @param name [String]
-      # @param comments [Array<Google::Example::Library::V1::Comment>]
+      # @param comments [Array<Google::Example::Library::V1::Comment | Hash>]
+      #   A hash of the same form as `Array`
+      #   can also be provided.
       # @param options [Google::Gax::CallOptions]
       #   Overrides the default settings for this call, e.g, timeout,
       #   retries, etc.
@@ -978,6 +1000,8 @@ module Library
       #   The name of the index for the book
       # @param index_map [Hash{String => String}]
       #   The index to update the book with
+      #   A hash of the same form as `Hash`
+      #   can also be provided.
       # @param options [Google::Gax::CallOptions]
       #   Overrides the default settings for this call, e.g, timeout,
       #   retries, etc.
@@ -1371,7 +1395,9 @@ module Library
       # @param required_singular_enum [Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerEnum]
       # @param required_singular_string [String]
       # @param required_singular_bytes [String]
-      # @param required_singular_message [Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage]
+      # @param required_singular_message [Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage | Hash]
+      #   A hash of the same form as `Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage`
+      #   can also be provided.
       # @param required_singular_resource_name [String]
       # @param required_singular_resource_name_oneof [String]
       # @param required_singular_fixed32 [Integer]
@@ -1384,12 +1410,16 @@ module Library
       # @param required_repeated_enum [Array<Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerEnum>]
       # @param required_repeated_string [Array<String>]
       # @param required_repeated_bytes [Array<String>]
-      # @param required_repeated_message [Array<Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage>]
+      # @param required_repeated_message [Array<Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage | Hash>]
+      #   A hash of the same form as `Array`
+      #   can also be provided.
       # @param required_repeated_resource_name [Array<String>]
       # @param required_repeated_resource_name_oneof [Array<String>]
       # @param required_repeated_fixed32 [Array<Integer>]
       # @param required_repeated_fixed64 [Array<Integer>]
       # @param required_map [Hash{Integer => String}]
+      #   A hash of the same form as `Hash`
+      #   can also be provided.
       # @param optional_singular_int32 [Integer]
       # @param optional_singular_int64 [Integer]
       # @param optional_singular_float [Float]
@@ -1398,7 +1428,9 @@ module Library
       # @param optional_singular_enum [Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerEnum]
       # @param optional_singular_string [String]
       # @param optional_singular_bytes [String]
-      # @param optional_singular_message [Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage]
+      # @param optional_singular_message [Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage | Hash]
+      #   A hash of the same form as `Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage`
+      #   can also be provided.
       # @param optional_singular_resource_name [String]
       # @param optional_singular_resource_name_oneof [String]
       # @param optional_singular_fixed32 [Integer]
@@ -1411,12 +1443,16 @@ module Library
       # @param optional_repeated_enum [Array<Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerEnum>]
       # @param optional_repeated_string [Array<String>]
       # @param optional_repeated_bytes [Array<String>]
-      # @param optional_repeated_message [Array<Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage>]
+      # @param optional_repeated_message [Array<Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage | Hash>]
+      #   A hash of the same form as `Array`
+      #   can also be provided.
       # @param optional_repeated_resource_name [Array<String>]
       # @param optional_repeated_resource_name_oneof [Array<String>]
       # @param optional_repeated_fixed32 [Array<Integer>]
       # @param optional_repeated_fixed64 [Array<Integer>]
       # @param optional_map [Hash{Integer => String}]
+      #   A hash of the same form as `Hash`
+      #   can also be provided.
       # @param options [Google::Gax::CallOptions]
       #   Overrides the default settings for this call, e.g, timeout,
       #   retries, etc.

--- a/src/test/java/com/google/api/codegen/testdata/ruby_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_doc_main_library.baseline
@@ -431,15 +431,16 @@ module Library
       #   require "library/v1"
       #
       #   library_service_client = Library::V1::LibraryServiceClient.new
-      #   shelf = Google::Example::Library::V1::Shelf.new
+      #   shelf = {}
       #   response = library_service_client.create_shelf(shelf)
 
       def create_shelf \
           shelf,
           options: nil
-        req = Google::Example::Library::V1::CreateShelfRequest.new({
+        req = {
           shelf: shelf
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::CreateShelfRequest)
         @create_shelf.call(req, options)
       end
 
@@ -471,12 +472,13 @@ module Library
           message: nil,
           string_builder: nil,
           options: nil
-        req = Google::Example::Library::V1::GetShelfRequest.new({
+        req = {
           name: name,
           options: options_,
           message: message,
           string_builder: string_builder
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::GetShelfRequest)
         @get_shelf.call(req, options)
       end
 
@@ -532,9 +534,10 @@ module Library
       def delete_shelf \
           name,
           options: nil
-        req = Google::Example::Library::V1::DeleteShelfRequest.new({
+        req = {
           name: name
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::DeleteShelfRequest)
         @delete_shelf.call(req, options)
         nil
       end
@@ -564,10 +567,11 @@ module Library
           name,
           other_shelf_name,
           options: nil
-        req = Google::Example::Library::V1::MergeShelvesRequest.new({
+        req = {
           name: name,
           other_shelf_name: other_shelf_name
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::MergeShelvesRequest)
         @merge_shelves.call(req, options)
       end
 
@@ -587,17 +591,18 @@ module Library
       #
       #   library_service_client = Library::V1::LibraryServiceClient.new
       #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
-      #   book = Google::Example::Library::V1::Book.new
+      #   book = {}
       #   response = library_service_client.create_book(formatted_name, book)
 
       def create_book \
           name,
           book,
           options: nil
-        req = Google::Example::Library::V1::CreateBookRequest.new({
+        req = {
           name: name,
           book: book
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::CreateBookRequest)
         @create_book.call(req, options)
       end
 
@@ -622,10 +627,10 @@ module Library
       #   require "library/v1"
       #
       #   library_service_client = Library::V1::LibraryServiceClient.new
-      #   shelf = Google::Example::Library::V1::Shelf.new
+      #   shelf = {}
       #   books = []
       #   series_string = "foobar"
-      #   series_uuid = Google::Example::Library::V1::SeriesUuid.new(series_string: series_string)
+      #   series_uuid = { series_string: series_string }
       #   response = library_service_client.publish_series(shelf, books, series_uuid)
 
       def publish_series \
@@ -635,13 +640,14 @@ module Library
           edition: nil,
           review_copy: nil,
           options: nil
-        req = Google::Example::Library::V1::PublishSeriesRequest.new({
+        req = {
           shelf: shelf,
           books: books,
           series_uuid: series_uuid,
           edition: edition,
           review_copy: review_copy
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::PublishSeriesRequest)
         @publish_series.call(req, options)
       end
 
@@ -664,9 +670,10 @@ module Library
       def get_book \
           name,
           options: nil
-        req = Google::Example::Library::V1::GetBookRequest.new({
+        req = {
           name: name
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::GetBookRequest)
         @get_book.call(req, options)
       end
 
@@ -715,11 +722,12 @@ module Library
           page_size: nil,
           filter: nil,
           options: nil
-        req = Google::Example::Library::V1::ListBooksRequest.new({
+        req = {
           name: name,
           page_size: page_size,
           filter: filter
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::ListBooksRequest)
         @list_books.call(req, options)
       end
 
@@ -741,9 +749,10 @@ module Library
       def delete_book \
           name,
           options: nil
-        req = Google::Example::Library::V1::DeleteBookRequest.new({
+        req = {
           name: name
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::DeleteBookRequest)
         @delete_book.call(req, options)
         nil
       end
@@ -768,7 +777,7 @@ module Library
       #
       #   library_service_client = Library::V1::LibraryServiceClient.new
       #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
-      #   book = Google::Example::Library::V1::Book.new
+      #   book = {}
       #   response = library_service_client.update_book(formatted_name, book)
 
       def update_book \
@@ -777,12 +786,13 @@ module Library
           update_mask: nil,
           physical_mask: nil,
           options: nil
-        req = Google::Example::Library::V1::UpdateBookRequest.new({
+        req = {
           name: name,
           book: book,
           update_mask: update_mask,
           physical_mask: physical_mask
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::UpdateBookRequest)
         @update_book.call(req, options)
       end
 
@@ -809,10 +819,11 @@ module Library
           name,
           other_shelf_name,
           options: nil
-        req = Google::Example::Library::V1::MoveBookRequest.new({
+        req = {
           name: name,
           other_shelf_name: other_shelf_name
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::MoveBookRequest)
         @move_book.call(req, options)
       end
 
@@ -856,10 +867,11 @@ module Library
           name: nil,
           page_size: nil,
           options: nil
-        req = Google::Example::Library::V1::ListStringsRequest.new({
+        req = {
           name: name,
           page_size: page_size
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::ListStringsRequest)
         @list_strings.call(req, options)
       end
 
@@ -879,11 +891,11 @@ module Library
       #   comment = ''
       #   stage = :UNSET
       #   alignment = :CHAR
-      #   comments_element = Google::Example::Library::V1::Comment.new(
+      #   comments_element = {
       #     comment: comment,
       #     stage: stage,
       #     alignment: alignment
-      #   )
+      #   }
       #   comments = [comments_element]
       #   library_service_client.add_comments(formatted_name, comments)
 
@@ -891,10 +903,11 @@ module Library
           name,
           comments,
           options: nil
-        req = Google::Example::Library::V1::AddCommentsRequest.new({
+        req = {
           name: name,
           comments: comments
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::AddCommentsRequest)
         @add_comments.call(req, options)
         nil
       end
@@ -918,9 +931,10 @@ module Library
       def get_book_from_archive \
           name,
           options: nil
-        req = Google::Example::Library::V1::GetBookFromArchiveRequest.new({
+        req = {
           name: name
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::GetBookFromArchiveRequest)
         @get_book_from_archive.call(req, options)
       end
 
@@ -948,10 +962,11 @@ module Library
           name,
           alt_book_name,
           options: nil
-        req = Google::Example::Library::V1::GetBookFromAnywhereRequest.new({
+        req = {
           name: name,
           alt_book_name: alt_book_name
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::GetBookFromAnywhereRequest)
         @get_book_from_anywhere.call(req, options)
       end
 
@@ -982,11 +997,12 @@ module Library
           index_name,
           index_map,
           options: nil
-        req = Google::Example::Library::V1::UpdateBookIndexRequest.new({
+        req = {
           name: name,
           index_name: index_name,
           index_map: index_map
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::UpdateBookIndexRequest)
         @update_book_index.call(req, options)
         nil
       end
@@ -1038,9 +1054,10 @@ module Library
       def stream_books \
           name,
           options: nil
-        req = Google::Example::Library::V1::StreamBooksRequest.new({
+        req = {
           name: name
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::StreamBooksRequest)
         @stream_books.call(req, options)
       end
 
@@ -1067,7 +1084,7 @@ module Library
       #
       #   library_service_client = Library::V1::LibraryServiceClient.new
       #   name = ''
-      #   request = Google::Example::Library::V1::DiscussBookRequest.new(name: name)
+      #   request = { name: name }
       #   requests = [request]
       #   library_service_client.discuss_book(requests).each do |element|
       #     # Process element.
@@ -1098,7 +1115,7 @@ module Library
       #
       #   library_service_client = Library::V1::LibraryServiceClient.new
       #   name = ''
-      #   request = Google::Example::Library::V1::DiscussBookRequest.new(name: name)
+      #   request = { name: name }
       #   requests = [request]
       #   response = library_service_client.monolog_about_book(requests)
 
@@ -1149,11 +1166,12 @@ module Library
           shelves,
           page_size: nil,
           options: nil
-        req = Google::Example::Library::V1::FindRelatedBooksRequest.new({
+        req = {
           names: names,
           shelves: shelves,
           page_size: page_size
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::FindRelatedBooksRequest)
         @find_related_books.call(req, options)
       end
 
@@ -1182,10 +1200,11 @@ module Library
           resource,
           tag,
           options: nil
-        req = Google::Tagger::V1::AddTagRequest.new({
+        req = {
           resource: resource,
           tag: tag
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Tagger::V1::AddTagRequest)
         @add_tag.call(req, options)
       end
 
@@ -1214,10 +1233,11 @@ module Library
           resource,
           label,
           options: nil
-        req = Google::Tagger::V1::AddLabelRequest.new({
+        req = {
           resource: resource,
           label: label
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Tagger::V1::AddLabelRequest)
         @add_label.call(req, options)
       end
 
@@ -1266,9 +1286,10 @@ module Library
       def get_big_book \
           name,
           options: nil
-        req = Google::Example::Library::V1::GetBookRequest.new({
+        req = {
           name: name
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::GetBookRequest)
         operation = Google::Gax::Operation.new(
           @get_big_book.call(req, options),
           @operations_client,
@@ -1325,9 +1346,10 @@ module Library
       def get_big_nothing \
           name,
           options: nil
-        req = Google::Example::Library::V1::GetBookRequest.new({
+        req = {
           name: name
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::GetBookRequest)
         operation = Google::Gax::Operation.new(
           @get_big_nothing.call(req, options),
           @operations_client,
@@ -1412,7 +1434,7 @@ module Library
       #   required_singular_enum = :ZERO
       #   required_singular_string = ''
       #   required_singular_bytes = ''
-      #   required_singular_message = Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage.new
+      #   required_singular_message = {}
       #   required_singular_resource_name = ''
       #   required_singular_resource_name_oneof = ''
       #   required_singular_fixed32 = 0
@@ -1489,7 +1511,7 @@ module Library
           optional_repeated_fixed64: nil,
           optional_map: nil,
           options: nil
-        req = Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest.new({
+        req = {
           required_singular_int32: required_singular_int32,
           required_singular_int64: required_singular_int64,
           required_singular_float: required_singular_float,
@@ -1544,7 +1566,8 @@ module Library
           optional_repeated_fixed32: optional_repeated_fixed32,
           optional_repeated_fixed64: optional_repeated_fixed64,
           optional_map: optional_map
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest)
         @test_optional_required_flattening_params.call(req, options)
       end
     end

--- a/src/test/java/com/google/api/codegen/testdata/ruby_doc_smoke_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_doc_smoke_test_library.baseline
@@ -29,7 +29,7 @@ describe "LibraryServiceSmokeTest" do
     library_service_client = Library::V1::LibraryServiceClient.new
     formatted_name = Library::V1::LibraryServiceClient.book_path("testShelf-" + Time.new.to_i.to_s, project_id)
     rating = :GOOD
-    book = Google::Example::Library::V1::Book.new(rating: rating)
+    book = { rating: rating }
     response = library_service_client.update_book(formatted_name, book)
   end
 end

--- a/src/test/java/com/google/api/codegen/testdata/ruby_doc_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_doc_test_library.baseline
@@ -61,21 +61,23 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes create_shelf without error' do
       # Create request parameters
-      shelf = Google::Example::Library::V1::Shelf.new
+      shelf = {}
 
       # Create expected grpc response
       name = "name3373707"
       theme = "theme110327241"
       internal_theme = "internalTheme792518087"
-      expected_response = Google::Example::Library::V1::Shelf.new(
+      expected_response = {
         name: name,
         theme: theme,
         internal_theme: internal_theme
-      )
+      }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::Shelf)
 
       # Mock Grpc layer
       mock_method = proc do |request|
-        assert_equal(shelf, request.shelf)
+        assert_instance_of(Google::Example::Library::V1::CreateShelfRequest, request)
+        assert_equal(Google::Gax::to_proto(shelf, Google::Example::Library::V1::Shelf), request.shelf)
         expected_response
       end
       mock_stub = MockGrpcClientStub.new(:create_shelf, mock_method)
@@ -93,11 +95,12 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes create_shelf with error' do
       # Create request parameters
-      shelf = Google::Example::Library::V1::Shelf.new
+      shelf = {}
 
       # Mock Grpc layer
       mock_method = proc do |request|
-        assert_equal(shelf, request.shelf)
+        assert_instance_of(Google::Example::Library::V1::CreateShelfRequest, request)
+        assert_equal(Google::Gax::to_proto(shelf, Google::Example::Library::V1::Shelf), request.shelf)
         raise custom_error
       end
       mock_stub = MockGrpcClientStub.new(:create_shelf, mock_method)
@@ -128,14 +131,16 @@ describe Library::V1::LibraryServiceClient do
       name_2 = "name2-1052831874"
       theme = "theme110327241"
       internal_theme = "internalTheme792518087"
-      expected_response = Google::Example::Library::V1::Shelf.new(
+      expected_response = {
         name: name_2,
         theme: theme,
         internal_theme: internal_theme
-      )
+      }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::Shelf)
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::GetShelfRequest, request)
         assert_equal(formatted_name, request.name)
         assert_equal(options_, request.options)
         expected_response
@@ -160,6 +165,7 @@ describe Library::V1::LibraryServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::GetShelfRequest, request)
         assert_equal(formatted_name, request.name)
         assert_equal(options_, request.options)
         raise custom_error
@@ -186,9 +192,10 @@ describe Library::V1::LibraryServiceClient do
     it 'invokes list_shelves without error' do
       # Create expected grpc response
       next_page_token = ""
-      shelves_element = Google::Example::Library::V1::Shelf.new
+      shelves_element = {}
       shelves = [shelves_element]
-      expected_response = Google::Example::Library::V1::ListShelvesResponse.new(next_page_token: next_page_token, shelves: shelves)
+      expected_response = { next_page_token: next_page_token, shelves: shelves }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::ListShelvesResponse)
 
       # Mock Grpc layer
       mock_method = proc do
@@ -240,6 +247,7 @@ describe Library::V1::LibraryServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::DeleteShelfRequest, request)
         assert_equal(formatted_name, request.name)
         nil
       end
@@ -262,6 +270,7 @@ describe Library::V1::LibraryServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::DeleteShelfRequest, request)
         assert_equal(formatted_name, request.name)
         raise custom_error
       end
@@ -293,14 +302,16 @@ describe Library::V1::LibraryServiceClient do
       name_2 = "name2-1052831874"
       theme = "theme110327241"
       internal_theme = "internalTheme792518087"
-      expected_response = Google::Example::Library::V1::Shelf.new(
+      expected_response = {
         name: name_2,
         theme: theme,
         internal_theme: internal_theme
-      )
+      }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::Shelf)
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::MergeShelvesRequest, request)
         assert_equal(formatted_name, request.name)
         assert_equal(formatted_other_shelf_name, request.other_shelf_name)
         expected_response
@@ -325,6 +336,7 @@ describe Library::V1::LibraryServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::MergeShelvesRequest, request)
         assert_equal(formatted_name, request.name)
         assert_equal(formatted_other_shelf_name, request.other_shelf_name)
         raise custom_error
@@ -351,24 +363,26 @@ describe Library::V1::LibraryServiceClient do
     it 'invokes create_book without error' do
       # Create request parameters
       formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
-      book = Google::Example::Library::V1::Book.new
+      book = {}
 
       # Create expected grpc response
       name_2 = "name2-1052831874"
       author = "author-1406328437"
       title = "title110371416"
       read = true
-      expected_response = Google::Example::Library::V1::Book.new(
+      expected_response = {
         name: name_2,
         author: author,
         title: title,
         read: read
-      )
+      }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::Book)
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::CreateBookRequest, request)
         assert_equal(formatted_name, request.name)
-        assert_equal(book, request.book)
+        assert_equal(Google::Gax::to_proto(book, Google::Example::Library::V1::Book), request.book)
         expected_response
       end
       mock_stub = MockGrpcClientStub.new(:create_book, mock_method)
@@ -387,12 +401,13 @@ describe Library::V1::LibraryServiceClient do
     it 'invokes create_book with error' do
       # Create request parameters
       formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
-      book = Google::Example::Library::V1::Book.new
+      book = {}
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::CreateBookRequest, request)
         assert_equal(formatted_name, request.name)
-        assert_equal(book, request.book)
+        assert_equal(Google::Gax::to_proto(book, Google::Example::Library::V1::Book), request.book)
         raise custom_error
       end
       mock_stub = MockGrpcClientStub.new(:create_book, mock_method)
@@ -416,21 +431,23 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes publish_series without error' do
       # Create request parameters
-      shelf = Google::Example::Library::V1::Shelf.new
+      shelf = {}
       books = []
       series_string = "foobar"
-      series_uuid = Google::Example::Library::V1::SeriesUuid.new(series_string: series_string)
+      series_uuid = { series_string: series_string }
 
       # Create expected grpc response
       book_names_element = "bookNamesElement1491670575"
       book_names = [book_names_element]
-      expected_response = Google::Example::Library::V1::PublishSeriesResponse.new(book_names: book_names)
+      expected_response = { book_names: book_names }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::PublishSeriesResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
-        assert_equal(shelf, request.shelf)
+        assert_instance_of(Google::Example::Library::V1::PublishSeriesRequest, request)
+        assert_equal(Google::Gax::to_proto(shelf, Google::Example::Library::V1::Shelf), request.shelf)
         assert_equal(books, request.books)
-        assert_equal(series_uuid, request.series_uuid)
+        assert_equal(Google::Gax::to_proto(series_uuid, Google::Example::Library::V1::SeriesUuid), request.series_uuid)
         expected_response
       end
       mock_stub = MockGrpcClientStub.new(:publish_series, mock_method)
@@ -452,16 +469,17 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes publish_series with error' do
       # Create request parameters
-      shelf = Google::Example::Library::V1::Shelf.new
+      shelf = {}
       books = []
       series_string = "foobar"
-      series_uuid = Google::Example::Library::V1::SeriesUuid.new(series_string: series_string)
+      series_uuid = { series_string: series_string }
 
       # Mock Grpc layer
       mock_method = proc do |request|
-        assert_equal(shelf, request.shelf)
+        assert_instance_of(Google::Example::Library::V1::PublishSeriesRequest, request)
+        assert_equal(Google::Gax::to_proto(shelf, Google::Example::Library::V1::Shelf), request.shelf)
         assert_equal(books, request.books)
-        assert_equal(series_uuid, request.series_uuid)
+        assert_equal(Google::Gax::to_proto(series_uuid, Google::Example::Library::V1::SeriesUuid), request.series_uuid)
         raise custom_error
       end
       mock_stub = MockGrpcClientStub.new(:publish_series, mock_method)
@@ -496,15 +514,17 @@ describe Library::V1::LibraryServiceClient do
       author = "author-1406328437"
       title = "title110371416"
       read = true
-      expected_response = Google::Example::Library::V1::Book.new(
+      expected_response = {
         name: name_2,
         author: author,
         title: title,
         read: read
-      )
+      }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::Book)
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::GetBookRequest, request)
         assert_equal(formatted_name, request.name)
         expected_response
       end
@@ -527,6 +547,7 @@ describe Library::V1::LibraryServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::GetBookRequest, request)
         assert_equal(formatted_name, request.name)
         raise custom_error
       end
@@ -555,12 +576,14 @@ describe Library::V1::LibraryServiceClient do
 
       # Create expected grpc response
       next_page_token = ""
-      books_element = Google::Example::Library::V1::Book.new
+      books_element = {}
       books = [books_element]
-      expected_response = Google::Example::Library::V1::ListBooksResponse.new(next_page_token: next_page_token, books: books)
+      expected_response = { next_page_token: next_page_token, books: books }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::ListBooksResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::ListBooksRequest, request)
         assert_equal(formatted_name, request.name)
         expected_response
       end
@@ -586,6 +609,7 @@ describe Library::V1::LibraryServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::ListBooksRequest, request)
         assert_equal(formatted_name, request.name)
         raise custom_error
       end
@@ -614,6 +638,7 @@ describe Library::V1::LibraryServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::DeleteBookRequest, request)
         assert_equal(formatted_name, request.name)
         nil
       end
@@ -636,6 +661,7 @@ describe Library::V1::LibraryServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::DeleteBookRequest, request)
         assert_equal(formatted_name, request.name)
         raise custom_error
       end
@@ -661,24 +687,26 @@ describe Library::V1::LibraryServiceClient do
     it 'invokes update_book without error' do
       # Create request parameters
       formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
-      book = Google::Example::Library::V1::Book.new
+      book = {}
 
       # Create expected grpc response
       name_2 = "name2-1052831874"
       author = "author-1406328437"
       title = "title110371416"
       read = true
-      expected_response = Google::Example::Library::V1::Book.new(
+      expected_response = {
         name: name_2,
         author: author,
         title: title,
         read: read
-      )
+      }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::Book)
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::UpdateBookRequest, request)
         assert_equal(formatted_name, request.name)
-        assert_equal(book, request.book)
+        assert_equal(Google::Gax::to_proto(book, Google::Example::Library::V1::Book), request.book)
         expected_response
       end
       mock_stub = MockGrpcClientStub.new(:update_book, mock_method)
@@ -697,12 +725,13 @@ describe Library::V1::LibraryServiceClient do
     it 'invokes update_book with error' do
       # Create request parameters
       formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
-      book = Google::Example::Library::V1::Book.new
+      book = {}
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::UpdateBookRequest, request)
         assert_equal(formatted_name, request.name)
-        assert_equal(book, request.book)
+        assert_equal(Google::Gax::to_proto(book, Google::Example::Library::V1::Book), request.book)
         raise custom_error
       end
       mock_stub = MockGrpcClientStub.new(:update_book, mock_method)
@@ -734,15 +763,17 @@ describe Library::V1::LibraryServiceClient do
       author = "author-1406328437"
       title = "title110371416"
       read = true
-      expected_response = Google::Example::Library::V1::Book.new(
+      expected_response = {
         name: name_2,
         author: author,
         title: title,
         read: read
-      )
+      }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::Book)
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::MoveBookRequest, request)
         assert_equal(formatted_name, request.name)
         assert_equal(formatted_other_shelf_name, request.other_shelf_name)
         expected_response
@@ -767,6 +798,7 @@ describe Library::V1::LibraryServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::MoveBookRequest, request)
         assert_equal(formatted_name, request.name)
         assert_equal(formatted_other_shelf_name, request.other_shelf_name)
         raise custom_error
@@ -795,7 +827,8 @@ describe Library::V1::LibraryServiceClient do
       next_page_token = ""
       strings_element = "stringsElement474465855"
       strings = [strings_element]
-      expected_response = Google::Example::Library::V1::ListStringsResponse.new(next_page_token: next_page_token, strings: strings)
+      expected_response = { next_page_token: next_page_token, strings: strings }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::ListStringsResponse)
 
       # Mock Grpc layer
       mock_method = proc do
@@ -847,15 +880,16 @@ describe Library::V1::LibraryServiceClient do
       comment = ''
       stage = :UNSET
       alignment = :CHAR
-      comments_element = Google::Example::Library::V1::Comment.new(
+      comments_element = {
         comment: comment,
         stage: stage,
         alignment: alignment
-      )
+      }
       comments = [comments_element]
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::AddCommentsRequest, request)
         assert_equal(formatted_name, request.name)
         assert_equal(comments, request.comments)
         nil
@@ -879,15 +913,16 @@ describe Library::V1::LibraryServiceClient do
       comment = ''
       stage = :UNSET
       alignment = :CHAR
-      comments_element = Google::Example::Library::V1::Comment.new(
+      comments_element = {
         comment: comment,
         stage: stage,
         alignment: alignment
-      )
+      }
       comments = [comments_element]
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::AddCommentsRequest, request)
         assert_equal(formatted_name, request.name)
         assert_equal(comments, request.comments)
         raise custom_error
@@ -920,15 +955,17 @@ describe Library::V1::LibraryServiceClient do
       author = "author-1406328437"
       title = "title110371416"
       read = true
-      expected_response = Google::Example::Library::V1::BookFromArchive.new(
+      expected_response = {
         name: name_2,
         author: author,
         title: title,
         read: read
-      )
+      }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::BookFromArchive)
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::GetBookFromArchiveRequest, request)
         assert_equal(formatted_name, request.name)
         expected_response
       end
@@ -951,6 +988,7 @@ describe Library::V1::LibraryServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::GetBookFromArchiveRequest, request)
         assert_equal(formatted_name, request.name)
         raise custom_error
       end
@@ -983,15 +1021,17 @@ describe Library::V1::LibraryServiceClient do
       author = "author-1406328437"
       title = "title110371416"
       read = true
-      expected_response = Google::Example::Library::V1::BookFromAnywhere.new(
+      expected_response = {
         name: name_2,
         author: author,
         title: title,
         read: read
-      )
+      }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::BookFromAnywhere)
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::GetBookFromAnywhereRequest, request)
         assert_equal(formatted_name, request.name)
         assert_equal(formatted_alt_book_name, request.alt_book_name)
         expected_response
@@ -1016,6 +1056,7 @@ describe Library::V1::LibraryServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::GetBookFromAnywhereRequest, request)
         assert_equal(formatted_name, request.name)
         assert_equal(formatted_alt_book_name, request.alt_book_name)
         raise custom_error
@@ -1048,6 +1089,7 @@ describe Library::V1::LibraryServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::UpdateBookIndexRequest, request)
         assert_equal(formatted_name, request.name)
         assert_equal(index_name, request.index_name)
         assert_equal(index_map, request.index_map)
@@ -1079,6 +1121,7 @@ describe Library::V1::LibraryServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::UpdateBookIndexRequest, request)
         assert_equal(formatted_name, request.name)
         assert_equal(index_name, request.index_name)
         assert_equal(index_map, request.index_map)
@@ -1109,10 +1152,11 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes stream_shelves without error' do
       # Create request parameters
-      request = Google::Example::Library::V1::StreamShelvesRequest.new
+      request = {}
 
       # Create expected grpc response
-      expected_response = Google::Example::Library::V1::StreamShelvesResponse.new
+      expected_response = {}
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::StreamShelvesResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -1134,7 +1178,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes stream_shelves with error' do
       # Create request parameters
-      request = Google::Example::Library::V1::StreamShelvesRequest.new
+      request = {}
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -1162,22 +1206,24 @@ describe Library::V1::LibraryServiceClient do
     it 'invokes stream_books without error' do
       # Create request parameters
       name = ''
-      request = Google::Example::Library::V1::StreamBooksRequest.new(name: name)
+      request = { name: name }
 
       # Create expected grpc response
       name_2 = "name2-1052831874"
       author = "author-1406328437"
       title = "title110371416"
       read = true
-      expected_response = Google::Example::Library::V1::Book.new(
+      expected_response = {
         name: name_2,
         author: author,
         title: title,
         read: read
-      )
+      }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::Book)
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::StreamBooksRequest, request)
         assert_equal(name, request.name)
         [expected_response]
       end
@@ -1198,10 +1244,11 @@ describe Library::V1::LibraryServiceClient do
     it 'invokes stream_books with error' do
       # Create request parameters
       name = ''
-      request = Google::Example::Library::V1::StreamBooksRequest.new(name: name)
+      request = { name: name }
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::StreamBooksRequest, request)
         assert_equal(name, request.name)
         raise custom_error
       end
@@ -1227,16 +1274,18 @@ describe Library::V1::LibraryServiceClient do
     it 'invokes discuss_book without error' do
       # Create request parameters
       name = ''
-      request = Google::Example::Library::V1::DiscussBookRequest.new(name: name)
+      request = { name: name }
 
       # Create expected grpc response
       user_name = "userName339340927"
       comment = "95"
-      expected_response = Google::Example::Library::V1::Comment.new(user_name: user_name, comment: comment)
+      expected_response = { user_name: user_name, comment: comment }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::Comment)
 
       # Mock Grpc layer
       mock_method = proc do |requests|
         request = requests.first
+        assert_instance_of(Google::Example::Library::V1::DiscussBookRequest, request)
         assert_equal(name, request.name)
         [expected_response]
       end
@@ -1257,11 +1306,12 @@ describe Library::V1::LibraryServiceClient do
     it 'invokes discuss_book with error' do
       # Create request parameters
       name = ''
-      request = Google::Example::Library::V1::DiscussBookRequest.new(name: name)
+      request = { name: name }
 
       # Mock Grpc layer
       mock_method = proc do |requests|
         request = requests.first
+        assert_instance_of(Google::Example::Library::V1::DiscussBookRequest, request)
         assert_equal(name, request.name)
         raise custom_error
       end
@@ -1287,16 +1337,18 @@ describe Library::V1::LibraryServiceClient do
     it 'invokes monolog_about_book without error' do
       # Create request parameters
       name = ''
-      request = Google::Example::Library::V1::DiscussBookRequest.new(name: name)
+      request = { name: name }
 
       # Create expected grpc response
       user_name = "userName339340927"
       comment = "95"
-      expected_response = Google::Example::Library::V1::Comment.new(user_name: user_name, comment: comment)
+      expected_response = { user_name: user_name, comment: comment }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::Comment)
 
       # Mock Grpc layer
       mock_method = proc do |requests|
         request = requests.first
+        assert_instance_of(Google::Example::Library::V1::DiscussBookRequest, request)
         assert_equal(name, request.name)
         expected_response
       end
@@ -1316,11 +1368,12 @@ describe Library::V1::LibraryServiceClient do
     it 'invokes monolog_about_book with error' do
       # Create request parameters
       name = ''
-      request = Google::Example::Library::V1::DiscussBookRequest.new(name: name)
+      request = { name: name }
 
       # Mock Grpc layer
       mock_method = proc do |requests|
         request = requests.first
+        assert_instance_of(Google::Example::Library::V1::DiscussBookRequest, request)
         assert_equal(name, request.name)
         raise custom_error
       end
@@ -1353,10 +1406,12 @@ describe Library::V1::LibraryServiceClient do
       next_page_token = ""
       names_element_2 = "namesElement21120252792"
       names_2 = [names_element_2]
-      expected_response = Google::Example::Library::V1::FindRelatedBooksResponse.new(next_page_token: next_page_token, names: names_2)
+      expected_response = { next_page_token: next_page_token, names: names_2 }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::FindRelatedBooksResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::FindRelatedBooksRequest, request)
         assert_equal(names, request.names)
         assert_equal(shelves, request.shelves)
         expected_response
@@ -1385,6 +1440,7 @@ describe Library::V1::LibraryServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::FindRelatedBooksRequest, request)
         assert_equal(names, request.names)
         assert_equal(shelves, request.shelves)
         raise custom_error
@@ -1414,10 +1470,12 @@ describe Library::V1::LibraryServiceClient do
       tag = ''
 
       # Create expected grpc response
-      expected_response = Google::Tagger::V1::AddTagResponse.new
+      expected_response = {}
+      expected_response = Google::Gax::to_proto(expected_response, Google::Tagger::V1::AddTagResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Tagger::V1::AddTagRequest, request)
         assert_equal(formatted_resource, request.resource)
         assert_equal(tag, request.tag)
         expected_response
@@ -1442,6 +1500,7 @@ describe Library::V1::LibraryServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Tagger::V1::AddTagRequest, request)
         assert_equal(formatted_resource, request.resource)
         assert_equal(tag, request.tag)
         raise custom_error
@@ -1471,10 +1530,12 @@ describe Library::V1::LibraryServiceClient do
       label = ''
 
       # Create expected grpc response
-      expected_response = Google::Tagger::V1::AddLabelResponse.new
+      expected_response = {}
+      expected_response = Google::Gax::to_proto(expected_response, Google::Tagger::V1::AddLabelResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Tagger::V1::AddLabelRequest, request)
         assert_equal(formatted_resource, request.resource)
         assert_equal(label, request.label)
         expected_response
@@ -1499,6 +1560,7 @@ describe Library::V1::LibraryServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Tagger::V1::AddLabelRequest, request)
         assert_equal(formatted_resource, request.resource)
         assert_equal(label, request.label)
         raise custom_error
@@ -1531,12 +1593,13 @@ describe Library::V1::LibraryServiceClient do
       author = "author-1406328437"
       title = "title110371416"
       read = true
-      expected_response = Google::Example::Library::V1::Book.new(
+      expected_response = {
         name: name_2,
         author: author,
         title: title,
         read: read
-      )
+      }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::Book)
       result = Google::Protobuf::Any.new
       result.pack(expected_response)
       operation = Google::Longrunning::Operation.new(
@@ -1547,6 +1610,7 @@ describe Library::V1::LibraryServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::GetBookRequest, request)
         assert_equal(formatted_name, request.name)
         operation
       end
@@ -1579,6 +1643,7 @@ describe Library::V1::LibraryServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::GetBookRequest, request)
         assert_equal(formatted_name, request.name)
         operation
       end
@@ -1602,6 +1667,7 @@ describe Library::V1::LibraryServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::GetBookRequest, request)
         assert_equal(formatted_name, request.name)
         raise custom_error
       end
@@ -1629,7 +1695,8 @@ describe Library::V1::LibraryServiceClient do
       formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
 
       # Create expected grpc response
-      expected_response = Google::Protobuf::Empty.new
+      expected_response = {}
+      expected_response = Google::Gax::to_proto(expected_response, Google::Protobuf::Empty)
       result = Google::Protobuf::Any.new
       result.pack(expected_response)
       operation = Google::Longrunning::Operation.new(
@@ -1640,6 +1707,7 @@ describe Library::V1::LibraryServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::GetBookRequest, request)
         assert_equal(formatted_name, request.name)
         operation
       end
@@ -1672,6 +1740,7 @@ describe Library::V1::LibraryServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::GetBookRequest, request)
         assert_equal(formatted_name, request.name)
         operation
       end
@@ -1695,6 +1764,7 @@ describe Library::V1::LibraryServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::GetBookRequest, request)
         assert_equal(formatted_name, request.name)
         raise custom_error
       end
@@ -1727,7 +1797,7 @@ describe Library::V1::LibraryServiceClient do
       required_singular_enum = :ZERO
       required_singular_string = ''
       required_singular_bytes = ''
-      required_singular_message = Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage.new
+      required_singular_message = {}
       required_singular_resource_name = ''
       required_singular_resource_name_oneof = ''
       required_singular_fixed32 = 0
@@ -1748,10 +1818,12 @@ describe Library::V1::LibraryServiceClient do
       required_map = {}
 
       # Create expected grpc response
-      expected_response = Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsResponse.new
+      expected_response = {}
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest, request)
         assert_equal(required_singular_int32, request.required_singular_int32)
         assert_equal(required_singular_int64, request.required_singular_int64)
         assert_equal(required_singular_float, request.required_singular_float)
@@ -1760,7 +1832,7 @@ describe Library::V1::LibraryServiceClient do
         assert_equal(required_singular_enum, request.required_singular_enum)
         assert_equal(required_singular_string, request.required_singular_string)
         assert_equal(required_singular_bytes, request.required_singular_bytes)
-        assert_equal(required_singular_message, request.required_singular_message)
+        assert_equal(Google::Gax::to_proto(required_singular_message, Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage), request.required_singular_message)
         assert_equal(required_singular_resource_name, request.required_singular_resource_name)
         assert_equal(required_singular_resource_name_oneof, request.required_singular_resource_name_oneof)
         assert_equal(required_singular_fixed32, request.required_singular_fixed32)
@@ -1832,7 +1904,7 @@ describe Library::V1::LibraryServiceClient do
       required_singular_enum = :ZERO
       required_singular_string = ''
       required_singular_bytes = ''
-      required_singular_message = Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage.new
+      required_singular_message = {}
       required_singular_resource_name = ''
       required_singular_resource_name_oneof = ''
       required_singular_fixed32 = 0
@@ -1854,6 +1926,7 @@ describe Library::V1::LibraryServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest, request)
         assert_equal(required_singular_int32, request.required_singular_int32)
         assert_equal(required_singular_int64, request.required_singular_int64)
         assert_equal(required_singular_float, request.required_singular_float)
@@ -1862,7 +1935,7 @@ describe Library::V1::LibraryServiceClient do
         assert_equal(required_singular_enum, request.required_singular_enum)
         assert_equal(required_singular_string, request.required_singular_string)
         assert_equal(required_singular_bytes, request.required_singular_bytes)
-        assert_equal(required_singular_message, request.required_singular_message)
+        assert_equal(Google::Gax::to_proto(required_singular_message, Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage), request.required_singular_message)
         assert_equal(required_singular_resource_name, request.required_singular_resource_name)
         assert_equal(required_singular_resource_name_oneof, request.required_singular_resource_name_oneof)
         assert_equal(required_singular_fixed32, request.required_singular_fixed32)

--- a/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
@@ -622,7 +622,7 @@ module Library
       #   can also be provided.
       # @param books [Array<Google::Example::Library::V1::Book | Hash>]
       #   The books to publish in the series.
-      #   A hash of the same form as `Array`
+      #   A hash of the same form as `Google::Example::Library::V1::Book`
       #   can also be provided.
       # @param series_uuid [Google::Example::Library::V1::SeriesUuid | Hash]
       #   Uniquely identifies the series to the publishing house.
@@ -899,7 +899,7 @@ module Library
       #
       # @param name [String]
       # @param comments [Array<Google::Example::Library::V1::Comment | Hash>]
-      #   A hash of the same form as `Array`
+      #   A hash of the same form as `Google::Example::Library::V1::Comment`
       #   can also be provided.
       # @param options [Google::Gax::CallOptions]
       #   Overrides the default settings for this call, e.g, timeout,
@@ -1000,8 +1000,6 @@ module Library
       #   The name of the index for the book
       # @param index_map [Hash{String => String}]
       #   The index to update the book with
-      #   A hash of the same form as `Hash`
-      #   can also be provided.
       # @param options [Google::Gax::CallOptions]
       #   Overrides the default settings for this call, e.g, timeout,
       #   retries, etc.
@@ -1411,15 +1409,13 @@ module Library
       # @param required_repeated_string [Array<String>]
       # @param required_repeated_bytes [Array<String>]
       # @param required_repeated_message [Array<Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage | Hash>]
-      #   A hash of the same form as `Array`
+      #   A hash of the same form as `Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage`
       #   can also be provided.
       # @param required_repeated_resource_name [Array<String>]
       # @param required_repeated_resource_name_oneof [Array<String>]
       # @param required_repeated_fixed32 [Array<Integer>]
       # @param required_repeated_fixed64 [Array<Integer>]
       # @param required_map [Hash{Integer => String}]
-      #   A hash of the same form as `Hash`
-      #   can also be provided.
       # @param optional_singular_int32 [Integer]
       # @param optional_singular_int64 [Integer]
       # @param optional_singular_float [Float]
@@ -1444,15 +1440,13 @@ module Library
       # @param optional_repeated_string [Array<String>]
       # @param optional_repeated_bytes [Array<String>]
       # @param optional_repeated_message [Array<Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage | Hash>]
-      #   A hash of the same form as `Array`
+      #   A hash of the same form as `Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage`
       #   can also be provided.
       # @param optional_repeated_resource_name [Array<String>]
       # @param optional_repeated_resource_name_oneof [Array<String>]
       # @param optional_repeated_fixed32 [Array<Integer>]
       # @param optional_repeated_fixed64 [Array<Integer>]
       # @param optional_map [Hash{Integer => String}]
-      #   A hash of the same form as `Hash`
-      #   can also be provided.
       # @param options [Google::Gax::CallOptions]
       #   Overrides the default settings for this call, e.g, timeout,
       #   retries, etc.

--- a/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
@@ -420,8 +420,10 @@ module Library
       # Creates a shelf, and returns the new Shelf.
       # RPC method comment may include special characters: <>&"+'@.
       #
-      # @param shelf [Google::Example::Library::V1::Shelf]
+      # @param shelf [Google::Example::Library::V1::Shelf | Hash]
       #   The shelf to create.
+      #   A hash of the same form as `Google::Example::Library::V1::Shelf`
+      #   can also be provided.
       # @param options [Google::Gax::CallOptions]
       #   Overrides the default settings for this call, e.g, timeout,
       #   retries, etc.
@@ -450,9 +452,13 @@ module Library
       #   The name of the shelf to retrieve.
       # @param options_ [String]
       #   To test 'options' parameter name conflict.
-      # @param message [Google::Example::Library::V1::SomeMessage]
+      # @param message [Google::Example::Library::V1::SomeMessage | Hash]
       #   Field to verify that message-type query parameter gets flattened.
-      # @param string_builder [Google::Example::Library::V1::StringBuilder]
+      #   A hash of the same form as `Google::Example::Library::V1::SomeMessage`
+      #   can also be provided.
+      # @param string_builder [Google::Example::Library::V1::StringBuilder | Hash]
+      #   A hash of the same form as `Google::Example::Library::V1::StringBuilder`
+      #   can also be provided.
       # @param options [Google::Gax::CallOptions]
       #   Overrides the default settings for this call, e.g, timeout,
       #   retries, etc.
@@ -579,8 +585,10 @@ module Library
       #
       # @param name [String]
       #   The name of the shelf in which the book is created.
-      # @param book [Google::Example::Library::V1::Book]
+      # @param book [Google::Example::Library::V1::Book | Hash]
       #   The book to create.
+      #   A hash of the same form as `Google::Example::Library::V1::Book`
+      #   can also be provided.
       # @param options [Google::Gax::CallOptions]
       #   Overrides the default settings for this call, e.g, timeout,
       #   retries, etc.
@@ -608,12 +616,18 @@ module Library
 
       # Creates a series of books.
       #
-      # @param shelf [Google::Example::Library::V1::Shelf]
+      # @param shelf [Google::Example::Library::V1::Shelf | Hash]
       #   The shelf in which the series is created.
-      # @param books [Array<Google::Example::Library::V1::Book>]
+      #   A hash of the same form as `Google::Example::Library::V1::Shelf`
+      #   can also be provided.
+      # @param books [Array<Google::Example::Library::V1::Book | Hash>]
       #   The books to publish in the series.
-      # @param series_uuid [Google::Example::Library::V1::SeriesUuid]
+      #   A hash of the same form as `Array`
+      #   can also be provided.
+      # @param series_uuid [Google::Example::Library::V1::SeriesUuid | Hash]
       #   Uniquely identifies the series to the publishing house.
+      #   A hash of the same form as `Google::Example::Library::V1::SeriesUuid`
+      #   can also be provided.
       # @param edition [Integer]
       #   The edition of the series
       # @param review_copy [true, false]
@@ -761,12 +775,18 @@ module Library
       #
       # @param name [String]
       #   The name of the book to update.
-      # @param book [Google::Example::Library::V1::Book]
+      # @param book [Google::Example::Library::V1::Book | Hash]
       #   The book to update with.
-      # @param update_mask [Google::Protobuf::FieldMask]
+      #   A hash of the same form as `Google::Example::Library::V1::Book`
+      #   can also be provided.
+      # @param update_mask [Google::Protobuf::FieldMask | Hash]
       #   A field mask to apply, rendered as an HTTP parameter.
-      # @param physical_mask [Google::Example::Library::V1::FieldMask]
+      #   A hash of the same form as `Google::Protobuf::FieldMask`
+      #   can also be provided.
+      # @param physical_mask [Google::Example::Library::V1::FieldMask | Hash]
       #   To test Python import clash resolution.
+      #   A hash of the same form as `Google::Example::Library::V1::FieldMask`
+      #   can also be provided.
       # @param options [Google::Gax::CallOptions]
       #   Overrides the default settings for this call, e.g, timeout,
       #   retries, etc.
@@ -878,7 +898,9 @@ module Library
       # Adds comments to a book
       #
       # @param name [String]
-      # @param comments [Array<Google::Example::Library::V1::Comment>]
+      # @param comments [Array<Google::Example::Library::V1::Comment | Hash>]
+      #   A hash of the same form as `Array`
+      #   can also be provided.
       # @param options [Google::Gax::CallOptions]
       #   Overrides the default settings for this call, e.g, timeout,
       #   retries, etc.
@@ -978,6 +1000,8 @@ module Library
       #   The name of the index for the book
       # @param index_map [Hash{String => String}]
       #   The index to update the book with
+      #   A hash of the same form as `Hash`
+      #   can also be provided.
       # @param options [Google::Gax::CallOptions]
       #   Overrides the default settings for this call, e.g, timeout,
       #   retries, etc.
@@ -1371,7 +1395,9 @@ module Library
       # @param required_singular_enum [Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerEnum]
       # @param required_singular_string [String]
       # @param required_singular_bytes [String]
-      # @param required_singular_message [Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage]
+      # @param required_singular_message [Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage | Hash]
+      #   A hash of the same form as `Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage`
+      #   can also be provided.
       # @param required_singular_resource_name [String]
       # @param required_singular_resource_name_oneof [String]
       # @param required_singular_fixed32 [Integer]
@@ -1384,12 +1410,16 @@ module Library
       # @param required_repeated_enum [Array<Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerEnum>]
       # @param required_repeated_string [Array<String>]
       # @param required_repeated_bytes [Array<String>]
-      # @param required_repeated_message [Array<Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage>]
+      # @param required_repeated_message [Array<Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage | Hash>]
+      #   A hash of the same form as `Array`
+      #   can also be provided.
       # @param required_repeated_resource_name [Array<String>]
       # @param required_repeated_resource_name_oneof [Array<String>]
       # @param required_repeated_fixed32 [Array<Integer>]
       # @param required_repeated_fixed64 [Array<Integer>]
       # @param required_map [Hash{Integer => String}]
+      #   A hash of the same form as `Hash`
+      #   can also be provided.
       # @param optional_singular_int32 [Integer]
       # @param optional_singular_int64 [Integer]
       # @param optional_singular_float [Float]
@@ -1398,7 +1428,9 @@ module Library
       # @param optional_singular_enum [Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerEnum]
       # @param optional_singular_string [String]
       # @param optional_singular_bytes [String]
-      # @param optional_singular_message [Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage]
+      # @param optional_singular_message [Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage | Hash]
+      #   A hash of the same form as `Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage`
+      #   can also be provided.
       # @param optional_singular_resource_name [String]
       # @param optional_singular_resource_name_oneof [String]
       # @param optional_singular_fixed32 [Integer]
@@ -1411,12 +1443,16 @@ module Library
       # @param optional_repeated_enum [Array<Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerEnum>]
       # @param optional_repeated_string [Array<String>]
       # @param optional_repeated_bytes [Array<String>]
-      # @param optional_repeated_message [Array<Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage>]
+      # @param optional_repeated_message [Array<Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage | Hash>]
+      #   A hash of the same form as `Array`
+      #   can also be provided.
       # @param optional_repeated_resource_name [Array<String>]
       # @param optional_repeated_resource_name_oneof [Array<String>]
       # @param optional_repeated_fixed32 [Array<Integer>]
       # @param optional_repeated_fixed64 [Array<Integer>]
       # @param optional_map [Hash{Integer => String}]
+      #   A hash of the same form as `Hash`
+      #   can also be provided.
       # @param options [Google::Gax::CallOptions]
       #   Overrides the default settings for this call, e.g, timeout,
       #   retries, etc.

--- a/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
@@ -431,15 +431,16 @@ module Library
       #   require "library/v1"
       #
       #   library_service_client = Library::V1::LibraryServiceClient.new
-      #   shelf = Google::Example::Library::V1::Shelf.new
+      #   shelf = {}
       #   response = library_service_client.create_shelf(shelf)
 
       def create_shelf \
           shelf,
           options: nil
-        req = Google::Example::Library::V1::CreateShelfRequest.new({
+        req = {
           shelf: shelf
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::CreateShelfRequest)
         @create_shelf.call(req, options)
       end
 
@@ -471,12 +472,13 @@ module Library
           message: nil,
           string_builder: nil,
           options: nil
-        req = Google::Example::Library::V1::GetShelfRequest.new({
+        req = {
           name: name,
           options: options_,
           message: message,
           string_builder: string_builder
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::GetShelfRequest)
         @get_shelf.call(req, options)
       end
 
@@ -532,9 +534,10 @@ module Library
       def delete_shelf \
           name,
           options: nil
-        req = Google::Example::Library::V1::DeleteShelfRequest.new({
+        req = {
           name: name
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::DeleteShelfRequest)
         @delete_shelf.call(req, options)
         nil
       end
@@ -564,10 +567,11 @@ module Library
           name,
           other_shelf_name,
           options: nil
-        req = Google::Example::Library::V1::MergeShelvesRequest.new({
+        req = {
           name: name,
           other_shelf_name: other_shelf_name
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::MergeShelvesRequest)
         @merge_shelves.call(req, options)
       end
 
@@ -587,17 +591,18 @@ module Library
       #
       #   library_service_client = Library::V1::LibraryServiceClient.new
       #   formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
-      #   book = Google::Example::Library::V1::Book.new
+      #   book = {}
       #   response = library_service_client.create_book(formatted_name, book)
 
       def create_book \
           name,
           book,
           options: nil
-        req = Google::Example::Library::V1::CreateBookRequest.new({
+        req = {
           name: name,
           book: book
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::CreateBookRequest)
         @create_book.call(req, options)
       end
 
@@ -622,10 +627,10 @@ module Library
       #   require "library/v1"
       #
       #   library_service_client = Library::V1::LibraryServiceClient.new
-      #   shelf = Google::Example::Library::V1::Shelf.new
+      #   shelf = {}
       #   books = []
       #   series_string = "foobar"
-      #   series_uuid = Google::Example::Library::V1::SeriesUuid.new(series_string: series_string)
+      #   series_uuid = { series_string: series_string }
       #   response = library_service_client.publish_series(shelf, books, series_uuid)
 
       def publish_series \
@@ -635,13 +640,14 @@ module Library
           edition: nil,
           review_copy: nil,
           options: nil
-        req = Google::Example::Library::V1::PublishSeriesRequest.new({
+        req = {
           shelf: shelf,
           books: books,
           series_uuid: series_uuid,
           edition: edition,
           review_copy: review_copy
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::PublishSeriesRequest)
         @publish_series.call(req, options)
       end
 
@@ -664,9 +670,10 @@ module Library
       def get_book \
           name,
           options: nil
-        req = Google::Example::Library::V1::GetBookRequest.new({
+        req = {
           name: name
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::GetBookRequest)
         @get_book.call(req, options)
       end
 
@@ -715,11 +722,12 @@ module Library
           page_size: nil,
           filter: nil,
           options: nil
-        req = Google::Example::Library::V1::ListBooksRequest.new({
+        req = {
           name: name,
           page_size: page_size,
           filter: filter
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::ListBooksRequest)
         @list_books.call(req, options)
       end
 
@@ -741,9 +749,10 @@ module Library
       def delete_book \
           name,
           options: nil
-        req = Google::Example::Library::V1::DeleteBookRequest.new({
+        req = {
           name: name
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::DeleteBookRequest)
         @delete_book.call(req, options)
         nil
       end
@@ -768,7 +777,7 @@ module Library
       #
       #   library_service_client = Library::V1::LibraryServiceClient.new
       #   formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
-      #   book = Google::Example::Library::V1::Book.new
+      #   book = {}
       #   response = library_service_client.update_book(formatted_name, book)
 
       def update_book \
@@ -777,12 +786,13 @@ module Library
           update_mask: nil,
           physical_mask: nil,
           options: nil
-        req = Google::Example::Library::V1::UpdateBookRequest.new({
+        req = {
           name: name,
           book: book,
           update_mask: update_mask,
           physical_mask: physical_mask
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::UpdateBookRequest)
         @update_book.call(req, options)
       end
 
@@ -809,10 +819,11 @@ module Library
           name,
           other_shelf_name,
           options: nil
-        req = Google::Example::Library::V1::MoveBookRequest.new({
+        req = {
           name: name,
           other_shelf_name: other_shelf_name
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::MoveBookRequest)
         @move_book.call(req, options)
       end
 
@@ -856,10 +867,11 @@ module Library
           name: nil,
           page_size: nil,
           options: nil
-        req = Google::Example::Library::V1::ListStringsRequest.new({
+        req = {
           name: name,
           page_size: page_size
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::ListStringsRequest)
         @list_strings.call(req, options)
       end
 
@@ -879,11 +891,11 @@ module Library
       #   comment = ''
       #   stage = :UNSET
       #   alignment = :CHAR
-      #   comments_element = Google::Example::Library::V1::Comment.new(
+      #   comments_element = {
       #     comment: comment,
       #     stage: stage,
       #     alignment: alignment
-      #   )
+      #   }
       #   comments = [comments_element]
       #   library_service_client.add_comments(formatted_name, comments)
 
@@ -891,10 +903,11 @@ module Library
           name,
           comments,
           options: nil
-        req = Google::Example::Library::V1::AddCommentsRequest.new({
+        req = {
           name: name,
           comments: comments
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::AddCommentsRequest)
         @add_comments.call(req, options)
         nil
       end
@@ -918,9 +931,10 @@ module Library
       def get_book_from_archive \
           name,
           options: nil
-        req = Google::Example::Library::V1::GetBookFromArchiveRequest.new({
+        req = {
           name: name
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::GetBookFromArchiveRequest)
         @get_book_from_archive.call(req, options)
       end
 
@@ -948,10 +962,11 @@ module Library
           name,
           alt_book_name,
           options: nil
-        req = Google::Example::Library::V1::GetBookFromAnywhereRequest.new({
+        req = {
           name: name,
           alt_book_name: alt_book_name
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::GetBookFromAnywhereRequest)
         @get_book_from_anywhere.call(req, options)
       end
 
@@ -982,11 +997,12 @@ module Library
           index_name,
           index_map,
           options: nil
-        req = Google::Example::Library::V1::UpdateBookIndexRequest.new({
+        req = {
           name: name,
           index_name: index_name,
           index_map: index_map
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::UpdateBookIndexRequest)
         @update_book_index.call(req, options)
         nil
       end
@@ -1038,9 +1054,10 @@ module Library
       def stream_books \
           name,
           options: nil
-        req = Google::Example::Library::V1::StreamBooksRequest.new({
+        req = {
           name: name
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::StreamBooksRequest)
         @stream_books.call(req, options)
       end
 
@@ -1067,7 +1084,7 @@ module Library
       #
       #   library_service_client = Library::V1::LibraryServiceClient.new
       #   name = ''
-      #   request = Google::Example::Library::V1::DiscussBookRequest.new(name: name)
+      #   request = { name: name }
       #   requests = [request]
       #   library_service_client.discuss_book(requests).each do |element|
       #     # Process element.
@@ -1098,7 +1115,7 @@ module Library
       #
       #   library_service_client = Library::V1::LibraryServiceClient.new
       #   name = ''
-      #   request = Google::Example::Library::V1::DiscussBookRequest.new(name: name)
+      #   request = { name: name }
       #   requests = [request]
       #   response = library_service_client.monolog_about_book(requests)
 
@@ -1149,11 +1166,12 @@ module Library
           shelves,
           page_size: nil,
           options: nil
-        req = Google::Example::Library::V1::FindRelatedBooksRequest.new({
+        req = {
           names: names,
           shelves: shelves,
           page_size: page_size
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::FindRelatedBooksRequest)
         @find_related_books.call(req, options)
       end
 
@@ -1182,10 +1200,11 @@ module Library
           resource,
           tag,
           options: nil
-        req = Google::Tagger::V1::AddTagRequest.new({
+        req = {
           resource: resource,
           tag: tag
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Tagger::V1::AddTagRequest)
         @add_tag.call(req, options)
       end
 
@@ -1214,10 +1233,11 @@ module Library
           resource,
           label,
           options: nil
-        req = Google::Tagger::V1::AddLabelRequest.new({
+        req = {
           resource: resource,
           label: label
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Tagger::V1::AddLabelRequest)
         @add_label.call(req, options)
       end
 
@@ -1266,9 +1286,10 @@ module Library
       def get_big_book \
           name,
           options: nil
-        req = Google::Example::Library::V1::GetBookRequest.new({
+        req = {
           name: name
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::GetBookRequest)
         operation = Google::Gax::Operation.new(
           @get_big_book.call(req, options),
           @operations_client,
@@ -1325,9 +1346,10 @@ module Library
       def get_big_nothing \
           name,
           options: nil
-        req = Google::Example::Library::V1::GetBookRequest.new({
+        req = {
           name: name
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::GetBookRequest)
         operation = Google::Gax::Operation.new(
           @get_big_nothing.call(req, options),
           @operations_client,
@@ -1412,7 +1434,7 @@ module Library
       #   required_singular_enum = :ZERO
       #   required_singular_string = ''
       #   required_singular_bytes = ''
-      #   required_singular_message = Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage.new
+      #   required_singular_message = {}
       #   required_singular_resource_name = ''
       #   required_singular_resource_name_oneof = ''
       #   required_singular_fixed32 = 0
@@ -1489,7 +1511,7 @@ module Library
           optional_repeated_fixed64: nil,
           optional_map: nil,
           options: nil
-        req = Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest.new({
+        req = {
           required_singular_int32: required_singular_int32,
           required_singular_int64: required_singular_int64,
           required_singular_float: required_singular_float,
@@ -1544,7 +1566,8 @@ module Library
           optional_repeated_fixed32: optional_repeated_fixed32,
           optional_repeated_fixed64: optional_repeated_fixed64,
           optional_map: optional_map
-        }.delete_if { |_, v| v.nil? })
+        }.delete_if { |_, v| v.nil? }
+        req = Google::Gax::to_proto(req, Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest)
         @test_optional_required_flattening_params.call(req, options)
       end
     end

--- a/src/test/java/com/google/api/codegen/testdata/ruby_smoke_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_smoke_test_library.baseline
@@ -29,7 +29,7 @@ describe "LibraryServiceSmokeTest" do
     library_service_client = Library::V1::LibraryServiceClient.new
     formatted_name = Library::V1::LibraryServiceClient.book_path("testShelf-" + Time.new.to_i.to_s, project_id)
     rating = :GOOD
-    book = Google::Example::Library::V1::Book.new(rating: rating)
+    book = { rating: rating }
     response = library_service_client.update_book(formatted_name, book)
   end
 end

--- a/src/test/java/com/google/api/codegen/testdata/ruby_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_test_library.baseline
@@ -61,21 +61,23 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes create_shelf without error' do
       # Create request parameters
-      shelf = Google::Example::Library::V1::Shelf.new
+      shelf = {}
 
       # Create expected grpc response
       name = "name3373707"
       theme = "theme110327241"
       internal_theme = "internalTheme792518087"
-      expected_response = Google::Example::Library::V1::Shelf.new(
+      expected_response = {
         name: name,
         theme: theme,
         internal_theme: internal_theme
-      )
+      }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::Shelf)
 
       # Mock Grpc layer
       mock_method = proc do |request|
-        assert_equal(shelf, request.shelf)
+        assert_instance_of(Google::Example::Library::V1::CreateShelfRequest, request)
+        assert_equal(Google::Gax::to_proto(shelf, Google::Example::Library::V1::Shelf), request.shelf)
         expected_response
       end
       mock_stub = MockGrpcClientStub.new(:create_shelf, mock_method)
@@ -93,11 +95,12 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes create_shelf with error' do
       # Create request parameters
-      shelf = Google::Example::Library::V1::Shelf.new
+      shelf = {}
 
       # Mock Grpc layer
       mock_method = proc do |request|
-        assert_equal(shelf, request.shelf)
+        assert_instance_of(Google::Example::Library::V1::CreateShelfRequest, request)
+        assert_equal(Google::Gax::to_proto(shelf, Google::Example::Library::V1::Shelf), request.shelf)
         raise custom_error
       end
       mock_stub = MockGrpcClientStub.new(:create_shelf, mock_method)
@@ -128,14 +131,16 @@ describe Library::V1::LibraryServiceClient do
       name_2 = "name2-1052831874"
       theme = "theme110327241"
       internal_theme = "internalTheme792518087"
-      expected_response = Google::Example::Library::V1::Shelf.new(
+      expected_response = {
         name: name_2,
         theme: theme,
         internal_theme: internal_theme
-      )
+      }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::Shelf)
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::GetShelfRequest, request)
         assert_equal(formatted_name, request.name)
         assert_equal(options_, request.options)
         expected_response
@@ -160,6 +165,7 @@ describe Library::V1::LibraryServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::GetShelfRequest, request)
         assert_equal(formatted_name, request.name)
         assert_equal(options_, request.options)
         raise custom_error
@@ -186,9 +192,10 @@ describe Library::V1::LibraryServiceClient do
     it 'invokes list_shelves without error' do
       # Create expected grpc response
       next_page_token = ""
-      shelves_element = Google::Example::Library::V1::Shelf.new
+      shelves_element = {}
       shelves = [shelves_element]
-      expected_response = Google::Example::Library::V1::ListShelvesResponse.new(next_page_token: next_page_token, shelves: shelves)
+      expected_response = { next_page_token: next_page_token, shelves: shelves }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::ListShelvesResponse)
 
       # Mock Grpc layer
       mock_method = proc do
@@ -240,6 +247,7 @@ describe Library::V1::LibraryServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::DeleteShelfRequest, request)
         assert_equal(formatted_name, request.name)
         nil
       end
@@ -262,6 +270,7 @@ describe Library::V1::LibraryServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::DeleteShelfRequest, request)
         assert_equal(formatted_name, request.name)
         raise custom_error
       end
@@ -293,14 +302,16 @@ describe Library::V1::LibraryServiceClient do
       name_2 = "name2-1052831874"
       theme = "theme110327241"
       internal_theme = "internalTheme792518087"
-      expected_response = Google::Example::Library::V1::Shelf.new(
+      expected_response = {
         name: name_2,
         theme: theme,
         internal_theme: internal_theme
-      )
+      }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::Shelf)
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::MergeShelvesRequest, request)
         assert_equal(formatted_name, request.name)
         assert_equal(formatted_other_shelf_name, request.other_shelf_name)
         expected_response
@@ -325,6 +336,7 @@ describe Library::V1::LibraryServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::MergeShelvesRequest, request)
         assert_equal(formatted_name, request.name)
         assert_equal(formatted_other_shelf_name, request.other_shelf_name)
         raise custom_error
@@ -351,24 +363,26 @@ describe Library::V1::LibraryServiceClient do
     it 'invokes create_book without error' do
       # Create request parameters
       formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
-      book = Google::Example::Library::V1::Book.new
+      book = {}
 
       # Create expected grpc response
       name_2 = "name2-1052831874"
       author = "author-1406328437"
       title = "title110371416"
       read = true
-      expected_response = Google::Example::Library::V1::Book.new(
+      expected_response = {
         name: name_2,
         author: author,
         title: title,
         read: read
-      )
+      }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::Book)
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::CreateBookRequest, request)
         assert_equal(formatted_name, request.name)
-        assert_equal(book, request.book)
+        assert_equal(Google::Gax::to_proto(book, Google::Example::Library::V1::Book), request.book)
         expected_response
       end
       mock_stub = MockGrpcClientStub.new(:create_book, mock_method)
@@ -387,12 +401,13 @@ describe Library::V1::LibraryServiceClient do
     it 'invokes create_book with error' do
       # Create request parameters
       formatted_name = Library::V1::LibraryServiceClient.shelf_path("[SHELF_ID]")
-      book = Google::Example::Library::V1::Book.new
+      book = {}
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::CreateBookRequest, request)
         assert_equal(formatted_name, request.name)
-        assert_equal(book, request.book)
+        assert_equal(Google::Gax::to_proto(book, Google::Example::Library::V1::Book), request.book)
         raise custom_error
       end
       mock_stub = MockGrpcClientStub.new(:create_book, mock_method)
@@ -416,21 +431,23 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes publish_series without error' do
       # Create request parameters
-      shelf = Google::Example::Library::V1::Shelf.new
+      shelf = {}
       books = []
       series_string = "foobar"
-      series_uuid = Google::Example::Library::V1::SeriesUuid.new(series_string: series_string)
+      series_uuid = { series_string: series_string }
 
       # Create expected grpc response
       book_names_element = "bookNamesElement1491670575"
       book_names = [book_names_element]
-      expected_response = Google::Example::Library::V1::PublishSeriesResponse.new(book_names: book_names)
+      expected_response = { book_names: book_names }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::PublishSeriesResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
-        assert_equal(shelf, request.shelf)
+        assert_instance_of(Google::Example::Library::V1::PublishSeriesRequest, request)
+        assert_equal(Google::Gax::to_proto(shelf, Google::Example::Library::V1::Shelf), request.shelf)
         assert_equal(books, request.books)
-        assert_equal(series_uuid, request.series_uuid)
+        assert_equal(Google::Gax::to_proto(series_uuid, Google::Example::Library::V1::SeriesUuid), request.series_uuid)
         expected_response
       end
       mock_stub = MockGrpcClientStub.new(:publish_series, mock_method)
@@ -452,16 +469,17 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes publish_series with error' do
       # Create request parameters
-      shelf = Google::Example::Library::V1::Shelf.new
+      shelf = {}
       books = []
       series_string = "foobar"
-      series_uuid = Google::Example::Library::V1::SeriesUuid.new(series_string: series_string)
+      series_uuid = { series_string: series_string }
 
       # Mock Grpc layer
       mock_method = proc do |request|
-        assert_equal(shelf, request.shelf)
+        assert_instance_of(Google::Example::Library::V1::PublishSeriesRequest, request)
+        assert_equal(Google::Gax::to_proto(shelf, Google::Example::Library::V1::Shelf), request.shelf)
         assert_equal(books, request.books)
-        assert_equal(series_uuid, request.series_uuid)
+        assert_equal(Google::Gax::to_proto(series_uuid, Google::Example::Library::V1::SeriesUuid), request.series_uuid)
         raise custom_error
       end
       mock_stub = MockGrpcClientStub.new(:publish_series, mock_method)
@@ -496,15 +514,17 @@ describe Library::V1::LibraryServiceClient do
       author = "author-1406328437"
       title = "title110371416"
       read = true
-      expected_response = Google::Example::Library::V1::Book.new(
+      expected_response = {
         name: name_2,
         author: author,
         title: title,
         read: read
-      )
+      }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::Book)
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::GetBookRequest, request)
         assert_equal(formatted_name, request.name)
         expected_response
       end
@@ -527,6 +547,7 @@ describe Library::V1::LibraryServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::GetBookRequest, request)
         assert_equal(formatted_name, request.name)
         raise custom_error
       end
@@ -555,12 +576,14 @@ describe Library::V1::LibraryServiceClient do
 
       # Create expected grpc response
       next_page_token = ""
-      books_element = Google::Example::Library::V1::Book.new
+      books_element = {}
       books = [books_element]
-      expected_response = Google::Example::Library::V1::ListBooksResponse.new(next_page_token: next_page_token, books: books)
+      expected_response = { next_page_token: next_page_token, books: books }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::ListBooksResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::ListBooksRequest, request)
         assert_equal(formatted_name, request.name)
         expected_response
       end
@@ -586,6 +609,7 @@ describe Library::V1::LibraryServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::ListBooksRequest, request)
         assert_equal(formatted_name, request.name)
         raise custom_error
       end
@@ -614,6 +638,7 @@ describe Library::V1::LibraryServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::DeleteBookRequest, request)
         assert_equal(formatted_name, request.name)
         nil
       end
@@ -636,6 +661,7 @@ describe Library::V1::LibraryServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::DeleteBookRequest, request)
         assert_equal(formatted_name, request.name)
         raise custom_error
       end
@@ -661,24 +687,26 @@ describe Library::V1::LibraryServiceClient do
     it 'invokes update_book without error' do
       # Create request parameters
       formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
-      book = Google::Example::Library::V1::Book.new
+      book = {}
 
       # Create expected grpc response
       name_2 = "name2-1052831874"
       author = "author-1406328437"
       title = "title110371416"
       read = true
-      expected_response = Google::Example::Library::V1::Book.new(
+      expected_response = {
         name: name_2,
         author: author,
         title: title,
         read: read
-      )
+      }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::Book)
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::UpdateBookRequest, request)
         assert_equal(formatted_name, request.name)
-        assert_equal(book, request.book)
+        assert_equal(Google::Gax::to_proto(book, Google::Example::Library::V1::Book), request.book)
         expected_response
       end
       mock_stub = MockGrpcClientStub.new(:update_book, mock_method)
@@ -697,12 +725,13 @@ describe Library::V1::LibraryServiceClient do
     it 'invokes update_book with error' do
       # Create request parameters
       formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
-      book = Google::Example::Library::V1::Book.new
+      book = {}
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::UpdateBookRequest, request)
         assert_equal(formatted_name, request.name)
-        assert_equal(book, request.book)
+        assert_equal(Google::Gax::to_proto(book, Google::Example::Library::V1::Book), request.book)
         raise custom_error
       end
       mock_stub = MockGrpcClientStub.new(:update_book, mock_method)
@@ -734,15 +763,17 @@ describe Library::V1::LibraryServiceClient do
       author = "author-1406328437"
       title = "title110371416"
       read = true
-      expected_response = Google::Example::Library::V1::Book.new(
+      expected_response = {
         name: name_2,
         author: author,
         title: title,
         read: read
-      )
+      }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::Book)
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::MoveBookRequest, request)
         assert_equal(formatted_name, request.name)
         assert_equal(formatted_other_shelf_name, request.other_shelf_name)
         expected_response
@@ -767,6 +798,7 @@ describe Library::V1::LibraryServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::MoveBookRequest, request)
         assert_equal(formatted_name, request.name)
         assert_equal(formatted_other_shelf_name, request.other_shelf_name)
         raise custom_error
@@ -795,7 +827,8 @@ describe Library::V1::LibraryServiceClient do
       next_page_token = ""
       strings_element = "stringsElement474465855"
       strings = [strings_element]
-      expected_response = Google::Example::Library::V1::ListStringsResponse.new(next_page_token: next_page_token, strings: strings)
+      expected_response = { next_page_token: next_page_token, strings: strings }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::ListStringsResponse)
 
       # Mock Grpc layer
       mock_method = proc do
@@ -847,15 +880,16 @@ describe Library::V1::LibraryServiceClient do
       comment = ''
       stage = :UNSET
       alignment = :CHAR
-      comments_element = Google::Example::Library::V1::Comment.new(
+      comments_element = {
         comment: comment,
         stage: stage,
         alignment: alignment
-      )
+      }
       comments = [comments_element]
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::AddCommentsRequest, request)
         assert_equal(formatted_name, request.name)
         assert_equal(comments, request.comments)
         nil
@@ -879,15 +913,16 @@ describe Library::V1::LibraryServiceClient do
       comment = ''
       stage = :UNSET
       alignment = :CHAR
-      comments_element = Google::Example::Library::V1::Comment.new(
+      comments_element = {
         comment: comment,
         stage: stage,
         alignment: alignment
-      )
+      }
       comments = [comments_element]
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::AddCommentsRequest, request)
         assert_equal(formatted_name, request.name)
         assert_equal(comments, request.comments)
         raise custom_error
@@ -920,15 +955,17 @@ describe Library::V1::LibraryServiceClient do
       author = "author-1406328437"
       title = "title110371416"
       read = true
-      expected_response = Google::Example::Library::V1::BookFromArchive.new(
+      expected_response = {
         name: name_2,
         author: author,
         title: title,
         read: read
-      )
+      }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::BookFromArchive)
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::GetBookFromArchiveRequest, request)
         assert_equal(formatted_name, request.name)
         expected_response
       end
@@ -951,6 +988,7 @@ describe Library::V1::LibraryServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::GetBookFromArchiveRequest, request)
         assert_equal(formatted_name, request.name)
         raise custom_error
       end
@@ -983,15 +1021,17 @@ describe Library::V1::LibraryServiceClient do
       author = "author-1406328437"
       title = "title110371416"
       read = true
-      expected_response = Google::Example::Library::V1::BookFromAnywhere.new(
+      expected_response = {
         name: name_2,
         author: author,
         title: title,
         read: read
-      )
+      }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::BookFromAnywhere)
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::GetBookFromAnywhereRequest, request)
         assert_equal(formatted_name, request.name)
         assert_equal(formatted_alt_book_name, request.alt_book_name)
         expected_response
@@ -1016,6 +1056,7 @@ describe Library::V1::LibraryServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::GetBookFromAnywhereRequest, request)
         assert_equal(formatted_name, request.name)
         assert_equal(formatted_alt_book_name, request.alt_book_name)
         raise custom_error
@@ -1048,6 +1089,7 @@ describe Library::V1::LibraryServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::UpdateBookIndexRequest, request)
         assert_equal(formatted_name, request.name)
         assert_equal(index_name, request.index_name)
         assert_equal(index_map, request.index_map)
@@ -1079,6 +1121,7 @@ describe Library::V1::LibraryServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::UpdateBookIndexRequest, request)
         assert_equal(formatted_name, request.name)
         assert_equal(index_name, request.index_name)
         assert_equal(index_map, request.index_map)
@@ -1109,10 +1152,11 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes stream_shelves without error' do
       # Create request parameters
-      request = Google::Example::Library::V1::StreamShelvesRequest.new
+      request = {}
 
       # Create expected grpc response
-      expected_response = Google::Example::Library::V1::StreamShelvesResponse.new
+      expected_response = {}
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::StreamShelvesResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -1134,7 +1178,7 @@ describe Library::V1::LibraryServiceClient do
 
     it 'invokes stream_shelves with error' do
       # Create request parameters
-      request = Google::Example::Library::V1::StreamShelvesRequest.new
+      request = {}
 
       # Mock Grpc layer
       mock_method = proc do |request|
@@ -1162,22 +1206,24 @@ describe Library::V1::LibraryServiceClient do
     it 'invokes stream_books without error' do
       # Create request parameters
       name = ''
-      request = Google::Example::Library::V1::StreamBooksRequest.new(name: name)
+      request = { name: name }
 
       # Create expected grpc response
       name_2 = "name2-1052831874"
       author = "author-1406328437"
       title = "title110371416"
       read = true
-      expected_response = Google::Example::Library::V1::Book.new(
+      expected_response = {
         name: name_2,
         author: author,
         title: title,
         read: read
-      )
+      }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::Book)
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::StreamBooksRequest, request)
         assert_equal(name, request.name)
         [expected_response]
       end
@@ -1198,10 +1244,11 @@ describe Library::V1::LibraryServiceClient do
     it 'invokes stream_books with error' do
       # Create request parameters
       name = ''
-      request = Google::Example::Library::V1::StreamBooksRequest.new(name: name)
+      request = { name: name }
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::StreamBooksRequest, request)
         assert_equal(name, request.name)
         raise custom_error
       end
@@ -1227,16 +1274,18 @@ describe Library::V1::LibraryServiceClient do
     it 'invokes discuss_book without error' do
       # Create request parameters
       name = ''
-      request = Google::Example::Library::V1::DiscussBookRequest.new(name: name)
+      request = { name: name }
 
       # Create expected grpc response
       user_name = "userName339340927"
       comment = "95"
-      expected_response = Google::Example::Library::V1::Comment.new(user_name: user_name, comment: comment)
+      expected_response = { user_name: user_name, comment: comment }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::Comment)
 
       # Mock Grpc layer
       mock_method = proc do |requests|
         request = requests.first
+        assert_instance_of(Google::Example::Library::V1::DiscussBookRequest, request)
         assert_equal(name, request.name)
         [expected_response]
       end
@@ -1257,11 +1306,12 @@ describe Library::V1::LibraryServiceClient do
     it 'invokes discuss_book with error' do
       # Create request parameters
       name = ''
-      request = Google::Example::Library::V1::DiscussBookRequest.new(name: name)
+      request = { name: name }
 
       # Mock Grpc layer
       mock_method = proc do |requests|
         request = requests.first
+        assert_instance_of(Google::Example::Library::V1::DiscussBookRequest, request)
         assert_equal(name, request.name)
         raise custom_error
       end
@@ -1287,16 +1337,18 @@ describe Library::V1::LibraryServiceClient do
     it 'invokes monolog_about_book without error' do
       # Create request parameters
       name = ''
-      request = Google::Example::Library::V1::DiscussBookRequest.new(name: name)
+      request = { name: name }
 
       # Create expected grpc response
       user_name = "userName339340927"
       comment = "95"
-      expected_response = Google::Example::Library::V1::Comment.new(user_name: user_name, comment: comment)
+      expected_response = { user_name: user_name, comment: comment }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::Comment)
 
       # Mock Grpc layer
       mock_method = proc do |requests|
         request = requests.first
+        assert_instance_of(Google::Example::Library::V1::DiscussBookRequest, request)
         assert_equal(name, request.name)
         expected_response
       end
@@ -1316,11 +1368,12 @@ describe Library::V1::LibraryServiceClient do
     it 'invokes monolog_about_book with error' do
       # Create request parameters
       name = ''
-      request = Google::Example::Library::V1::DiscussBookRequest.new(name: name)
+      request = { name: name }
 
       # Mock Grpc layer
       mock_method = proc do |requests|
         request = requests.first
+        assert_instance_of(Google::Example::Library::V1::DiscussBookRequest, request)
         assert_equal(name, request.name)
         raise custom_error
       end
@@ -1353,10 +1406,12 @@ describe Library::V1::LibraryServiceClient do
       next_page_token = ""
       names_element_2 = "namesElement21120252792"
       names_2 = [names_element_2]
-      expected_response = Google::Example::Library::V1::FindRelatedBooksResponse.new(next_page_token: next_page_token, names: names_2)
+      expected_response = { next_page_token: next_page_token, names: names_2 }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::FindRelatedBooksResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::FindRelatedBooksRequest, request)
         assert_equal(names, request.names)
         assert_equal(shelves, request.shelves)
         expected_response
@@ -1385,6 +1440,7 @@ describe Library::V1::LibraryServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::FindRelatedBooksRequest, request)
         assert_equal(names, request.names)
         assert_equal(shelves, request.shelves)
         raise custom_error
@@ -1414,10 +1470,12 @@ describe Library::V1::LibraryServiceClient do
       tag = ''
 
       # Create expected grpc response
-      expected_response = Google::Tagger::V1::AddTagResponse.new
+      expected_response = {}
+      expected_response = Google::Gax::to_proto(expected_response, Google::Tagger::V1::AddTagResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Tagger::V1::AddTagRequest, request)
         assert_equal(formatted_resource, request.resource)
         assert_equal(tag, request.tag)
         expected_response
@@ -1442,6 +1500,7 @@ describe Library::V1::LibraryServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Tagger::V1::AddTagRequest, request)
         assert_equal(formatted_resource, request.resource)
         assert_equal(tag, request.tag)
         raise custom_error
@@ -1471,10 +1530,12 @@ describe Library::V1::LibraryServiceClient do
       label = ''
 
       # Create expected grpc response
-      expected_response = Google::Tagger::V1::AddLabelResponse.new
+      expected_response = {}
+      expected_response = Google::Gax::to_proto(expected_response, Google::Tagger::V1::AddLabelResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Tagger::V1::AddLabelRequest, request)
         assert_equal(formatted_resource, request.resource)
         assert_equal(label, request.label)
         expected_response
@@ -1499,6 +1560,7 @@ describe Library::V1::LibraryServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Tagger::V1::AddLabelRequest, request)
         assert_equal(formatted_resource, request.resource)
         assert_equal(label, request.label)
         raise custom_error
@@ -1531,12 +1593,13 @@ describe Library::V1::LibraryServiceClient do
       author = "author-1406328437"
       title = "title110371416"
       read = true
-      expected_response = Google::Example::Library::V1::Book.new(
+      expected_response = {
         name: name_2,
         author: author,
         title: title,
         read: read
-      )
+      }
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::Book)
       result = Google::Protobuf::Any.new
       result.pack(expected_response)
       operation = Google::Longrunning::Operation.new(
@@ -1547,6 +1610,7 @@ describe Library::V1::LibraryServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::GetBookRequest, request)
         assert_equal(formatted_name, request.name)
         operation
       end
@@ -1579,6 +1643,7 @@ describe Library::V1::LibraryServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::GetBookRequest, request)
         assert_equal(formatted_name, request.name)
         operation
       end
@@ -1602,6 +1667,7 @@ describe Library::V1::LibraryServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::GetBookRequest, request)
         assert_equal(formatted_name, request.name)
         raise custom_error
       end
@@ -1629,7 +1695,8 @@ describe Library::V1::LibraryServiceClient do
       formatted_name = Library::V1::LibraryServiceClient.book_path("[SHELF_ID]", "[BOOK_ID]")
 
       # Create expected grpc response
-      expected_response = Google::Protobuf::Empty.new
+      expected_response = {}
+      expected_response = Google::Gax::to_proto(expected_response, Google::Protobuf::Empty)
       result = Google::Protobuf::Any.new
       result.pack(expected_response)
       operation = Google::Longrunning::Operation.new(
@@ -1640,6 +1707,7 @@ describe Library::V1::LibraryServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::GetBookRequest, request)
         assert_equal(formatted_name, request.name)
         operation
       end
@@ -1672,6 +1740,7 @@ describe Library::V1::LibraryServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::GetBookRequest, request)
         assert_equal(formatted_name, request.name)
         operation
       end
@@ -1695,6 +1764,7 @@ describe Library::V1::LibraryServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::GetBookRequest, request)
         assert_equal(formatted_name, request.name)
         raise custom_error
       end
@@ -1727,7 +1797,7 @@ describe Library::V1::LibraryServiceClient do
       required_singular_enum = :ZERO
       required_singular_string = ''
       required_singular_bytes = ''
-      required_singular_message = Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage.new
+      required_singular_message = {}
       required_singular_resource_name = ''
       required_singular_resource_name_oneof = ''
       required_singular_fixed32 = 0
@@ -1748,10 +1818,12 @@ describe Library::V1::LibraryServiceClient do
       required_map = {}
 
       # Create expected grpc response
-      expected_response = Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsResponse.new
+      expected_response = {}
+      expected_response = Google::Gax::to_proto(expected_response, Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsResponse)
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest, request)
         assert_equal(required_singular_int32, request.required_singular_int32)
         assert_equal(required_singular_int64, request.required_singular_int64)
         assert_equal(required_singular_float, request.required_singular_float)
@@ -1760,7 +1832,7 @@ describe Library::V1::LibraryServiceClient do
         assert_equal(required_singular_enum, request.required_singular_enum)
         assert_equal(required_singular_string, request.required_singular_string)
         assert_equal(required_singular_bytes, request.required_singular_bytes)
-        assert_equal(required_singular_message, request.required_singular_message)
+        assert_equal(Google::Gax::to_proto(required_singular_message, Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage), request.required_singular_message)
         assert_equal(required_singular_resource_name, request.required_singular_resource_name)
         assert_equal(required_singular_resource_name_oneof, request.required_singular_resource_name_oneof)
         assert_equal(required_singular_fixed32, request.required_singular_fixed32)
@@ -1832,7 +1904,7 @@ describe Library::V1::LibraryServiceClient do
       required_singular_enum = :ZERO
       required_singular_string = ''
       required_singular_bytes = ''
-      required_singular_message = Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage.new
+      required_singular_message = {}
       required_singular_resource_name = ''
       required_singular_resource_name_oneof = ''
       required_singular_fixed32 = 0
@@ -1854,6 +1926,7 @@ describe Library::V1::LibraryServiceClient do
 
       # Mock Grpc layer
       mock_method = proc do |request|
+        assert_instance_of(Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest, request)
         assert_equal(required_singular_int32, request.required_singular_int32)
         assert_equal(required_singular_int64, request.required_singular_int64)
         assert_equal(required_singular_float, request.required_singular_float)
@@ -1862,7 +1935,7 @@ describe Library::V1::LibraryServiceClient do
         assert_equal(required_singular_enum, request.required_singular_enum)
         assert_equal(required_singular_string, request.required_singular_string)
         assert_equal(required_singular_bytes, request.required_singular_bytes)
-        assert_equal(required_singular_message, request.required_singular_message)
+        assert_equal(Google::Gax::to_proto(required_singular_message, Google::Example::Library::V1::TestOptionalRequiredFlatteningParamsRequest::InnerMessage), request.required_singular_message)
         assert_equal(required_singular_resource_name, request.required_singular_resource_name)
         assert_equal(required_singular_resource_name_oneof, request.required_singular_resource_name_oneof)
         assert_equal(required_singular_fixed32, request.required_singular_fixed32)


### PR DESCRIPTION
Updated the main gapic to use it as well as the samples and tests to verify that it works. I hand tested the generated unit tests for spanner_admin_database and monitoring and all tests pass.
