### PR TITLE
Update expected exception message in unit tests

### DIFF
--- a/src/main/resources/com/google/api/codegen/php/test.snip
+++ b/src/main/resources/com/google/api/codegen/php/test.snip
@@ -163,9 +163,7 @@
         $grpcStub = $this->createStub([$this, 'create{@test.mockGrpcStubTypeName}']);
         $client = $this->createClient('{@test.createStubFunctionName}', $grpcStub);
 
-        $status = new stdClass();
-        $status->code = Grpc\STATUS_DATA_LOSS;
-        $status->details = 'internal error';
+        {@createErrorStatus()}
 
         $grpcStub->setStreamingStatus($status);
 
@@ -180,7 +178,7 @@
             $this->fail("Expected an ApiException, but no exception was thrown.");
         }  catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($status->details, $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
 
         // Call popReceivedCalls to ensure the stub is exhausted
@@ -226,9 +224,7 @@
         $grpcStub = $this->createStub([$this, 'create{@test.mockGrpcStubTypeName}']);
         $client = $this->createClient('{@test.createStubFunctionName}', $grpcStub);
 
-        $status = new stdClass();
-        $status->code = Grpc\STATUS_DATA_LOSS;
-        $status->details = 'internal error';
+        {@createErrorStatus()}
 
         $grpcStub->setStreamingStatus($status);
 
@@ -246,7 +242,7 @@
             $this->fail("Expected an ApiException, but no exception was thrown.");
         }  catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($status->details, $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
 
         // Call popReceivedCalls to ensure the stub is exhausted
@@ -269,6 +265,19 @@
     @default
         $unhandled case: {@test.clientMethodType}$
     @end
+@end
+
+@private createErrorStatus()
+    $status = new stdClass();
+    $status->code = Grpc\STATUS_DATA_LOSS;
+    $status->details = 'internal error';
+
+    $expectedExceptionMessage = json_encode([
+       "message" => "internal error",
+       "code" => Grpc\STATUS_DATA_LOSS,
+       "status" => "DATA_LOSS",
+       "details" => [],
+    ], JSON_PRETTY_PRINT);
 @end
 
 @private simpleTestCase(test)
@@ -322,9 +331,7 @@
 
         $this->assertTrue($grpcStub->isExhausted());
 
-        $status = new stdClass();
-        $status->code = Grpc\STATUS_DATA_LOSS;
-        $status->details = 'internal error';
+        {@createErrorStatus()}
         $grpcStub->addResponse(null, $status);
 
         @if test.hasRequestParameters
@@ -338,7 +345,7 @@
             $this->fail("Expected an ApiException, but no exception was thrown.");
         } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($status->details, $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
 
         // Call popReceivedCalls to ensure the stub is exhausted
@@ -443,9 +450,7 @@
         $incompleteOperation->setName('operations/{@test.name}')->setDone(false);
         $grpcStub->addResponse($incompleteOperation);
 
-        $status = new stdClass();
-        $status->code = Grpc\STATUS_DATA_LOSS;
-        $status->details = 'internal error';
+        {@createErrorStatus()}
         $operationsStub->addResponse(null, $status);
 
         @if test.hasRequestParameters
@@ -466,7 +471,7 @@
             $this->fail("Expected an ApiException, but no exception was thrown.");
         } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($status->details, $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
 
         // Call popReceivedCalls to ensure the stubs are exhausted

--- a/src/test/java/com/google/api/codegen/testdata/php_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/php_test_library.baseline
@@ -175,6 +175,13 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $status = new stdClass();
         $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           "message" => "internal error",
+           "code" => Grpc\STATUS_DATA_LOSS,
+           "status" => "DATA_LOSS",
+           "details" => [],
+        ], JSON_PRETTY_PRINT);
         $grpcStub->addResponse(null, $status);
 
         // Mock request
@@ -186,7 +193,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->fail("Expected an ApiException, but no exception was thrown.");
         } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($status->details, $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
 
         // Call popReceivedCalls to ensure the stub is exhausted
@@ -245,6 +252,13 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $status = new stdClass();
         $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           "message" => "internal error",
+           "code" => Grpc\STATUS_DATA_LOSS,
+           "status" => "DATA_LOSS",
+           "details" => [],
+        ], JSON_PRETTY_PRINT);
         $grpcStub->addResponse(null, $status);
 
         // Mock request
@@ -257,7 +271,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->fail("Expected an ApiException, but no exception was thrown.");
         } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($status->details, $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
 
         // Call popReceivedCalls to ensure the stub is exhausted
@@ -314,6 +328,13 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $status = new stdClass();
         $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           "message" => "internal error",
+           "code" => Grpc\STATUS_DATA_LOSS,
+           "status" => "DATA_LOSS",
+           "details" => [],
+        ], JSON_PRETTY_PRINT);
         $grpcStub->addResponse(null, $status);
 
         try {
@@ -322,7 +343,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->fail("Expected an ApiException, but no exception was thrown.");
         } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($status->details, $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
 
         // Call popReceivedCalls to ensure the stub is exhausted
@@ -372,6 +393,13 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $status = new stdClass();
         $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           "message" => "internal error",
+           "code" => Grpc\STATUS_DATA_LOSS,
+           "status" => "DATA_LOSS",
+           "details" => [],
+        ], JSON_PRETTY_PRINT);
         $grpcStub->addResponse(null, $status);
 
         // Mock request
@@ -383,7 +411,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->fail("Expected an ApiException, but no exception was thrown.");
         } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($status->details, $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
 
         // Call popReceivedCalls to ensure the stub is exhausted
@@ -442,6 +470,13 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $status = new stdClass();
         $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           "message" => "internal error",
+           "code" => Grpc\STATUS_DATA_LOSS,
+           "status" => "DATA_LOSS",
+           "details" => [],
+        ], JSON_PRETTY_PRINT);
         $grpcStub->addResponse(null, $status);
 
         // Mock request
@@ -454,7 +489,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->fail("Expected an ApiException, but no exception was thrown.");
         } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($status->details, $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
 
         // Call popReceivedCalls to ensure the stub is exhausted
@@ -515,6 +550,13 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $status = new stdClass();
         $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           "message" => "internal error",
+           "code" => Grpc\STATUS_DATA_LOSS,
+           "status" => "DATA_LOSS",
+           "details" => [],
+        ], JSON_PRETTY_PRINT);
         $grpcStub->addResponse(null, $status);
 
         // Mock request
@@ -527,7 +569,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->fail("Expected an ApiException, but no exception was thrown.");
         } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($status->details, $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
 
         // Call popReceivedCalls to ensure the stub is exhausted
@@ -589,6 +631,13 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $status = new stdClass();
         $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           "message" => "internal error",
+           "code" => Grpc\STATUS_DATA_LOSS,
+           "status" => "DATA_LOSS",
+           "details" => [],
+        ], JSON_PRETTY_PRINT);
         $grpcStub->addResponse(null, $status);
 
         // Mock request
@@ -604,7 +653,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->fail("Expected an ApiException, but no exception was thrown.");
         } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($status->details, $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
 
         // Call popReceivedCalls to ensure the stub is exhausted
@@ -663,6 +712,13 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $status = new stdClass();
         $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           "message" => "internal error",
+           "code" => Grpc\STATUS_DATA_LOSS,
+           "status" => "DATA_LOSS",
+           "details" => [],
+        ], JSON_PRETTY_PRINT);
         $grpcStub->addResponse(null, $status);
 
         // Mock request
@@ -674,7 +730,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->fail("Expected an ApiException, but no exception was thrown.");
         } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($status->details, $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
 
         // Call popReceivedCalls to ensure the stub is exhausted
@@ -735,6 +791,13 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $status = new stdClass();
         $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           "message" => "internal error",
+           "code" => Grpc\STATUS_DATA_LOSS,
+           "status" => "DATA_LOSS",
+           "details" => [],
+        ], JSON_PRETTY_PRINT);
         $grpcStub->addResponse(null, $status);
 
         // Mock request
@@ -746,7 +809,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->fail("Expected an ApiException, but no exception was thrown.");
         } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($status->details, $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
 
         // Call popReceivedCalls to ensure the stub is exhausted
@@ -796,6 +859,13 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $status = new stdClass();
         $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           "message" => "internal error",
+           "code" => Grpc\STATUS_DATA_LOSS,
+           "status" => "DATA_LOSS",
+           "details" => [],
+        ], JSON_PRETTY_PRINT);
         $grpcStub->addResponse(null, $status);
 
         // Mock request
@@ -807,7 +877,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->fail("Expected an ApiException, but no exception was thrown.");
         } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($status->details, $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
 
         // Call popReceivedCalls to ensure the stub is exhausted
@@ -868,6 +938,13 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $status = new stdClass();
         $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           "message" => "internal error",
+           "code" => Grpc\STATUS_DATA_LOSS,
+           "status" => "DATA_LOSS",
+           "details" => [],
+        ], JSON_PRETTY_PRINT);
         $grpcStub->addResponse(null, $status);
 
         // Mock request
@@ -880,7 +957,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->fail("Expected an ApiException, but no exception was thrown.");
         } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($status->details, $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
 
         // Call popReceivedCalls to ensure the stub is exhausted
@@ -941,6 +1018,13 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $status = new stdClass();
         $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           "message" => "internal error",
+           "code" => Grpc\STATUS_DATA_LOSS,
+           "status" => "DATA_LOSS",
+           "details" => [],
+        ], JSON_PRETTY_PRINT);
         $grpcStub->addResponse(null, $status);
 
         // Mock request
@@ -953,7 +1037,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->fail("Expected an ApiException, but no exception was thrown.");
         } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($status->details, $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
 
         // Call popReceivedCalls to ensure the stub is exhausted
@@ -1010,6 +1094,13 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $status = new stdClass();
         $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           "message" => "internal error",
+           "code" => Grpc\STATUS_DATA_LOSS,
+           "status" => "DATA_LOSS",
+           "details" => [],
+        ], JSON_PRETTY_PRINT);
         $grpcStub->addResponse(null, $status);
 
         try {
@@ -1018,7 +1109,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->fail("Expected an ApiException, but no exception was thrown.");
         } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($status->details, $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
 
         // Call popReceivedCalls to ensure the stub is exhausted
@@ -1077,6 +1168,13 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $status = new stdClass();
         $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           "message" => "internal error",
+           "code" => Grpc\STATUS_DATA_LOSS,
+           "status" => "DATA_LOSS",
+           "details" => [],
+        ], JSON_PRETTY_PRINT);
         $grpcStub->addResponse(null, $status);
 
         // Mock request
@@ -1096,7 +1194,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->fail("Expected an ApiException, but no exception was thrown.");
         } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($status->details, $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
 
         // Call popReceivedCalls to ensure the stub is exhausted
@@ -1155,6 +1253,13 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $status = new stdClass();
         $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           "message" => "internal error",
+           "code" => Grpc\STATUS_DATA_LOSS,
+           "status" => "DATA_LOSS",
+           "details" => [],
+        ], JSON_PRETTY_PRINT);
         $grpcStub->addResponse(null, $status);
 
         // Mock request
@@ -1166,7 +1271,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->fail("Expected an ApiException, but no exception was thrown.");
         } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($status->details, $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
 
         // Call popReceivedCalls to ensure the stub is exhausted
@@ -1227,6 +1332,13 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $status = new stdClass();
         $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           "message" => "internal error",
+           "code" => Grpc\STATUS_DATA_LOSS,
+           "status" => "DATA_LOSS",
+           "details" => [],
+        ], JSON_PRETTY_PRINT);
         $grpcStub->addResponse(null, $status);
 
         // Mock request
@@ -1239,7 +1351,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->fail("Expected an ApiException, but no exception was thrown.");
         } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($status->details, $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
 
         // Call popReceivedCalls to ensure the stub is exhausted
@@ -1294,6 +1406,13 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $status = new stdClass();
         $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           "message" => "internal error",
+           "code" => Grpc\STATUS_DATA_LOSS,
+           "status" => "DATA_LOSS",
+           "details" => [],
+        ], JSON_PRETTY_PRINT);
         $grpcStub->addResponse(null, $status);
 
         // Mock request
@@ -1308,7 +1427,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->fail("Expected an ApiException, but no exception was thrown.");
         } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($status->details, $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
 
         // Call popReceivedCalls to ensure the stub is exhausted
@@ -1385,6 +1504,13 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
 
+        $expectedExceptionMessage = json_encode([
+           "message" => "internal error",
+           "code" => Grpc\STATUS_DATA_LOSS,
+           "status" => "DATA_LOSS",
+           "details" => [],
+        ], JSON_PRETTY_PRINT);
+
         $grpcStub->setStreamingStatus($status);
 
         $this->assertTrue($grpcStub->isExhausted());
@@ -1401,7 +1527,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->fail("Expected an ApiException, but no exception was thrown.");
         }  catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($status->details, $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
 
         // Call popReceivedCalls to ensure the stub is exhausted
@@ -1488,6 +1614,13 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
 
+        $expectedExceptionMessage = json_encode([
+           "message" => "internal error",
+           "code" => Grpc\STATUS_DATA_LOSS,
+           "status" => "DATA_LOSS",
+           "details" => [],
+        ], JSON_PRETTY_PRINT);
+
         $grpcStub->setStreamingStatus($status);
 
         $this->assertTrue($grpcStub->isExhausted());
@@ -1504,7 +1637,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->fail("Expected an ApiException, but no exception was thrown.");
         }  catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($status->details, $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
 
         // Call popReceivedCalls to ensure the stub is exhausted
@@ -1604,6 +1737,13 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
 
+        $expectedExceptionMessage = json_encode([
+           "message" => "internal error",
+           "code" => Grpc\STATUS_DATA_LOSS,
+           "status" => "DATA_LOSS",
+           "details" => [],
+        ], JSON_PRETTY_PRINT);
+
         $grpcStub->setStreamingStatus($status);
 
         $this->assertTrue($grpcStub->isExhausted());
@@ -1617,7 +1757,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->fail("Expected an ApiException, but no exception was thrown.");
         }  catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($status->details, $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
 
         // Call popReceivedCalls to ensure the stub is exhausted
@@ -1681,6 +1821,13 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $status = new stdClass();
         $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           "message" => "internal error",
+           "code" => Grpc\STATUS_DATA_LOSS,
+           "status" => "DATA_LOSS",
+           "details" => [],
+        ], JSON_PRETTY_PRINT);
         $grpcStub->addResponse(null, $status);
 
         // Mock request
@@ -1694,7 +1841,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->fail("Expected an ApiException, but no exception was thrown.");
         } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($status->details, $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
 
         // Call popReceivedCalls to ensure the stub is exhausted
@@ -1747,6 +1894,13 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $status = new stdClass();
         $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           "message" => "internal error",
+           "code" => Grpc\STATUS_DATA_LOSS,
+           "status" => "DATA_LOSS",
+           "details" => [],
+        ], JSON_PRETTY_PRINT);
         $grpcStub->addResponse(null, $status);
 
         // Mock request
@@ -1759,7 +1913,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->fail("Expected an ApiException, but no exception was thrown.");
         } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($status->details, $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
 
         // Call popReceivedCalls to ensure the stub is exhausted
@@ -1812,6 +1966,13 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $status = new stdClass();
         $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           "message" => "internal error",
+           "code" => Grpc\STATUS_DATA_LOSS,
+           "status" => "DATA_LOSS",
+           "details" => [],
+        ], JSON_PRETTY_PRINT);
         $grpcStub->addResponse(null, $status);
 
         // Mock request
@@ -1824,7 +1985,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->fail("Expected an ApiException, but no exception was thrown.");
         } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($status->details, $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
 
         // Call popReceivedCalls to ensure the stub is exhausted
@@ -1937,6 +2098,13 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $status = new stdClass();
         $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           "message" => "internal error",
+           "code" => Grpc\STATUS_DATA_LOSS,
+           "status" => "DATA_LOSS",
+           "details" => [],
+        ], JSON_PRETTY_PRINT);
         $operationsStub->addResponse(null, $status);
 
         // Mock request
@@ -1955,7 +2123,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->fail("Expected an ApiException, but no exception was thrown.");
         } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($status->details, $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
 
         // Call popReceivedCalls to ensure the stubs are exhausted
@@ -2062,6 +2230,13 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $status = new stdClass();
         $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           "message" => "internal error",
+           "code" => Grpc\STATUS_DATA_LOSS,
+           "status" => "DATA_LOSS",
+           "details" => [],
+        ], JSON_PRETTY_PRINT);
         $operationsStub->addResponse(null, $status);
 
         // Mock request
@@ -2080,7 +2255,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->fail("Expected an ApiException, but no exception was thrown.");
         } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($status->details, $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
 
         // Call popReceivedCalls to ensure the stubs are exhausted
@@ -2185,6 +2360,13 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
         $status = new stdClass();
         $status->code = Grpc\STATUS_DATA_LOSS;
         $status->details = 'internal error';
+
+        $expectedExceptionMessage = json_encode([
+           "message" => "internal error",
+           "code" => Grpc\STATUS_DATA_LOSS,
+           "status" => "DATA_LOSS",
+           "details" => [],
+        ], JSON_PRETTY_PRINT);
         $grpcStub->addResponse(null, $status);
 
         // Mock request
@@ -2222,7 +2404,7 @@ class LibraryServiceClientTest extends PHPUnit_Framework_TestCase
             $this->fail("Expected an ApiException, but no exception was thrown.");
         } catch (ApiException $ex) {
             $this->assertEquals($status->code, $ex->getCode());
-            $this->assertEquals($status->details, $ex->getMessage());
+            $this->assertEquals($expectedExceptionMessage, $ex->getMessage());
         }
 
         // Call popReceivedCalls to ensure the stub is exhausted


### PR DESCRIPTION
Update the expected exception message to reflect GAX update.

api-client-staging PR: https://github.com/googleapis/api-client-staging/pull/349