### PR TITLE
Ruby: update tests to stop using default credentials.

### DIFF
--- a/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/SurfaceNamer.java
@@ -179,6 +179,11 @@ public class SurfaceNamer extends NameFormatterDelegator {
     return qualifiedName(namePath.withoutHead());
   }
 
+  /** The qualified namespace of an API. */
+  public String getTopLevelNamespace() {
+    return getNotImplementedString("SurfaceNamer.getTopLevelNamespace");
+  }
+
   /** The modules of the package. */
   public ImmutableList<String> getApiModules() {
     return ImmutableList.<String>of();
@@ -961,6 +966,10 @@ public class SurfaceNamer extends NameFormatterDelegator {
 
   public String getStreamTypeName(GrpcStreamingConfig.GrpcStreamingType type) {
     return getNotImplementedString("SurfaceNamer.getStreamTypeName");
+  }
+
+  public String getFullyQualifiedCredentialsClassName() {
+    return getNotImplementedString("SurfaceNamer.getFullyQualifiedCredentialsClassName");
   }
 
   /////////////////////////////////////// Resource names //////////////////////////////////////////

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubyGapicSurfaceTestTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubyGapicSurfaceTestTransformer.java
@@ -130,6 +130,7 @@ public class RubyGapicSurfaceTestTransformer implements ModelToViewTransformer {
         .apiHasLongRunningMethods(context.getInterfaceConfig().hasLongRunningOperations())
         .missingDefaultServiceAddress(!context.getInterfaceConfig().hasDefaultServiceAddress())
         .missingDefaultServiceScopes(!context.getInterfaceConfig().hasDefaultServiceScopes())
+        .fullyQualifiedCredentialsClassName(namer.getFullyQualifiedCredentialsClassName())
         .mockServices(ImmutableList.<MockServiceUsageView>of())
         .build();
   }

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubyGapicSurfaceTransformer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubyGapicSurfaceTransformer.java
@@ -182,7 +182,7 @@ public class RubyGapicSurfaceTransformer implements ModelToViewTransformer {
     xapiClass.packageVersion(
         packageConfig.generatedPackageVersionBound(TargetLanguage.RUBY).lower());
 
-    xapiClass.fullyQualifiedCredentialsClassName(topLevelNamespace(namer) + "::Credentials");
+    xapiClass.fullyQualifiedCredentialsClassName(namer.getFullyQualifiedCredentialsClassName());
     return xapiClass.build();
   }
 
@@ -301,7 +301,7 @@ public class RubyGapicSurfaceTransformer implements ModelToViewTransformer {
       if (hasMultipleServices) {
         clientName += "::" + serviceName;
       }
-      String topLevelNamespace = topLevelNamespace(namer);
+      String topLevelNamespace = namer.getTopLevelNamespace();
       requireViews.add(
           VersionIndexRequireView.newBuilder()
               .clientName(clientName)
@@ -406,10 +406,6 @@ public class RubyGapicSurfaceTransformer implements ModelToViewTransformer {
       paths.add(namer.packageFilePathPiece(Name.upperCamel(part)));
     }
     return Joiner.on(File.separator).join(paths);
-  }
-
-  private String topLevelNamespace(SurfaceNamer namer) {
-    return Joiner.on("::").join(namer.getTopLevelApiModules());
   }
 
   private GapicInterfaceContext createContext(

--- a/src/main/java/com/google/api/codegen/transformer/ruby/RubySurfaceNamer.java
+++ b/src/main/java/com/google/api/codegen/transformer/ruby/RubySurfaceNamer.java
@@ -209,6 +209,11 @@ public class RubySurfaceNamer extends SurfaceNamer {
   }
 
   @Override
+  public String getFullyQualifiedCredentialsClassName() {
+    return getTopLevelNamespace() + "::Credentials";
+  }
+
+  @Override
   public List<String> getThrowsDocLines(GapicMethodConfig methodConfig) {
     return ImmutableList.of("@raise [Google::Gax::GaxError] if the RPC is aborted.");
   }
@@ -275,7 +280,8 @@ public class RubySurfaceNamer extends SurfaceNamer {
         : getPackageName();
   }
 
-  private String getTopLevelNamespace() {
+  @Override
+  public String getTopLevelNamespace() {
     return Joiner.on("::").join(getTopLevelApiModules());
   }
 

--- a/src/main/java/com/google/api/codegen/viewmodel/testing/ClientTestClassView.java
+++ b/src/main/java/com/google/api/codegen/viewmodel/testing/ClientTestClassView.java
@@ -49,6 +49,9 @@ public abstract class ClientTestClassView {
   @Nullable
   public abstract String apiVersion();
 
+  @Nullable
+  public abstract String fullyQualifiedCredentialsClassName();
+
   public static Builder newBuilder() {
     return new AutoValue_ClientTestClassView.Builder();
   }
@@ -80,6 +83,8 @@ public abstract class ClientTestClassView {
     public abstract Builder missingDefaultServiceScopes(boolean val);
 
     public abstract Builder apiVersion(String val);
+
+    public abstract Builder fullyQualifiedCredentialsClassName(String val);
 
     public abstract ClientTestClassView build();
   }

--- a/src/main/resources/com/google/api/codegen/ruby/test.snip
+++ b/src/main/resources/com/google/api/codegen/ruby/test.snip
@@ -5,7 +5,7 @@
 @snippet generate(apiTest)
   {@header(apiTest.fileHeader)}
 
-  {@helpers()}
+  {@helpers(apiTest.testClass.fullyQualifiedCredentialsClassName)}
 
   {@testClass(apiTest.apiVersion, apiTest.testClass)}
 @end
@@ -20,7 +20,7 @@
   {@importList(fileHeader.importSection.appImports)}
 @end
 
-@private helpers()
+@private helpers(credentialsClassName)
   class CustomTestError < StandardError; end
 
   @# Mock for the GRPC::ClientStub class.
@@ -51,6 +51,19 @@
       end
     end
   end
+  
+  class MockCredentialsClass < {@credentialsClassName}
+    def initialize(method_name)
+      @@method_name = method_name
+    end
+    
+    def updater_proc
+      proc do
+        raise "The method `#{@@method_name}` was trying to make a grpc request. This should not " @\
+            "happen since the grpc layer is being mocked."
+      end
+    end
+  end
 @end
 
 @private testClass(apiVersion, testClass)
@@ -60,54 +73,54 @@
       describe '{@test.clientMethodName}' do
         custom_error = CustomTestError.new "Custom test error for {@test.fullyQualifiedServiceClassName}#{@test.clientMethodName}."
 
-        {@testCase(apiVersion, test)}
+        {@testCase(apiVersion, testClass.fullyQualifiedCredentialsClassName, test)}
 
-        {@errorTestCase(apiVersion, test)}
+        {@errorTestCase(apiVersion, testClass.fullyQualifiedCredentialsClassName, test)}
       end
     @end
   end
 @end
 
-@private testCase(apiVersion, test)
+@private testCase(apiVersion, credentialsClassName, test)
   @switch test.grpcStreamingType
   @case "NonStreaming"
     @switch test.clientMethodType
     @case "RequestObjectMethod"
-      {@requestObjectTestCase(apiVersion, test)}
+      {@requestObjectTestCase(apiVersion, credentialsClassName, test)}
     @case "PagedRequestObjectMethod"
-      {@pageIterationTestCase(apiVersion, test)}
+      {@pageIterationTestCase(apiVersion, credentialsClassName, test)}
     @case "OperationCallableMethod"
-      {@longrunningTestCase(apiVersion, test)}
+      {@longrunningTestCase(apiVersion, credentialsClassName, test)}
     @default
       $unhandled case: {@test.clientMethodType.toString}$
     @end
   @case "ServerStreaming"
-    {@serverStreamingTest(apiVersion, test)}
+    {@serverStreamingTest(apiVersion, credentialsClassName, test)}
   @case "BidiStreaming"
-    {@bidiStreamingTest(apiVersion, test)}
+    {@bidiStreamingTest(apiVersion, credentialsClassName, test)}
   @case "ClientStreaming"
-    {@clientStreamingTest(apiVersion, test)}
+    {@clientStreamingTest(apiVersion, credentialsClassName, test)}
   @default
     $unhandled case: {@test.grpcStreamingType.toString}$
   @end
 @end
 
-@private errorTestCase(apiVersion, test)
+@private errorTestCase(apiVersion, credentialsClassName, test)
   @switch test.grpcStreamingType
     @case "NonStreaming"
-      {@simpleErrorTestCase(apiVersion, test)}
+      {@simpleErrorTestCase(apiVersion, credentialsClassName, test)}
     @case "ServerStreaming"
-      {@simpleErrorTestCase(apiVersion, test)}
+      {@simpleErrorTestCase(apiVersion, credentialsClassName, test)}
     @case "BidiStreaming"
-      {@clientStreamingErrorTestCase(apiVersion, test)}
+      {@clientStreamingErrorTestCase(apiVersion, credentialsClassName, test)}
     @case "ClientStreaming"
-       {@clientStreamingErrorTestCase(apiVersion, test)}
+       {@clientStreamingErrorTestCase(apiVersion, credentialsClassName, test)}
     @default
       $unhandled case: {@test.grpcStreamingType.toString}$
     @end
 @end
 
-@private requestObjectTestCase(apiVersion, test)
+@private requestObjectTestCase(apiVersion, credentialsClassName, test)
   it 'invokes {@test.clientMethodName} without error' do
     @if initCode(test.initCode)
       @# Create request parameters
@@ -126,23 +139,28 @@
     {@mockUnaryRequest(test)}
     mock_stub = MockGrpcClientStub.new(:{@test.clientMethodName}, mock_method)
 
+    @# Mock auth layer
+    {@mockAuth(test.clientMethodName)}
+
     {@test.grpcStubCallString}.stub(:new, mock_stub) do
-      client = {@test.fullyQualifiedAliasedServiceClassName}.new(version: :{@apiVersion})
+      {@credentialsClassName}.stub(:default, mock_credentials) do
+        client = {@test.fullyQualifiedAliasedServiceClassName}.new(version: :{@apiVersion})
 
-      @# Call method
-      {@methodCallWithResponse(test)}
+        @# Call method
+        {@methodCallWithResponse(test)}
 
-      @# Verify the response
-      @if test.hasReturnValue
-        assert_equal(expected_response, response)
-      @else
-        assert_nil(response)
-      @end
+        @# Verify the response
+        @if test.hasReturnValue
+          assert_equal(expected_response, response)
+        @else
+          assert_nil(response)
+        @end
+      end
     end
   end
 @end
 
-@private pageIterationTestCase(apiVersion, test)
+@private pageIterationTestCase(apiVersion, credentialsClassName, test)
   it 'invokes {@test.clientMethodName} without error' do
     @if initCode(test.initCode)
       @# Create request parameters
@@ -157,24 +175,29 @@
     {@mockUnaryRequest(test)}
     mock_stub = MockGrpcClientStub.new(:{@test.clientMethodName}, mock_method)
 
+    @# Mock auth layer
+    {@mockAuth(test.clientMethodName)}
+
     {@test.grpcStubCallString}.stub(:new, mock_stub) do
-      client = {@test.fullyQualifiedAliasedServiceClassName}.new(version: :{@apiVersion})
+      {@credentialsClassName}.stub(:default, mock_credentials) do
+        client = {@test.fullyQualifiedAliasedServiceClassName}.new(version: :{@apiVersion})
 
-      @# Call method
-      {@methodCallWithResponse(test)}
+        @# Call method
+        {@methodCallWithResponse(test)}
 
-      @# Verify the response
-      assert(response.instance_of?(Google::Gax::PagedEnumerable))
-      assert_equal(expected_response, response.page.response)
-      assert_nil(response.next_page)
-      @join pageResponseView : test.pageStreamingResponseViews on BREAK
-        assert_equal(expected_response.{@pageResponseView.resourcesFieldGetterName}.to_a, response.to_a)
-      @end
+        @# Verify the response
+        assert(response.instance_of?(Google::Gax::PagedEnumerable))
+        assert_equal(expected_response, response.page.response)
+        assert_nil(response.next_page)
+        @join pageResponseView : test.pageStreamingResponseViews on BREAK
+          assert_equal(expected_response.{@pageResponseView.resourcesFieldGetterName}.to_a, response.to_a)
+        @end
+      end
     end
   end
 @end
 
-@private longrunningTestCase(apiVersion, test)
+@private longrunningTestCase(apiVersion, credentialsClassName, test)
   it 'invokes {@test.clientMethodName} without error' do
     @if initCode(test.initCode)
       @# Create request parameters
@@ -196,14 +219,19 @@
     {@mockLongrunningRequest(test)}
     mock_stub = MockGrpcClientStub.new(:{@test.clientMethodName}, mock_method)
 
+    @# Mock auth layer
+    {@mockAuth(test.clientMethodName)}
+
     {@test.grpcStubCallString}.stub(:new, mock_stub) do
-      client = {@test.fullyQualifiedAliasedServiceClassName}.new(version: :{@apiVersion})
+      {@credentialsClassName}.stub(:default, mock_credentials) do
+        client = {@test.fullyQualifiedAliasedServiceClassName}.new(version: :{@apiVersion})
 
-      @# Call method
-      {@methodCallWithResponse(test)}
+        @# Call method
+        {@methodCallWithResponse(test)}
 
-      @# Verify the response
-      assert_equal(expected_response, response.response)
+        @# Verify the response
+        assert_equal(expected_response, response.response)
+      end
     end
   end
 
@@ -240,7 +268,7 @@
   end
 @end
 
-@private serverStreamingTest(apiVersion, test)
+@private serverStreamingTest(apiVersion, credentialsClassName, test)
   it 'invokes {@test.clientMethodName} without error' do
     @if test.hasRequestParameters
       @# Create request parameters
@@ -255,20 +283,25 @@
     {@mockServerStreamingRequest(test)}
     mock_stub = MockGrpcClientStub.new(:{@test.clientMethodName}, mock_method)
 
+    @# Mock auth layer
+    {@mockAuth(test.clientMethodName)}
+
     {@test.grpcStubCallString}.stub(:new, mock_stub) do
-      client = {@test.fullyQualifiedAliasedServiceClassName}.new(version: :{@apiVersion})
+      {@credentialsClassName}.stub(:default, mock_credentials) do
+        client = {@test.fullyQualifiedAliasedServiceClassName}.new(version: :{@apiVersion})
 
-      @# Call method
-      {@methodCallWithResponse(test)}
+        @# Call method
+        {@methodCallWithResponse(test)}
 
-      @# Verify the response
-      assert_equal(1, response.count)
-      assert_equal(expected_response, response.first)
+        @# Verify the response
+        assert_equal(1, response.count)
+        assert_equal(expected_response, response.first)
+      end
     end
   end
 @end
 
-@private clientStreamingTest(apiVersion, test)
+@private clientStreamingTest(apiVersion, credentialsClassName, test)
   it 'invokes {@test.clientMethodName} without error' do
     @# Create request parameters
     {@initCode(test.initCode)}
@@ -283,23 +316,28 @@
     {@mockClientStreamingRequest(test)}
     mock_stub = MockGrpcClientStub.new(:{@test.clientMethodName}, mock_method)
 
+    @# Mock auth layer
+    {@mockAuth(test.clientMethodName)}
+
     {@test.grpcStubCallString}.stub(:new, mock_stub) do
-      client = {@test.fullyQualifiedAliasedServiceClassName}.new(version: :{@apiVersion})
+      {@credentialsClassName}.stub(:default, mock_credentials) do
+        client = {@test.fullyQualifiedAliasedServiceClassName}.new(version: :{@apiVersion})
 
-      @# Call method
-      {@clientStreamingCall(test)}
+        @# Call method
+        {@clientStreamingCall(test)}
 
-      @# Verify the response
-      @if test.hasReturnValue
-        assert_equal(expected_response, response)
-      @else
-        assert_nil(response)
-      @end
+        @# Verify the response
+        @if test.hasReturnValue
+          assert_equal(expected_response, response)
+        @else
+          assert_nil(response)
+        @end
+      end
     end
   end
 @end
 
-@private bidiStreamingTest(apiVersion, test)
+@private bidiStreamingTest(apiVersion, credentialsClassName, test)
   it 'invokes {@test.clientMethodName} without error' do
     @# Create request parameters
     {@initCode(test.initCode)}
@@ -312,20 +350,25 @@
     {@mockBidiStreamingRequest(test)}
     mock_stub = MockGrpcClientStub.new(:{@test.clientMethodName}, mock_method)
 
+    @# Mock auth layer
+    {@mockAuth(test.clientMethodName)}
+
     {@test.grpcStubCallString}.stub(:new, mock_stub) do
-      client = {@test.fullyQualifiedAliasedServiceClassName}.new(version: :{@apiVersion})
+      {@credentialsClassName}.stub(:default, mock_credentials) do
+        client = {@test.fullyQualifiedAliasedServiceClassName}.new(version: :{@apiVersion})
 
-      @# Call method
-      {@clientStreamingCall(test)}
+        @# Call method
+        {@clientStreamingCall(test)}
 
-      @# Verify the response
-      assert_equal(1, response.count)
-      assert_equal(expected_response, response.first)
+        @# Verify the response
+        assert_equal(1, response.count)
+        assert_equal(expected_response, response.first)
+      end
     end
   end
 @end
 
-@private simpleErrorTestCase(apiVersion, test)
+@private simpleErrorTestCase(apiVersion, credentialsClassName, test)
   it 'invokes {@test.clientMethodName} with error' do
     @if initCode(test.initCode)
       @# Create request parameters
@@ -336,21 +379,26 @@
     {@mockUnaryError(test)}
     mock_stub = MockGrpcClientStub.new(:{@test.clientMethodName}, mock_method)
 
+    @# Mock auth layer
+    {@mockAuth(test.clientMethodName)}
+
     {@test.grpcStubCallString}.stub(:new, mock_stub) do
-      client = {@test.fullyQualifiedAliasedServiceClassName}.new(version: :{@apiVersion})
+      {@credentialsClassName}.stub(:default, mock_credentials) do
+        client = {@test.fullyQualifiedAliasedServiceClassName}.new(version: :{@apiVersion})
 
-      @# Call method
-      err = assert_raises Google::Gax::GaxError do
-        {@methodCall(test)}
+        @# Call method
+        err = assert_raises Google::Gax::GaxError do
+          {@methodCall(test)}
+        end
+
+        @# Verify the GaxError wrapped the custom error that was raised.
+        assert_match(custom_error.message, err.message)
       end
-
-      @# Verify the GaxError wrapped the custom error that was raised.
-      assert_match(custom_error.message, err.message)
     end
   end
 @end
 
-@private clientStreamingErrorTestCase(apiVersion, test)
+@private clientStreamingErrorTestCase(apiVersion, credentialsClassName, test)
   it 'invokes {@test.clientMethodName} with error' do
     @# Create request parameters
     {@initCode(test.initCode)}
@@ -359,16 +407,21 @@
     {@mockClientStreamingError(test)}
     mock_stub = MockGrpcClientStub.new(:{@test.clientMethodName}, mock_method)
 
+    @# Mock auth layer
+    {@mockAuth(test.clientMethodName)}
+
     {@test.grpcStubCallString}.stub(:new, mock_stub) do
-      client = {@test.fullyQualifiedAliasedServiceClassName}.new(version: :{@apiVersion})
+      {@credentialsClassName}.stub(:default, mock_credentials) do
+        client = {@test.fullyQualifiedAliasedServiceClassName}.new(version: :{@apiVersion})
 
-      @# Call method
-      err = assert_raises Google::Gax::GaxError do
-        client.{@test.clientMethodName}([request])
+        @# Call method
+        err = assert_raises Google::Gax::GaxError do
+          client.{@test.clientMethodName}([request])
+        end
+
+        @# Verify the GaxError wrapped the custom error that was raised.
+        assert_match(custom_error.message, err.message)
       end
-
-      @# Verify the GaxError wrapped the custom error that was raised.
-      assert_match(custom_error.message, err.message)
     end
   end
 @end
@@ -453,6 +506,10 @@
     @end
     raise custom_error
   end
+@end
+
+@private mockAuth(methodName)
+  mock_credentials = MockCredentialsClass.new("{@methodName}")
 @end
 
 @private requestAsserts(test)

--- a/src/test/java/com/google/api/codegen/testdata/ruby_doc_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_doc_test_library.baseline
@@ -55,6 +55,19 @@ class MockGrpcClientStub
   end
 end
 
+class MockCredentialsClass < Library::Credentials
+  def initialize(method_name)
+    @method_name = method_name
+  end
+
+  def updater_proc
+    proc do
+      raise "The method `#{@method_name}` was trying to make a grpc request. This should not " \
+          "happen since the grpc layer is being mocked."
+    end
+  end
+end
+
 describe Library::V1::LibraryServiceClient do
 
   describe 'create_shelf' do
@@ -83,14 +96,19 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:create_shelf, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("create_shelf")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.create_shelf(shelf)
+          # Call method
+          response = client.create_shelf(shelf)
 
-        # Verify the response
-        assert_equal(expected_response, response)
+          # Verify the response
+          assert_equal(expected_response, response)
+        end
       end
     end
 
@@ -106,16 +124,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:create_shelf, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("create_shelf")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.create_shelf(shelf)
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.create_shelf(shelf)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -148,14 +171,19 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:get_shelf, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("get_shelf")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.get_shelf(formatted_name, options_)
+          # Call method
+          response = client.get_shelf(formatted_name, options_)
 
-        # Verify the response
-        assert_equal(expected_response, response)
+          # Verify the response
+          assert_equal(expected_response, response)
+        end
       end
     end
 
@@ -173,16 +201,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:get_shelf, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("get_shelf")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.get_shelf(formatted_name, options_)
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.get_shelf(formatted_name, options_)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -204,17 +237,22 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:list_shelves, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("list_shelves")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.list_shelves
+          # Call method
+          response = client.list_shelves
 
-        # Verify the response
-        assert(response.instance_of?(Google::Gax::PagedEnumerable))
-        assert_equal(expected_response, response.page.response)
-        assert_nil(response.next_page)
-        assert_equal(expected_response.shelves.to_a, response.to_a)
+          # Verify the response
+          assert(response.instance_of?(Google::Gax::PagedEnumerable))
+          assert_equal(expected_response, response.page.response)
+          assert_nil(response.next_page)
+          assert_equal(expected_response.shelves.to_a, response.to_a)
+        end
       end
     end
 
@@ -225,16 +263,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:list_shelves, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("list_shelves")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.list_shelves
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.list_shelves
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -254,14 +297,19 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:delete_shelf, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("delete_shelf")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.delete_shelf(formatted_name)
+          # Call method
+          response = client.delete_shelf(formatted_name)
 
-        # Verify the response
-        assert_nil(response)
+          # Verify the response
+          assert_nil(response)
+        end
       end
     end
 
@@ -277,16 +325,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:delete_shelf, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("delete_shelf")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.delete_shelf(formatted_name)
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.delete_shelf(formatted_name)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -319,14 +372,19 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:merge_shelves, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("merge_shelves")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.merge_shelves(formatted_name, formatted_other_shelf_name)
+          # Call method
+          response = client.merge_shelves(formatted_name, formatted_other_shelf_name)
 
-        # Verify the response
-        assert_equal(expected_response, response)
+          # Verify the response
+          assert_equal(expected_response, response)
+        end
       end
     end
 
@@ -344,16 +402,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:merge_shelves, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("merge_shelves")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.merge_shelves(formatted_name, formatted_other_shelf_name)
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.merge_shelves(formatted_name, formatted_other_shelf_name)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -388,14 +451,19 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:create_book, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("create_book")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.create_book(formatted_name, book)
+          # Call method
+          response = client.create_book(formatted_name, book)
 
-        # Verify the response
-        assert_equal(expected_response, response)
+          # Verify the response
+          assert_equal(expected_response, response)
+        end
       end
     end
 
@@ -413,16 +481,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:create_book, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("create_book")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.create_book(formatted_name, book)
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.create_book(formatted_name, book)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -453,18 +526,23 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:publish_series, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("publish_series")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.publish_series(
-          shelf,
-          books,
-          series_uuid
-        )
+          # Call method
+          response = client.publish_series(
+            shelf,
+            books,
+            series_uuid
+          )
 
-        # Verify the response
-        assert_equal(expected_response, response)
+          # Verify the response
+          assert_equal(expected_response, response)
+        end
       end
     end
 
@@ -485,20 +563,25 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:publish_series, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("publish_series")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.publish_series(
-            shelf,
-            books,
-            series_uuid
-          )
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.publish_series(
+              shelf,
+              books,
+              series_uuid
+            )
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -531,14 +614,19 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:get_book, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("get_book")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.get_book(formatted_name)
+          # Call method
+          response = client.get_book(formatted_name)
 
-        # Verify the response
-        assert_equal(expected_response, response)
+          # Verify the response
+          assert_equal(expected_response, response)
+        end
       end
     end
 
@@ -554,16 +642,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:get_book, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("get_book")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.get_book(formatted_name)
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.get_book(formatted_name)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -590,17 +683,22 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:list_books, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("list_books")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.list_books(formatted_name)
+          # Call method
+          response = client.list_books(formatted_name)
 
-        # Verify the response
-        assert(response.instance_of?(Google::Gax::PagedEnumerable))
-        assert_equal(expected_response, response.page.response)
-        assert_nil(response.next_page)
-        assert_equal(expected_response.books.to_a, response.to_a)
+          # Verify the response
+          assert(response.instance_of?(Google::Gax::PagedEnumerable))
+          assert_equal(expected_response, response.page.response)
+          assert_nil(response.next_page)
+          assert_equal(expected_response.books.to_a, response.to_a)
+        end
       end
     end
 
@@ -616,16 +714,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:list_books, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("list_books")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.list_books(formatted_name)
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.list_books(formatted_name)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -645,14 +748,19 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:delete_book, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("delete_book")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.delete_book(formatted_name)
+          # Call method
+          response = client.delete_book(formatted_name)
 
-        # Verify the response
-        assert_nil(response)
+          # Verify the response
+          assert_nil(response)
+        end
       end
     end
 
@@ -668,16 +776,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:delete_book, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("delete_book")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.delete_book(formatted_name)
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.delete_book(formatted_name)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -712,14 +825,19 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:update_book, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("update_book")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.update_book(formatted_name, book)
+          # Call method
+          response = client.update_book(formatted_name, book)
 
-        # Verify the response
-        assert_equal(expected_response, response)
+          # Verify the response
+          assert_equal(expected_response, response)
+        end
       end
     end
 
@@ -737,16 +855,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:update_book, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("update_book")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.update_book(formatted_name, book)
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.update_book(formatted_name, book)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -781,14 +904,19 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:move_book, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("move_book")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.move_book(formatted_name, formatted_other_shelf_name)
+          # Call method
+          response = client.move_book(formatted_name, formatted_other_shelf_name)
 
-        # Verify the response
-        assert_equal(expected_response, response)
+          # Verify the response
+          assert_equal(expected_response, response)
+        end
       end
     end
 
@@ -806,16 +934,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:move_book, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("move_book")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.move_book(formatted_name, formatted_other_shelf_name)
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.move_book(formatted_name, formatted_other_shelf_name)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -837,17 +970,22 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:list_strings, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("list_strings")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.list_strings
+          # Call method
+          response = client.list_strings
 
-        # Verify the response
-        assert(response.instance_of?(Google::Gax::PagedEnumerable))
-        assert_equal(expected_response, response.page.response)
-        assert_nil(response.next_page)
-        assert_equal(expected_response.strings.to_a, response.to_a)
+          # Verify the response
+          assert(response.instance_of?(Google::Gax::PagedEnumerable))
+          assert_equal(expected_response, response.page.response)
+          assert_nil(response.next_page)
+          assert_equal(expected_response.strings.to_a, response.to_a)
+        end
       end
     end
 
@@ -858,16 +996,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:list_strings, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("list_strings")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.list_strings
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.list_strings
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -897,14 +1040,19 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:add_comments, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("add_comments")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.add_comments(formatted_name, comments)
+          # Call method
+          response = client.add_comments(formatted_name, comments)
 
-        # Verify the response
-        assert_nil(response)
+          # Verify the response
+          assert_nil(response)
+        end
       end
     end
 
@@ -930,16 +1078,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:add_comments, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("add_comments")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.add_comments(formatted_name, comments)
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.add_comments(formatted_name, comments)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -972,14 +1125,19 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:get_book_from_archive, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("get_book_from_archive")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.get_book_from_archive(formatted_name)
+          # Call method
+          response = client.get_book_from_archive(formatted_name)
 
-        # Verify the response
-        assert_equal(expected_response, response)
+          # Verify the response
+          assert_equal(expected_response, response)
+        end
       end
     end
 
@@ -995,16 +1153,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:get_book_from_archive, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("get_book_from_archive")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.get_book_from_archive(formatted_name)
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.get_book_from_archive(formatted_name)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -1039,14 +1202,19 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:get_book_from_anywhere, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("get_book_from_anywhere")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.get_book_from_anywhere(formatted_name, formatted_alt_book_name)
+          # Call method
+          response = client.get_book_from_anywhere(formatted_name, formatted_alt_book_name)
 
-        # Verify the response
-        assert_equal(expected_response, response)
+          # Verify the response
+          assert_equal(expected_response, response)
+        end
       end
     end
 
@@ -1064,16 +1232,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:get_book_from_anywhere, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("get_book_from_anywhere")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.get_book_from_anywhere(formatted_name, formatted_alt_book_name)
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.get_book_from_anywhere(formatted_name, formatted_alt_book_name)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -1106,14 +1279,19 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:get_book_from_absolutely_anywhere, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("get_book_from_absolutely_anywhere")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.get_book_from_absolutely_anywhere(formatted_name)
+          # Call method
+          response = client.get_book_from_absolutely_anywhere(formatted_name)
 
-        # Verify the response
-        assert_equal(expected_response, response)
+          # Verify the response
+          assert_equal(expected_response, response)
+        end
       end
     end
 
@@ -1129,16 +1307,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:get_book_from_absolutely_anywhere, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("get_book_from_absolutely_anywhere")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.get_book_from_absolutely_anywhere(formatted_name)
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.get_book_from_absolutely_anywhere(formatted_name)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -1163,18 +1346,23 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:update_book_index, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("update_book_index")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.update_book_index(
-          formatted_name,
-          index_name,
-          index_map
-        )
+          # Call method
+          response = client.update_book_index(
+            formatted_name,
+            index_name,
+            index_map
+          )
 
-        # Verify the response
-        assert_nil(response)
+          # Verify the response
+          assert_nil(response)
+        end
       end
     end
 
@@ -1195,20 +1383,25 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:update_book_index, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("update_book_index")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.update_book_index(
-            formatted_name,
-            index_name,
-            index_map
-          )
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.update_book_index(
+              formatted_name,
+              index_name,
+              index_map
+            )
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -1232,15 +1425,20 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:stream_shelves, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("stream_shelves")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.stream_shelves(request)
+          # Call method
+          response = client.stream_shelves(request)
 
-        # Verify the response
-        assert_equal(1, response.count)
-        assert_equal(expected_response, response.first)
+          # Verify the response
+          assert_equal(1, response.count)
+          assert_equal(expected_response, response.first)
+        end
       end
     end
 
@@ -1254,16 +1452,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:stream_shelves, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("stream_shelves")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.stream_shelves(request)
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.stream_shelves(request)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -1297,15 +1500,20 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:stream_books, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("stream_books")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.stream_books(request)
+          # Call method
+          response = client.stream_books(request)
 
-        # Verify the response
-        assert_equal(1, response.count)
-        assert_equal(expected_response, response.first)
+          # Verify the response
+          assert_equal(1, response.count)
+          assert_equal(expected_response, response.first)
+        end
       end
     end
 
@@ -1322,16 +1530,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:stream_books, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("stream_books")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.stream_books(request)
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.stream_books(request)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -1359,15 +1572,20 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:discuss_book, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("discuss_book")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.discuss_book([request])
+          # Call method
+          response = client.discuss_book([request])
 
-        # Verify the response
-        assert_equal(1, response.count)
-        assert_equal(expected_response, response.first)
+          # Verify the response
+          assert_equal(1, response.count)
+          assert_equal(expected_response, response.first)
+        end
       end
     end
 
@@ -1385,16 +1603,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:discuss_book, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("discuss_book")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.discuss_book([request])
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.discuss_book([request])
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -1422,14 +1645,19 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:monolog_about_book, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("monolog_about_book")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.monolog_about_book([request])
+          # Call method
+          response = client.monolog_about_book([request])
 
-        # Verify the response
-        assert_equal(expected_response, response)
+          # Verify the response
+          assert_equal(expected_response, response)
+        end
       end
     end
 
@@ -1447,16 +1675,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:monolog_about_book, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("monolog_about_book")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.monolog_about_book([request])
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.monolog_about_book([request])
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -1486,17 +1719,22 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:find_related_books, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("find_related_books")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.find_related_books(names, shelves)
+          # Call method
+          response = client.find_related_books(names, shelves)
 
-        # Verify the response
-        assert(response.instance_of?(Google::Gax::PagedEnumerable))
-        assert_equal(expected_response, response.page.response)
-        assert_nil(response.next_page)
-        assert_equal(expected_response.names.to_a, response.to_a)
+          # Verify the response
+          assert(response.instance_of?(Google::Gax::PagedEnumerable))
+          assert_equal(expected_response, response.page.response)
+          assert_nil(response.next_page)
+          assert_equal(expected_response.names.to_a, response.to_a)
+        end
       end
     end
 
@@ -1515,16 +1753,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:find_related_books, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("find_related_books")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.find_related_books(names, shelves)
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.find_related_books(names, shelves)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -1550,14 +1793,19 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:add_tag, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("add_tag")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.add_tag(formatted_resource, tag)
+          # Call method
+          response = client.add_tag(formatted_resource, tag)
 
-        # Verify the response
-        assert_equal(expected_response, response)
+          # Verify the response
+          assert_equal(expected_response, response)
+        end
       end
     end
 
@@ -1575,16 +1823,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:add_tag, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("add_tag")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.add_tag(formatted_resource, tag)
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.add_tag(formatted_resource, tag)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -1610,14 +1863,19 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:add_label, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("add_label")
+
       Google::Tagger::V1::Labeler::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.add_label(formatted_resource, label)
+          # Call method
+          response = client.add_label(formatted_resource, label)
 
-        # Verify the response
-        assert_equal(expected_response, response)
+          # Verify the response
+          assert_equal(expected_response, response)
+        end
       end
     end
 
@@ -1635,16 +1893,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:add_label, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("add_label")
+
       Google::Tagger::V1::Labeler::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.add_label(formatted_resource, label)
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.add_label(formatted_resource, label)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -1684,14 +1947,19 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:get_big_book, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("get_big_book")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.get_big_book(formatted_name)
+          # Call method
+          response = client.get_big_book(formatted_name)
 
-        # Verify the response
-        assert_equal(expected_response, response.response)
+          # Verify the response
+          assert_equal(expected_response, response.response)
+        end
       end
     end
 
@@ -1741,16 +2009,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:get_big_book, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("get_big_book")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.get_big_book(formatted_name)
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.get_big_book(formatted_name)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -1781,14 +2054,19 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:get_big_nothing, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("get_big_nothing")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.get_big_nothing(formatted_name)
+          # Call method
+          response = client.get_big_nothing(formatted_name)
 
-        # Verify the response
-        assert_equal(expected_response, response.response)
+          # Verify the response
+          assert_equal(expected_response, response.response)
+        end
       end
     end
 
@@ -1838,16 +2116,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:get_big_nothing, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("get_big_nothing")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.get_big_nothing(formatted_name)
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.get_big_nothing(formatted_name)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -1923,42 +2206,47 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:test_optional_required_flattening_params, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("test_optional_required_flattening_params")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.test_optional_required_flattening_params(
-          required_singular_int32,
-          required_singular_int64,
-          required_singular_float,
-          required_singular_double,
-          required_singular_bool,
-          required_singular_enum,
-          required_singular_string,
-          required_singular_bytes,
-          required_singular_message,
-          required_singular_resource_name,
-          required_singular_resource_name_oneof,
-          required_singular_fixed32,
-          required_singular_fixed64,
-          required_repeated_int32,
-          required_repeated_int64,
-          required_repeated_float,
-          required_repeated_double,
-          required_repeated_bool,
-          required_repeated_enum,
-          required_repeated_string,
-          required_repeated_bytes,
-          required_repeated_message,
-          formatted_required_repeated_resource_name,
-          formatted_required_repeated_resource_name_oneof,
-          required_repeated_fixed32,
-          required_repeated_fixed64,
-          required_map
-        )
+          # Call method
+          response = client.test_optional_required_flattening_params(
+            required_singular_int32,
+            required_singular_int64,
+            required_singular_float,
+            required_singular_double,
+            required_singular_bool,
+            required_singular_enum,
+            required_singular_string,
+            required_singular_bytes,
+            required_singular_message,
+            required_singular_resource_name,
+            required_singular_resource_name_oneof,
+            required_singular_fixed32,
+            required_singular_fixed64,
+            required_repeated_int32,
+            required_repeated_int64,
+            required_repeated_float,
+            required_repeated_double,
+            required_repeated_bool,
+            required_repeated_enum,
+            required_repeated_string,
+            required_repeated_bytes,
+            required_repeated_message,
+            formatted_required_repeated_resource_name,
+            formatted_required_repeated_resource_name_oneof,
+            required_repeated_fixed32,
+            required_repeated_fixed64,
+            required_map
+          )
 
-        # Verify the response
-        assert_equal(expected_response, response)
+          # Verify the response
+          assert_equal(expected_response, response)
+        end
       end
     end
 
@@ -2026,44 +2314,49 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:test_optional_required_flattening_params, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("test_optional_required_flattening_params")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.test_optional_required_flattening_params(
-            required_singular_int32,
-            required_singular_int64,
-            required_singular_float,
-            required_singular_double,
-            required_singular_bool,
-            required_singular_enum,
-            required_singular_string,
-            required_singular_bytes,
-            required_singular_message,
-            required_singular_resource_name,
-            required_singular_resource_name_oneof,
-            required_singular_fixed32,
-            required_singular_fixed64,
-            required_repeated_int32,
-            required_repeated_int64,
-            required_repeated_float,
-            required_repeated_double,
-            required_repeated_bool,
-            required_repeated_enum,
-            required_repeated_string,
-            required_repeated_bytes,
-            required_repeated_message,
-            formatted_required_repeated_resource_name,
-            formatted_required_repeated_resource_name_oneof,
-            required_repeated_fixed32,
-            required_repeated_fixed64,
-            required_map
-          )
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.test_optional_required_flattening_params(
+              required_singular_int32,
+              required_singular_int64,
+              required_singular_float,
+              required_singular_double,
+              required_singular_bool,
+              required_singular_enum,
+              required_singular_string,
+              required_singular_bytes,
+              required_singular_message,
+              required_singular_resource_name,
+              required_singular_resource_name_oneof,
+              required_singular_fixed32,
+              required_singular_fixed64,
+              required_repeated_int32,
+              required_repeated_int64,
+              required_repeated_float,
+              required_repeated_double,
+              required_repeated_bool,
+              required_repeated_enum,
+              required_repeated_string,
+              required_repeated_bytes,
+              required_repeated_message,
+              formatted_required_repeated_resource_name,
+              formatted_required_repeated_resource_name_oneof,
+              required_repeated_fixed32,
+              required_repeated_fixed64,
+              required_map
+            )
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end

--- a/src/test/java/com/google/api/codegen/testdata/ruby_test_library.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_test_library.baseline
@@ -55,6 +55,19 @@ class MockGrpcClientStub
   end
 end
 
+class MockCredentialsClass < Library::Credentials
+  def initialize(method_name)
+    @method_name = method_name
+  end
+
+  def updater_proc
+    proc do
+      raise "The method `#{@method_name}` was trying to make a grpc request. This should not " \
+          "happen since the grpc layer is being mocked."
+    end
+  end
+end
+
 describe Library::V1::LibraryServiceClient do
 
   describe 'create_shelf' do
@@ -83,14 +96,19 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:create_shelf, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("create_shelf")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.create_shelf(shelf)
+          # Call method
+          response = client.create_shelf(shelf)
 
-        # Verify the response
-        assert_equal(expected_response, response)
+          # Verify the response
+          assert_equal(expected_response, response)
+        end
       end
     end
 
@@ -106,16 +124,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:create_shelf, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("create_shelf")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.create_shelf(shelf)
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.create_shelf(shelf)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -148,14 +171,19 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:get_shelf, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("get_shelf")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.get_shelf(formatted_name, options_)
+          # Call method
+          response = client.get_shelf(formatted_name, options_)
 
-        # Verify the response
-        assert_equal(expected_response, response)
+          # Verify the response
+          assert_equal(expected_response, response)
+        end
       end
     end
 
@@ -173,16 +201,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:get_shelf, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("get_shelf")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.get_shelf(formatted_name, options_)
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.get_shelf(formatted_name, options_)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -204,17 +237,22 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:list_shelves, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("list_shelves")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.list_shelves
+          # Call method
+          response = client.list_shelves
 
-        # Verify the response
-        assert(response.instance_of?(Google::Gax::PagedEnumerable))
-        assert_equal(expected_response, response.page.response)
-        assert_nil(response.next_page)
-        assert_equal(expected_response.shelves.to_a, response.to_a)
+          # Verify the response
+          assert(response.instance_of?(Google::Gax::PagedEnumerable))
+          assert_equal(expected_response, response.page.response)
+          assert_nil(response.next_page)
+          assert_equal(expected_response.shelves.to_a, response.to_a)
+        end
       end
     end
 
@@ -225,16 +263,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:list_shelves, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("list_shelves")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.list_shelves
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.list_shelves
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -254,14 +297,19 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:delete_shelf, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("delete_shelf")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.delete_shelf(formatted_name)
+          # Call method
+          response = client.delete_shelf(formatted_name)
 
-        # Verify the response
-        assert_nil(response)
+          # Verify the response
+          assert_nil(response)
+        end
       end
     end
 
@@ -277,16 +325,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:delete_shelf, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("delete_shelf")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.delete_shelf(formatted_name)
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.delete_shelf(formatted_name)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -319,14 +372,19 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:merge_shelves, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("merge_shelves")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.merge_shelves(formatted_name, formatted_other_shelf_name)
+          # Call method
+          response = client.merge_shelves(formatted_name, formatted_other_shelf_name)
 
-        # Verify the response
-        assert_equal(expected_response, response)
+          # Verify the response
+          assert_equal(expected_response, response)
+        end
       end
     end
 
@@ -344,16 +402,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:merge_shelves, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("merge_shelves")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.merge_shelves(formatted_name, formatted_other_shelf_name)
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.merge_shelves(formatted_name, formatted_other_shelf_name)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -388,14 +451,19 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:create_book, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("create_book")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.create_book(formatted_name, book)
+          # Call method
+          response = client.create_book(formatted_name, book)
 
-        # Verify the response
-        assert_equal(expected_response, response)
+          # Verify the response
+          assert_equal(expected_response, response)
+        end
       end
     end
 
@@ -413,16 +481,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:create_book, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("create_book")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.create_book(formatted_name, book)
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.create_book(formatted_name, book)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -453,18 +526,23 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:publish_series, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("publish_series")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.publish_series(
-          shelf,
-          books,
-          series_uuid
-        )
+          # Call method
+          response = client.publish_series(
+            shelf,
+            books,
+            series_uuid
+          )
 
-        # Verify the response
-        assert_equal(expected_response, response)
+          # Verify the response
+          assert_equal(expected_response, response)
+        end
       end
     end
 
@@ -485,20 +563,25 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:publish_series, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("publish_series")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.publish_series(
-            shelf,
-            books,
-            series_uuid
-          )
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.publish_series(
+              shelf,
+              books,
+              series_uuid
+            )
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -531,14 +614,19 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:get_book, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("get_book")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.get_book(formatted_name)
+          # Call method
+          response = client.get_book(formatted_name)
 
-        # Verify the response
-        assert_equal(expected_response, response)
+          # Verify the response
+          assert_equal(expected_response, response)
+        end
       end
     end
 
@@ -554,16 +642,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:get_book, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("get_book")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.get_book(formatted_name)
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.get_book(formatted_name)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -590,17 +683,22 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:list_books, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("list_books")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.list_books(formatted_name)
+          # Call method
+          response = client.list_books(formatted_name)
 
-        # Verify the response
-        assert(response.instance_of?(Google::Gax::PagedEnumerable))
-        assert_equal(expected_response, response.page.response)
-        assert_nil(response.next_page)
-        assert_equal(expected_response.books.to_a, response.to_a)
+          # Verify the response
+          assert(response.instance_of?(Google::Gax::PagedEnumerable))
+          assert_equal(expected_response, response.page.response)
+          assert_nil(response.next_page)
+          assert_equal(expected_response.books.to_a, response.to_a)
+        end
       end
     end
 
@@ -616,16 +714,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:list_books, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("list_books")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.list_books(formatted_name)
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.list_books(formatted_name)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -645,14 +748,19 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:delete_book, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("delete_book")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.delete_book(formatted_name)
+          # Call method
+          response = client.delete_book(formatted_name)
 
-        # Verify the response
-        assert_nil(response)
+          # Verify the response
+          assert_nil(response)
+        end
       end
     end
 
@@ -668,16 +776,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:delete_book, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("delete_book")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.delete_book(formatted_name)
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.delete_book(formatted_name)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -712,14 +825,19 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:update_book, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("update_book")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.update_book(formatted_name, book)
+          # Call method
+          response = client.update_book(formatted_name, book)
 
-        # Verify the response
-        assert_equal(expected_response, response)
+          # Verify the response
+          assert_equal(expected_response, response)
+        end
       end
     end
 
@@ -737,16 +855,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:update_book, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("update_book")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.update_book(formatted_name, book)
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.update_book(formatted_name, book)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -781,14 +904,19 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:move_book, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("move_book")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.move_book(formatted_name, formatted_other_shelf_name)
+          # Call method
+          response = client.move_book(formatted_name, formatted_other_shelf_name)
 
-        # Verify the response
-        assert_equal(expected_response, response)
+          # Verify the response
+          assert_equal(expected_response, response)
+        end
       end
     end
 
@@ -806,16 +934,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:move_book, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("move_book")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.move_book(formatted_name, formatted_other_shelf_name)
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.move_book(formatted_name, formatted_other_shelf_name)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -837,17 +970,22 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:list_strings, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("list_strings")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.list_strings
+          # Call method
+          response = client.list_strings
 
-        # Verify the response
-        assert(response.instance_of?(Google::Gax::PagedEnumerable))
-        assert_equal(expected_response, response.page.response)
-        assert_nil(response.next_page)
-        assert_equal(expected_response.strings.to_a, response.to_a)
+          # Verify the response
+          assert(response.instance_of?(Google::Gax::PagedEnumerable))
+          assert_equal(expected_response, response.page.response)
+          assert_nil(response.next_page)
+          assert_equal(expected_response.strings.to_a, response.to_a)
+        end
       end
     end
 
@@ -858,16 +996,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:list_strings, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("list_strings")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.list_strings
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.list_strings
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -897,14 +1040,19 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:add_comments, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("add_comments")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.add_comments(formatted_name, comments)
+          # Call method
+          response = client.add_comments(formatted_name, comments)
 
-        # Verify the response
-        assert_nil(response)
+          # Verify the response
+          assert_nil(response)
+        end
       end
     end
 
@@ -930,16 +1078,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:add_comments, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("add_comments")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.add_comments(formatted_name, comments)
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.add_comments(formatted_name, comments)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -972,14 +1125,19 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:get_book_from_archive, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("get_book_from_archive")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.get_book_from_archive(formatted_name)
+          # Call method
+          response = client.get_book_from_archive(formatted_name)
 
-        # Verify the response
-        assert_equal(expected_response, response)
+          # Verify the response
+          assert_equal(expected_response, response)
+        end
       end
     end
 
@@ -995,16 +1153,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:get_book_from_archive, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("get_book_from_archive")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.get_book_from_archive(formatted_name)
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.get_book_from_archive(formatted_name)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -1039,14 +1202,19 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:get_book_from_anywhere, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("get_book_from_anywhere")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.get_book_from_anywhere(formatted_name, formatted_alt_book_name)
+          # Call method
+          response = client.get_book_from_anywhere(formatted_name, formatted_alt_book_name)
 
-        # Verify the response
-        assert_equal(expected_response, response)
+          # Verify the response
+          assert_equal(expected_response, response)
+        end
       end
     end
 
@@ -1064,16 +1232,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:get_book_from_anywhere, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("get_book_from_anywhere")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.get_book_from_anywhere(formatted_name, formatted_alt_book_name)
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.get_book_from_anywhere(formatted_name, formatted_alt_book_name)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -1106,14 +1279,19 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:get_book_from_absolutely_anywhere, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("get_book_from_absolutely_anywhere")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.get_book_from_absolutely_anywhere(formatted_name)
+          # Call method
+          response = client.get_book_from_absolutely_anywhere(formatted_name)
 
-        # Verify the response
-        assert_equal(expected_response, response)
+          # Verify the response
+          assert_equal(expected_response, response)
+        end
       end
     end
 
@@ -1129,16 +1307,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:get_book_from_absolutely_anywhere, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("get_book_from_absolutely_anywhere")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.get_book_from_absolutely_anywhere(formatted_name)
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.get_book_from_absolutely_anywhere(formatted_name)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -1163,18 +1346,23 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:update_book_index, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("update_book_index")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.update_book_index(
-          formatted_name,
-          index_name,
-          index_map
-        )
+          # Call method
+          response = client.update_book_index(
+            formatted_name,
+            index_name,
+            index_map
+          )
 
-        # Verify the response
-        assert_nil(response)
+          # Verify the response
+          assert_nil(response)
+        end
       end
     end
 
@@ -1195,20 +1383,25 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:update_book_index, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("update_book_index")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.update_book_index(
-            formatted_name,
-            index_name,
-            index_map
-          )
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.update_book_index(
+              formatted_name,
+              index_name,
+              index_map
+            )
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -1232,15 +1425,20 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:stream_shelves, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("stream_shelves")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.stream_shelves(request)
+          # Call method
+          response = client.stream_shelves(request)
 
-        # Verify the response
-        assert_equal(1, response.count)
-        assert_equal(expected_response, response.first)
+          # Verify the response
+          assert_equal(1, response.count)
+          assert_equal(expected_response, response.first)
+        end
       end
     end
 
@@ -1254,16 +1452,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:stream_shelves, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("stream_shelves")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.stream_shelves(request)
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.stream_shelves(request)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -1297,15 +1500,20 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:stream_books, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("stream_books")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.stream_books(request)
+          # Call method
+          response = client.stream_books(request)
 
-        # Verify the response
-        assert_equal(1, response.count)
-        assert_equal(expected_response, response.first)
+          # Verify the response
+          assert_equal(1, response.count)
+          assert_equal(expected_response, response.first)
+        end
       end
     end
 
@@ -1322,16 +1530,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:stream_books, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("stream_books")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.stream_books(request)
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.stream_books(request)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -1359,15 +1572,20 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:discuss_book, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("discuss_book")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.discuss_book([request])
+          # Call method
+          response = client.discuss_book([request])
 
-        # Verify the response
-        assert_equal(1, response.count)
-        assert_equal(expected_response, response.first)
+          # Verify the response
+          assert_equal(1, response.count)
+          assert_equal(expected_response, response.first)
+        end
       end
     end
 
@@ -1385,16 +1603,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:discuss_book, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("discuss_book")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.discuss_book([request])
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.discuss_book([request])
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -1422,14 +1645,19 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:monolog_about_book, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("monolog_about_book")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.monolog_about_book([request])
+          # Call method
+          response = client.monolog_about_book([request])
 
-        # Verify the response
-        assert_equal(expected_response, response)
+          # Verify the response
+          assert_equal(expected_response, response)
+        end
       end
     end
 
@@ -1447,16 +1675,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:monolog_about_book, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("monolog_about_book")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.monolog_about_book([request])
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.monolog_about_book([request])
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -1486,17 +1719,22 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:find_related_books, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("find_related_books")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.find_related_books(names, shelves)
+          # Call method
+          response = client.find_related_books(names, shelves)
 
-        # Verify the response
-        assert(response.instance_of?(Google::Gax::PagedEnumerable))
-        assert_equal(expected_response, response.page.response)
-        assert_nil(response.next_page)
-        assert_equal(expected_response.names.to_a, response.to_a)
+          # Verify the response
+          assert(response.instance_of?(Google::Gax::PagedEnumerable))
+          assert_equal(expected_response, response.page.response)
+          assert_nil(response.next_page)
+          assert_equal(expected_response.names.to_a, response.to_a)
+        end
       end
     end
 
@@ -1515,16 +1753,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:find_related_books, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("find_related_books")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.find_related_books(names, shelves)
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.find_related_books(names, shelves)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -1550,14 +1793,19 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:add_tag, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("add_tag")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.add_tag(formatted_resource, tag)
+          # Call method
+          response = client.add_tag(formatted_resource, tag)
 
-        # Verify the response
-        assert_equal(expected_response, response)
+          # Verify the response
+          assert_equal(expected_response, response)
+        end
       end
     end
 
@@ -1575,16 +1823,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:add_tag, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("add_tag")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.add_tag(formatted_resource, tag)
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.add_tag(formatted_resource, tag)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -1610,14 +1863,19 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:add_label, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("add_label")
+
       Google::Tagger::V1::Labeler::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.add_label(formatted_resource, label)
+          # Call method
+          response = client.add_label(formatted_resource, label)
 
-        # Verify the response
-        assert_equal(expected_response, response)
+          # Verify the response
+          assert_equal(expected_response, response)
+        end
       end
     end
 
@@ -1635,16 +1893,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:add_label, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("add_label")
+
       Google::Tagger::V1::Labeler::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.add_label(formatted_resource, label)
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.add_label(formatted_resource, label)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -1684,14 +1947,19 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:get_big_book, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("get_big_book")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.get_big_book(formatted_name)
+          # Call method
+          response = client.get_big_book(formatted_name)
 
-        # Verify the response
-        assert_equal(expected_response, response.response)
+          # Verify the response
+          assert_equal(expected_response, response.response)
+        end
       end
     end
 
@@ -1741,16 +2009,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:get_big_book, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("get_big_book")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.get_big_book(formatted_name)
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.get_big_book(formatted_name)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -1781,14 +2054,19 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:get_big_nothing, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("get_big_nothing")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.get_big_nothing(formatted_name)
+          # Call method
+          response = client.get_big_nothing(formatted_name)
 
-        # Verify the response
-        assert_equal(expected_response, response.response)
+          # Verify the response
+          assert_equal(expected_response, response.response)
+        end
       end
     end
 
@@ -1838,16 +2116,21 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:get_big_nothing, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("get_big_nothing")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.get_big_nothing(formatted_name)
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.get_big_nothing(formatted_name)
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -1923,42 +2206,47 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:test_optional_required_flattening_params, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("test_optional_required_flattening_params")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        response = client.test_optional_required_flattening_params(
-          required_singular_int32,
-          required_singular_int64,
-          required_singular_float,
-          required_singular_double,
-          required_singular_bool,
-          required_singular_enum,
-          required_singular_string,
-          required_singular_bytes,
-          required_singular_message,
-          required_singular_resource_name,
-          required_singular_resource_name_oneof,
-          required_singular_fixed32,
-          required_singular_fixed64,
-          required_repeated_int32,
-          required_repeated_int64,
-          required_repeated_float,
-          required_repeated_double,
-          required_repeated_bool,
-          required_repeated_enum,
-          required_repeated_string,
-          required_repeated_bytes,
-          required_repeated_message,
-          formatted_required_repeated_resource_name,
-          formatted_required_repeated_resource_name_oneof,
-          required_repeated_fixed32,
-          required_repeated_fixed64,
-          required_map
-        )
+          # Call method
+          response = client.test_optional_required_flattening_params(
+            required_singular_int32,
+            required_singular_int64,
+            required_singular_float,
+            required_singular_double,
+            required_singular_bool,
+            required_singular_enum,
+            required_singular_string,
+            required_singular_bytes,
+            required_singular_message,
+            required_singular_resource_name,
+            required_singular_resource_name_oneof,
+            required_singular_fixed32,
+            required_singular_fixed64,
+            required_repeated_int32,
+            required_repeated_int64,
+            required_repeated_float,
+            required_repeated_double,
+            required_repeated_bool,
+            required_repeated_enum,
+            required_repeated_string,
+            required_repeated_bytes,
+            required_repeated_message,
+            formatted_required_repeated_resource_name,
+            formatted_required_repeated_resource_name_oneof,
+            required_repeated_fixed32,
+            required_repeated_fixed64,
+            required_map
+          )
 
-        # Verify the response
-        assert_equal(expected_response, response)
+          # Verify the response
+          assert_equal(expected_response, response)
+        end
       end
     end
 
@@ -2026,44 +2314,49 @@ describe Library::V1::LibraryServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:test_optional_required_flattening_params, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("test_optional_required_flattening_params")
+
       Google::Example::Library::V1::LibraryService::Stub.stub(:new, mock_stub) do
-        client = Library.new(version: :v1)
+        Library::Credentials.stub(:default, mock_credentials) do
+          client = Library.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.test_optional_required_flattening_params(
-            required_singular_int32,
-            required_singular_int64,
-            required_singular_float,
-            required_singular_double,
-            required_singular_bool,
-            required_singular_enum,
-            required_singular_string,
-            required_singular_bytes,
-            required_singular_message,
-            required_singular_resource_name,
-            required_singular_resource_name_oneof,
-            required_singular_fixed32,
-            required_singular_fixed64,
-            required_repeated_int32,
-            required_repeated_int64,
-            required_repeated_float,
-            required_repeated_double,
-            required_repeated_bool,
-            required_repeated_enum,
-            required_repeated_string,
-            required_repeated_bytes,
-            required_repeated_message,
-            formatted_required_repeated_resource_name,
-            formatted_required_repeated_resource_name_oneof,
-            required_repeated_fixed32,
-            required_repeated_fixed64,
-            required_map
-          )
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.test_optional_required_flattening_params(
+              required_singular_int32,
+              required_singular_int64,
+              required_singular_float,
+              required_singular_double,
+              required_singular_bool,
+              required_singular_enum,
+              required_singular_string,
+              required_singular_bytes,
+              required_singular_message,
+              required_singular_resource_name,
+              required_singular_resource_name_oneof,
+              required_singular_fixed32,
+              required_singular_fixed64,
+              required_repeated_int32,
+              required_repeated_int64,
+              required_repeated_float,
+              required_repeated_double,
+              required_repeated_bool,
+              required_repeated_enum,
+              required_repeated_string,
+              required_repeated_bytes,
+              required_repeated_message,
+              formatted_required_repeated_resource_name,
+              formatted_required_repeated_resource_name_oneof,
+              required_repeated_fixed32,
+              required_repeated_fixed64,
+              required_map
+            )
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end

--- a/src/test/java/com/google/api/codegen/testdata/ruby_test_multiple_services.baseline
+++ b/src/test/java/com/google/api/codegen/testdata/ruby_test_multiple_services.baseline
@@ -53,6 +53,19 @@ class MockGrpcClientStub
   end
 end
 
+class MockCredentialsClass < Google::Example::Credentials
+  def initialize(method_name)
+    @method_name = method_name
+  end
+
+  def updater_proc
+    proc do
+      raise "The method `#{@method_name}` was trying to make a grpc request. This should not " \
+          "happen since the grpc layer is being mocked."
+    end
+  end
+end
+
 describe Google::Example::V1::DecrementerServiceClient do
 
   describe 'decrement' do
@@ -66,14 +79,19 @@ describe Google::Example::V1::DecrementerServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:decrement, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("decrement")
+
       Google::Cloud::Example::V1::DecrementerService::Stub.stub(:new, mock_stub) do
-        client = Google::Example::Decrementer.new(version: :v1)
+        Google::Example::Credentials.stub(:default, mock_credentials) do
+          client = Google::Example::Decrementer.new(version: :v1)
 
-        # Call method
-        response = client.decrement
+          # Call method
+          response = client.decrement
 
-        # Verify the response
-        assert_nil(response)
+          # Verify the response
+          assert_nil(response)
+        end
       end
     end
 
@@ -84,16 +102,21 @@ describe Google::Example::V1::DecrementerServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:decrement, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("decrement")
+
       Google::Cloud::Example::V1::DecrementerService::Stub.stub(:new, mock_stub) do
-        client = Google::Example::Decrementer.new(version: :v1)
+        Google::Example::Credentials.stub(:default, mock_credentials) do
+          client = Google::Example::Decrementer.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.decrement
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.decrement
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end
@@ -153,6 +176,19 @@ class MockGrpcClientStub
   end
 end
 
+class MockCredentialsClass < Google::Example::Credentials
+  def initialize(method_name)
+    @method_name = method_name
+  end
+
+  def updater_proc
+    proc do
+      raise "The method `#{@method_name}` was trying to make a grpc request. This should not " \
+          "happen since the grpc layer is being mocked."
+    end
+  end
+end
+
 describe Google::Example::V1::IncrementerServiceClient do
 
   describe 'increment' do
@@ -166,14 +202,19 @@ describe Google::Example::V1::IncrementerServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:increment, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("increment")
+
       Google::Cloud::Example::V1::IncrementerService::Stub.stub(:new, mock_stub) do
-        client = Google::Example::Incrementer.new(version: :v1)
+        Google::Example::Credentials.stub(:default, mock_credentials) do
+          client = Google::Example::Incrementer.new(version: :v1)
 
-        # Call method
-        response = client.increment
+          # Call method
+          response = client.increment
 
-        # Verify the response
-        assert_nil(response)
+          # Verify the response
+          assert_nil(response)
+        end
       end
     end
 
@@ -184,16 +225,21 @@ describe Google::Example::V1::IncrementerServiceClient do
       end
       mock_stub = MockGrpcClientStub.new(:increment, mock_method)
 
+      # Mock auth layer
+      mock_credentials = MockCredentialsClass.new("increment")
+
       Google::Cloud::Example::V1::IncrementerService::Stub.stub(:new, mock_stub) do
-        client = Google::Example::Incrementer.new(version: :v1)
+        Google::Example::Credentials.stub(:default, mock_credentials) do
+          client = Google::Example::Incrementer.new(version: :v1)
 
-        # Call method
-        err = assert_raises Google::Gax::GaxError do
-          client.increment
+          # Call method
+          err = assert_raises Google::Gax::GaxError do
+            client.increment
+          end
+
+          # Verify the GaxError wrapped the custom error that was raised.
+          assert_match(custom_error.message, err.message)
         end
-
-        # Verify the GaxError wrapped the custom error that was raised.
-        assert_match(custom_error.message, err.message)
       end
     end
   end


### PR DESCRIPTION
Resolves #1280
This is also necessary for getting ruby CI in api-client-staging.