### PR TITLE
harden firstLine

### DIFF
--- a/src/main/java/com/google/api/codegen/viewmodel/ServiceDocView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/ServiceDocView.java
@@ -15,6 +15,7 @@
 package com.google.api.codegen.viewmodel;
 
 import com.google.auto.value.AutoValue;
+import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nullable;
 
@@ -40,11 +41,17 @@ public abstract class ServiceDocView {
   }
 
   public String firstLine() {
-    return lines().get(0);
+    if (lines().size() > 0) {
+      return lines().get(0);
+    }
+    return "";
   }
 
   public List<String> remainingLines() {
-    return lines().subList(1, lines().size());
+    if (lines().size() > 0) {
+      return lines().subList(1, lines().size());
+    }
+    return Collections.<String>emptyList();
   }
 
   @AutoValue.Builder


### PR DESCRIPTION
Previously this method simply throws if the API defines no doc.
Make this return empty string instead.
The doc will render weird but at least we don't crash.