### PR TITLE
Support sample app generation without smoke config

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSampleAppTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSampleAppTransformer.java
@@ -18,12 +18,12 @@ import com.google.api.codegen.InterfaceView;
 import com.google.api.codegen.config.GapicProductConfig;
 import com.google.api.codegen.gapic.GapicCodePathMapper;
 import com.google.api.codegen.transformer.*;
+import com.google.api.codegen.viewmodel.FileHeaderView;
 import com.google.api.codegen.viewmodel.ViewModel;
 import com.google.api.codegen.viewmodel.testing.SmokeTestClassView;
 import com.google.api.tools.framework.model.Interface;
 import com.google.api.tools.framework.model.Model;
 import com.google.common.collect.Lists;
-import java.util.ArrayList;
 import java.util.List;
 
 /** Responsible for producing sample application related views for Java GAPIC clients */
@@ -35,6 +35,8 @@ public class JavaGapicSampleAppTransformer implements ModelToViewTransformer {
 
   private final GapicCodePathMapper pathMapper;
   private final JavaGapicSurfaceTestTransformer testTransformer;
+  private final FileHeaderTransformer fileHeaderTransformer =
+      new FileHeaderTransformer(new StandardImportSectionTransformer());
 
   public JavaGapicSampleAppTransformer(GapicCodePathMapper javaPathMapper) {
     this.pathMapper = javaPathMapper;
@@ -44,11 +46,7 @@ public class JavaGapicSampleAppTransformer implements ModelToViewTransformer {
   @Override
   public List<ViewModel> transform(Model model, GapicProductConfig productConfig) {
     GapicInterfaceContext context = getSampleContext(model, productConfig);
-    if (context != null) {
-      return Lists.newArrayList(createSampleClassView(context));
-    } else {
-      return new ArrayList<>();
-    }
+    return Lists.newArrayList(createSampleClassView(context));
   }
 
   @Override
@@ -64,20 +62,48 @@ public class JavaGapicSampleAppTransformer implements ModelToViewTransformer {
         return testTransformer.createContext(apiInterface, productConfig);
       }
     }
-    throw new IllegalArgumentException("No smoke test config is found.");
+
+    // Use the first interface as the default one if no smoke test config is found
+    Interface defaultInterface = new InterfaceView().getElementIterable(model).iterator().next();
+    return testTransformer.createContext(defaultInterface, productConfig);
   }
 
   private ViewModel createSampleClassView(GapicInterfaceContext context) {
+    if (context.getInterfaceConfig().getSmokeTestConfig() != null) {
+      String outputPath =
+          pathMapper.getOutputPath(context.getInterface(), context.getProductConfig());
+      SurfaceNamer namer = context.getNamer();
+      String name = namer.getSampleAppClassName();
+
+      // Most of the fields in the sample view are the same as smoke tests
+      SmokeTestClassView.Builder testClass =
+          testTransformer.createSmokeTestClassViewBuilder(context);
+      testClass.name(name);
+      testClass.outputPath(namer.getSourceFilePath(outputPath, name));
+      return testClass.build();
+    } else {
+      // Create a sample application without a method call (only creating the client) if no smoke test config is found.
+      return createSmokeTestClassViewNoMethod(context);
+    }
+  }
+
+  private SmokeTestClassView createSmokeTestClassViewNoMethod(GapicInterfaceContext context) {
+    testTransformer.addSmokeTestImports(context);
+
+    SurfaceNamer namer = context.getNamer();
+    SmokeTestClassView.Builder testClass = SmokeTestClassView.newBuilder();
     String outputPath =
         pathMapper.getOutputPath(context.getInterface(), context.getProductConfig());
-    SurfaceNamer namer = context.getNamer();
     String name = namer.getSampleAppClassName();
+    FileHeaderView fileHeader = fileHeaderTransformer.generateFileHeader(context);
 
-    // Most of the fields in the sample view are the same as smoke tests
-    SmokeTestClassView.Builder testClass = testTransformer.createSmokeTestClassViewBuilder(context);
-
-    testClass.name(name);
-    testClass.outputPath(namer.getSourceFilePath(outputPath, name));
-    return testClass.build();
+    return SmokeTestClassView.newBuilder()
+        .apiSettingsClassName(namer.getApiSettingsClassName(context.getInterfaceConfig()))
+        .apiClassName(namer.getApiWrapperClassName(context.getInterfaceConfig()))
+        .templateFileName(SAMPLE_TEMPLATE_FILE)
+        .name(name)
+        .outputPath(namer.getSourceFilePath(outputPath, name))
+        .fileHeader(fileHeader)
+        .build();
   }
 }

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
@@ -351,7 +351,8 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
     }
   }
 
-  private void addSmokeTestImports(GapicInterfaceContext context) {
+  /** package-private */
+  void addSmokeTestImports(GapicInterfaceContext context) {
     ModelTypeTable typeTable = context.getModelTypeTable();
     typeTable.saveNicknameFor("java.util.logging.Level");
     typeTable.saveNicknameFor("java.util.logging.Logger");

--- a/src/main/java/com/google/api/codegen/viewmodel/testing/SmokeTestClassView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/testing/SmokeTestClassView.java
@@ -35,9 +35,15 @@ public abstract class SmokeTestClassView implements ViewModel {
 
   public abstract String apiSettingsClassName();
 
+  @Nullable
   public abstract ApiMethodView apiMethod();
 
+  @Nullable
   public abstract TestCaseView method();
+
+  public boolean hasMethod() {
+    return method() != null;
+  }
 
   public abstract boolean requireProjectId();
 

--- a/src/main/resources/com/google/api/codegen/java/smoke_sample.snip
+++ b/src/main/resources/com/google/api/codegen/java/smoke_sample.snip
@@ -61,7 +61,11 @@
 @private executeWithNoProjectID(smokeTest)
   public static void executeNoCatch() throws Exception {
     try ({@smokeTest.apiClassName} client = {@smokeTest.apiClassName}.create()) {
-      {@methodCall(smokeTest.method)}
+      @if smokeTest.hasMethod
+        {@methodCall(smokeTest.method)}
+      @else
+        // Add your method call here.
+      @end
     }
   }
 @end


### PR DESCRIPTION
If the smoke test config is not set, the sample app will only create the service client.
For example (trace): 

```java
  public static void executeNoCatch() throws Exception {
    try (TraceServiceClient client = TraceServiceClient.create()) {
      // Add your method call here.
    }
  }
```
Tested and verified manually with latest Artman.