### PR TITLE
Ruby: Credentials bugs fix

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/FileHeaderTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/FileHeaderTransformer.java
@@ -18,6 +18,7 @@ import com.google.api.codegen.GeneratorVersionProvider;
 import com.google.api.codegen.config.ProductConfig;
 import com.google.api.codegen.viewmodel.FileHeaderView;
 import com.google.api.codegen.viewmodel.ImportSectionView;
+import com.google.common.collect.ImmutableList;
 
 public class FileHeaderTransformer {
 
@@ -35,7 +36,15 @@ public class FileHeaderTransformer {
   }
 
   public FileHeaderView generateFileHeader(
-      ProductConfig productConfig, ImportSectionView importSection, SurfaceNamer namer) {
+      ProductConfig productConfig, ImportSectionView importSectionView, SurfaceNamer namer) {
+    return generateFileHeader(productConfig, importSectionView, namer, namer.getApiModules());
+  }
+
+  public FileHeaderView generateFileHeader(
+      ProductConfig productConfig,
+      ImportSectionView importSection,
+      SurfaceNamer namer,
+      ImmutableList<String> apiModules) {
     FileHeaderView.Builder fileHeader = FileHeaderView.newBuilder();
 
     fileHeader.copyrightLines(productConfig.getCopyrightLines());
@@ -47,7 +56,7 @@ public class FileHeaderTransformer {
     fileHeader.importSection(importSection);
     fileHeader.version(namer.getApiWrapperModuleVersion());
     fileHeader.generatorVersion(GeneratorVersionProvider.getGeneratorVersion());
-    fileHeader.modules(namer.getApiModules());
+    fileHeader.modules(apiModules);
 
     return fileHeader.build();
   }

--- a/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
@@ -1156,6 +1156,10 @@ public class SurfaceNamer extends NameFormatterDelegator {
   public String getTopLevelIndexFileImportName() {
     return getNotImplementedString("SurfaceNamer.getTopLevelIndexFileImportName");
   }
+
+  public String getCredentialsClassImportName() {
+    return getNotImplementedString("SurfaceNamer.getCredentialsClassImportName");
+  }
   /////////////////////////////////// Docs & Annotations //////////////////////////////////////////
 
   /** The documentation name of a parameter for the given lower-case field name. */

--- a/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
@@ -184,6 +184,11 @@ public class SurfaceNamer extends NameFormatterDelegator {
     return ImmutableList.<String>of();
   }
 
+  /** The top level modules of the package. */
+  public List<String> getTopLevelApiModules() {
+    return ImmutableList.of();
+  }
+
   /////////////////////////////////// Protos methods /////////////////////////////////////////////
 
   /** The function name to set the given proto field. */

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubyImportSectionTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubyImportSectionTransformer.java
@@ -83,6 +83,7 @@ public class RubyImportSectionTransformer implements ImportSectionTransformer {
     for (String filename : filenames) {
       imports.add(createImport(context.getNamer().getProtoFileImportName(filename)));
     }
+    imports.add(createImport(context.getNamer().getCredentialsClassImportName()));
     return imports.build();
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubySurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubySurfaceNamer.java
@@ -41,7 +41,6 @@ import com.google.api.tools.framework.model.TypeRef;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
@@ -277,14 +276,18 @@ public class RubySurfaceNamer extends SurfaceNamer {
   }
 
   private String getTopLevelNamespace() {
-    List<String> parts = Lists.newArrayList(getPackageName().split("::"));
-    parts = parts.subList(0, parts.size() - 1);
-    return Joiner.on("::").join(parts);
+    return Joiner.on("::").join(getTopLevelApiModules());
   }
 
   @Override
   public ImmutableList<String> getApiModules() {
     return ImmutableList.copyOf(Splitter.on("::").split(getPackageName()));
+  }
+
+  @Override
+  public List<String> getTopLevelApiModules() {
+    List<String> apiModules = getApiModules();
+    return apiModules.subList(0, apiModules.size() - 1);
   }
 
   @Override
@@ -334,11 +337,9 @@ public class RubySurfaceNamer extends SurfaceNamer {
 
   @Override
   public String getCredentialsClassImportName() {
-    List<String> parts = getApiModules();
     // Place credentials in top-level namespace.
-    parts = parts.subList(0, parts.size() - 1);
     List<String> paths = new ArrayList<>();
-    for (String part : parts) {
+    for (String part : getTopLevelApiModules()) {
       paths.add(packageFilePathPiece(Name.upperCamel(part)));
     }
     paths.add("credentials");

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubySurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubySurfaceNamer.java
@@ -332,6 +332,19 @@ public class RubySurfaceNamer extends SurfaceNamer {
     return Joiner.on(File.separator).join(newNames.toArray());
   }
 
+  @Override
+  public String getCredentialsClassImportName() {
+    List<String> parts = getApiModules();
+    // Place credentials in top-level namespace.
+    parts = parts.subList(0, parts.size() - 1);
+    List<String> paths = new ArrayList<>();
+    for (String part : parts) {
+      paths.add(packageFilePathPiece(Name.upperCamel(part)));
+    }
+    paths.add("credentials");
+    return Joiner.on(File.separator).join(paths);
+  }
+
   private String getPackageFilePath() {
     List<String> newNames = new ArrayList<>();
     for (String name : getPackageName().split("::")) {

--- a/src/main/java/com/google/api/codegen/viewmodel/CredentialsClassView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/CredentialsClassView.java
@@ -19,13 +19,11 @@ import java.util.List;
 
 @AutoValue
 public abstract class CredentialsClassView {
-  public abstract String serviceAddress();
+  public abstract List<String> scopes();
 
   public abstract List<String> pathEnvVars();
 
   public abstract List<String> jsonEnvVars();
-
-  public abstract String packageName();
 
   public static Builder newBuilder() {
     return new AutoValue_CredentialsClassView.Builder();
@@ -33,13 +31,11 @@ public abstract class CredentialsClassView {
 
   @AutoValue.Builder
   public abstract static class Builder {
-    public abstract Builder serviceAddress(String val);
+    public abstract Builder scopes(List<String> vals);
 
     public abstract Builder pathEnvVars(List<String> vals);
 
     public abstract Builder jsonEnvVars(List<String> vals);
-
-    public abstract Builder packageName(String val);
 
     public abstract CredentialsClassView build();
   }

--- a/src/main/java/com/google/api/codegen/viewmodel/DynamicLangXApiView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/DynamicLangXApiView.java
@@ -118,8 +118,12 @@ public abstract class DynamicLangXApiView implements ViewModel {
 
   public abstract boolean isGcloud();
 
+  /**
+   * The name of the class that controls the credentials information of an api. It is currently only
+   * used by Ruby.
+   */
   @Nullable
-  public abstract CredentialsClassView credentialsClass();
+  public abstract String fullyQualifiedCredentialsClassName();
 
   @Override
   public String resourceRoot() {
@@ -207,7 +211,7 @@ public abstract class DynamicLangXApiView implements ViewModel {
 
     public abstract Builder isGcloud(boolean val);
 
-    public abstract Builder credentialsClass(CredentialsClassView val);
+    public abstract Builder fullyQualifiedCredentialsClassName(String val);
 
     public abstract DynamicLangXApiView build();
   }

--- a/src/main/resources/com/google/api/codegen/ruby/credentials.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/credentials.snip
@@ -17,10 +17,14 @@
 @end
 
 @private credentialsClass(view)
-  class Credentials << Google::Gax::Credentials
+  class Credentials < Google::Gax::Credentials
     # TODO(landrito): move the scope constant into it's own file since this string is being defined
     # in multiple places
-    SCOPE = {@view.serviceAddress}
+    SCOPE = [
+      @join scope : view.scopes on ",".add(BREAK)
+        "{@scope}"
+      @end
+    ].freeze
     PATH_ENV_VARS = {@stringList(view.pathEnvVars)}
     JSON_ENV_VARS = {@stringList(view.jsonEnvVars)}
   end

--- a/src/main/resources/com/google/api/codegen/ruby/main.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/main.snip
@@ -182,8 +182,9 @@
       )
 
     @end
+    credentials ||= {@xapiClass.fullyQualifiedCredentialsClassName}.default
     if credentials.is_a?(String) || credentials.is_a?(Hash)
-      updater_proc = {@xapiClass.credentialsClass.packageName}::Credentials.new(credentials).updater_proc
+      updater_proc = {@xapiClass.fullyQualifiedCredentialsClassName}.new(credentials).updater_proc
     end
     if credentials.is_a?(GRPC::Core::Channel)
       channel = credentials
@@ -194,7 +195,7 @@
     if credentials.is_a?(Proc)
       updater_proc = credentials
     end
-    if credentials.ia_a(Google::Gax::Credentials)
+    if credentials.is_a?(Google::Gax::Credentials)
       updater_proc = credentials.updater_proc
     end
 

--- a/src/main/resources/com/google/api/codegen/ruby/version_index.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/version_index.snip
@@ -12,6 +12,9 @@
     @end
 
 
+  @case "TopLevelIndex"
+    require "google/gax"
+
   @default
   @end
   @if index.modules

--- a/src/test/java/com/google/api/codegen/testdata/ruby_credentials_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_credentials_library.baseline
@@ -1,4 +1,4 @@
-============== file: lib/library/v1/credentials.rb ==============
+============== file: lib/library/credentials.rb ==============
 # Copyright 2017, Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,11 +16,12 @@
 require "google/gax"
 
 module Library
-  module V1
-    class Credentials << Google::Gax::Credentials
-      SCOPE = library-example.googleapis.com
-      PATH_ENV_VARS = %w(LIBRARY_KEYFILE, GOOGLE_CLOUD_KEYFILE, GCLOUD_KEYFILE)
-      JSON_ENV_VARS = %w(LIBRARY_KEYFILE_JSON, GOOGLE_CLOUD_KEYFILE_JSON, GCLOUD_KEYFILE_JSON)
-    end
+  class Credentials < Google::Gax::Credentials
+    SCOPE = [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/library"
+    ].freeze
+    PATH_ENV_VARS = %w(LIBRARY_KEYFILE, GOOGLE_CLOUD_KEYFILE, GCLOUD_KEYFILE)
+    JSON_ENV_VARS = %w(LIBRARY_KEYFILE_JSON, GOOGLE_CLOUD_KEYFILE_JSON, GCLOUD_KEYFILE_JSON)
   end
 end

--- a/src/test/java/com/google/api/codegen/testdata/ruby_credentials_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_credentials_multiple_services.baseline
@@ -1,4 +1,4 @@
-============== file: lib/google/example/v1/credentials.rb ==============
+============== file: lib/google/example/credentials.rb ==============
 # Copyright 2017, Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,12 +17,11 @@ require "google/gax"
 
 module Google
   module Example
-    module V1
-      class Credentials << Google::Gax::Credentials
-        SCOPE = no-path-templates.googleapis.com
-        PATH_ENV_VARS = %w(LIBRARY_KEYFILE, GOOGLE_CLOUD_KEYFILE, GCLOUD_KEYFILE)
-        JSON_ENV_VARS = %w(LIBRARY_KEYFILE_JSON, GOOGLE_CLOUD_KEYFILE_JSON, GCLOUD_KEYFILE_JSON)
-      end
+    class Credentials < Google::Gax::Credentials
+      SCOPE = [
+      ].freeze
+      PATH_ENV_VARS = %w(LIBRARY_KEYFILE, GOOGLE_CLOUD_KEYFILE, GCLOUD_KEYFILE)
+      JSON_ENV_VARS = %w(LIBRARY_KEYFILE_JSON, GOOGLE_CLOUD_KEYFILE_JSON, GCLOUD_KEYFILE_JSON)
     end
   end
 end

--- a/src/test/java/com/google/api/codegen/testdata/ruby_doc_credentials_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_doc_credentials_library.baseline
@@ -1,4 +1,4 @@
-============== file: lib/library/v1/credentials.rb ==============
+============== file: lib/library/credentials.rb ==============
 # Copyright 2017, Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,11 +16,12 @@
 require "google/gax"
 
 module Library
-  module V1
-    class Credentials << Google::Gax::Credentials
-      SCOPE = library-example.googleapis.com
-      PATH_ENV_VARS = %w(LIBRARY_KEYFILE, GOOGLE_CLOUD_KEYFILE, GCLOUD_KEYFILE)
-      JSON_ENV_VARS = %w(LIBRARY_KEYFILE_JSON, GOOGLE_CLOUD_KEYFILE_JSON, GCLOUD_KEYFILE_JSON)
-    end
+  class Credentials < Google::Gax::Credentials
+    SCOPE = [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/library"
+    ].freeze
+    PATH_ENV_VARS = %w(LIBRARY_KEYFILE, GOOGLE_CLOUD_KEYFILE, GCLOUD_KEYFILE)
+    JSON_ENV_VARS = %w(LIBRARY_KEYFILE_JSON, GOOGLE_CLOUD_KEYFILE_JSON, GCLOUD_KEYFILE_JSON)
   end
 end

--- a/src/test/java/com/google/api/codegen/testdata/ruby_doc_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_doc_main_library.baseline
@@ -32,6 +32,7 @@ require "google/longrunning/operations_client"
 
 require "library_pb"
 require "tagger_pb"
+require "library/credentials"
 
 module Library
   module V1
@@ -235,8 +236,9 @@ module Library
           lib_version: lib_version,
         )
 
+        credentials ||= Library::Credentials.default
         if credentials.is_a?(String) || credentials.is_a?(Hash)
-          updater_proc = Library::V1::Credentials.new(credentials).updater_proc
+          updater_proc = Library::Credentials.new(credentials).updater_proc
         end
         if credentials.is_a?(GRPC::Core::Channel)
           channel = credentials
@@ -247,7 +249,7 @@ module Library
         if credentials.is_a?(Proc)
           updater_proc = credentials
         end
-        if credentials.ia_a(Google::Gax::Credentials)
+        if credentials.is_a?(Google::Gax::Credentials)
           updater_proc = credentials.updater_proc
         end
 

--- a/src/test/java/com/google/api/codegen/testdata/ruby_doc_version_index_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_doc_version_index_library.baseline
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "google/gax"
+
 ##
 # # Ruby Client for Google Example Library API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
 #

--- a/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_main_library.baseline
@@ -32,6 +32,7 @@ require "google/longrunning/operations_client"
 
 require "library_pb"
 require "tagger_pb"
+require "library/credentials"
 
 module Library
   module V1
@@ -235,8 +236,9 @@ module Library
           lib_version: lib_version,
         )
 
+        credentials ||= Library::Credentials.default
         if credentials.is_a?(String) || credentials.is_a?(Hash)
-          updater_proc = Library::V1::Credentials.new(credentials).updater_proc
+          updater_proc = Library::Credentials.new(credentials).updater_proc
         end
         if credentials.is_a?(GRPC::Core::Channel)
           channel = credentials
@@ -247,7 +249,7 @@ module Library
         if credentials.is_a?(Proc)
           updater_proc = credentials
         end
-        if credentials.ia_a(Google::Gax::Credentials)
+        if credentials.is_a?(Google::Gax::Credentials)
           updater_proc = credentials.updater_proc
         end
 

--- a/src/test/java/com/google/api/codegen/testdata/ruby_main_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_main_multiple_services.baseline
@@ -29,6 +29,7 @@ require "pathname"
 require "google/gax"
 
 require "multiple_services_pb"
+require "google/example/credentials"
 
 module Google
   module Example
@@ -111,8 +112,9 @@ module Google
             warn "`app_name` and `app_version` are no longer being used in the request headers."
           end
 
+          credentials ||= Google::Example::Credentials.default
           if credentials.is_a?(String) || credentials.is_a?(Hash)
-            updater_proc = Google::Example::V1::Credentials.new(credentials).updater_proc
+            updater_proc = Google::Example::Credentials.new(credentials).updater_proc
           end
           if credentials.is_a?(GRPC::Core::Channel)
             channel = credentials
@@ -123,7 +125,7 @@ module Google
           if credentials.is_a?(Proc)
             updater_proc = credentials
           end
-          if credentials.ia_a(Google::Gax::Credentials)
+          if credentials.is_a?(Google::Gax::Credentials)
             updater_proc = credentials.updater_proc
           end
 
@@ -219,6 +221,7 @@ require "pathname"
 require "google/gax"
 
 require "multiple_services_pb"
+require "google/example/credentials"
 
 module Google
   module Example
@@ -301,8 +304,9 @@ module Google
             warn "`app_name` and `app_version` are no longer being used in the request headers."
           end
 
+          credentials ||= Google::Example::Credentials.default
           if credentials.is_a?(String) || credentials.is_a?(Hash)
-            updater_proc = Google::Example::V1::Credentials.new(credentials).updater_proc
+            updater_proc = Google::Example::Credentials.new(credentials).updater_proc
           end
           if credentials.is_a?(GRPC::Core::Channel)
             channel = credentials
@@ -313,7 +317,7 @@ module Google
           if credentials.is_a?(Proc)
             updater_proc = credentials
           end
-          if credentials.ia_a(Google::Gax::Credentials)
+          if credentials.is_a?(Google::Gax::Credentials)
             updater_proc = credentials.updater_proc
           end
 

--- a/src/test/java/com/google/api/codegen/testdata/ruby_version_index_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_version_index_library.baseline
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "google/gax"
+
 ##
 # # Ruby Client for Google Example Library API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
 #

--- a/src/test/java/com/google/api/codegen/testdata/ruby_version_index_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_version_index_multiple_services.baseline
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require "google/gax"
+
 module Google
   ##
   # # Ruby Client for Google Example API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))


### PR DESCRIPTION
This also moves the credentials class to the top level scope since the scopes are not per interface but rather a property of the model.

Monitoring unit and smoke tests now pass with these changes.