### PR TITLE
Relax NodeJS version regex

### DIFF
--- a/src/main/java/com/google/api/codegen/nodejs/NodeJSCodePathMapper.java
+++ b/src/main/java/com/google/api/codegen/nodejs/NodeJSCodePathMapper.java
@@ -16,6 +16,7 @@ package com.google.api.codegen.nodejs;
 
 import com.google.api.codegen.config.ProductConfig;
 import com.google.api.codegen.gapic.GapicCodePathMapper;
+import com.google.api.tools.framework.aspects.versioning.model.ApiVersionUtil;
 import com.google.api.tools.framework.model.ProtoElement;
 import com.google.common.base.Splitter;
 import java.util.List;
@@ -27,7 +28,7 @@ public class NodeJSCodePathMapper implements GapicCodePathMapper {
     List<String> packages = Splitter.on(".").splitToList(element.getFullName());
     if (packages.size() > 2) {
       String parentName = packages.get(packages.size() - 2);
-      if (parentName.matches("v[0-9]+((alpha|beta)[0-9]+)?")) {
+      if (ApiVersionUtil.SEMANTIC_VERSION_REGEX_PATTERN.matcher(parentName).matches()) {
         apiVersion = parentName;
       }
     }


### PR DESCRIPTION
Instead of the custom, overrestrictive version regex, reuse the
version regex provided by api-compiler.

Fixes #1335 