### PR TITLE
Fix ResourceName != UntypedResourceName runtime test failure bug

### DIFF
--- a/src/main/java/com/google/api/codegen/config/FieldConfig.java
+++ b/src/main/java/com/google/api/codegen/config/FieldConfig.java
@@ -212,8 +212,12 @@ public abstract class FieldConfig {
   public boolean requiresParamTransformation() {
     return getResourceNameConfig() != null
         && getMessageResourceNameConfig() != null
-        && getMessageResourceNameConfig().getResourceNameType() != ResourceNameType.ANY
         && !getResourceNameConfig().equals(getMessageResourceNameConfig());
+  }
+
+  public boolean requiresAnyParamTransformation() {
+    return getMessageResourceNameConfig() != null
+        && getMessageResourceNameConfig().getResourceNameType() == ResourceNameType.ANY;
   }
 
   public FieldConfig getMessageFieldConfig() {

--- a/src/main/java/com/google/api/codegen/config/FieldConfig.java
+++ b/src/main/java/com/google/api/codegen/config/FieldConfig.java
@@ -215,7 +215,7 @@ public abstract class FieldConfig {
         && !getResourceNameConfig().equals(getMessageResourceNameConfig());
   }
 
-  public boolean requiresAnyParamTransformation() {
+  public boolean requiresParamTransformationFromAny() {
     return getMessageResourceNameConfig() != null
         && getMessageResourceNameConfig().getResourceNameType() == ResourceNameType.ANY;
   }

--- a/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
@@ -125,7 +125,7 @@ public class InitCodeTransformer {
       String expectedTransformFunction = null;
       String actualTransformFunction = null;
       if (methodContext.getFeatureConfig().useResourceNameFormatOption(fieldConfig)) {
-        if (fieldConfig.requiresAnyParamTransformation()) {
+        if (fieldConfig.requiresParamTransformationFromAny()) {
           expectedTransformFunction = namer.getToStringMethod();
           actualTransformFunction = namer.getToStringMethod();
         } else if (fieldConfig.requiresParamTransformation()) {

--- a/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
@@ -123,10 +123,15 @@ public class InitCodeTransformer {
 
       String expectedValueIdentifier = getVariableName(methodContext, fieldItemTree);
       String expectedTransformFunction = null;
-      if (methodContext.getFeatureConfig().useResourceNameFormatOption(fieldConfig)
-          && fieldConfig.requiresParamTransformation()) {
-        expectedTransformFunction =
-            namer.getResourceOneofCreateMethod(methodContext.getTypeTable(), fieldConfig);
+      String actualTransformFunction = null;
+      if (methodContext.getFeatureConfig().useResourceNameFormatOption(fieldConfig)) {
+        if (fieldConfig.requiresAnyParamTransformation()) {
+          expectedTransformFunction = namer.getToStringMethod();
+          actualTransformFunction = namer.getToStringMethod();
+        } else if (fieldConfig.requiresParamTransformation()) {
+          expectedTransformFunction =
+              namer.getResourceOneofCreateMethod(methodContext.getTypeTable(), fieldConfig);
+        }
       }
 
       boolean isArray =
@@ -148,6 +153,7 @@ public class InitCodeTransformer {
           createAssertView(
               expectedValueIdentifier,
               expectedTransformFunction,
+              actualTransformFunction,
               isArray,
               getterMethod,
               enumTypeName,
@@ -179,6 +185,7 @@ public class InitCodeTransformer {
   private ClientTestAssertView createAssertView(
       String expected,
       String expectedTransformFunction,
+      String actualTransformFunction,
       boolean isArray,
       String actual,
       String enumTypeName,
@@ -187,6 +194,7 @@ public class InitCodeTransformer {
         .expectedValueIdentifier(expected)
         .isArray(isArray)
         .expectedValueTransformFunction(expectedTransformFunction)
+        .actualValueTransformFunction(actualTransformFunction)
         .actualValueGetter(actual)
         .enumTypeName(enumTypeName)
         .messageTypeName(messageTypeName)

--- a/src/main/java/com/google/api/codegen/transformer/StaticLangApiMethodTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/StaticLangApiMethodTransformer.java
@@ -808,7 +808,7 @@ public class StaticLangApiMethodTransformer {
     String transformParamFunctionName = null;
     if (context.getFeatureConfig().useResourceNameFormatOption(fieldConfig)
         && fieldConfig.requiresParamTransformation()) {
-      if (!fieldConfig.requiresAnyParamTransformation()) {
+      if (!fieldConfig.requiresParamTransformationFromAny()) {
         transformParamFunctionName = namer.getResourceOneofCreateMethod(typeTable, fieldConfig);
       }
     }

--- a/src/main/java/com/google/api/codegen/transformer/StaticLangApiMethodTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/StaticLangApiMethodTransformer.java
@@ -808,7 +808,9 @@ public class StaticLangApiMethodTransformer {
     String transformParamFunctionName = null;
     if (context.getFeatureConfig().useResourceNameFormatOption(fieldConfig)
         && fieldConfig.requiresParamTransformation()) {
-      transformParamFunctionName = namer.getResourceOneofCreateMethod(typeTable, fieldConfig);
+      if (!fieldConfig.requiresAnyParamTransformation()) {
+        transformParamFunctionName = namer.getResourceOneofCreateMethod(typeTable, fieldConfig);
+      }
     }
 
     RequestObjectParamView.Builder param = RequestObjectParamView.newBuilder();

--- a/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
@@ -1389,4 +1389,8 @@ public class SurfaceNamer extends NameFormatterDelegator {
   public String getOptionalFieldDefaultValue(FieldConfig fieldConfig, GapicMethodContext context) {
     return getNotImplementedString("SurfaceNamer.getOptionalFieldDefaultValue");
   }
+
+  public String getToStringMethod() {
+    return getNotImplementedString("SurfaceNamer.getToStringMethod");
+  }
 }

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaGapicSurfaceTestTransformer.java
@@ -342,6 +342,7 @@ public class JavaGapicSurfaceTestTransformer implements ModelToViewTransformer {
     typeTable.saveNicknameFor("java.util.Arrays");
     typeTable.saveNicknameFor("java.util.concurrent.ExecutionException");
     typeTable.saveNicknameFor("java.util.List");
+    typeTable.saveNicknameFor("java.util.Objects");
     typeTable.saveNicknameFor("org.junit.After");
     typeTable.saveNicknameFor("org.junit.AfterClass");
     typeTable.saveNicknameFor("org.junit.Assert");

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceNamer.java
@@ -266,4 +266,9 @@ public class JavaSurfaceNamer extends SurfaceNamer {
     }
     return Joiner.on("/").join(packagePath.subList(0, endIndex));
   }
+
+  @Override
+  public String getToStringMethod() {
+    return "Objects.toString";
+  }
 }

--- a/src/main/java/com/google/api/codegen/viewmodel/testing/ClientTestAssertView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/testing/ClientTestAssertView.java
@@ -28,6 +28,9 @@ public abstract class ClientTestAssertView {
   @Nullable
   public abstract String expectedValueTransformFunction();
 
+  @Nullable
+  public abstract String actualValueTransformFunction();
+
   // Enum type name is needed for ruby because enum fields are converted to symbols when assigned
   // for a message. In order to do comparison, the enum value will need to be resolved to the
   // corresponding symbol using the enumTypeName.
@@ -42,6 +45,10 @@ public abstract class ClientTestAssertView {
 
   public boolean hasExpectedValueTransformFunction() {
     return expectedValueTransformFunction() != null;
+  }
+
+  public boolean hasActualValueTransformFunction() {
+    return actualValueTransformFunction() != null;
   }
 
   public boolean hasEnumTypeName() {
@@ -65,6 +72,8 @@ public abstract class ClientTestAssertView {
     public abstract Builder isArray(boolean val);
 
     public abstract Builder expectedValueTransformFunction(String val);
+
+    public abstract Builder actualValueTransformFunction(String val);
 
     public abstract Builder enumTypeName(String val);
 

--- a/src/main/resources/com/google/api/codegen/java/test.snip
+++ b/src/main/resources/com/google/api/codegen/java/test.snip
@@ -283,7 +283,7 @@
       @end
     @else
       @if assert.hasActualValueTransformFunction
-        "$ NOT IMPLEMENTED: hasActualValueTransformFunction == true while hasExpectedValueTransformFunction == false";
+        "$ NOT IMPLEMENTED: hasActualValueTransformFunction == true while hasExpectedValueTransformFunction == false $";
       @else
         Assert.assertEquals({@assert.expectedValueIdentifier}, \
           actualRequest.{@assert.actualValueGetter}());

--- a/src/main/resources/com/google/api/codegen/java/test.snip
+++ b/src/main/resources/com/google/api/codegen/java/test.snip
@@ -282,8 +282,12 @@
           actualRequest.{@assert.actualValueGetter}());
       @end
     @else
-      Assert.assertEquals({@assert.expectedValueIdentifier}, \
-        actualRequest.{@assert.actualValueGetter}());
+      @if assert.hasActualValueTransformFunction
+        "$ NOT IMPLEMENTED: hasActualValueTransformFunction == true while hasExpectedValueTransformFunction == false";
+      @else
+        Assert.assertEquals({@assert.expectedValueIdentifier}, \
+          actualRequest.{@assert.actualValueGetter}());
+      @end
     @end
   @end
 @end

--- a/src/main/resources/com/google/api/codegen/java/test.snip
+++ b/src/main/resources/com/google/api/codegen/java/test.snip
@@ -272,9 +272,15 @@
 
   @join assert : test.asserts
     @if assert.hasExpectedValueTransformFunction
-      Assert.assertEquals({@assert.expectedValueTransformFunction}(\
-        {@assert.expectedValueIdentifier}), \
-        actualRequest.{@assert.actualValueGetter}());
+      @if assert.hasActualValueTransformFunction
+        Assert.assertEquals({@assert.expectedValueTransformFunction}(\
+          {@assert.expectedValueIdentifier}), \
+          {@assert.actualValueTransformFunction}(actualRequest.{@assert.actualValueGetter}()));
+      @else
+        Assert.assertEquals({@assert.expectedValueTransformFunction}(\
+          {@assert.expectedValueIdentifier}), \
+          actualRequest.{@assert.actualValueGetter}());
+      @end
     @else
       Assert.assertEquals({@assert.expectedValueIdentifier}, \
         actualRequest.{@assert.actualValueGetter}());

--- a/src/test/java/com/google/api/codegen/testdata/java_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_test_library.baseline
@@ -94,6 +94,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -880,7 +881,7 @@ public class LibraryClientTest {
     Assert.assertEquals(1, actualRequests.size());
     ListStringsRequest actualRequest = (ListStringsRequest)actualRequests.get(0);
 
-    Assert.assertEquals(name, actualRequest.getNameAsResourceName());
+    Assert.assertEquals(Objects.toString(name), Objects.toString(actualRequest.getNameAsResourceName()));
   }
 
   @Test
@@ -1067,7 +1068,7 @@ public class LibraryClientTest {
     Assert.assertEquals(1, actualRequests.size());
     GetBookFromAbsolutelyAnywhereRequest actualRequest = (GetBookFromAbsolutelyAnywhereRequest)actualRequests.get(0);
 
-    Assert.assertEquals(name, actualRequest.getNameAsResourceName());
+    Assert.assertEquals(Objects.toString(name), Objects.toString(actualRequest.getNameAsResourceName()));
   }
 
   @Test

--- a/src/test/java/com/google/api/codegen/testdata/java_test_no_path_templates.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/java_test_no_path_templates.baseline
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import org.junit.After;
 import org.junit.AfterClass;


### PR DESCRIPTION
When a message expects any resource name, and actual resource name is used, in `Assert.equals()` they have type mismatch, because `getResourceNameAsName()` always returns `UntypedResourceName`, while equals implementation for resource names checks for `instanceof`.
