### PR TITLE
Disable rubocop in version index README

### DIFF
--- a/src/main/resources/com/google/api/codegen/ruby/version_index.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/version_index.snip
@@ -36,8 +36,11 @@
 @end
 
 @private readmeModule(indexType, module, iterator, content)
+  @# rubocop:disable LineLength
   @##
   {@toComments(util.getDocLines(generateReadme(indexType, module)))}
+  @#
+  @# rubocop:enable LineLength
   @#
   {@simpleModule(indexType, module, iterator, content)}
 @end

--- a/src/test/java/com/google/api/codegen/testdata/ruby_doc_version_index_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_doc_version_index_library.baseline
@@ -15,6 +15,7 @@
 
 require "google/gax"
 
+# rubocop:disable LineLength
 ##
 # # Ruby Client for Google Example Library API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
 #
@@ -50,6 +51,8 @@ require "google/gax"
 # - View this [repository's main README](https://github.com/GoogleCloudPlatform/google-cloud-ruby/blob/master/README.md) to see the full list of Cloud APIs that we cover.
 #
 # [Product Documentation]: https://cloud.google.com/library
+#
+# rubocop:enable LineLength
 #
 module Library
   FILE_DIR = File.realdirpath(Pathname.new(__FILE__).join("..").join("library"))
@@ -139,6 +142,7 @@ end
 
 require "library/v1/library_service_client"
 
+# rubocop:disable LineLength
 ##
 # # Ruby Client for Google Example Library API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
 #
@@ -174,6 +178,8 @@ require "library/v1/library_service_client"
 # - View this [repository's main README](https://github.com/GoogleCloudPlatform/google-cloud-ruby/blob/master/README.md) to see the full list of Cloud APIs that we cover.
 #
 # [Product Documentation]: https://cloud.google.com/library
+#
+# rubocop:enable LineLength
 #
 module Library
   ##

--- a/src/test/java/com/google/api/codegen/testdata/ruby_version_index_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_version_index_library.baseline
@@ -15,6 +15,7 @@
 
 require "google/gax"
 
+# rubocop:disable LineLength
 ##
 # # Ruby Client for Google Example Library API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
 #
@@ -50,6 +51,8 @@ require "google/gax"
 # - View this [repository's main README](https://github.com/GoogleCloudPlatform/google-cloud-ruby/blob/master/README.md) to see the full list of Cloud APIs that we cover.
 #
 # [Product Documentation]: https://cloud.google.com/library
+#
+# rubocop:enable LineLength
 #
 module Library
   FILE_DIR = File.realdirpath(Pathname.new(__FILE__).join("..").join("library"))
@@ -139,6 +142,7 @@ end
 
 require "library/v1/library_service_client"
 
+# rubocop:disable LineLength
 ##
 # # Ruby Client for Google Example Library API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
 #
@@ -174,6 +178,8 @@ require "library/v1/library_service_client"
 # - View this [repository's main README](https://github.com/GoogleCloudPlatform/google-cloud-ruby/blob/master/README.md) to see the full list of Cloud APIs that we cover.
 #
 # [Product Documentation]: https://cloud.google.com/library
+#
+# rubocop:enable LineLength
 #
 module Library
   ##

--- a/src/test/java/com/google/api/codegen/testdata/ruby_version_index_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_version_index_multiple_services.baseline
@@ -16,6 +16,7 @@
 require "google/gax"
 
 module Google
+  # rubocop:disable LineLength
   ##
   # # Ruby Client for Google Example API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
   #
@@ -39,6 +40,8 @@ module Google
   # - View this [repository's main README](https://github.com/GoogleCloudPlatform/google-cloud-ruby/blob/master/README.md) to see the full list of Cloud APIs that we cover.
   #
   # [Product Documentation]: https://cloud.google.com/library
+  #
+  # rubocop:enable LineLength
   #
   module Example
     FILE_DIR = File.realdirpath(Pathname.new(__FILE__).join("..").join("example"))
@@ -167,6 +170,7 @@ require "google/example/v1/incrementer_service_client"
 require "google/example/v1/decrementer_service_client"
 
 module Google
+  # rubocop:disable LineLength
   ##
   # # Ruby Client for Google Example API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
   #
@@ -190,6 +194,8 @@ module Google
   # - View this [repository's main README](https://github.com/GoogleCloudPlatform/google-cloud-ruby/blob/master/README.md) to see the full list of Cloud APIs that we cover.
   #
   # [Product Documentation]: https://cloud.google.com/library
+  #
+  # rubocop:enable LineLength
   #
   module Example
     ##


### PR DESCRIPTION
Due to variability in the product name length, it's difficult to place
line breaks appropriately in this file.