### PR TITLE
Update generated PHP documentation

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/php/PhpApiMethodParamTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpApiMethodParamTransformer.java
@@ -102,6 +102,20 @@ public class PhpApiMethodParamTransformer implements ApiMethodParamTransformer {
         docLines.addAll(context.getNamer().getDocLines(field));
       }
 
+      if (field.getType().isEnum()) {
+        // For enums, we alter the param type to int, and document where to find the relevant
+        // const values
+        String typeNameSingular =
+            context.getTypeTable().getAndSaveNicknameFor(field.getType().makeOptional());
+        if (field.getType().isRepeated()) {
+          paramDoc.typeName("int[]");
+        } else {
+          paramDoc.typeName("int");
+        }
+        docLines.add(
+            "For allowed values, use constants defined on {@see " + typeNameSingular + "}");
+      }
+
       paramDoc.lines(docLines.build());
 
       paramDocs.add(paramDoc.build());

--- a/src/main/java/com/google/api/codegen/transformer/php/PhpApiMethodParamTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpApiMethodParamTransformer.java
@@ -106,7 +106,7 @@ public class PhpApiMethodParamTransformer implements ApiMethodParamTransformer {
         // For enums, we alter the param type to int, and document where to find the relevant
         // const values
         String typeNameSingular =
-            context.getTypeTable().getAndSaveNicknameFor(field.getType().makeOptional());
+            context.getTypeTable().getFullNameFor(field.getType().makeOptional());
         if (field.getType().isRepeated()) {
           paramDoc.typeName("int[]");
         } else {

--- a/src/main/java/com/google/api/codegen/util/php/PhpCommentReformatter.java
+++ b/src/main/java/com/google/api/codegen/util/php/PhpCommentReformatter.java
@@ -20,12 +20,12 @@ import com.google.api.codegen.util.LinkPattern;
 import java.util.regex.Pattern;
 
 public class PhpCommentReformatter implements CommentReformatter {
-  public static final Pattern ASTERISK_PATTERN = Pattern.compile("\\*");
+  public static final Pattern CLOSE_COMMENT_PATTERN = Pattern.compile("\\*/");
   public static final Pattern AMPERSAND_PATTERN = Pattern.compile("@");
 
   private CommentTransformer transformer =
       CommentTransformer.newBuilder()
-          .replace(ASTERISK_PATTERN, "&#42;")
+          .replace(CLOSE_COMMENT_PATTERN, "&#42;/")
           .replace(AMPERSAND_PATTERN, "&#64;")
           .transform(
               LinkPattern.RELATIVE

--- a/src/main/java/com/google/api/codegen/viewmodel/DynamicLangXApiView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/DynamicLangXApiView.java
@@ -45,6 +45,10 @@ public abstract class DynamicLangXApiView implements ViewModel {
 
   public abstract List<ParseResourceFunctionView> parseResourceFunctions();
 
+  public boolean hasFormatOrParseResourceFunctions() {
+    return formatResourceFunctions().size() > 0 || parseResourceFunctions().size() > 0;
+  }
+
   public abstract List<PathTemplateGetterFunctionView> pathTemplateGetterFunctions();
 
   public abstract List<PageStreamingDescriptorView> pageStreamingDescriptors();

--- a/src/main/resources/com/google/api/codegen/php/main.snip
+++ b/src/main/resources/com/google/api/codegen/php/main.snip
@@ -34,11 +34,11 @@
 @private serviceDoc(xapiClass)
     @let coreSampleCode = sampleCode(xapiClass.doc.exampleApiMethod), \
          decoratedSampleCode = decorateSampleCode(xapiClass, xapiClass.doc.exampleApiMethod, coreSampleCode)
-        {@renderServiceDoc(xapiClass.doc, decoratedSampleCode)}
+        {@renderServiceDoc(xapiClass.doc, decoratedSampleCode, xapiClass.hasFormatOrParseResourceFunctions)}
     @end
 @end
 
-@private renderServiceDoc(xapiClassDoc, exampleMethodSampleCode)
+@private renderServiceDoc(xapiClassDoc, exampleMethodSampleCode, hasFormatOrParseResourceFunctions)
     /**
      * Service Description: {@xapiClassDoc.firstLine}
     @if xapiClassDoc.remainingLines
@@ -60,10 +60,12 @@
     @end
      * ```
      *
-     * Many parameters require resource names to be formatted in a particular way. To assist
-     * with these names, this class includes a format method for each type of name, and additionally
-     * a parse method to extract the individual identifiers contained within names that are
-     * returned.
+    @if hasFormatOrParseResourceFunctions
+        {@""} * Many parameters require resource names to be formatted in a particular way. To assist
+         * with these names, this class includes a format method for each type of name, and additionally
+         * a parse method to extract the individual identifiers contained within names that are
+         * returned.
+    @end
      */
 @end
 
@@ -141,6 +143,11 @@
     /**
      * Formats a string containing the fully-qualified path to represent
      * a {@function.entityName} resource.
+     *
+    @join param : function.resourceIdParams
+        {@""} * @@param string ${@param.name}
+    @end
+     * @@return string The formatted {@function.entityName} resource.
      */
     public static function {@function.name}(\
             {@formatResourceFunctionParams(function.resourceIdParams)})
@@ -168,6 +175,9 @@
     /**
      * Parses the {@function.outputResourceId} from the given fully-qualified path which
      * represents a {@function.entityName} resource.
+     *
+     * @@param string ${@function.entityNameParamName} The fully-qualified {@function.entityName} resource.
+     * @@return string The extracted {@function.outputResourceId} value.
      */
     public static function {@function.name}(${@function.entityNameParamName})
     {

--- a/src/main/resources/com/google/api/codegen/php/main.snip
+++ b/src/main/resources/com/google/api/codegen/php/main.snip
@@ -28,6 +28,8 @@
      * EXPERIMENTAL: this client library class has not yet been declared beta. This class may change
      * more frequently than those which have been declared beta or 1.0, including changes which break
      * backwards compatibility.
+     *
+     * @@experimental
      */
 @end
 
@@ -66,6 +68,7 @@
          * a parse method to extract the individual identifiers contained within names that are
          * returned.
     @end
+     * @@experimental
      */
 @end
 
@@ -148,6 +151,7 @@
         {@""} * @@param string ${@param.name}
     @end
      * @@return string The formatted {@function.entityName} resource.
+     * @@experimental
      */
     public static function {@function.name}(\
             {@formatResourceFunctionParams(function.resourceIdParams)})
@@ -178,6 +182,7 @@
      *
      * @@param string ${@function.entityNameParamName} The fully-qualified {@function.entityName} resource.
      * @@return string The extracted {@function.outputResourceId} value.
+     * @@experimental
      */
     public static function {@function.name}(${@function.entityNameParamName})
     {
@@ -283,6 +288,7 @@
          * Return an OperationsClient object with the same endpoint as $this.
          *
          * @@return \Google\GAX\LongRunning\OperationsClient
+         * @@experimental
          */
         public function getOperationsClient()
         {
@@ -298,8 +304,8 @@
          *
          * @@param string $operationName The name of the long running operation
          * @@param string $methodName The name of the method used to start the operation
-         *
          * @@return \Google\GAX\OperationResponse
+         * @@experimental
          */
         public function resumeOperation($operationName, $methodName = null)
         {
@@ -365,6 +371,7 @@
          * @@throws ValidationException Throws a ValidationException if required arguments are missing
          *                             from the $options array.
      @end
+     * @@experimental
      */
     public function __construct($options = [])
     {
@@ -583,6 +590,7 @@
     @end
      *
      * @@throws \Google\GAX\ApiException if the remote call fails
+     * @@experimental
      */
     {@""}
 @end
@@ -639,6 +647,7 @@
     /**
      * Initiates an orderly shutdown in which preexisting calls continue but new
      * calls are immediately cancelled.
+     * @@experimental
      */
     public function close()
     {

--- a/src/test/java/com/google/api/codegen/testdata/php_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php_main_library.baseline
@@ -86,10 +86,10 @@ use google\tagger\v1\LabelerGrpcClient;
  * resource model:
  *
  * - The API has a collection of [Shelf][google.example.library.v1.Shelf]
- *   resources, named ``bookShelves/&#42;``
+ *   resources, named ``bookShelves/*``
  *
  * - Each Shelf has a collection of [Book][google.example.library.v1.Book]
- *   resources, named `bookShelves/&#42;/books/&#42;`
+ *   resources, named `bookShelves/&#42;/books/*`
  *
  * Check out [cloud docs!](https://cloud.google.com/library/example/link).
  * This is [not a cloud link](http://www.google.com).
@@ -160,6 +160,9 @@ class LibraryServiceClient
     /**
      * Formats a string containing the fully-qualified path to represent
      * a shelf resource.
+     *
+     * @param string $shelfId
+     * @return string The formatted shelf resource.
      */
     public static function formatShelfName($shelfId)
     {
@@ -171,6 +174,10 @@ class LibraryServiceClient
     /**
      * Formats a string containing the fully-qualified path to represent
      * a book resource.
+     *
+     * @param string $shelfId
+     * @param string $bookId
+     * @return string The formatted book resource.
      */
     public static function formatBookName($shelfId, $bookId)
     {
@@ -183,6 +190,11 @@ class LibraryServiceClient
     /**
      * Formats a string containing the fully-qualified path to represent
      * a return resource.
+     *
+     * @param string $shelf
+     * @param string $book
+     * @param string $return
+     * @return string The formatted return resource.
      */
     public static function formatReturnName($shelf, $book, $return)
     {
@@ -196,6 +208,9 @@ class LibraryServiceClient
     /**
      * Parses the shelf_id from the given fully-qualified path which
      * represents a shelf resource.
+     *
+     * @param string $shelfName The fully-qualified shelf resource.
+     * @return string The extracted shelf_id value.
      */
     public static function parseShelfIdFromShelfName($shelfName)
     {
@@ -205,6 +220,9 @@ class LibraryServiceClient
     /**
      * Parses the shelf_id from the given fully-qualified path which
      * represents a book resource.
+     *
+     * @param string $bookName The fully-qualified book resource.
+     * @return string The extracted shelf_id value.
      */
     public static function parseShelfIdFromBookName($bookName)
     {
@@ -214,6 +232,9 @@ class LibraryServiceClient
     /**
      * Parses the book_id from the given fully-qualified path which
      * represents a book resource.
+     *
+     * @param string $bookName The fully-qualified book resource.
+     * @return string The extracted book_id value.
      */
     public static function parseBookIdFromBookName($bookName)
     {
@@ -223,6 +244,9 @@ class LibraryServiceClient
     /**
      * Parses the shelf from the given fully-qualified path which
      * represents a return resource.
+     *
+     * @param string $returnName The fully-qualified return resource.
+     * @return string The extracted shelf value.
      */
     public static function parseShelfFromReturnName($returnName)
     {
@@ -232,6 +256,9 @@ class LibraryServiceClient
     /**
      * Parses the book from the given fully-qualified path which
      * represents a return resource.
+     *
+     * @param string $returnName The fully-qualified return resource.
+     * @return string The extracted book value.
      */
     public static function parseBookFromReturnName($returnName)
     {
@@ -241,6 +268,9 @@ class LibraryServiceClient
     /**
      * Parses the return from the given fully-qualified path which
      * represents a return resource.
+     *
+     * @param string $returnName The fully-qualified return resource.
+     * @return string The extracted return value.
      */
     public static function parseReturnFromReturnName($returnName)
     {

--- a/src/test/java/com/google/api/codegen/testdata/php_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php_main_library.baseline
@@ -2101,7 +2101,7 @@ class LibraryServiceClient
      * @param float $requiredSingularFloat
      * @param float $requiredSingularDouble
      * @param bool $requiredSingularBool
-     * @param int $requiredSingularEnum For allowed values, use constants defined on {@see InnerEnum}
+     * @param int $requiredSingularEnum For allowed values, use constants defined on {@see \google\example\library\v1\TestOptionalRequiredFlatteningParamsRequest\InnerEnum}
      * @param string $requiredSingularString
      * @param string $requiredSingularBytes
      * @param InnerMessage $requiredSingularMessage
@@ -2114,7 +2114,7 @@ class LibraryServiceClient
      * @param float[] $requiredRepeatedFloat
      * @param float[] $requiredRepeatedDouble
      * @param bool[] $requiredRepeatedBool
-     * @param int[] $requiredRepeatedEnum For allowed values, use constants defined on {@see InnerEnum}
+     * @param int[] $requiredRepeatedEnum For allowed values, use constants defined on {@see \google\example\library\v1\TestOptionalRequiredFlatteningParamsRequest\InnerEnum}
      * @param string[] $requiredRepeatedString
      * @param string[] $requiredRepeatedBytes
      * @param InnerMessage[] $requiredRepeatedMessage
@@ -2131,7 +2131,7 @@ class LibraryServiceClient
      *     @type float $optionalSingularDouble
      *     @type bool $optionalSingularBool
      *     @type int $optionalSingularEnum
-     *          For allowed values, use constants defined on {@see InnerEnum}
+     *          For allowed values, use constants defined on {@see \google\example\library\v1\TestOptionalRequiredFlatteningParamsRequest\InnerEnum}
      *     @type string $optionalSingularString
      *     @type string $optionalSingularBytes
      *     @type InnerMessage $optionalSingularMessage
@@ -2145,7 +2145,7 @@ class LibraryServiceClient
      *     @type float[] $optionalRepeatedDouble
      *     @type bool[] $optionalRepeatedBool
      *     @type int[] $optionalRepeatedEnum
-     *          For allowed values, use constants defined on {@see InnerEnum}
+     *          For allowed values, use constants defined on {@see \google\example\library\v1\TestOptionalRequiredFlatteningParamsRequest\InnerEnum}
      *     @type string[] $optionalRepeatedString
      *     @type string[] $optionalRepeatedBytes
      *     @type InnerMessage[] $optionalRepeatedMessage

--- a/src/test/java/com/google/api/codegen/testdata/php_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php_main_library.baseline
@@ -25,6 +25,8 @@
  * EXPERIMENTAL: this client library class has not yet been declared beta. This class may change
  * more frequently than those which have been declared beta or 1.0, including changes which break
  * backwards compatibility.
+ *
+ * @experimental
  */
 
 namespace Google\Example\Library\V1;
@@ -117,6 +119,7 @@ use google\tagger\v1\LabelerGrpcClient;
  * with these names, this class includes a format method for each type of name, and additionally
  * a parse method to extract the individual identifiers contained within names that are
  * returned.
+ * @experimental
  */
 class LibraryServiceClient
 {
@@ -163,6 +166,7 @@ class LibraryServiceClient
      *
      * @param string $shelfId
      * @return string The formatted shelf resource.
+     * @experimental
      */
     public static function formatShelfName($shelfId)
     {
@@ -178,6 +182,7 @@ class LibraryServiceClient
      * @param string $shelfId
      * @param string $bookId
      * @return string The formatted book resource.
+     * @experimental
      */
     public static function formatBookName($shelfId, $bookId)
     {
@@ -195,6 +200,7 @@ class LibraryServiceClient
      * @param string $book
      * @param string $return
      * @return string The formatted return resource.
+     * @experimental
      */
     public static function formatReturnName($shelf, $book, $return)
     {
@@ -211,6 +217,7 @@ class LibraryServiceClient
      *
      * @param string $shelfName The fully-qualified shelf resource.
      * @return string The extracted shelf_id value.
+     * @experimental
      */
     public static function parseShelfIdFromShelfName($shelfName)
     {
@@ -223,6 +230,7 @@ class LibraryServiceClient
      *
      * @param string $bookName The fully-qualified book resource.
      * @return string The extracted shelf_id value.
+     * @experimental
      */
     public static function parseShelfIdFromBookName($bookName)
     {
@@ -235,6 +243,7 @@ class LibraryServiceClient
      *
      * @param string $bookName The fully-qualified book resource.
      * @return string The extracted book_id value.
+     * @experimental
      */
     public static function parseBookIdFromBookName($bookName)
     {
@@ -247,6 +256,7 @@ class LibraryServiceClient
      *
      * @param string $returnName The fully-qualified return resource.
      * @return string The extracted shelf value.
+     * @experimental
      */
     public static function parseShelfFromReturnName($returnName)
     {
@@ -259,6 +269,7 @@ class LibraryServiceClient
      *
      * @param string $returnName The fully-qualified return resource.
      * @return string The extracted book value.
+     * @experimental
      */
     public static function parseBookFromReturnName($returnName)
     {
@@ -271,6 +282,7 @@ class LibraryServiceClient
      *
      * @param string $returnName The fully-qualified return resource.
      * @return string The extracted return value.
+     * @experimental
      */
     public static function parseReturnFromReturnName($returnName)
     {
@@ -393,6 +405,7 @@ class LibraryServiceClient
      * Return an OperationsClient object with the same endpoint as $this.
      *
      * @return \Google\GAX\LongRunning\OperationsClient
+     * @experimental
      */
     public function getOperationsClient()
     {
@@ -408,8 +421,8 @@ class LibraryServiceClient
      *
      * @param string $operationName The name of the long running operation
      * @param string $methodName The name of the method used to start the operation
-     *
      * @return \Google\GAX\OperationResponse
+     * @experimental
      */
     public function resumeOperation($operationName, $methodName = null)
     {
@@ -453,6 +466,7 @@ class LibraryServiceClient
      *                              A CredentialsLoader object created using the
      *                              Google\Auth library.
      * }
+     * @experimental
      */
     public function __construct($options = [])
     {
@@ -601,6 +615,7 @@ class LibraryServiceClient
      * @return \google\example\library\v1\Shelf
      *
      * @throws \Google\GAX\ApiException if the remote call fails
+     * @experimental
      */
     public function createShelf($shelf, $optionalArgs = [])
     {
@@ -651,6 +666,7 @@ class LibraryServiceClient
      * @return \google\example\library\v1\Shelf
      *
      * @throws \Google\GAX\ApiException if the remote call fails
+     * @experimental
      */
     public function getShelf($name, $options, $optionalArgs = [])
     {
@@ -719,6 +735,7 @@ class LibraryServiceClient
      * @return \Google\GAX\PagedListResponse
      *
      * @throws \Google\GAX\ApiException if the remote call fails
+     * @experimental
      */
     public function listShelves($optionalArgs = [])
     {
@@ -764,6 +781,7 @@ class LibraryServiceClient
      * }
      *
      * @throws \Google\GAX\ApiException if the remote call fails
+     * @experimental
      */
     public function deleteShelf($name, $optionalArgs = [])
     {
@@ -813,6 +831,7 @@ class LibraryServiceClient
      * @return \google\example\library\v1\Shelf
      *
      * @throws \Google\GAX\ApiException if the remote call fails
+     * @experimental
      */
     public function mergeShelves($name, $otherShelfName, $optionalArgs = [])
     {
@@ -861,6 +880,7 @@ class LibraryServiceClient
      * @return \google\example\library\v1\Book
      *
      * @throws \Google\GAX\ApiException if the remote call fails
+     * @experimental
      */
     public function createBook($name, $book, $optionalArgs = [])
     {
@@ -917,6 +937,7 @@ class LibraryServiceClient
      * @return \google\example\library\v1\PublishSeriesResponse
      *
      * @throws \Google\GAX\ApiException if the remote call fails
+     * @experimental
      */
     public function publishSeries($shelf, $books, $seriesUuid, $optionalArgs = [])
     {
@@ -972,6 +993,7 @@ class LibraryServiceClient
      * @return \google\example\library\v1\Book
      *
      * @throws \Google\GAX\ApiException if the remote call fails
+     * @experimental
      */
     public function getBook($name, $optionalArgs = [])
     {
@@ -1040,6 +1062,7 @@ class LibraryServiceClient
      * @return \Google\GAX\PagedListResponse
      *
      * @throws \Google\GAX\ApiException if the remote call fails
+     * @experimental
      */
     public function listBooks($name, $optionalArgs = [])
     {
@@ -1092,6 +1115,7 @@ class LibraryServiceClient
      * }
      *
      * @throws \Google\GAX\ApiException if the remote call fails
+     * @experimental
      */
     public function deleteBook($name, $optionalArgs = [])
     {
@@ -1143,6 +1167,7 @@ class LibraryServiceClient
      * @return \google\example\library\v1\Book
      *
      * @throws \Google\GAX\ApiException if the remote call fails
+     * @experimental
      */
     public function updateBook($name, $book, $optionalArgs = [])
     {
@@ -1197,6 +1222,7 @@ class LibraryServiceClient
      * @return \google\example\library\v1\Book
      *
      * @throws \Google\GAX\ApiException if the remote call fails
+     * @experimental
      */
     public function moveBook($name, $otherShelfName, $optionalArgs = [])
     {
@@ -1264,6 +1290,7 @@ class LibraryServiceClient
      * @return \Google\GAX\PagedListResponse
      *
      * @throws \Google\GAX\ApiException if the remote call fails
+     * @experimental
      */
     public function listStrings($optionalArgs = [])
     {
@@ -1324,6 +1351,7 @@ class LibraryServiceClient
      * }
      *
      * @throws \Google\GAX\ApiException if the remote call fails
+     * @experimental
      */
     public function addComments($name, $comments, $optionalArgs = [])
     {
@@ -1372,6 +1400,7 @@ class LibraryServiceClient
      * @return \google\example\library\v1\BookFromArchive
      *
      * @throws \Google\GAX\ApiException if the remote call fails
+     * @experimental
      */
     public function getBookFromArchive($name, $optionalArgs = [])
     {
@@ -1420,6 +1449,7 @@ class LibraryServiceClient
      * @return \google\example\library\v1\BookFromAnywhere
      *
      * @throws \Google\GAX\ApiException if the remote call fails
+     * @experimental
      */
     public function getBookFromAnywhere($name, $altBookName, $optionalArgs = [])
     {
@@ -1469,6 +1499,7 @@ class LibraryServiceClient
      * }
      *
      * @throws \Google\GAX\ApiException if the remote call fails
+     * @experimental
      */
     public function updateBookIndex($name, $indexName, $indexMap, $optionalArgs = [])
     {
@@ -1518,6 +1549,7 @@ class LibraryServiceClient
      * @return \Google\GAX\ServerStreamingResponse
      *
      * @throws \Google\GAX\ApiException if the remote call fails
+     * @experimental
      */
     public function streamShelves($optionalArgs = [])
     {
@@ -1563,6 +1595,7 @@ class LibraryServiceClient
      * @return \Google\GAX\ServerStreamingResponse
      *
      * @throws \Google\GAX\ApiException if the remote call fails
+     * @experimental
      */
     public function streamBooks($name, $optionalArgs = [])
     {
@@ -1631,6 +1664,7 @@ class LibraryServiceClient
      * @return \Google\GAX\BidiStreamingResponse
      *
      * @throws \Google\GAX\ApiException if the remote call fails
+     * @experimental
      */
     public function discussBook($optionalArgs = [])
     {
@@ -1684,6 +1718,7 @@ class LibraryServiceClient
      * @return \Google\GAX\ClientStreamingResponse
      *
      * @throws \Google\GAX\ApiException if the remote call fails
+     * @experimental
      */
     public function monologAboutBook($optionalArgs = [])
     {
@@ -1750,6 +1785,7 @@ class LibraryServiceClient
      * @return \Google\GAX\PagedListResponse
      *
      * @throws \Google\GAX\ApiException if the remote call fails
+     * @experimental
      */
     public function findRelatedBooks($names, $shelves, $optionalArgs = [])
     {
@@ -1810,6 +1846,7 @@ class LibraryServiceClient
      * @return \google\tagger\v1\AddTagResponse
      *
      * @throws \Google\GAX\ApiException if the remote call fails
+     * @experimental
      */
     public function addTag($resource, $tag, $optionalArgs = [])
     {
@@ -1860,6 +1897,7 @@ class LibraryServiceClient
      * @return \google\tagger\v1\AddLabelResponse
      *
      * @throws \Google\GAX\ApiException if the remote call fails
+     * @experimental
      */
     public function addLabel($resource, $label, $optionalArgs = [])
     {
@@ -1931,6 +1969,7 @@ class LibraryServiceClient
      * @return \google\longrunning\Operation
      *
      * @throws \Google\GAX\ApiException if the remote call fails
+     * @experimental
      */
     public function getBigBook($name, $optionalArgs = [])
     {
@@ -1999,6 +2038,7 @@ class LibraryServiceClient
      * @return \google\longrunning\Operation
      *
      * @throws \Google\GAX\ApiException if the remote call fails
+     * @experimental
      */
     public function getBigNothing($name, $optionalArgs = [])
     {
@@ -2123,6 +2163,7 @@ class LibraryServiceClient
      * @return \google\example\library\v1\TestOptionalRequiredFlatteningParamsResponse
      *
      * @throws \Google\GAX\ApiException if the remote call fails
+     * @experimental
      */
     public function testOptionalRequiredFlatteningParams($requiredSingularInt32, $requiredSingularInt64, $requiredSingularFloat, $requiredSingularDouble, $requiredSingularBool, $requiredSingularEnum, $requiredSingularString, $requiredSingularBytes, $requiredSingularMessage, $requiredSingularResourceName, $requiredSingularResourceNameOneof, $requiredSingularFixed32, $requiredSingularFixed64, $requiredRepeatedInt32, $requiredRepeatedInt64, $requiredRepeatedFloat, $requiredRepeatedDouble, $requiredRepeatedBool, $requiredRepeatedEnum, $requiredRepeatedString, $requiredRepeatedBytes, $requiredRepeatedMessage, $requiredRepeatedResourceName, $requiredRepeatedResourceNameOneof, $requiredRepeatedFixed32, $requiredRepeatedFixed64, $requiredMap, $optionalArgs = [])
     {
@@ -2306,6 +2347,7 @@ class LibraryServiceClient
     /**
      * Initiates an orderly shutdown in which preexisting calls continue but new
      * calls are immediately cancelled.
+     * @experimental
      */
     public function close()
     {

--- a/src/test/java/com/google/api/codegen/testdata/php_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php_main_library.baseline
@@ -2101,7 +2101,7 @@ class LibraryServiceClient
      * @param float $requiredSingularFloat
      * @param float $requiredSingularDouble
      * @param bool $requiredSingularBool
-     * @param InnerEnum $requiredSingularEnum
+     * @param int $requiredSingularEnum For allowed values, use constants defined on {@see InnerEnum}
      * @param string $requiredSingularString
      * @param string $requiredSingularBytes
      * @param InnerMessage $requiredSingularMessage
@@ -2114,7 +2114,7 @@ class LibraryServiceClient
      * @param float[] $requiredRepeatedFloat
      * @param float[] $requiredRepeatedDouble
      * @param bool[] $requiredRepeatedBool
-     * @param InnerEnum[] $requiredRepeatedEnum
+     * @param int[] $requiredRepeatedEnum For allowed values, use constants defined on {@see InnerEnum}
      * @param string[] $requiredRepeatedString
      * @param string[] $requiredRepeatedBytes
      * @param InnerMessage[] $requiredRepeatedMessage
@@ -2130,7 +2130,8 @@ class LibraryServiceClient
      *     @type float $optionalSingularFloat
      *     @type float $optionalSingularDouble
      *     @type bool $optionalSingularBool
-     *     @type InnerEnum $optionalSingularEnum
+     *     @type int $optionalSingularEnum
+     *          For allowed values, use constants defined on {@see InnerEnum}
      *     @type string $optionalSingularString
      *     @type string $optionalSingularBytes
      *     @type InnerMessage $optionalSingularMessage
@@ -2143,7 +2144,8 @@ class LibraryServiceClient
      *     @type float[] $optionalRepeatedFloat
      *     @type float[] $optionalRepeatedDouble
      *     @type bool[] $optionalRepeatedBool
-     *     @type InnerEnum[] $optionalRepeatedEnum
+     *     @type int[] $optionalRepeatedEnum
+     *          For allowed values, use constants defined on {@see InnerEnum}
      *     @type string[] $optionalRepeatedString
      *     @type string[] $optionalRepeatedBytes
      *     @type InnerMessage[] $optionalRepeatedMessage


### PR DESCRIPTION
- Adds `@experimental` annotation to client class and methods
- Escape only `*/` exactly instead of `*` (https://github.com/googleapis/toolkit/issues/1278)
- Update generated param doc for enums (https://github.com/googleapis/toolkit/issues/1277)
- Remove class comment when no resource format method present (https://github.com/googleapis/toolkit/issues/1276)

cc @dwsupplee @jdpedrie