### PR TITLE
all: make interface renaming work for go

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/DynamicLangApiMethodTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/DynamicLangApiMethodTransformer.java
@@ -128,7 +128,7 @@ public class DynamicLangApiMethodTransformer {
 
     apiMethod.packageName(namer.getPackageName());
     apiMethod.packageHasMultipleServices(packageHasMultipleServices);
-    apiMethod.packageServiceName(namer.getPackageServiceName(context.getInterface()));
+    apiMethod.packageServiceName(namer.getPackageServiceName(context.getInterfaceConfig()));
     apiMethod.apiVersion(namer.getApiWrapperModuleVersion());
     apiMethod.longRunningView(
         context.getMethodConfig().isLongRunningOperation()

--- a/src/main/java/com/google/api/codegen/transformer/IamResourceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/IamResourceTransformer.java
@@ -39,7 +39,7 @@ public class IamResourceTransformer {
               .exampleName(
                   context
                       .getNamer()
-                      .getIamResourceGetterFunctionExampleName(context.getInterface(), field))
+                      .getIamResourceGetterFunctionExampleName(context.getInterfaceConfig(), field))
               .fieldName(context.getNamer().publicFieldName(Name.from(field.getSimpleName())))
               .resourceTypeName(resourceTypeName)
               .resourceConstructorName(context.getNamer().getTypeConstructor(resourceTypeName))

--- a/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/InitCodeTransformer.java
@@ -435,7 +435,7 @@ public class InitCodeTransformer {
             context
                 .getNamer()
                 .getFormatFunctionName(
-                    context.getInterface(), initValueConfig.getSingleResourceNameConfig()));
+                    context.getInterfaceConfig(), initValueConfig.getSingleResourceNameConfig()));
 
         List<String> varList =
             Lists.newArrayList(

--- a/src/main/java/com/google/api/codegen/transformer/PathTemplateTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/PathTemplateTransformer.java
@@ -64,7 +64,7 @@ public class PathTemplateTransformer {
         interfaceConfig.getSingleResourceNameConfigs()) {
       PathTemplateView.Builder pathTemplate = PathTemplateView.newBuilder();
       pathTemplate.name(
-          context.getNamer().getPathTemplateName(context.getInterface(), resourceNameConfig));
+          context.getNamer().getPathTemplateName(context.getInterfaceConfig(), resourceNameConfig));
       pathTemplate.pattern(resourceNameConfig.getNamePattern());
       pathTemplates.add(pathTemplate.build());
     }
@@ -233,10 +233,10 @@ public class PathTemplateTransformer {
       FormatResourceFunctionView.Builder function =
           FormatResourceFunctionView.newBuilder()
               .entityName(resourceNameConfig.getEntityName())
-              .name(namer.getFormatFunctionName(apiInterface, resourceNameConfig))
-              .pathTemplateName(namer.getPathTemplateName(apiInterface, resourceNameConfig))
+              .name(namer.getFormatFunctionName(interfaceConfig, resourceNameConfig))
+              .pathTemplateName(namer.getPathTemplateName(interfaceConfig, resourceNameConfig))
               .pathTemplateGetterName(
-                  namer.getPathTemplateNameGetter(apiInterface, resourceNameConfig))
+                  namer.getPathTemplateNameGetter(interfaceConfig, resourceNameConfig))
               .pattern(resourceNameConfig.getNamePattern());
       List<ResourceIdParamView> resourceIdParams = new ArrayList<>();
       for (String var : resourceNameConfig.getNameTemplate().vars()) {
@@ -273,9 +273,9 @@ public class PathTemplateTransformer {
             ParseResourceFunctionView.newBuilder()
                 .entityName(resourceNameConfig.getEntityName())
                 .name(namer.getParseFunctionName(var, resourceNameConfig))
-                .pathTemplateName(namer.getPathTemplateName(apiInterface, resourceNameConfig))
+                .pathTemplateName(namer.getPathTemplateName(interfaceConfig, resourceNameConfig))
                 .pathTemplateGetterName(
-                    namer.getPathTemplateNameGetter(apiInterface, resourceNameConfig))
+                    namer.getPathTemplateNameGetter(interfaceConfig, resourceNameConfig))
                 .entityNameParamName(namer.getEntityNameParamName(resourceNameConfig))
                 .outputResourceId(var);
         functions.add(function.build());
@@ -296,9 +296,9 @@ public class PathTemplateTransformer {
         interfaceConfig.getSingleResourceNameConfigs()) {
       PathTemplateGetterFunctionView.Builder function =
           PathTemplateGetterFunctionView.newBuilder()
-              .name(namer.getPathTemplateNameGetter(apiInterface, resourceNameConfig))
+              .name(namer.getPathTemplateNameGetter(interfaceConfig, resourceNameConfig))
               .resourceName(namer.getPathTemplateResourcePhraseName(resourceNameConfig))
-              .pathTemplateName(namer.getPathTemplateName(apiInterface, resourceNameConfig))
+              .pathTemplateName(namer.getPathTemplateName(interfaceConfig, resourceNameConfig))
               .pattern(resourceNameConfig.getNamePattern());
 
       List<PathTemplateArgumentView> args = new ArrayList<>();

--- a/src/main/java/com/google/api/codegen/transformer/StaticLangApiMethodTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/StaticLangApiMethodTransformer.java
@@ -64,7 +64,7 @@ public class StaticLangApiMethodTransformer {
     methodViewBuilder.name(
         namer.getApiMethodName(context.getMethod(), context.getMethodConfig().getVisibility()));
     methodViewBuilder.exampleName(
-        namer.getApiMethodExampleName(context.getInterface(), context.getMethod()));
+        namer.getApiMethodExampleName(context.getInterfaceConfig(), context.getMethod()));
     setListMethodFields(context, Synchronicity.Sync, methodViewBuilder);
     setFlattenedMethodFields(context, additionalParams, Synchronicity.Sync, methodViewBuilder);
 
@@ -85,7 +85,7 @@ public class StaticLangApiMethodTransformer {
         namer.getAsyncApiMethodName(
             context.getMethod(), context.getMethodConfig().getVisibility()));
     methodViewBuilder.exampleName(
-        namer.getAsyncApiMethodExampleName(context.getInterface(), context.getMethod()));
+        namer.getAsyncApiMethodExampleName(context.getInterfaceConfig(), context.getMethod()));
     setListMethodFields(context, Synchronicity.Async, methodViewBuilder);
     setFlattenedMethodFields(context, additionalParams, Synchronicity.Async, methodViewBuilder);
 
@@ -105,7 +105,7 @@ public class StaticLangApiMethodTransformer {
     methodViewBuilder.name(
         namer.getApiMethodName(context.getMethod(), context.getMethodConfig().getVisibility()));
     methodViewBuilder.exampleName(
-        namer.getApiMethodExampleName(context.getInterface(), context.getMethod()));
+        namer.getApiMethodExampleName(context.getInterfaceConfig(), context.getMethod()));
     setListMethodFields(context, Synchronicity.Sync, methodViewBuilder);
     setRequestObjectMethodFields(
         context,
@@ -127,7 +127,7 @@ public class StaticLangApiMethodTransformer {
         namer.getAsyncApiMethodName(
             context.getMethod(), context.getMethodConfig().getVisibility()));
     methodViewBuilder.exampleName(
-        namer.getAsyncApiMethodExampleName(context.getInterface(), context.getMethod()));
+        namer.getAsyncApiMethodExampleName(context.getInterfaceConfig(), context.getMethod()));
     setListMethodFields(context, Synchronicity.Async, methodViewBuilder);
     setRequestObjectMethodFields(
         context,
@@ -146,7 +146,7 @@ public class StaticLangApiMethodTransformer {
     setCommonFields(context, methodViewBuilder);
     methodViewBuilder.name(namer.getPagedCallableMethodName(context.getMethod()));
     methodViewBuilder.exampleName(
-        namer.getPagedCallableMethodExampleName(context.getInterface(), context.getMethod()));
+        namer.getPagedCallableMethodExampleName(context.getInterfaceConfig(), context.getMethod()));
     setListMethodFields(context, Synchronicity.Sync, methodViewBuilder);
     setCallableMethodFields(
         context, namer.getPagedCallableName(context.getMethod()), methodViewBuilder);
@@ -161,7 +161,7 @@ public class StaticLangApiMethodTransformer {
     setCommonFields(context, methodViewBuilder);
     methodViewBuilder.name(namer.getCallableMethodName(context.getMethod()));
     methodViewBuilder.exampleName(
-        namer.getCallableMethodExampleName(context.getInterface(), context.getMethod()));
+        namer.getCallableMethodExampleName(context.getInterfaceConfig(), context.getMethod()));
     setListMethodFields(context, Synchronicity.Sync, methodViewBuilder);
     setCallableMethodFields(context, namer.getCallableName(context.getMethod()), methodViewBuilder);
 
@@ -199,7 +199,7 @@ public class StaticLangApiMethodTransformer {
         namer.getAsyncApiMethodName(
             context.getMethod(), context.getMethodConfig().getVisibility()));
     methodViewBuilder.exampleName(
-        namer.getCallableMethodExampleName(context.getInterface(), context.getMethod()));
+        namer.getCallableMethodExampleName(context.getInterfaceConfig(), context.getMethod()));
     methodViewBuilder.callableName(namer.getCallableName(context.getMethod()));
     setFlattenedMethodFields(context, additionalParams, Synchronicity.Async, methodViewBuilder);
     setStaticLangAsyncReturnTypeName(context, methodViewBuilder);
@@ -220,7 +220,7 @@ public class StaticLangApiMethodTransformer {
     methodViewBuilder.name(
         namer.getApiMethodName(context.getMethod(), context.getMethodConfig().getVisibility()));
     methodViewBuilder.exampleName(
-        namer.getApiMethodExampleName(context.getInterface(), context.getMethod()));
+        namer.getApiMethodExampleName(context.getInterfaceConfig(), context.getMethod()));
     methodViewBuilder.callableName(namer.getCallableName(context.getMethod()));
     setFlattenedMethodFields(context, additionalParams, Synchronicity.Sync, methodViewBuilder);
     setStaticLangReturnTypeName(context, methodViewBuilder);
@@ -241,7 +241,7 @@ public class StaticLangApiMethodTransformer {
     methodViewBuilder.name(
         namer.getApiMethodName(context.getMethod(), context.getMethodConfig().getVisibility()));
     methodViewBuilder.exampleName(
-        namer.getApiMethodExampleName(context.getInterface(), context.getMethod()));
+        namer.getApiMethodExampleName(context.getInterfaceConfig(), context.getMethod()));
     setRequestObjectMethodFields(
         context,
         namer.getCallableMethodName(context.getMethod()),
@@ -267,7 +267,7 @@ public class StaticLangApiMethodTransformer {
         namer.getAsyncApiMethodName(
             context.getMethod(), context.getMethodConfig().getVisibility()));
     methodViewBuilder.exampleName(
-        namer.getAsyncApiMethodExampleName(context.getInterface(), context.getMethod()));
+        namer.getAsyncApiMethodExampleName(context.getInterfaceConfig(), context.getMethod()));
     setRequestObjectMethodFields(
         context,
         namer.getCallableAsyncMethodName(context.getMethod()),
@@ -288,7 +288,7 @@ public class StaticLangApiMethodTransformer {
     methodViewBuilder.exampleName(
         context
             .getNamer()
-            .getCallableMethodExampleName(context.getInterface(), context.getMethod()));
+            .getCallableMethodExampleName(context.getInterfaceConfig(), context.getMethod()));
     setCallableMethodFields(context, namer.getCallableName(context.getMethod()), methodViewBuilder);
     methodViewBuilder.responseTypeName(
         context.getTypeTable().getAndSaveNicknameFor(context.getMethod().getOutputType()));
@@ -308,7 +308,8 @@ public class StaticLangApiMethodTransformer {
     methodViewBuilder.exampleName(
         context
             .getNamer()
-            .getGrpcStreamingApiMethodExampleName(context.getInterface(), context.getMethod()));
+            .getGrpcStreamingApiMethodExampleName(
+                context.getInterfaceConfig(), context.getMethod()));
     setRequestObjectMethodFields(
         context,
         namer.getCallableMethodName(context.getMethod()),
@@ -333,7 +334,7 @@ public class StaticLangApiMethodTransformer {
     methodViewBuilder.name(
         namer.getApiMethodName(context.getMethod(), context.getMethodConfig().getVisibility()));
     methodViewBuilder.exampleName(
-        namer.getApiMethodExampleName(context.getInterface(), context.getMethod()));
+        namer.getApiMethodExampleName(context.getInterfaceConfig(), context.getMethod()));
     setRequestObjectMethodFields(
         context,
         namer.getCallableMethodName(context.getMethod()),
@@ -356,7 +357,7 @@ public class StaticLangApiMethodTransformer {
     methodViewBuilder.name(
         namer.getApiMethodName(context.getMethod(), context.getMethodConfig().getVisibility()));
     methodViewBuilder.exampleName(
-        namer.getApiMethodExampleName(context.getInterface(), context.getMethod()));
+        namer.getApiMethodExampleName(context.getInterfaceConfig(), context.getMethod()));
     methodViewBuilder.callableName(namer.getCallableName(context.getMethod()));
     setFlattenedMethodFields(context, additionalParams, Synchronicity.Sync, methodViewBuilder);
     methodViewBuilder.operationMethod(lroTransformer.generateDetailView(context));
@@ -387,7 +388,7 @@ public class StaticLangApiMethodTransformer {
         namer.getAsyncApiMethodName(
             context.getMethod(), context.getMethodConfig().getVisibility()));
     methodViewBuilder.exampleName(
-        namer.getAsyncApiMethodExampleName(context.getInterface(), context.getMethod()));
+        namer.getAsyncApiMethodExampleName(context.getInterfaceConfig(), context.getMethod()));
     methodViewBuilder.callableName(namer.getCallableName(context.getMethod()));
     setFlattenedMethodFields(context, additionalParams, Synchronicity.Async, methodViewBuilder);
     if (requiresOperationMethod) {
@@ -418,7 +419,7 @@ public class StaticLangApiMethodTransformer {
         namer.getAsyncApiMethodName(
             context.getMethod(), context.getMethodConfig().getVisibility()));
     methodViewBuilder.exampleName(
-        namer.getAsyncApiMethodExampleName(context.getInterface(), context.getMethod()));
+        namer.getAsyncApiMethodExampleName(context.getInterfaceConfig(), context.getMethod()));
     setRequestObjectMethodFields(
         context,
         namer.getOperationCallableMethodName(context.getMethod()),
@@ -444,7 +445,8 @@ public class StaticLangApiMethodTransformer {
     methodViewBuilder.exampleName(
         context
             .getNamer()
-            .getOperationCallableMethodExampleName(context.getInterface(), context.getMethod()));
+            .getOperationCallableMethodExampleName(
+                context.getInterfaceConfig(), context.getMethod()));
     setCallableMethodFields(
         context, namer.getOperationCallableName(context.getMethod()), methodViewBuilder);
     TypeRef returnType = context.getMethodConfig().getLongRunningConfig().getReturnType();
@@ -738,7 +740,9 @@ public class StaticLangApiMethodTransformer {
         }
         PathTemplateCheckView.Builder check = PathTemplateCheckView.newBuilder();
         check.pathTemplateName(
-            context.getNamer().getPathTemplateName(context.getInterface(), resourceNameConfig));
+            context
+                .getNamer()
+                .getPathTemplateName(context.getInterfaceConfig(), resourceNameConfig));
         check.paramName(context.getNamer().getVariableName(field));
         check.allowEmptyString(shouldAllowEmpty(context, field));
         check.validationMessageContext(

--- a/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
@@ -125,13 +125,13 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** Returns the service name exported by the package */
-  public String getPackageServiceName(Interface apiInterface) {
+  public String getPackageServiceName(InterfaceConfig interfaceConfig) {
     return getNotImplementedString("SurfaceNamer.getPackageServiceName");
   }
 
   /** Human-friendly name of this API interface */
-  public String getServicePhraseName(Interface apiInterface) {
-    return Name.upperCamel(apiInterface.getSimpleName()).toPhrase();
+  public String getServicePhraseName(InterfaceConfig interfaceConfig) {
+    return Name.upperCamel(interfaceConfig.getRawName()).toPhrase();
   }
 
   /////////////////////////////////////// Constructors /////////////////////////////////////////////
@@ -140,8 +140,8 @@ public class SurfaceNamer extends NameFormatterDelegator {
    * The name of the constructor for the apiInterface client. The client is VKit generated, not
    * GRPC.
    */
-  public String getApiWrapperClassConstructorName(Interface apiInterface) {
-    return publicClassName(Name.upperCamel(apiInterface.getSimpleName(), "Client"));
+  public String getApiWrapperClassConstructorName(InterfaceConfig interfaceConfig) {
+    return publicClassName(Name.upperCamel(interfaceConfig.getRawName(), "Client"));
   }
 
   /** Constructor name for the type with the given nickname. */
@@ -314,7 +314,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
   ///////////////////////////////// Function & Callable names /////////////////////////////////////
 
   /** The function name to retrieve default client option */
-  public String getDefaultApiSettingsFunctionName(Interface apiInterface) {
+  public String getDefaultApiSettingsFunctionName(InterfaceConfig interfaceConfig) {
     return getNotImplementedString("SurfaceNamer.getDefaultClientOptionFunctionName");
   }
 
@@ -475,8 +475,8 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** The function name to retrieve default call option */
-  public String getDefaultCallSettingsFunctionName(Interface apiInterface) {
-    return publicMethodName(Name.upperCamel(apiInterface.getSimpleName(), "Settings"));
+  public String getDefaultCallSettingsFunctionName(InterfaceConfig interfaceConfig) {
+    return publicMethodName(Name.upperCamel(interfaceConfig.getRawName(), "Settings"));
   }
 
   /** The name of the IAM resource getter function. */
@@ -609,13 +609,13 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** The name of the implementation class that implements a particular proto interface. */
-  public String getApiWrapperClassImplName(Interface apiInterface) {
+  public String getApiWrapperClassImplName(InterfaceConfig interfaceConfig) {
     return getNotImplementedString("SurfaceNamer.getApiWrapperClassImplName");
   }
 
   /** The name of the class that implements snippets for a particular proto interface. */
-  public String getApiSnippetsClassName(Interface apiInterface) {
-    return publicClassName(Name.upperCamel(apiInterface.getSimpleName(), "ApiSnippets"));
+  public String getApiSnippetsClassName(InterfaceConfig interfaceConfig) {
+    return publicClassName(Name.upperCamel(interfaceConfig.getRawName(), "ApiSnippets"));
   }
 
   /**
@@ -822,8 +822,8 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** The type name of call options */
-  public String getCallSettingsTypeName(Interface apiInterface) {
-    return publicClassName(Name.upperCamel(apiInterface.getSimpleName(), "Settings"));
+  public String getCallSettingsTypeName(InterfaceConfig interfaceConfig) {
+    return publicClassName(Name.upperCamel(interfaceConfig.getRawName(), "Settings"));
   }
 
   /** The name of the return type of the given grpc streaming method. */
@@ -984,13 +984,13 @@ public class SurfaceNamer extends NameFormatterDelegator {
    * class.
    */
   public String getPathTemplateName(
-      Interface apiInterface, SingleResourceNameConfig resourceNameConfig) {
+      InterfaceConfig interfaceConfig, SingleResourceNameConfig resourceNameConfig) {
     return inittedConstantName(Name.from(resourceNameConfig.getEntityName(), "path", "template"));
   }
 
   /** The name of a getter function to get a particular path template for the given collection. */
   public String getPathTemplateNameGetter(
-      Interface apiInterface, SingleResourceNameConfig resourceNameConfig) {
+      InterfaceConfig interfaceConfig, SingleResourceNameConfig resourceNameConfig) {
     return publicMethodName(
         Name.from("get", resourceNameConfig.getEntityName(), "name", "template"));
   }
@@ -1002,7 +1002,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
 
   /** The function name to format the entity for the given collection. */
   public String getFormatFunctionName(
-      Interface apiInterface, SingleResourceNameConfig resourceNameConfig) {
+      InterfaceConfig interfaceConfig, SingleResourceNameConfig resourceNameConfig) {
     return staticFunctionName(Name.from("format", resourceNameConfig.getEntityName(), "name"));
   }
 
@@ -1065,7 +1065,7 @@ public class SurfaceNamer extends NameFormatterDelegator {
   }
 
   /** The path to the client config for the given interface. */
-  public String getClientConfigPath(Interface apiInterface) {
+  public String getClientConfigPath(InterfaceConfig interfaceConfig) {
     return getNotImplementedString("SurfaceNamer.getClientConfigPath");
   }
 
@@ -1304,32 +1304,33 @@ public class SurfaceNamer extends NameFormatterDelegator {
    * The name of example of the constructor for the service client. The client is VKit generated,
    * not GRPC.
    */
-  public String getApiWrapperClassConstructorExampleName(Interface apiInterface) {
-    return getApiWrapperClassConstructorName(apiInterface);
+  public String getApiWrapperClassConstructorExampleName(InterfaceConfig interfaceConfig) {
+    return getApiWrapperClassConstructorName(interfaceConfig);
   }
 
   /** The name of the example for the paged callable variant. */
-  public String getPagedCallableMethodExampleName(Interface apiInterface, Method method) {
+  public String getPagedCallableMethodExampleName(InterfaceConfig interfaceConfig, Method method) {
     return getPagedCallableMethodName(method);
   }
 
   /** The name of the example for the plain callable variant. */
-  public String getCallableMethodExampleName(Interface apiInterface, Method method) {
+  public String getCallableMethodExampleName(InterfaceConfig interfaceConfig, Method method) {
     return getCallableMethodName(method);
   }
 
   /** The name of the example for the operation callable variant of the given method. */
-  public String getOperationCallableMethodExampleName(Interface apiInterface, Method method) {
+  public String getOperationCallableMethodExampleName(
+      InterfaceConfig interfaceConfig, Method method) {
     return getOperationCallableMethodName(method);
   }
 
   /** The name of the example for the method. */
-  public String getApiMethodExampleName(Interface apiInterface, Method method) {
+  public String getApiMethodExampleName(InterfaceConfig interfaceConfig, Method method) {
     return getApiMethodName(method, VisibilityConfig.PUBLIC);
   }
 
   /** The name of the example for the async variant of the given method. */
-  public String getAsyncApiMethodExampleName(Interface apiInterface, Method method) {
+  public String getAsyncApiMethodExampleName(InterfaceConfig interfaceConfig, Method method) {
     return getAsyncApiMethodName(method, VisibilityConfig.PUBLIC);
   }
 
@@ -1337,17 +1338,19 @@ public class SurfaceNamer extends NameFormatterDelegator {
    * The name of the example of the GRPC streaming surface method which can call the given API
    * method.
    */
-  public String getGrpcStreamingApiMethodExampleName(Interface apiInterface, Method method) {
+  public String getGrpcStreamingApiMethodExampleName(
+      InterfaceConfig interfaceConfig, Method method) {
     return getGrpcStreamingApiMethodName(method, VisibilityConfig.PUBLIC);
   }
 
   /** The example name of the IAM resource getter function. */
-  public String getIamResourceGetterFunctionExampleName(Interface apiInterface, Field field) {
+  public String getIamResourceGetterFunctionExampleName(
+      InterfaceConfig interfaceConfig, Field field) {
     return getIamResourceGetterFunctionName(field);
   }
 
   /** The file name for the example of an API interface. */
-  public String getExampleFileName(Interface apiInterface) {
+  public String getExampleFileName(InterfaceConfig interfaceConfig) {
     return getNotImplementedString("SurfaceNamer.getExampleFileName");
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/TestCaseTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/TestCaseTransformer.java
@@ -152,7 +152,7 @@ public class TestCaseTransformer {
             methodContext.getTypeTable().getFullNameFor(method.getInputType()))
         .fullyQualifiedResponseTypeName(fullyQualifiedResponseTypeName)
         .serviceConstructorName(
-            namer.getApiWrapperClassConstructorName(methodContext.getInterface()))
+            namer.getApiWrapperClassConstructorName(methodContext.getInterfaceConfig()))
         .fullyQualifiedServiceClassName(
             namer.getFullyQualifiedApiWrapperClassName(methodContext.getInterfaceConfig()))
         .fullyQualifiedAliasedServiceClassName(

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicClientTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicClientTransformer.java
@@ -173,7 +173,7 @@ public class CSharpGapicClientTransformer implements ModelToViewTransformer {
     apiClass.doc(serviceTransformer.generateServiceDoc(context, null));
 
     apiClass.name(namer.getApiWrapperClassName(context.getInterfaceConfig()));
-    apiClass.implName(namer.getApiWrapperClassImplName(context.getInterface()));
+    apiClass.implName(namer.getApiWrapperClassImplName(context.getInterfaceConfig()));
     apiClass.grpcServiceName(namer.getGrpcContainerTypeName(context.getInterface()));
     apiClass.grpcTypeName(namer.getGrpcServiceClassName(context.getInterface()));
     apiClass.settingsClassName(

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicSnippetsTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpGapicSnippetsTransformer.java
@@ -97,7 +97,7 @@ public class CSharpGapicSnippetsTransformer implements ModelToViewTransformer {
 
   private SnippetsFileView generateSnippets(GapicInterfaceContext context) {
     SurfaceNamer namer = context.getNamer();
-    String name = namer.getApiSnippetsClassName(context.getInterface());
+    String name = namer.getApiSnippetsClassName(context.getInterfaceConfig());
     SnippetsFileView.Builder snippetsBuilder = SnippetsFileView.newBuilder();
 
     snippetsBuilder.templateFileName(SNIPPETS_TEMPLATE_FILENAME);

--- a/src/main/java/com/google/api/codegen/transformer/csharp/CSharpSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/csharp/CSharpSurfaceNamer.java
@@ -18,6 +18,7 @@ import com.google.api.codegen.ServiceMessages;
 import com.google.api.codegen.config.FieldConfig;
 import com.google.api.codegen.config.GapicInterfaceConfig;
 import com.google.api.codegen.config.GapicMethodConfig;
+import com.google.api.codegen.config.InterfaceConfig;
 import com.google.api.codegen.config.ResourceNameConfig;
 import com.google.api.codegen.config.ResourceNameType;
 import com.google.api.codegen.config.SingleResourceNameConfig;
@@ -180,9 +181,9 @@ public class CSharpSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getApiSnippetsClassName(Interface apiInterface) {
+  public String getApiSnippetsClassName(InterfaceConfig interfaceConfig) {
     return publicClassName(
-        Name.upperCamel("Generated", apiInterface.getSimpleName(), "ClientSnippets"));
+        Name.upperCamel("Generated", interfaceConfig.getRawName(), "ClientSnippets"));
   }
 
   @Override
@@ -199,7 +200,7 @@ public class CSharpSurfaceNamer extends SurfaceNamer {
 
   @Override
   public String getPathTemplateName(
-      Interface apiInterface, SingleResourceNameConfig resourceNameConfig) {
+      InterfaceConfig interfaceConfig, SingleResourceNameConfig resourceNameConfig) {
     return inittedConstantName(Name.from(resourceNameConfig.getEntityName(), "template"));
   }
 
@@ -272,7 +273,7 @@ public class CSharpSurfaceNamer extends SurfaceNamer {
 
   @Override
   public String getFormatFunctionName(
-      Interface apiInterface, SingleResourceNameConfig resourceNameConfig) {
+      InterfaceConfig interfaceConfig, SingleResourceNameConfig resourceNameConfig) {
     return getResourceTypeName(resourceNameConfig);
   }
 
@@ -353,8 +354,8 @@ public class CSharpSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getApiWrapperClassImplName(Interface apiInterface) {
-    return publicClassName(Name.upperCamel(apiInterface.getSimpleName(), "ClientImpl"));
+  public String getApiWrapperClassImplName(InterfaceConfig interfaceConfig) {
+    return publicClassName(Name.upperCamel(interfaceConfig.getRawName(), "ClientImpl"));
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTestTransformer.java
@@ -108,7 +108,7 @@ public class GoGapicSurfaceTestTransformer implements ModelToViewTransformer {
       impls.add(
           MockServiceImplView.newBuilder()
               .grpcClassName(namer.getGrpcServerTypeName(apiInterface))
-              .name(namer.getMockGrpcServiceImplName(apiInterface))
+              .name(namer.getMockGrpcServiceImplName(context.getInterface()))
               .grpcMethods(mockServiceTransformer.createMockGrpcMethodViews(context))
               .build());
     }

--- a/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/go/GoGapicSurfaceTransformer.java
@@ -132,12 +132,15 @@ public class GoGapicSurfaceTransformer implements ModelToViewTransformer {
     view.templateFileName(API_TEMPLATE_FILENAME);
     view.serviceDoc(serviceTransformer.generateServiceDoc(context, null));
     view.clientTypeName(namer.getApiWrapperClassName(context.getInterfaceConfig()));
-    view.clientConstructorName(namer.getApiWrapperClassConstructorName(apiInterface));
-    view.defaultClientOptionFunctionName(namer.getDefaultApiSettingsFunctionName(apiInterface));
-    view.defaultCallOptionFunctionName(namer.getDefaultCallSettingsFunctionName(apiInterface));
-    view.callOptionsTypeName(namer.getCallSettingsTypeName(apiInterface));
+    view.clientConstructorName(
+        namer.getApiWrapperClassConstructorName(context.getInterfaceConfig()));
+    view.defaultClientOptionFunctionName(
+        namer.getDefaultApiSettingsFunctionName(context.getInterfaceConfig()));
+    view.defaultCallOptionFunctionName(
+        namer.getDefaultCallSettingsFunctionName(context.getInterfaceConfig()));
+    view.callOptionsTypeName(namer.getCallSettingsTypeName(context.getInterfaceConfig()));
     view.serviceOriginalName(model.getServiceConfig().getTitle());
-    view.servicePhraseName(namer.getServicePhraseName(apiInterface));
+    view.servicePhraseName(namer.getServicePhraseName(context.getInterfaceConfig()));
 
     String outputPath = pathMapper.getOutputPath(apiInterface, productConfig);
     String fileName = namer.getServiceFileName(context.getInterfaceConfig());
@@ -201,12 +204,14 @@ public class GoGapicSurfaceTransformer implements ModelToViewTransformer {
     view.templateFileName(SAMPLE_TEMPLATE_FILENAME);
 
     String outputPath = pathMapper.getOutputPath(apiInterface, productConfig);
-    String fileName = namer.getExampleFileName(apiInterface);
+    String fileName = namer.getExampleFileName(context.getInterfaceConfig());
     view.outputPath(outputPath + File.separator + fileName);
 
     view.clientTypeName(namer.getApiWrapperClassName(context.getInterfaceConfig()));
-    view.clientConstructorName(namer.getApiWrapperClassConstructorName(apiInterface));
-    view.clientConstructorExampleName(namer.getApiWrapperClassConstructorExampleName(apiInterface));
+    view.clientConstructorName(
+        namer.getApiWrapperClassConstructorName(context.getInterfaceConfig()));
+    view.clientConstructorExampleName(
+        namer.getApiWrapperClassConstructorExampleName(context.getInterfaceConfig()));
     view.apiMethods(generateApiMethods(context, context.getPublicMethods()));
     view.iamResources(iamResourceTransformer.generateIamResources(context));
 

--- a/src/main/java/com/google/api/codegen/transformer/go/GoSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/go/GoSurfaceNamer.java
@@ -65,9 +65,9 @@ public class GoSurfaceNamer extends SurfaceNamer {
 
   @Override
   public String getPathTemplateName(
-      Interface apiInterface, SingleResourceNameConfig resourceNameConfig) {
+      InterfaceConfig interfaceConfig, SingleResourceNameConfig resourceNameConfig) {
     return inittedConstantName(
-        getReducedServiceName(apiInterface.getSimpleName())
+        getReducedServiceName(interfaceConfig.getRawName())
             .join(resourceNameConfig.getEntityName())
             .join("path")
             .join("template"));
@@ -75,15 +75,15 @@ public class GoSurfaceNamer extends SurfaceNamer {
 
   @Override
   public String getPathTemplateNameGetter(
-      Interface apiInterface, SingleResourceNameConfig resourceNameConfig) {
-    return getFormatFunctionName(apiInterface, resourceNameConfig);
+      InterfaceConfig interfaceConfig, SingleResourceNameConfig resourceNameConfig) {
+    return getFormatFunctionName(interfaceConfig, resourceNameConfig);
   }
 
   @Override
   public String getFormatFunctionName(
-      Interface apiInterface, SingleResourceNameConfig resourceNameConfig) {
+      InterfaceConfig interfaceConfig, SingleResourceNameConfig resourceNameConfig) {
     return publicMethodName(
-        clientNamePrefix(apiInterface.getSimpleName())
+        clientNamePrefix(interfaceConfig.getRawName())
             .join(resourceNameConfig.getEntityName())
             .join("path"));
   }
@@ -178,25 +178,25 @@ public class GoSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getCallSettingsTypeName(Interface apiInterface) {
+  public String getCallSettingsTypeName(InterfaceConfig interfaceConfig) {
     return publicClassName(
-        clientNamePrefix(apiInterface.getSimpleName()).join("call").join("options"));
+        clientNamePrefix(interfaceConfig.getRawName()).join("call").join("options"));
   }
 
   @Override
-  public String getDefaultApiSettingsFunctionName(Interface apiInterface) {
+  public String getDefaultApiSettingsFunctionName(InterfaceConfig interfaceConfig) {
     return privateMethodName(
         Name.from("default")
-            .join(clientNamePrefix(apiInterface.getSimpleName()))
+            .join(clientNamePrefix(interfaceConfig.getRawName()))
             .join("client")
             .join("options"));
   }
 
   @Override
-  public String getDefaultCallSettingsFunctionName(Interface apiInterface) {
+  public String getDefaultCallSettingsFunctionName(InterfaceConfig interfaceConfig) {
     return privateMethodName(
         Name.from("default")
-            .join(clientNamePrefix(apiInterface.getSimpleName()))
+            .join(clientNamePrefix(interfaceConfig.getRawName()))
             .join("call")
             .join("options"));
   }
@@ -208,35 +208,33 @@ public class GoSurfaceNamer extends SurfaceNamer {
 
   @Override
   public String getApiWrapperClassName(InterfaceConfig interfaceConfig) {
-    // TODO support non-Gapic inputs
-    GapicInterfaceConfig gapicInterfaceConfig = (GapicInterfaceConfig) interfaceConfig;
-    return publicClassName(
-        clientNamePrefix(gapicInterfaceConfig.getInterface().getSimpleName()).join("client"));
+    return publicClassName(clientNamePrefix(interfaceConfig.getRawName()).join("client"));
   }
 
   @Override
-  public String getApiWrapperClassConstructorName(Interface apiInterface) {
+  public String getApiWrapperClassConstructorName(InterfaceConfig interfaceConfig) {
     return publicMethodName(
-        Name.from("new").join(clientNamePrefix(apiInterface.getSimpleName())).join("client"));
+        Name.from("new").join(clientNamePrefix(interfaceConfig.getRawName())).join("client"));
   }
 
   @Override
-  public String getApiWrapperClassConstructorExampleName(Interface apiInterface) {
+  public String getApiWrapperClassConstructorExampleName(InterfaceConfig interfaceConfig) {
     return publicMethodName(
         Name.from("example")
             .join("new")
-            .join(clientNamePrefix(apiInterface.getSimpleName()))
+            .join(clientNamePrefix(interfaceConfig.getRawName()))
             .join("client"));
   }
 
   @Override
-  public String getApiMethodExampleName(Interface apiInterface, Method method) {
-    return exampleFunction(apiInterface, getApiMethodName(method, VisibilityConfig.PUBLIC));
+  public String getApiMethodExampleName(InterfaceConfig interfaceConfig, Method method) {
+    return exampleFunction(interfaceConfig, getApiMethodName(method, VisibilityConfig.PUBLIC));
   }
 
   @Override
-  public String getGrpcStreamingApiMethodExampleName(Interface apiInterface, Method method) {
-    return exampleFunction(apiInterface, getApiMethodName(method, VisibilityConfig.PUBLIC));
+  public String getGrpcStreamingApiMethodExampleName(
+      InterfaceConfig interfaceConfig, Method method) {
+    return exampleFunction(interfaceConfig, getApiMethodName(method, VisibilityConfig.PUBLIC));
   }
 
   @Override
@@ -299,9 +297,9 @@ public class GoSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getExampleFileName(Interface apiInterface) {
+  public String getExampleFileName(InterfaceConfig interfaceConfig) {
     return classFileNameBase(
-        getReducedServiceName(apiInterface.getSimpleName())
+        getReducedServiceName(interfaceConfig.getRawName())
             .join("client")
             .join("example")
             .join("test"));
@@ -343,8 +341,9 @@ public class GoSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getIamResourceGetterFunctionExampleName(Interface apiInterface, Field field) {
-    return exampleFunction(apiInterface, getIamResourceGetterFunctionName(field));
+  public String getIamResourceGetterFunctionExampleName(
+      InterfaceConfig interfaceConfig, Field field) {
+    return exampleFunction(interfaceConfig, getIamResourceGetterFunctionName(field));
   }
 
   @Override
@@ -352,13 +351,13 @@ public class GoSurfaceNamer extends SurfaceNamer {
     return publicFieldName(Name.upperCamel(method.getSimpleName()));
   }
 
-  private String exampleFunction(Interface apiInterface, String functionName) {
+  private String exampleFunction(InterfaceConfig interfaceConfig, String functionName) {
     // We use "unsafe" string concatenation here.
     // Godoc expects the name to be in format "ExampleMyType_MyMethod";
     // it is the only place we have mixed camel and underscore names.
     return publicMethodName(
             Name.from("example")
-                .join(clientNamePrefix(apiInterface.getSimpleName()))
+                .join(clientNamePrefix(interfaceConfig.getRawName()))
                 .join("client"))
         + "_"
         + functionName;

--- a/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/java/JavaSurfaceNamer.java
@@ -19,6 +19,7 @@ import com.google.api.codegen.ServiceMessages;
 import com.google.api.codegen.config.FieldConfig;
 import com.google.api.codegen.config.GapicInterfaceConfig;
 import com.google.api.codegen.config.GapicMethodConfig;
+import com.google.api.codegen.config.InterfaceConfig;
 import com.google.api.codegen.config.ResourceNameType;
 import com.google.api.codegen.metacode.InitFieldConfig;
 import com.google.api.codegen.transformer.ModelTypeFormatterImpl;
@@ -32,7 +33,6 @@ import com.google.api.codegen.util.java.JavaRenderingUtil;
 import com.google.api.codegen.util.java.JavaTypeTable;
 import com.google.api.codegen.viewmodel.ServiceMethodType;
 import com.google.api.tools.framework.model.Field;
-import com.google.api.tools.framework.model.Interface;
 import com.google.api.tools.framework.model.Method;
 import com.google.api.tools.framework.model.TypeRef;
 import com.google.common.base.Joiner;
@@ -64,8 +64,8 @@ public class JavaSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getApiSnippetsClassName(Interface apiInterface) {
-    return publicClassName(Name.upperCamel(apiInterface.getSimpleName(), "ClientSnippets"));
+  public String getApiSnippetsClassName(InterfaceConfig interfaceConfig) {
+    return publicClassName(Name.upperCamel(interfaceConfig.getRawName(), "ClientSnippets"));
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTestTransformer.java
@@ -112,8 +112,8 @@ public class NodeJSGapicSurfaceTestTransformer implements ModelToViewTransformer
               apiInterface, productConfig, typeTable, namer, featureConfig);
       impls.add(
           MockServiceImplView.newBuilder()
-              .grpcClassName(namer.getGrpcServerTypeName(apiInterface))
-              .name(namer.getMockGrpcServiceImplName(apiInterface))
+              .grpcClassName(namer.getGrpcServerTypeName(context.getInterface()))
+              .name(namer.getMockGrpcServiceImplName(context.getInterface()))
               .grpcMethods(mockServiceTransformer.createMockGrpcMethodViews(context))
               .build());
     }
@@ -134,7 +134,7 @@ public class NodeJSGapicSurfaceTestTransformer implements ModelToViewTransformer
                       "NodeJSGapicSurfaceTestTransformer.generateTestView - name"))
               .testCases(createTestCaseViews(context))
               .apiHasLongRunningMethods(context.getInterfaceConfig().hasLongRunningOperations())
-              .packageServiceName(namer.getPackageServiceName(apiInterface))
+              .packageServiceName(namer.getPackageServiceName(context.getInterfaceConfig()))
               .missingDefaultServiceAddress(
                   !context.getInterfaceConfig().hasDefaultServiceAddress())
               .missingDefaultServiceScopes(!context.getInterfaceConfig().hasDefaultServiceScopes())

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSGapicSurfaceTransformer.java
@@ -152,7 +152,7 @@ public class NodeJSGapicSurfaceTransformer implements ModelToViewTransformer {
 
     xapiClass.methodKeys(ImmutableList.<String>of());
     xapiClass.interfaceKey(context.getInterface().getFullName());
-    xapiClass.clientConfigPath(namer.getClientConfigPath(context.getInterface()));
+    xapiClass.clientConfigPath(namer.getClientConfigPath(context.getInterfaceConfig()));
     xapiClass.grpcClientTypeName(
         namer.getAndSaveNicknameForGrpcClientTypeName(
             context.getModelTypeTable(), context.getInterface()));
@@ -165,10 +165,11 @@ public class NodeJSGapicSurfaceTransformer implements ModelToViewTransformer {
         packageConfig.generatedPackageVersionBound(TargetLanguage.NODEJS).lower());
 
     xapiClass.packageHasMultipleServices(hasMultipleServices);
-    xapiClass.packageServiceName(namer.getPackageServiceName(context.getInterface()));
+    xapiClass.packageServiceName(namer.getPackageServiceName(context.getInterfaceConfig()));
 
     xapiClass.validDescriptorsNames(generateValidDescriptorsNames(context));
-    xapiClass.constructorName(namer.getApiWrapperClassConstructorName(context.getInterface()));
+    xapiClass.constructorName(
+        namer.getApiWrapperClassConstructorName(context.getInterfaceConfig()));
     xapiClass.isGcloud(NodeJSUtils.isGcloud(context.getProductConfig()));
 
     return xapiClass.build();
@@ -276,12 +277,12 @@ public class NodeJSGapicSurfaceTransformer implements ModelToViewTransformer {
           VersionIndexRequireView.newBuilder()
               .clientName(
                   namer.getApiWrapperVariableName(productConfig.getInterfaceConfig(apiInterface)))
-              .serviceName(namer.getPackageServiceName(apiInterface))
+              .serviceName(namer.getPackageServiceName(context.getInterfaceConfig()))
               .localName(localName)
               .doc(
                   serviceTransformer.generateServiceDoc(
                       context, generateApiMethods(context, packageHasMultipleServices).get(0)))
-              .fileName(namer.getClientFileName(apiInterface))
+              .fileName(namer.getClientFileName(context.getInterfaceConfig()))
               .build();
       requireViews.add(require);
     }

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSImportSectionTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSImportSectionTransformer.java
@@ -24,7 +24,6 @@ import com.google.api.codegen.transformer.StandardImportSectionTransformer;
 import com.google.api.codegen.viewmodel.ImportFileView;
 import com.google.api.codegen.viewmodel.ImportSectionView;
 import com.google.api.codegen.viewmodel.ImportTypeView;
-import com.google.api.tools.framework.model.Interface;
 import com.google.common.collect.ImmutableList;
 import java.util.Collections;
 import java.util.List;
@@ -46,8 +45,7 @@ public class NodeJSImportSectionTransformer implements ImportSectionTransformer 
 
   private List<ImportFileView> generateExternalImports(GapicInterfaceContext context) {
     ImmutableList.Builder<ImportFileView> imports = ImmutableList.builder();
-    Interface apiInterface = context.getInterface();
-    String configModule = context.getNamer().getClientConfigPath(apiInterface);
+    String configModule = context.getNamer().getClientConfigPath(context.getInterfaceConfig());
     imports.add(createImport("configData", "./" + configModule));
     imports.add(createImport("extend", "extend"));
     imports.add(createImport("gax", "google-gax"));

--- a/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/nodejs/NodeJSSurfaceNamer.java
@@ -19,6 +19,7 @@ import com.google.api.codegen.config.FieldConfig;
 import com.google.api.codegen.config.GapicInterfaceConfig;
 import com.google.api.codegen.config.GapicMethodConfig;
 import com.google.api.codegen.config.GrpcStreamingConfig.GrpcStreamingType;
+import com.google.api.codegen.config.InterfaceConfig;
 import com.google.api.codegen.config.SingleResourceNameConfig;
 import com.google.api.codegen.config.VisibilityConfig;
 import com.google.api.codegen.metacode.InitFieldConfig;
@@ -97,13 +98,13 @@ public class NodeJSSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getPackageServiceName(Interface apiInterface) {
-    return getReducedServiceName(apiInterface.getSimpleName()).toLowerCamel();
+  public String getPackageServiceName(InterfaceConfig interfaceConfig) {
+    return getReducedServiceName(interfaceConfig.getRawName()).toLowerCamel();
   }
 
   @Override
-  public String getApiWrapperClassConstructorName(Interface apiInterface) {
-    return publicFieldName(Name.upperCamel(apiInterface.getSimpleName(), "Client"));
+  public String getApiWrapperClassConstructorName(InterfaceConfig interfaceConfig) {
+    return publicFieldName(Name.upperCamel(interfaceConfig.getRawName(), "Client"));
   }
 
   @Override
@@ -117,7 +118,7 @@ public class NodeJSSurfaceNamer extends SurfaceNamer {
 
   @Override
   public String getPathTemplateName(
-      Interface apiInterface, SingleResourceNameConfig resourceNameConfig) {
+      InterfaceConfig interfaceConfig, SingleResourceNameConfig resourceNameConfig) {
     return inittedConstantName(Name.from(resourceNameConfig.getEntityName(), "path", "template"));
   }
 
@@ -129,17 +130,17 @@ public class NodeJSSurfaceNamer extends SurfaceNamer {
 
   @Override
   public String getFormatFunctionName(
-      Interface apiInterface, SingleResourceNameConfig resourceNameConfig) {
+      InterfaceConfig interfaceConfig, SingleResourceNameConfig resourceNameConfig) {
     return staticFunctionName(Name.from(resourceNameConfig.getEntityName(), "path"));
   }
 
   @Override
-  public String getClientConfigPath(Interface apiInterface) {
-    return Name.upperCamel(apiInterface.getSimpleName()).join("client_config").toLowerUnderscore();
+  public String getClientConfigPath(InterfaceConfig interfaceConfig) {
+    return Name.upperCamel(interfaceConfig.getRawName()).join("client_config").toLowerUnderscore();
   }
 
-  public String getClientFileName(Interface apiInterface) {
-    return Name.upperCamel(apiInterface.getSimpleName()).join("client").toLowerUnderscore();
+  public String getClientFileName(InterfaceConfig interfaceConfig) {
+    return Name.upperCamel(interfaceConfig.getRawName()).join("client").toLowerUnderscore();
   }
 
   @Override

--- a/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpGapicSurfaceTransformer.java
@@ -138,7 +138,7 @@ public class PhpGapicSurfaceTransformer implements ModelToViewTransformer {
     xapiClass.grpcStreamingDescriptors(createGrpcStreamingDescriptors(context));
 
     xapiClass.methodKeys(generateMethodKeys(context));
-    xapiClass.clientConfigPath(namer.getClientConfigPath(context.getInterface()));
+    xapiClass.clientConfigPath(namer.getClientConfigPath(context.getInterfaceConfig()));
     xapiClass.interfaceKey(context.getInterface().getFullName());
     String grpcClientTypeName =
         namer.getAndSaveNicknameForGrpcClientTypeName(

--- a/src/main/java/com/google/api/codegen/transformer/php/PhpSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/php/PhpSurfaceNamer.java
@@ -17,6 +17,7 @@ package com.google.api.codegen.transformer.php;
 import com.google.api.codegen.ServiceMessages;
 import com.google.api.codegen.config.GapicInterfaceConfig;
 import com.google.api.codegen.config.GapicMethodConfig;
+import com.google.api.codegen.config.InterfaceConfig;
 import com.google.api.codegen.config.SingleResourceNameConfig;
 import com.google.api.codegen.config.VisibilityConfig;
 import com.google.api.codegen.transformer.ModelTypeFormatterImpl;
@@ -68,14 +69,14 @@ public class PhpSurfaceNamer extends SurfaceNamer {
 
   @Override
   public String getPathTemplateName(
-      Interface apiInterface, SingleResourceNameConfig resourceNameConfig) {
+      InterfaceConfig interfaceConfig, SingleResourceNameConfig resourceNameConfig) {
     return inittedConstantName(Name.from(resourceNameConfig.getEntityName(), "name", "template"));
   }
 
   @Override
-  public String getClientConfigPath(Interface apiInterface) {
+  public String getClientConfigPath(InterfaceConfig interfaceConfig) {
     return "resources/"
-        + Name.upperCamel(apiInterface.getSimpleName()).join("client_config").toLowerUnderscore()
+        + Name.upperCamel(interfaceConfig.getRawName()).join("client_config").toLowerUnderscore()
         + ".json";
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/py/PythonSurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/py/PythonSurfaceNamer.java
@@ -64,8 +64,8 @@ public class PythonSurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getApiWrapperClassConstructorName(Interface apiInterface) {
-    return getApiWrapperClassName(apiInterface.getSimpleName());
+  public String getApiWrapperClassConstructorName(InterfaceConfig interfaceConfig) {
+    return getApiWrapperClassName(interfaceConfig.getRawName());
   }
 
   @Override
@@ -155,14 +155,14 @@ public class PythonSurfaceNamer extends SurfaceNamer {
 
   @Override
   public String getPathTemplateName(
-      Interface service, SingleResourceNameConfig resourceNameConfig) {
+      InterfaceConfig interfaceConfig, SingleResourceNameConfig resourceNameConfig) {
     return "_"
         + inittedConstantName(Name.from(resourceNameConfig.getEntityName(), "path", "template"));
   }
 
   @Override
   public String getFormatFunctionName(
-      Interface apiInterface, SingleResourceNameConfig resourceNameConfig) {
+      InterfaceConfig interfaceConfig, SingleResourceNameConfig resourceNameConfig) {
     return staticFunctionName(Name.from(resourceNameConfig.getEntityName(), "path"));
   }
 

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubyGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubyGapicSurfaceTransformer.java
@@ -171,7 +171,7 @@ public class RubyGapicSurfaceTransformer implements ModelToViewTransformer {
 
     xapiClass.methodKeys(ImmutableList.<String>of());
     xapiClass.interfaceKey(context.getInterface().getFullName());
-    xapiClass.clientConfigPath(namer.getClientConfigPath(context.getInterface()));
+    xapiClass.clientConfigPath(namer.getClientConfigPath(context.getInterfaceConfig()));
     xapiClass.grpcClientTypeName(
         namer.getAndSaveNicknameForGrpcClientTypeName(
             context.getModelTypeTable(), context.getInterface()));
@@ -210,7 +210,7 @@ public class RubyGapicSurfaceTransformer implements ModelToViewTransformer {
           VersionIndexRequireView.newBuilder()
               .clientName(namer.getFullyQualifiedApiWrapperClassName(interfaceConfig))
               .fileName(namer.getServiceFileName(interfaceConfig))
-              .serviceName(namer.getPackageServiceName(apiInterface))
+              .serviceName(namer.getPackageServiceName(interfaceConfig))
               .doc(
                   serviceTransformer.generateServiceDoc(
                       context, generateApiMethods(context).get(0)))
@@ -297,7 +297,7 @@ public class RubyGapicSurfaceTransformer implements ModelToViewTransformer {
     for (Interface apiInterface : interfaces) {
       GapicInterfaceContext context = createContext(apiInterface, productConfig);
       String clientName = namer.getPackageName();
-      String serviceName = namer.getPackageServiceName(apiInterface);
+      String serviceName = namer.getPackageServiceName(context.getInterfaceConfig());
       if (hasMultipleServices) {
         clientName += "::" + serviceName;
       }

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubySurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubySurfaceNamer.java
@@ -18,6 +18,7 @@ import com.google.api.codegen.ServiceMessages;
 import com.google.api.codegen.config.FieldConfig;
 import com.google.api.codegen.config.GapicInterfaceConfig;
 import com.google.api.codegen.config.GapicMethodConfig;
+import com.google.api.codegen.config.InterfaceConfig;
 import com.google.api.codegen.config.SingleResourceNameConfig;
 import com.google.api.codegen.config.VisibilityConfig;
 import com.google.api.codegen.metacode.InitFieldConfig;
@@ -64,8 +65,8 @@ public class RubySurfaceNamer extends SurfaceNamer {
 
   /** The name of the class that implements snippets for a particular proto interface. */
   @Override
-  public String getApiSnippetsClassName(Interface apiInterface) {
-    return publicClassName(Name.upperCamel(apiInterface.getSimpleName(), "ClientSnippets"));
+  public String getApiSnippetsClassName(InterfaceConfig interfaceConfig) {
+    return publicClassName(Name.upperCamel(interfaceConfig.getRawName(), "ClientSnippets"));
   }
 
   /** The function name to set a field having the given type and name. */
@@ -77,7 +78,7 @@ public class RubySurfaceNamer extends SurfaceNamer {
   /** The function name to format the entity for the given collection. */
   @Override
   public String getFormatFunctionName(
-      Interface apiInterface, SingleResourceNameConfig resourceNameConfig) {
+      InterfaceConfig interfaceConfig, SingleResourceNameConfig resourceNameConfig) {
     return staticFunctionName(Name.from(resourceNameConfig.getEntityName(), "path"));
   }
 
@@ -88,8 +89,8 @@ public class RubySurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getClientConfigPath(Interface apiInterface) {
-    return Name.upperCamel(apiInterface.getSimpleName()).join("client_config").toLowerUnderscore()
+  public String getClientConfigPath(InterfaceConfig interfaceConfig) {
+    return Name.upperCamel(interfaceConfig.getRawName()).join("client_config").toLowerUnderscore()
         + ".json";
   }
 
@@ -263,7 +264,7 @@ public class RubySurfaceNamer extends SurfaceNamer {
   public String getTopLevelAliasedApiClassName(
       GapicInterfaceConfig interfaceConfig, boolean packageHasMultipleServices) {
     return packageHasMultipleServices
-        ? getTopLevelNamespace() + "::" + getPackageServiceName(interfaceConfig.getInterface())
+        ? getTopLevelNamespace() + "::" + getPackageServiceName(interfaceConfig)
         : getTopLevelNamespace();
   }
 
@@ -271,7 +272,7 @@ public class RubySurfaceNamer extends SurfaceNamer {
   public String getVersionAliasedApiClassName(
       GapicInterfaceConfig interfaceConfig, boolean packageHasMultipleServices) {
     return packageHasMultipleServices
-        ? getPackageName() + "::" + getPackageServiceName(interfaceConfig.getInterface())
+        ? getPackageName() + "::" + getPackageServiceName(interfaceConfig)
         : getPackageName();
   }
 
@@ -375,7 +376,7 @@ public class RubySurfaceNamer extends SurfaceNamer {
   }
 
   @Override
-  public String getPackageServiceName(Interface apiInterface) {
-    return publicClassName(getReducedServiceName(apiInterface.getSimpleName()));
+  public String getPackageServiceName(InterfaceConfig interfaceConfig) {
+    return publicClassName(getReducedServiceName(interfaceConfig.getRawName()));
   }
 }


### PR DESCRIPTION
Go uses the interface name as parts of many other names
in the client.
This commit makes the rename available to SurfaceNamer implementations.
The renaming itself is not "threaded through" yet.
Since this change is already large, I plan to do this in a follow-up commit.

An alternative to this is to give GoSurfaceNamer the rename map.
This would put renaming logic in two places, but it will isolate the change
to Go and leave other languages alone.
Reviewers, please let me know if you'd rather I do that instead.

I tested that Go and Java googleapis clients remain the same after this change.