### PR TITLE
build.gradle: stop using << in tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -212,8 +212,10 @@ task setupProtocEnvironment {
 
 test.dependsOn setupProtocEnvironment
 
-task showRuntimeClassPath << {
-  println 'output: ' + sourceSets.main.runtimeClasspath.asPath
+task showRuntimeClassPath {
+  doLast {
+    println 'output: ' + sourceSets.main.runtimeClasspath.asPath
+  }
 }
 
 // Test Logging
@@ -358,11 +360,13 @@ allprojects {
   }
 }
 
-task createProperties(dependsOn: processResources) << {
-  new File("$buildDir/resources/main/com/google/api/codegen/").mkdirs()
-  Properties p = new Properties()
-  p['version'] = project.version.toString()
-  p.store(new PrintWriter("$buildDir/resources/main/com/google/api/codegen/codegen.properties", 'UTF-8'), null)
+task createProperties(dependsOn: processResources) {
+  doLast{
+    new File("$buildDir/resources/main/com/google/api/codegen/").mkdirs()
+    Properties p = new Properties()
+    p['version'] = project.version.toString()
+    p.store(new PrintWriter("$buildDir/resources/main/com/google/api/codegen/codegen.properties", 'UTF-8'), null)
+  }
 }
 
 classes {
@@ -396,24 +400,30 @@ task runSynchronizer(type: JavaExec) {
 }
 
 // Task to display the cache path of GRPC Java plugin
-task showGrpcJavaPluginPath << {
-  DependencyResolver resolver = new DependencyResolver(project)
-  println 'output: ' + resolver.resolveExecutable(
-    'io.grpc:protoc-gen-grpc-java:1.2.0')
+task showGrpcJavaPluginPath {
+  doLast {
+    DependencyResolver resolver = new DependencyResolver(project)
+    println 'output: ' + resolver.resolveExecutable(
+      'io.grpc:protoc-gen-grpc-java:1.2.0')
+  }
 }
 
 // Task to display the cache path of protobuf
-task showProtobufPath() << {
-  DependencyResolver resolver = new DependencyResolver(project)
-  println 'output: ' + resolver.extractArchive(
-    'com.google.protobuf:protobuf-java:' + protoVersion);
+task showProtobufPath() {
+  doLast {
+    DependencyResolver resolver = new DependencyResolver(project)
+    println 'output: ' + resolver.extractArchive(
+      'com.google.protobuf:protobuf-java:' + protoVersion);
+  }
 }
 
 // Task to display the cache path of Google Java formatter
-task showJavaFormatterPath << {
-  DependencyResolver resolver = new DependencyResolver(project)
-  println 'output: ' + resolver.locateArchive(
-    'com.google.googlejavaformat:google-java-format:1.1:all-deps')
+task showJavaFormatterPath {
+  doLast {
+    DependencyResolver resolver = new DependencyResolver(project)
+    println 'output: ' + resolver.locateArchive(
+      'com.google.googlejavaformat:google-java-format:1.1:all-deps')
+  }
 }
 
 // Task to run ConfigGeneratorTool
@@ -460,19 +470,21 @@ task runDiscoBatch(type: JavaExec) {
   }
 }
 
-task verifyLicense << {
-  def licenseText = new File(rootProject.rootDir, 'license-header-javadoc.txt').text
-  def srcFiles = []
-  sourceSets
-      .collectMany{it.allJava.getSrcDirs()}
-      .each{it.eachFileRecurse(FileType.FILES, {srcFiles << new Tuple(it, it.text)})}
-  srcFiles = srcFiles
-      .findAll{!it.get(0).path.contains('/generated/') && it.get(0).path.endsWith('.java')}
-      .collect{new Tuple(it.get(0), it.get(1).replaceAll("Copyright 20[0-9]{2}", 'Copyright 20xx'))}
-      .findAll{!it.get(1).startsWith(licenseText)}
-  if (srcFiles.asList().size() > 0) {
-    srcFiles.each({println 'missing license: ' + it.get(0)})
-    throw new IllegalStateException('Above files do not have licenses')
+task verifyLicense {
+  doLast {
+    def licenseText = new File(rootProject.rootDir, 'license-header-javadoc.txt').text
+    def srcFiles = []
+    sourceSets
+        .collectMany{it.allJava.getSrcDirs()}
+        .each{it.eachFileRecurse(FileType.FILES, {srcFiles << new Tuple(it, it.text)})}
+    srcFiles = srcFiles
+        .findAll{!it.get(0).path.contains('/generated/') && it.get(0).path.endsWith('.java')}
+        .collect{new Tuple(it.get(0), it.get(1).replaceAll("Copyright 20[0-9]{2}", 'Copyright 20xx'))}
+        .findAll{!it.get(1).startsWith(licenseText)}
+    if (srcFiles.asList().size() > 0) {
+      srcFiles.each({println 'missing license: ' + it.get(0)})
+      throw new IllegalStateException('Above files do not have licenses')
+    }
   }
 }
 


### PR DESCRIPTION
The << operation is deprecated. Gradle docs suggest we use doLast instead.