### PR TITLE
go: render code to render path template

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/PathTemplateTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/PathTemplateTransformer.java
@@ -27,6 +27,7 @@ import com.google.api.codegen.viewmodel.FormatResourceFunctionView;
 import com.google.api.codegen.viewmodel.ParseResourceFunctionView;
 import com.google.api.codegen.viewmodel.PathTemplateArgumentView;
 import com.google.api.codegen.viewmodel.PathTemplateGetterFunctionView;
+import com.google.api.codegen.viewmodel.PathTemplateRenderView;
 import com.google.api.codegen.viewmodel.PathTemplateView;
 import com.google.api.codegen.viewmodel.ResourceIdParamView;
 import com.google.api.codegen.viewmodel.ResourceNameFixedView;
@@ -36,8 +37,10 @@ import com.google.api.codegen.viewmodel.ResourceNameSingleView;
 import com.google.api.codegen.viewmodel.ResourceNameView;
 import com.google.api.codegen.viewmodel.ResourceProtoFieldView;
 import com.google.api.codegen.viewmodel.ResourceProtoView;
+import com.google.api.gax.protobuf.PathTemplate;
 import com.google.api.tools.framework.model.Field;
 import com.google.api.tools.framework.model.Interface;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ListMultimap;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -49,6 +52,7 @@ import java.util.Map.Entry;
 
 /** PathTemplateTransformer generates view objects for path templates from a service model. */
 public class PathTemplateTransformer {
+  private static final String VAR_PLACE_HOLDER = "__GAPIC_VARIABLE__";
 
   public List<PathTemplateView> generatePathTemplates(GapicInterfaceContext context) {
     List<PathTemplateView> pathTemplates = new ArrayList<>();
@@ -302,10 +306,38 @@ public class PathTemplateTransformer {
         String name = context.getNamer().localVarName(Name.from(templateKey));
         args.add(PathTemplateArgumentView.newBuilder().templateKey(templateKey).name(name).build());
       }
-      function.args(args);
+      function.args(args).render(generateRenderView(resourceNameConfig.getNameTemplate(), args));
       functions.add(function.build());
     }
 
     return functions;
+  }
+
+  private PathTemplateRenderView generateRenderView(
+      PathTemplate template, List<PathTemplateArgumentView> args) {
+    int varNum = template.vars().size();
+    String[] values = new String[varNum];
+    for (int i = 0; i < varNum; i++) {
+      values[i] = VAR_PLACE_HOLDER;
+    }
+    String[] literals = template.withoutVars().encode(values).split(VAR_PLACE_HOLDER);
+
+    PathTemplateRenderView.Piece[] pieces =
+        new PathTemplateRenderView.Piece[literals.length + args.size()];
+    for (int i = 0; i < literals.length; i++) {
+      pieces[2 * i] =
+          PathTemplateRenderView.Piece.builder()
+              .value(literals[i])
+              .kind(PathTemplateRenderView.PieceKind.LITERAL)
+              .build();
+    }
+    for (int i = 0; i < args.size(); i++) {
+      pieces[2 * i + 1] =
+          PathTemplateRenderView.Piece.builder()
+              .value(args.get(i).name())
+              .kind(PathTemplateRenderView.PieceKind.VARIABLE)
+              .build();
+    }
+    return PathTemplateRenderView.builder().pieces(ImmutableList.copyOf(pieces)).build();
   }
 }

--- a/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformer.java
@@ -42,6 +42,7 @@ import com.google.api.codegen.viewmodel.ImportSectionView;
 import com.google.api.codegen.viewmodel.LongRunningOperationDetailView;
 import com.google.api.codegen.viewmodel.PackageInfoView;
 import com.google.api.codegen.viewmodel.PageStreamingDescriptorClassView;
+import com.google.api.codegen.viewmodel.PathTemplateView;
 import com.google.api.codegen.viewmodel.RetryConfigDefinitionView;
 import com.google.api.codegen.viewmodel.ServiceDocView;
 import com.google.api.codegen.viewmodel.StaticLangApiMethodView;
@@ -146,7 +147,7 @@ public class GoGapicSurfaceTransformer implements ModelToViewTransformer {
         generateRetryConfigDefinitions(context, context.getSupportedMethods());
     view.retryPairDefinitions(retryDef);
 
-    view.pathTemplates(pathTemplateTransformer.generatePathTemplates(context));
+    view.pathTemplates(Collections.<PathTemplateView>emptyList());
     view.pathTemplateGetters(pathTemplateTransformer.generatePathTemplateGetterFunctions(context));
     view.callSettings(apiCallableTransformer.generateCallSettings(context));
 

--- a/src/main/java/com/google/api/codegen/viewmodel/PathTemplateGetterFunctionView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/PathTemplateGetterFunctionView.java
@@ -26,6 +26,8 @@ public abstract class PathTemplateGetterFunctionView {
 
   public abstract List<PathTemplateArgumentView> args();
 
+  public abstract PathTemplateRenderView render();
+
   public abstract String pathTemplateName();
 
   public abstract String pattern();
@@ -43,6 +45,8 @@ public abstract class PathTemplateGetterFunctionView {
     public abstract Builder pathTemplateName(String val);
 
     public abstract Builder args(List<PathTemplateArgumentView> val);
+
+    public abstract Builder render(PathTemplateRenderView val);
 
     public abstract Builder pattern(String val);
 

--- a/src/main/java/com/google/api/codegen/viewmodel/PathTemplateRenderView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/PathTemplateRenderView.java
@@ -1,0 +1,59 @@
+/* Copyright 2017 Google Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.api.codegen.viewmodel;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+
+@AutoValue
+public abstract class PathTemplateRenderView {
+  public enum PieceKind {
+    LITERAL,
+    VARIABLE
+  }
+
+  @AutoValue
+  public abstract static class Piece {
+    public abstract String value();
+
+    public abstract PieceKind kind();
+
+    public static Builder builder() {
+      return new AutoValue_PathTemplateRenderView_Piece.Builder();
+    }
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+      public abstract Builder value(String val);
+
+      public abstract Builder kind(PieceKind val);
+
+      public abstract Piece build();
+    }
+  }
+
+  public abstract ImmutableList<Piece> pieces();
+
+  public static Builder builder() {
+    return new AutoValue_PathTemplateRenderView.Builder();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder pieces(ImmutableList<Piece> val);
+
+    public abstract PathTemplateRenderView build();
+  }
+}

--- a/src/main/resources/com/google/api/codegen/go/main.snip
+++ b/src/main/resources/com/google/api/codegen/go/main.snip
@@ -9,14 +9,6 @@
         {@renderImportSection(view.fileHeader.importSection)}
     )
 
-    @if view.pathTemplates
-        var (
-            @join pathTemplate : view.pathTemplates
-                {@pathTemplate.name} = gax.MustCompilePathTemplate("{@pathTemplate.pattern}")
-            @end
-        )
-    @end
-
     // {@view.callOptionsTypeName} contains the retry settings for each method of {@view.clientTypeName}.
     type {@view.callOptionsTypeName} struct {
         @join settings : view.callSettings
@@ -139,15 +131,16 @@
     @join getter : view.pathTemplateGetters
         // {@getter.name} returns the path for the {@getter.resourceName} resource.
         func {@getter.name}({@pathTemplateParams(getter.args)} string) string {
-            path, err := {@getter.pathTemplateName}.Render(map[string]string{
-                @join arg : getter.args
-                    "{@arg.templateKey}": {@arg.name},
+            return "" +
+                @join piece : getter.render.pieces
+                    @switch piece.kind
+                    @case "LITERAL"
+                        "{@piece.value}" +
+                    @case "VARIABLE"
+                        {@piece.value} +
+                    @end
                 @end
-            })
-            if err != nil {
-                panic(err)
-            }
-            return path
+                ""
         }
 
     @end

--- a/src/test/java/com/google/api/codegen/testdata/go_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/go_main_library.baseline
@@ -37,12 +37,6 @@ import (
     "google.golang.org/grpc/codes"
 )
 
-var (
-    libraryShelfPathTemplate = gax.MustCompilePathTemplate("shelves/{shelf_id}")
-    libraryBookPathTemplate = gax.MustCompilePathTemplate("shelves/{shelf_id}/books/{book_id}")
-    libraryReturnPathTemplate = gax.MustCompilePathTemplate("shelves/{shelf}/books/{book}/returns/{return}")
-)
-
 // CallOptions contains the retry settings for each method of Client.
 type CallOptions struct {
     CreateShelf []gax.CallOption
@@ -213,38 +207,32 @@ func (c *Client) SetGoogleClientInfo(keyval ...string) {
 
 // ShelfPath returns the path for the shelf resource.
 func ShelfPath(shelfId string) string {
-    path, err := libraryShelfPathTemplate.Render(map[string]string{
-        "shelf_id": shelfId,
-    })
-    if err != nil {
-        panic(err)
-    }
-    return path
+    return "" +
+        "shelves/" +
+        shelfId +
+        ""
 }
 
 // BookPath returns the path for the book resource.
 func BookPath(shelfId, bookId string) string {
-    path, err := libraryBookPathTemplate.Render(map[string]string{
-        "shelf_id": shelfId,
-        "book_id": bookId,
-    })
-    if err != nil {
-        panic(err)
-    }
-    return path
+    return "" +
+        "shelves/" +
+        shelfId +
+        "/books/" +
+        bookId +
+        ""
 }
 
 // ReturnPath returns the path for the return resource.
 func ReturnPath(shelf, book, return_ string) string {
-    path, err := libraryReturnPathTemplate.Render(map[string]string{
-        "shelf": shelf,
-        "book": book,
-        "return": return_,
-    })
-    if err != nil {
-        panic(err)
-    }
-    return path
+    return "" +
+        "shelves/" +
+        shelf +
+        "/books/" +
+        book +
+        "/returns/" +
+        return_ +
+        ""
 }
 
 


### PR DESCRIPTION
The client library should no longer depend on gax.PathTemplate.
Updates googleapis/gax-go#32, since gax.PathTemplate can then
be removed and there would be nothing left to verify.

In addition to rendering gax.PathTemplate is also capable
of parsing a rendered string and returning the template "arguments".
This feature was never exposed by toolkit clients.
If we need it later, we can still easily create parsing code,
like we generate rendering code in this commit.

The Java implementation of PathTemplate escapes URL when rendering.
The Go implementation does not, and so the functionality is not
included here.

While this probably won't matter in production,
benchmarking pubsub's PublisherTopicPath shows
```
benchmark                    old ns/op     new ns/op     delta
BenchmarkPathTemplate-12     1052          104           -90.11%
```