### PR TITLE
Add a dereference method to Schema

### DIFF
--- a/src/main/java/com/google/api/codegen/discovery/Document.java
+++ b/src/main/java/com/google/api/codegen/discovery/Document.java
@@ -99,26 +99,6 @@ public abstract class Document implements Node {
     return thisDocument;
   }
 
-  /**
-   * Returns the schema the given schema references.
-   *
-   * <p>If the reference property of a schema is non-empty, then it references another schema. This
-   * method returns the schema that the given schema eventually references. If the given schema does
-   * not reference another schema, it is returned. If schema is null, null is returned.
-   *
-   * @param schema the schema to dereference.
-   * @return the first non-reference schema, or null if schema is null.
-   */
-  public Schema dereferenceSchema(Schema schema) {
-    if (schema == null) {
-      return null;
-    }
-    if (!schema.reference().isEmpty()) {
-      return dereferenceSchema(schemas().get(schema.reference()));
-    }
-    return schema;
-  }
-
   private static List<Method> parseMethods(DiscoveryNode root) {
     List<Method> methods = new ArrayList<>();
     DiscoveryNode methodsNode = root.getObject("methods");

--- a/src/main/java/com/google/api/codegen/discovery/Schema.java
+++ b/src/main/java/com/google/api/codegen/discovery/Schema.java
@@ -16,6 +16,8 @@ package com.google.api.codegen.discovery;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -27,6 +29,32 @@ import javax.annotation.Nullable;
  */
 @AutoValue
 public abstract class Schema implements Node {
+
+  /**
+   * Returns the schema this schema references, or this if this schema references no other.
+   *
+   * <p>If the reference property of a schema is non-empty, then it references another schema. This
+   * method returns the schema that this schema eventually references by walking back to a parent
+   * document. If the given schema does not reference another schema, this schema is returned.
+   *
+   * @return the first non-reference schema, or this if this schema references no other.
+   */
+  public Schema dereference() {
+    if (!Strings.isNullOrEmpty(reference())) {
+      Node document = parent;
+      while (document != null && !(document instanceof Document)) {
+        document = document.parent();
+      }
+      if (document != null) {
+        Schema schema = ((Document) document).schemas().get(reference());
+        // If a document is an eventual parent of this schema, then reference() must be a key in the
+        // document's "schemas" object.
+        Preconditions.checkState(schema != null);
+        return schema;
+      }
+    }
+    return this;
+  }
 
   /**
    * Returns true if this schema contains a property with the given name.

--- a/src/test/java/com/google/api/codegen/discovery/DocumentTest.java
+++ b/src/test/java/com/google/api/codegen/discovery/DocumentTest.java
@@ -55,6 +55,15 @@ public class DocumentTest {
     Truth.assertThat(methods.get(0).parent() instanceof Document);
     Truth.assertThat(methods.get(0).parent()).isEqualTo(document);
 
+    // Test de-referencing.
+    Truth.assertThat(methods.get(0).request().dereference())
+        .isEqualTo(document.schemas().get("GetBazRequest"));
+    Truth.assertThat(methods.get(0).response().dereference())
+        .isEqualTo(document.schemas().get("Baz"));
+    // De-referencing a schema that references no other should return the same schema.
+    Truth.assertThat(document.schemas().get("Baz").dereference())
+        .isEqualTo(document.schemas().get("Baz"));
+
     Map<String, Schema> parameters = methods.get(0).parameters();
     Truth.assertThat(parameters.get("p1").type()).isEqualTo(Schema.Type.BOOLEAN);
     Truth.assertThat(parameters.get("p1").required()).isTrue();


### PR DESCRIPTION
It's more convenient to allow Schemas to dereference themselves than it
is to pass around Document all over the place.

This commit adds a `dereference` function to Schema that

1. If the Schema references nothing, the Schema is returned
1. Walks up the Node tree to a Document, if one exists
2. Returns the Schema that represents the reference