### PR TITLE
java staging: move gax dependency into individual gapics

### DIFF
--- a/src/main/resources/com/google/api/codegen/java/build_gapic.gradle.snip
+++ b/src/main/resources/com/google/api/codegen/java/build_gapic.gradle.snip
@@ -19,6 +19,7 @@
 
   dependencies {
     compile project(":{@metadata.protoPackageName}")
+    compile libraries.gax, libraries.gaxGrpc
     testCompile project(":{@metadata.grpcPackageName}")
     @join dependency : metadata.protoPackageTestDependencies
       testCompile project(":{@dependency.name}")


### PR DESCRIPTION
In api-client-staging, the top-level build.gradle declares
dependency on gax and gax-grpc,
so that it is possible to test gapic clients in the repo.

This introduces a false dependency:
now all generated proto packages depend on gax and gax-grpc too.
This false dependency creates a version convergence error in google-cloud-java.
API clients depend on gax, which depends on protobuf client, which depends on gax.
Moving the dependency breaks the cycle.

The top-level build.gradle will still declare the *version*
of gax and gax-grpc gapic clients stored in api-client-staging will be compiled against,
so updating gax version is not more difficult than it was before.