### PR TITLE
Nodeify Discovery objects

### DIFF
--- a/src/main/java/com/google/api/codegen/discovery/Node.java
+++ b/src/main/java/com/google/api/codegen/discovery/Node.java
@@ -1,0 +1,28 @@
+/* Copyright 2017 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.discovery;
+
+import javax.annotation.Nullable;
+
+/** Represents a node in a tree of nodes. */
+public interface Node {
+  /** @return the ID of this node. */
+  @Nullable
+  String id();
+
+  /** @return the immediate parent of this node. */
+  @Nullable
+  Node parent();
+}

--- a/src/main/java/com/google/api/codegen/discovery/Schema.java
+++ b/src/main/java/com/google/api/codegen/discovery/Schema.java
@@ -14,6 +14,7 @@
  */
 package com.google.api.codegen.discovery;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.auto.value.AutoValue;
 import java.util.HashMap;
 import java.util.Map;
@@ -25,7 +26,7 @@ import javax.annotation.Nullable;
  * <p>Note that this class is not necessarily a 1-1 mapping of the official specification.
  */
 @AutoValue
-public abstract class Schema {
+public abstract class Schema implements Node {
 
   /**
    * Returns true if this schema contains a property with the given name.
@@ -41,15 +42,13 @@ public abstract class Schema {
    * Returns a schema constructed from root, or an empty schema if root has no children.
    *
    * @param root the root node to parse.
-   * @param path the full path to this node (ex: "methods.foo.parameters.bar").
    * @return a schema.
    */
-  public static Schema from(DiscoveryNode root, String path) {
+  public static Schema from(DiscoveryNode root, Node parent) {
     if (root.isEmpty()) {
       return empty();
     }
-    Schema additionalProperties =
-        Schema.from(root.getObject("additionalProperties"), path + ".additionalProperties");
+    Schema additionalProperties = Schema.from(root.getObject("additionalProperties"), null);
     if (additionalProperties.type() == Type.EMPTY && additionalProperties.reference().isEmpty()) {
       additionalProperties = null;
     }
@@ -58,7 +57,7 @@ public abstract class Schema {
     Format format = Format.getEnum(root.getString("format"));
     String id = root.getString("id");
     boolean isEnum = !root.getArray("enum").isEmpty();
-    Schema items = Schema.from(root.getObject("items"), path + ".items");
+    Schema items = Schema.from(root.getObject("items"), null);
     if (items.type() == Type.EMPTY && items.reference().isEmpty()) {
       items = null;
     }
@@ -68,8 +67,7 @@ public abstract class Schema {
     Map<String, Schema> properties = new HashMap<>();
     DiscoveryNode propertiesNode = root.getObject("properties");
     for (String name : propertiesNode.getFieldNames()) {
-      properties.put(
-          name, Schema.from(propertiesNode.getObject(name), path + ".properties." + name));
+      properties.put(name, Schema.from(propertiesNode.getObject(name), null));
     }
 
     String reference = root.getString("$ref");
@@ -77,22 +75,34 @@ public abstract class Schema {
     boolean required = root.getBoolean("required");
     Type type = Type.getEnum(root.getString("type"));
 
-    return new AutoValue_Schema(
-        additionalProperties,
-        defaultValue,
-        description,
-        format,
-        id,
-        isEnum,
-        items,
-        location,
-        path,
-        pattern,
-        properties,
-        reference,
-        repeated,
-        required,
-        type);
+    Schema thisSchema =
+        new AutoValue_Schema(
+            additionalProperties,
+            defaultValue,
+            description,
+            format,
+            id,
+            isEnum,
+            items,
+            location,
+            pattern,
+            properties,
+            reference,
+            repeated,
+            required,
+            type);
+    thisSchema.parent = parent;
+    if (items != null) {
+      items.setParent(thisSchema);
+    }
+    for (Schema schema : properties.values()) {
+      schema.setParent(thisSchema);
+    }
+    if (additionalProperties != null) {
+      additionalProperties.setParent(thisSchema);
+    }
+
+    return thisSchema;
   }
 
   public static Schema empty() {
@@ -106,12 +116,23 @@ public abstract class Schema {
         null,
         "",
         "",
-        "",
         new HashMap<String, Schema>(),
         "",
         false,
         false,
         Type.EMPTY);
+  }
+
+  @JsonIgnore @Nullable private Node parent;
+
+  /** @return the {@link Node} that contains this Schema. */
+  @Nullable
+  public Node parent() {
+    return parent;
+  }
+
+  void setParent(Node parent) {
+    this.parent = parent;
   }
 
   /** @return the schema of the additionalProperties, or null if none. */
@@ -141,9 +162,6 @@ public abstract class Schema {
 
   /** @return the location. */
   public abstract String location();
-
-  /** @return the fully qualified path to this schema. */
-  public abstract String path();
 
   /** @return the pattern. */
   public abstract String pattern();

--- a/src/test/java/com/google/api/codegen/discovery/DocumentTest.java
+++ b/src/test/java/com/google/api/codegen/discovery/DocumentTest.java
@@ -52,21 +52,22 @@ public class DocumentTest {
     Truth.assertThat(methods.get(0).description()).isEqualTo("Get a baz.");
     Truth.assertThat(methods.get(0).id()).isEqualTo("myapi.bar.baz.get");
     Truth.assertThat(methods.get(0).parameterOrder()).isEqualTo(Collections.singletonList("p1"));
-    Truth.assertThat(methods.get(0).path()).isEqualTo("resources.bar.methods.baz");
+    Truth.assertThat(methods.get(0).parent() instanceof Document);
+    Truth.assertThat(methods.get(0).parent()).isEqualTo(document);
 
     Map<String, Schema> parameters = methods.get(0).parameters();
     Truth.assertThat(parameters.get("p1").type()).isEqualTo(Schema.Type.BOOLEAN);
     Truth.assertThat(parameters.get("p1").required()).isTrue();
     Truth.assertThat(parameters.get("p1").location()).isEqualTo("query");
-    Truth.assertThat(parameters.get("p1").path())
-        .isEqualTo("resources.bar.methods.baz.parameters.p1");
+    Truth.assertThat(parameters.get("p1").parent() instanceof Method);
+    Truth.assertThat(parameters.get("p1").parent()).isEqualTo(methods.get(0));
 
     Truth.assertThat(methods.get(1).description()).isEqualTo("Insert a foo.");
     Truth.assertThat(methods.get(1).id()).isEqualTo("myapi.foo.insert");
     Truth.assertThat(methods.get(1).parameters().isEmpty()).isTrue();
     Truth.assertThat(methods.get(1).request()).isNull();
     Truth.assertThat(methods.get(1).response()).isNull();
-    Truth.assertThat(methods.get(1).path()).isEqualTo("methods.foo");
+    Truth.assertThat(methods.get(1).id()).isEqualTo("myapi.foo.insert");
 
     Truth.assertThat(document.name()).isEqualTo("myapi");
     Truth.assertThat(document.canonicalName()).isEqualTo("My API");
@@ -76,9 +77,10 @@ public class DocumentTest {
     Map<String, Schema> schemas = document.schemas();
 
     Truth.assertThat(schemas.get("GetBazRequest").type()).isEqualTo(Schema.Type.STRING);
-    Truth.assertThat(schemas.get("GetBazRequest").path()).isEqualTo("schemas.GetBazRequest");
-    Truth.assertThat(schemas.get("GetBazRequest").properties().get("foo").path())
-        .isEqualTo("schemas.GetBazRequest.properties.foo");
+    Truth.assertThat(schemas.get("GetBazRequest").properties().get("foo").parent())
+        .isEqualTo(schemas.get("GetBazRequest"));
+    Truth.assertThat(schemas.get("GetBazRequest").parent() instanceof Document);
+    Truth.assertThat(schemas.get("GetBazRequest").parent()).isEqualTo(document);
 
     Truth.assertThat(schemas.get("Baz").type()).isEqualTo(Schema.Type.STRING);
 

--- a/src/test/java/com/google/api/codegen/discovery/MethodTest.java
+++ b/src/test/java/com/google/api/codegen/discovery/MethodTest.java
@@ -35,7 +35,7 @@ public class MethodTest {
     ObjectMapper mapper = new ObjectMapper();
     JsonNode root = mapper.readTree(reader);
 
-    Method method = Method.from(new DiscoveryNode(root), "root");
+    Method method = Method.from(new DiscoveryNode(root), null);
 
     Truth.assertThat(method.description()).isEqualTo("Get a baz!");
     Truth.assertThat(method.httpMethod()).isEqualTo("GET");
@@ -46,7 +46,7 @@ public class MethodTest {
     Truth.assertThat(parameters.get("p1").type()).isEqualTo(Schema.Type.STRING);
     Truth.assertThat(parameters.get("p1").required()).isTrue();
     Truth.assertThat(parameters.get("p1").location()).isEqualTo("path");
-    Truth.assertThat(parameters.get("p1").path()).isEqualTo("root.parameters.p1");
+    Truth.assertThat(parameters.get("p1").parent().id()).isEqualTo("foo.bar.baz.get");
 
     Truth.assertThat(parameters.get("p2").type()).isEqualTo(Schema.Type.STRING);
     Truth.assertThat(parameters.get("p2").location()).isEqualTo("query");
@@ -57,8 +57,8 @@ public class MethodTest {
     Truth.assertThat(method.request().reference()).isEqualTo("GetBazRequest");
     Truth.assertThat(method.response().reference()).isEqualTo("Baz");
 
-    Truth.assertThat(method.request().path()).isEqualTo("root.request");
-    Truth.assertThat(method.response().path()).isEqualTo("root.response");
+    Truth.assertThat(method.request().parent().id()).isEqualTo("foo.bar.baz.get");
+    Truth.assertThat(method.response().parent().id()).isEqualTo("foo.bar.baz.get");
 
     Truth.assertThat(method.scopes())
         .isEqualTo(Arrays.asList("https://www.example.com/foo", "https://www.example.com/bar"));

--- a/src/test/java/com/google/api/codegen/discovery/SchemaTest.java
+++ b/src/test/java/com/google/api/codegen/discovery/SchemaTest.java
@@ -34,7 +34,7 @@ public class SchemaTest {
     ObjectMapper mapper = new ObjectMapper();
     JsonNode root = mapper.readTree(reader);
 
-    Schema schema = Schema.from(new DiscoveryNode(root), "root");
+    Schema schema = Schema.from(new DiscoveryNode(root), null);
 
     Truth.assertThat(schema.description()).isEqualTo("My Foo.");
     Truth.assertThat(schema.id()).isEqualTo("Foo");
@@ -95,16 +95,18 @@ public class SchemaTest {
     Truth.assertThat(properties.get("uint64").format()).isEqualTo(Schema.Format.UINT64);
 
     // Test path.
-    Truth.assertThat(schema.path()).isEqualTo("root");
-    Truth.assertThat(schema.properties().get("array").path()).isEqualTo("root.properties.array");
-    Truth.assertThat(schema.properties().get("array").items().path())
-        .isEqualTo("root.properties.array.items");
-    Truth.assertThat(schema.properties().get("object").additionalProperties().path())
-        .isEqualTo("root.properties.object.additionalProperties");
+    Truth.assertThat(schema.id()).isEqualTo("Foo");
+    Truth.assertThat(schema.properties().get("array").parent()).isEqualTo(schema);
+    Truth.assertThat(schema.properties().get("array").items().parent())
+        .isEqualTo(schema.properties().get("array"));
+
+    Truth.assertThat(schema.properties().get("object").additionalProperties().parent())
+        .isEqualTo(schema.properties().get("object"));
   }
 
   @Test
   public void testSchemaFromEmptyNode() {
-    Truth.assertThat(Schema.from(new DiscoveryNode(null), "").type()).isEqualTo(Schema.Type.EMPTY);
+    Truth.assertThat(Schema.from(new DiscoveryNode(null), null).type())
+        .isEqualTo(Schema.Type.EMPTY);
   }
 }

--- a/src/test/java/com/google/api/codegen/discoverytestdata/document_.json
+++ b/src/test/java/com/google/api/codegen/discoverytestdata/document_.json
@@ -1,4 +1,5 @@
 {
+  "id": "discovery#document",
   "auth": {
     "oauth2": {
       "scopes": {


### PR DESCRIPTION
Document, Method, and Schema are all created from DiscoveryNodes, which
should be part of a JSON tree structure. This PR unites Document,
Method, and Schema under one Node interface, which exposes a method to
get the parent of a node.

The ability to get the parent of a node is useful in the context it
provides when operating on a single Node; ex. when transforming a
Method, it would be easy to fetch the name "pubsub" from the parent
Document node.