### PR TITLE
Fixes to rubocop line length disable

### DIFF
--- a/src/main/resources/com/google/api/codegen/ruby/version_index.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/version_index.snip
@@ -37,10 +37,10 @@
 
 @private readmeModule(indexType, module, iterator, content)
   @# rubocop:disable LineLength
+
   @##
   {@toComments(util.getDocLines(generateReadme(indexType, module)))}
   @#
-  @# rubocop:enable LineLength
   @#
   {@simpleModule(indexType, module, iterator, content)}
 @end
@@ -67,6 +67,8 @@
     @if iterator.hasNext
       {@modules(iterator, indexType, content)}
     @else
+      @# rubocop:enable LineLength
+
       {@content}
     @end
   end

--- a/src/test/java/com/google/api/codegen/testdata/ruby_doc_version_index_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_doc_version_index_library.baseline
@@ -16,6 +16,7 @@
 require "google/gax"
 
 # rubocop:disable LineLength
+
 ##
 # # Ruby Client for Google Example Library API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
 #
@@ -52,9 +53,10 @@ require "google/gax"
 #
 # [Product Documentation]: https://cloud.google.com/library
 #
-# rubocop:enable LineLength
 #
 module Library
+  # rubocop:enable LineLength
+
   FILE_DIR = File.realdirpath(Pathname.new(__FILE__).join("..").join("library"))
 
   AVAILABLE_VERSIONS = Dir["#{FILE_DIR}/*"]
@@ -143,6 +145,7 @@ end
 require "library/v1/library_service_client"
 
 # rubocop:disable LineLength
+
 ##
 # # Ruby Client for Google Example Library API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
 #
@@ -179,7 +182,6 @@ require "library/v1/library_service_client"
 #
 # [Product Documentation]: https://cloud.google.com/library
 #
-# rubocop:enable LineLength
 #
 module Library
   ##
@@ -194,6 +196,8 @@ module Library
   # [Data Types]: https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/library/latest/google/library/v1/datatypes
   #
   module V1
+    # rubocop:enable LineLength
+
     ##
     # This API represents a simple digital library.  It lets you manage Shelf
     # resources and Book resources in the library. It defines the following

--- a/src/test/java/com/google/api/codegen/testdata/ruby_version_index_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_version_index_library.baseline
@@ -16,6 +16,7 @@
 require "google/gax"
 
 # rubocop:disable LineLength
+
 ##
 # # Ruby Client for Google Example Library API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
 #
@@ -52,9 +53,10 @@ require "google/gax"
 #
 # [Product Documentation]: https://cloud.google.com/library
 #
-# rubocop:enable LineLength
 #
 module Library
+  # rubocop:enable LineLength
+
   FILE_DIR = File.realdirpath(Pathname.new(__FILE__).join("..").join("library"))
 
   AVAILABLE_VERSIONS = Dir["#{FILE_DIR}/*"]
@@ -143,6 +145,7 @@ end
 require "library/v1/library_service_client"
 
 # rubocop:disable LineLength
+
 ##
 # # Ruby Client for Google Example Library API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
 #
@@ -179,7 +182,6 @@ require "library/v1/library_service_client"
 #
 # [Product Documentation]: https://cloud.google.com/library
 #
-# rubocop:enable LineLength
 #
 module Library
   ##
@@ -194,6 +196,8 @@ module Library
   # [Data Types]: https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/library/latest/google/library/v1/datatypes
   #
   module V1
+    # rubocop:enable LineLength
+
     ##
     # This API represents a simple digital library.  It lets you manage Shelf
     # resources and Book resources in the library. It defines the following

--- a/src/test/java/com/google/api/codegen/testdata/ruby_version_index_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_version_index_multiple_services.baseline
@@ -17,6 +17,7 @@ require "google/gax"
 
 module Google
   # rubocop:disable LineLength
+
   ##
   # # Ruby Client for Google Example API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
   #
@@ -41,9 +42,10 @@ module Google
   #
   # [Product Documentation]: https://cloud.google.com/library
   #
-  # rubocop:enable LineLength
   #
   module Example
+    # rubocop:enable LineLength
+
     FILE_DIR = File.realdirpath(Pathname.new(__FILE__).join("..").join("example"))
 
     AVAILABLE_VERSIONS = Dir["#{FILE_DIR}/*"]
@@ -171,6 +173,7 @@ require "google/example/v1/decrementer_service_client"
 
 module Google
   # rubocop:disable LineLength
+
   ##
   # # Ruby Client for Google Example API ([Alpha](https://github.com/GoogleCloudPlatform/google-cloud-ruby#versioning))
   #
@@ -195,7 +198,6 @@ module Google
   #
   # [Product Documentation]: https://cloud.google.com/library
   #
-  # rubocop:enable LineLength
   #
   module Example
     ##
@@ -212,6 +214,8 @@ module Google
     # [Data Types]: https://googlecloudplatform.github.io/google-cloud-ruby/#/docs/google-example/latest/google/library/v1/datatypes
     #
     module V1
+      # rubocop:enable LineLength
+
       module Incrementer
         ##
         # @param service_path [String]


### PR DESCRIPTION
- Re-enable line length checking only once
- Don't attach rubocop directive to YARD comments