### PR TITLE
go: tweak operation name

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/go/GoSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/go/GoSurfaceNamer.java
@@ -123,7 +123,19 @@ public class GoSurfaceNamer extends SurfaceNamer {
   @Override
   public String getAndSaveOperationResponseTypeName(
       Method method, ModelTypeTable typeTable, GapicMethodConfig methodConfig) {
-    return publicClassName(Name.upperCamel(method.getSimpleName()).join("operation"));
+    return getAndSaveOperationResponseTypeName(method.getSimpleName());
+  }
+
+  @VisibleForTesting
+  String getAndSaveOperationResponseTypeName(String methodName) {
+    Name name = Name.upperCamel(methodName);
+    if (methodName.endsWith("Operation")) {
+      // Avoid creating funny names like "CreateStuffOperationOperation".
+      name = name.join("handle");
+    } else {
+      name = name.join("operation");
+    }
+    return publicClassName(name);
   }
 
   @Override

--- a/src/test/java/com/google/api/codegen/transformer/go/GoSurfaceNamerTest.java
+++ b/src/test/java/com/google/api/codegen/transformer/go/GoSurfaceNamerTest.java
@@ -16,13 +16,9 @@ package com.google.api.codegen.transformer.go;
 
 import com.google.api.codegen.util.Name;
 import com.google.common.truth.Truth;
-import org.junit.ClassRule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
 public class GoSurfaceNamerTest {
-  @ClassRule public static TemporaryFolder tempDir = new TemporaryFolder();
-
   @Test
   public void testClientNamePrefix() {
     GoSurfaceNamer namer = new GoSurfaceNamer("cloud.google.com/go/gopher/apiv1");
@@ -43,5 +39,14 @@ public class GoSurfaceNamerTest {
     // use the service name as the prefix.
     Truth.assertThat(namer.getReducedServiceName("Guru")).isEqualTo(Name.from("guru"));
     Truth.assertThat(namer.clientNamePrefix("Guru")).isEqualTo(Name.from("guru"));
+  }
+
+  @Test
+  public void testOperationName() {
+    GoSurfaceNamer namer = new GoSurfaceNamer("cloud.google.com/go/gopher/apiv1");
+    Truth.assertThat(namer.getAndSaveOperationResponseTypeName("CreateStuff"))
+        .isEqualTo("CreateStuffOperation");
+    Truth.assertThat(namer.getAndSaveOperationResponseTypeName("CreateStuffOperation"))
+        .isEqualTo("CreateStuffOperationHandle");
   }
 }


### PR DESCRIPTION
We create a new type for each method that returns longrunning operation.

Previously the type name is `{MethodName}Operation`. Eg, the
`AnnotateVideo` method would return `AnnotateVideoOperation`. This works
OK if somewhat lengthy.

However, DLP client has a method `CreateInspectOperation`. The
corresponding type would be unfortunately named
`CreateInspectOperationOperation`.

This commit tweaks the operation name for methods whose name ends with
"Operation". The above type is named `CreateInspectOperationHandle`
instead.